### PR TITLE
Implement "storage pools" feature

### DIFF
--- a/api/misc.go
+++ b/api/misc.go
@@ -88,3 +88,27 @@ func (s *Server) DownloadSupportBundle(w http.ResponseWriter, req *http.Request)
 	}
 	return nil
 }
+
+func (s *Server) DiskTagList(rw http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	tags, err := s.m.GetDiskTags()
+	if err != nil {
+		return errors.Wrap(err, "failed to get all tags")
+	}
+
+	apiContext.Write(toTagCollection(tags, "disk", apiContext))
+	return nil
+}
+
+func (s *Server) NodeTagList(rw http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	tags, err := s.m.GetNodeTags()
+	if err != nil {
+		return errors.Wrap(err, "failed to get all tags")
+	}
+
+	apiContext.Write(toTagCollection(tags, "node", apiContext))
+	return nil
+}

--- a/api/model.go
+++ b/api/model.go
@@ -37,6 +37,8 @@ type Volume struct {
 	LastBackupAt        string                 `json:"lastBackupAt"`
 	Standby             bool                   `json:"standby"`
 	RestorationRequired bool                   `json:"restorationRequired"`
+	DiskSelector        []string               `json:"diskSelector"`
+	NodeSelector        []string               `json:"nodeSelector"`
 
 	RecurringJobs    []types.RecurringJob                          `json:"recurringJobs"`
 	Conditions       map[types.VolumeConditionType]types.Condition `json:"conditions"`
@@ -159,6 +161,7 @@ type Node struct {
 	AllowScheduling bool                                        `json:"allowScheduling"`
 	Disks           map[string]DiskInfo                         `json:"disks"`
 	Conditions      map[types.NodeConditionType]types.Condition `json:"conditions"`
+	Tags            []string                                    `json:"tags"`
 }
 
 type DiskInfo struct {
@@ -259,6 +262,10 @@ func nodeSchema(node *client.Schema) {
 	conditions := node.ResourceFields["conditions"]
 	conditions.Type = "map[nodeCondition]"
 	node.ResourceFields["conditions"] = conditions
+
+	tags := node.ResourceFields["tags"]
+	tags.Create = true
+	node.ResourceFields["tags"] = tags
 }
 
 func diskSchema(diskUpdateInput *client.Schema) {
@@ -456,6 +463,14 @@ func volumeSchema(volume *client.Schema) {
 	conditions := volume.ResourceFields["conditions"]
 	conditions.Type = "map[volumeCondition]"
 	volume.ResourceFields["conditions"] = conditions
+
+	diskSelector := volume.ResourceFields["diskSelector"]
+	diskSelector.Create = true
+	volume.ResourceFields["diskSelector"] = diskSelector
+
+	nodeSelector := volume.ResourceFields["nodeSelector"]
+	nodeSelector.Create = true
+	volume.ResourceFields["nodeSelector"] = nodeSelector
 }
 
 func toSettingResource(setting *longhorn.Setting) *Setting {
@@ -549,6 +564,8 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		LastBackupAt:        v.Status.LastBackupAt,
 		Standby:             v.Spec.Standby,
 		RestorationRequired: v.Spec.RestorationRequired,
+		DiskSelector:        v.Spec.DiskSelector,
+		NodeSelector:        v.Spec.NodeSelector,
 
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,
@@ -726,6 +743,7 @@ func toNodeResource(node *longhorn.Node, address string, apiContext *api.ApiCont
 		Address:         address,
 		AllowScheduling: node.Spec.AllowScheduling,
 		Conditions:      node.Status.Conditions,
+		Tags:            node.Spec.Tags,
 	}
 
 	disks := map[string]DiskInfo{}

--- a/api/model.go
+++ b/api/model.go
@@ -193,6 +193,12 @@ type SupportBundleInitateInput struct {
 	Description string `json:"description"`
 }
 
+type Tag struct {
+	client.Resource
+	Name    string `json:"name"`
+	TagType string `json:"tagType"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -227,6 +233,8 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("event", Event{})
 	schemas.AddType("supportBundle", SupportBundle{})
 	schemas.AddType("supportBundleInitateInput", SupportBundleInitateInput{})
+
+	schemas.AddType("tag", Tag{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))
@@ -805,4 +813,26 @@ func toSupportBundleResource(nodeID string, sb *manager.SupportBundle) *SupportB
 		ErrorMessage:       sb.Error,
 		ProgressPercentage: sb.ProgressPercentage,
 	}
+}
+
+func toTagResource(tag string, tagType string, apiContext *api.ApiContext) *Tag {
+	t := &Tag{
+		Resource: client.Resource{
+			Id:    tag,
+			Links: map[string]string{},
+			Type:  "tag",
+		},
+		Name:    tag,
+		TagType: tagType,
+	}
+	t.Links["self"] = apiContext.UrlBuilder.Current()
+	return t
+}
+
+func toTagCollection(tags []string, tagType string, apiContext *api.ApiContext) *client.GenericCollection {
+	var data []interface{}
+	for _, tag := range tags {
+		data = append(data, toTagResource(tag, tagType, apiContext))
+	}
+	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "tag"}}
 }

--- a/api/node.go
+++ b/api/node.go
@@ -67,7 +67,14 @@ func (s *Server) NodeUpdate(rw http.ResponseWriter, req *http.Request) error {
 		return errors.Wrap(err, "fail to get node ip")
 	}
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
-		return s.m.UpdateNode(id, n.AllowScheduling)
+		node, err := s.m.GetNode(id)
+		if err != nil {
+			return nil, err
+		}
+		node.Spec.AllowScheduling = n.AllowScheduling
+		node.Spec.Tags = n.Tags
+
+		return s.m.UpdateNode(node)
 	})
 	if err != nil {
 		return err

--- a/api/router.go
+++ b/api/router.go
@@ -121,6 +121,9 @@ func NewRouter(s *Server) *mux.Router {
 
 	r.Methods("Get").Path("/v1/events").Handler(f(schemas, s.EventList))
 
+	r.Methods("GET").Path("/v1/disktags").Handler(f(schemas, s.DiskTagList))
+	r.Methods("GET").Path("/v1/nodetags").Handler(f(schemas, s.NodeTagList))
+
 	r.Methods("POST").Path("/v1/supportbundles").Handler(f(schemas, s.InitiateSupportBundle))
 	r.Methods("GET").Path("/v1/supportbundles/{name}/{bundleName}").Handler(f(schemas,
 		s.fwd.Handler(OwnerIDFromNode(s.m), s.QuerySupportBundle)))

--- a/api/volume.go
+++ b/api/volume.go
@@ -133,6 +133,8 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		BaseImage:           volume.BaseImage,
 		RecurringJobs:       volume.RecurringJobs,
 		Standby:             volume.Standby,
+		DiskSelector:        volume.DiskSelector,
+		NodeSelector:        volume.NodeSelector,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create volume")

--- a/client/generated_disk_info.go
+++ b/client/generated_disk_info.go
@@ -20,6 +20,8 @@ type DiskInfo struct {
 	StorageReserved int64 `json:"storageReserved,omitempty" yaml:"storage_reserved,omitempty"`
 
 	StorageScheduled int64 `json:"storageScheduled,omitempty" yaml:"storage_scheduled,omitempty"`
+
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type DiskInfoCollection struct {

--- a/client/generated_disk_update.go
+++ b/client/generated_disk_update.go
@@ -14,6 +14,8 @@ type DiskUpdate struct {
 	StorageMaximum int64 `json:"storageMaximum,omitempty" yaml:"storage_maximum,omitempty"`
 
 	StorageReserved int64 `json:"storageReserved,omitempty" yaml:"storage_reserved,omitempty"`
+
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type DiskUpdateCollection struct {

--- a/client/generated_node.go
+++ b/client/generated_node.go
@@ -16,6 +16,8 @@ type Node struct {
 	Disks map[string]interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type NodeCollection struct {

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -17,6 +17,8 @@ type Volume struct {
 
 	CurrentImage string `json:"currentImage,omitempty" yaml:"current_image,omitempty"`
 
+	DiskSelector []string `json:"diskSelector,omitempty" yaml:"disk_selector,omitempty"`
+
 	EngineImage string `json:"engineImage,omitempty" yaml:"engine_image,omitempty"`
 
 	FromBackup string `json:"fromBackup,omitempty" yaml:"from_backup,omitempty"`
@@ -26,6 +28,8 @@ type Volume struct {
 	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NodeSelector []string `json:"nodeSelector,omitempty" yaml:"node_selector,omitempty"`
 
 	NumberOfReplicas int64 `json:"numberOfReplicas,omitempty" yaml:"number_of_replicas,omitempty"`
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -595,7 +595,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 		if r.Spec.NodeID != "" {
 			continue
 		}
-		scheduledReplica, err := vc.scheduler.ScheduleReplica(r, rs)
+		scheduledReplica, err := vc.scheduler.ScheduleReplica(r, rs, v)
 		if err != nil {
 			return err
 		}

--- a/csi/util.go
+++ b/csi/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/robfig/cron"
@@ -54,6 +55,14 @@ func getVolumeOptions(volOptions map[string]string) (*longhornclient.Volume, err
 			return nil, errors.Wrap(err, "Invalid parameter recurringJobs")
 		}
 		vol.RecurringJobs = recurringJobs
+	}
+
+	if diskSelector, ok := volOptions["diskSelector"]; ok {
+		vol.DiskSelector = strings.Split(diskSelector, ",")
+	}
+
+	if nodeSelector, ok := volOptions["nodeSelector"]; ok {
+		vol.NodeSelector = strings.Split(nodeSelector, ",")
 	}
 
 	return vol, nil

--- a/driver/longhorn
+++ b/driver/longhorn
@@ -119,8 +119,18 @@ createVolume() {
         baseImage=""
     fi
 
+    local diskSelector=$(echo ${jsonParams} | jq -r '.diskSelector')
+    if [ "${diskSelector}" == "null" ]; then
+        diskSelector="[]"
+    fi
+
+    local nodeSelector=$(echo ${jsonParams} | jq -r '.nodeSelector')
+    if [ "${nodeSelector}" == "null" ]; then
+        nodeSelector="[]"
+    fi
+
     OUT=$(curl -s -X POST --connect-timeout ${CURL_TIMEOUT} \
-            -d '{"name":"'${volumeName}'","size":"'${volumeSize}'","numberOfReplicas":'${numReplicas}',"staleReplicaTimeout":'${staleReplicaTimeout}',"fromBackup":"'${fromBackup}'","baseImage":"'${baseImage}'"}' \
+            -d '{"name":"'${volumeName}'","size":"'${volumeSize}'","numberOfReplicas":'${numReplicas}',"staleReplicaTimeout":'${staleReplicaTimeout}',"fromBackup":"'${fromBackup}'","baseImage":"'${baseImage}'","diskSelector":'${diskSelector}',"nodeSelector":'${nodeSelector}'}' \
             http://${LONGHORN_SVC}/v1/volumes)
     debug "create volume response from http://${LONGHORN_SVC}/v1/volumes: ${OUT}"
     local TYPE=$(echo ${OUT} | jq -r '.type')

--- a/manager/kubernetes.go
+++ b/manager/kubernetes.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -76,6 +77,9 @@ func (m *VolumeManager) PVCreate(name, pvName string) (v *longhorn.Volume, err e
 }
 
 func NewPVManifest(v *longhorn.Volume, pvName, storageClassName string) *apiv1.PersistentVolume {
+	diskSelector := strings.Join(v.Spec.DiskSelector, ",")
+	nodeSelector := strings.Join(v.Spec.NodeSelector, ",")
+
 	return &apiv1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvName,
@@ -99,6 +103,8 @@ func NewPVManifest(v *longhorn.Volume, pvName, storageClassName string) *apiv1.P
 					Driver: "io.rancher.longhorn",
 					FSType: "ext4",
 					VolumeAttributes: map[string]string{
+						"diskSelector":        diskSelector,
+						"nodeSelector":        nodeSelector,
 						"numberOfReplicas":    string(v.Spec.NumberOfReplicas),
 						"staleReplicaTimeout": string(v.Spec.StaleReplicaTimeout),
 					},

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -237,6 +237,8 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 			RecurringJobs:       spec.RecurringJobs,
 			Standby:             spec.Standby,
 			RestorationRequired: spec.RestorationRequired,
+			DiskSelector:        spec.DiskSelector,
+			NodeSelector:        spec.NodeSelector,
 		},
 		Status: types.VolumeStatus{
 			LastBackup: lastBackup,

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -511,7 +511,7 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 			c.Assert(r, NotNil)
 			rIndexer.Add(r)
 
-			sr, err := s.ScheduleReplica(r, tc.replicas)
+			sr, err := s.ScheduleReplica(r, tc.replicas, volume)
 			if tc.err {
 				c.Assert(err, NotNil)
 			} else {

--- a/types/resource.go
+++ b/types/resource.go
@@ -69,6 +69,8 @@ type VolumeSpec struct {
 	BaseImage           string         `json:"baseImage"`
 	Standby             bool           `json:"Standby"`
 	RestorationRequired bool           `json:"restorationRequired"`
+	DiskSelector        []string       `json:"diskSelector"`
+	NodeSelector        []string       `json:"nodeSelector"`
 }
 
 type KubernetesStatus struct {
@@ -220,6 +222,7 @@ type NodeSpec struct {
 	Name            string              `json:"name"`
 	Disks           map[string]DiskSpec `json:"disks"`
 	AllowScheduling bool                `json:"allowScheduling"`
+	Tags            []string            `json:"tags"`
 }
 
 type NodeConditionType string
@@ -258,9 +261,10 @@ type NodeStatus struct {
 }
 
 type DiskSpec struct {
-	Path            string `json:"path"`
-	AllowScheduling bool   `json:"allowScheduling"`
-	StorageReserved int64  `json:"storageReserved"`
+	Path            string   `json:"path"`
+	AllowScheduling bool     `json:"allowScheduling"`
+	StorageReserved int64    `json:"storageReserved"`
+	Tags            []string `json:"tags"`
 }
 
 type DiskStatus struct {

--- a/types/types.go
+++ b/types/types.go
@@ -48,6 +48,8 @@ const (
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"
 	OptionBaseImage           = "baseImage"
 	OptionFrontend            = "frontend"
+	OptionDiskSelector        = "diskSelector"
+	OptionNodeSelector        = "nodeSelector"
 
 	DefaultStaleReplicaTimeout = "30"
 


### PR DESCRIPTION
This PR adds a "storage pool" feature as requested in longhorn/longhorn#311 that allows users to divide up their `Nodes` and `Disks` and specify on their `Volumes` which `Nodes` and `Disks` a `Volume` should be scheduled to. There are multiple changes involved here:

1. `Disks` and `Nodes` have been modified to have a `Tags` attribute that allows a user to label them with as many `Tags` as they wish. `Tags` are stored as a `string slice`, can be modified by `PUT`-ing a `string array` in the `longhorn-manager` API, and must conform to the rules that validate `Kubernetes labels`. `Tags` that are applied to a `Node` are inherited by all `Disks` on that `Node`, but any `Tags` applied to a `Disk` apply to that one only.
2. `Volumes` now have a corresponding `TagSelector` attribute which is also stored as a `string slice` and populated by `POST`-ing a `string array` during its creation. If this field is left empty, the `Volume` will not attempt to filter eligible `Disks` and `Nodes` and schedule based on default rules. If this field is populated, the `replica_scheduler` will search for `Disks` and `Nodes` that have **all** of the specified `Tags`. If no eligible `Disks` or `Nodes` are found, scheduling will fail. After this filtering, scheduling based on default rules will continue.
3. When creating the `Volume`, the `longhorn-manager` will check to make sure that any specified `Tags` exist (i.e. at least one `Disk` or `Node` uses this tag). If not, the `Request` will fail with an appropriate error.
4. An API route for getting a `Collection` of `Tags` is available at `/v1/tags/` via `GET` request.
5. Both the `CSI` and `FlexVolume` provisioners have been updated to handle the `tagSelectors` field. `Tags` can be specified as a comma-separated `string`, and will be handled accordingly once `longhorn-manager` receives the provisioning `Request`.
6. The `longhorn-manager` generated `client` has been updated with the new fields so that the `FlexVolume` provisioner is able to utilize the `tagSelectors` field.