### PR TITLE
Add "Default Data Path" setting

### DIFF
--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -391,7 +391,7 @@ func newReplicaForVolume(v *longhorn.Volume, e *longhorn.Engine, nodeID, diskID 
 			},
 			EngineName: e.Name,
 			DiskID:     diskID,
-			DataPath:   filepath.Join(types.DefaultLonghornDirectory, "/replicas", replicaName),
+			DataPath:   filepath.Join(TestDefaultDataPath, "/replicas", replicaName),
 			Active:     true,
 		},
 	}

--- a/types/setting.go
+++ b/types/setting.go
@@ -17,6 +17,7 @@ type SettingName string
 const (
 	SettingNameBackupTarget                      = SettingName("backup-target")
 	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
+	SettingNameDefaultDataPath                   = SettingName("default-data-path")
 	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
 	SettingNameStorageOverProvisioningPercentage = SettingName("storage-over-provisioning-percentage")
 	SettingNameStorageMinimalAvailablePercentage = SettingName("storage-minimal-available-percentage")
@@ -32,6 +33,7 @@ var (
 	SettingNameList = []SettingName{
 		SettingNameBackupTarget,
 		SettingNameBackupTargetCredentialSecret,
+		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
 		SettingNameStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage,
@@ -65,6 +67,7 @@ var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
 		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
 		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
+		SettingNameDefaultDataPath:                   SettingDefinitionDefaultDataPath,
 		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
 		SettingNameStorageOverProvisioningPercentage: SettingDefinitionStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage: SettingDefinitionStorageMinimalAvailablePercentage,
@@ -102,6 +105,16 @@ var (
 		Required:    true,
 		ReadOnly:    false,
 		Default:     "300",
+	}
+
+	SettingDefinitionDefaultDataPath = SettingDefinition{
+		DisplayName: "Default Data Path",
+		Description: "Default path to use for mounting data on a host",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeString,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "/var/lib/rancher/longhorn/",
 	}
 
 	SettingDefinitionDefaultEngineImage = SettingDefinition{

--- a/types/types.go
+++ b/types/types.go
@@ -17,10 +17,6 @@ const (
 	EngineBinaryDirectoryInContainer = "/engine-binaries/"
 	EngineBinaryDirectoryOnHost      = "/var/lib/rancher/longhorn/engine-binaries/"
 
-	// DefaultLonghornDirectory is the directory going to be bind mounted on the
-	// host to provide storage space to replica data by default
-	DefaultLonghornDirectory = "/var/lib/rancher/longhorn/"
-
 	LonghornNodeKey = "longhornnode"
 
 	BaseImageLabel = "ranchervm-base-image"


### PR DESCRIPTION
This PR adds a new command line flag for the `longhorn-manager` `daemon` called `--default-data-path`, allowing the user to specify which path by default should be used to store the data and replicas created by `longhorn-manager`. This is an optional command line flag, and if not set, will default to the usual path of `/var/lib/rancher/longhorn/` automatically.

Because this would also affect nodes on initial setup of `longhorn-manager`, this setting can only be set via the command line. Additionally, the deployment scripts have been updated with comments indicating what fields in the `spec` a user has to change in order to change the default data path for their `Longhorn` installation.