### PR TITLE
Add "Replica Hard Anti-Affinity" Setting

### DIFF
--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -50,7 +50,7 @@ func (rcs *ReplicaScheduler) ScheduleReplica(replica *longhorn.Replica, replicas
 		return nil, err
 	}
 	if len(nodeInfo) == 0 {
-		logrus.Errorf("There's no available node for replica %+v", replica)
+		logrus.Errorf("There's no available node for replica %v, size %v", replica.ObjectMeta.Name, replica.Spec.VolumeSize)
 		return nil, nil
 	}
 
@@ -59,7 +59,7 @@ func (rcs *ReplicaScheduler) ScheduleReplica(replica *longhorn.Replica, replicas
 
 	// there's no disk that fit for current replica
 	if len(diskCandidates) == 0 {
-		logrus.Errorf("There's no available disk for replica %+v", replica)
+		logrus.Errorf("There's no available disk for replica %v, size %v", replica.ObjectMeta.Name, replica.Spec.VolumeSize)
 		return nil, nil
 	}
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -18,6 +18,7 @@ const (
 	SettingNameBackupTarget                      = SettingName("backup-target")
 	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
 	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
+	SettingNameReplicaHardAntiAffinity           = SettingName("replica-hard-anti-affinity")
 	SettingNameStorageOverProvisioningPercentage = SettingName("storage-over-provisioning-percentage")
 	SettingNameStorageMinimalAvailablePercentage = SettingName("storage-minimal-available-percentage")
 	SettingNameUpgradeChecker                    = SettingName("upgrade-checker")
@@ -33,6 +34,7 @@ var (
 		SettingNameBackupTarget,
 		SettingNameBackupTargetCredentialSecret,
 		SettingNameDefaultEngineImage,
+		SettingNameReplicaHardAntiAffinity,
 		SettingNameStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage,
 		SettingNameUpgradeChecker,
@@ -66,6 +68,7 @@ var (
 		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
 		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
 		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
+		SettingNameReplicaHardAntiAffinity:           SettingDefinitionReplicaHardAntiAffinity,
 		SettingNameStorageOverProvisioningPercentage: SettingDefinitionStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage: SettingDefinitionStorageMinimalAvailablePercentage,
 		SettingNameUpgradeChecker:                    SettingDefinitionUpgradeChecker,
@@ -111,6 +114,16 @@ var (
 		Type:        SettingTypeString,
 		Required:    true,
 		ReadOnly:    true,
+	}
+
+	SettingDefinitionReplicaHardAntiAffinity = SettingDefinition{
+		DisplayName: "Replica Hard Anti Affinity",
+		Description: "Prevent scheduling on nodes with existing healthy replicas of the same volume",
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "false",
 	}
 
 	SettingDefinitionStorageOverProvisioningPercentage = SettingDefinition{


### PR DESCRIPTION
This PR adds a setting as per #586 called "Replica Hard Anti-Affinity". This is a simple `boolean` value, which, when enabled, skips the logic for attempting to schedule on a `Node` that already has `Healthy` replicas, returning an empty `slice` of `diskCandidates` instead of trying to schedule this replica anyways.