### PR TITLE
Asynchronous Restore Progress in Longhorn Manager

### DIFF
--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -228,3 +228,16 @@ func (e *Engine) BackupRestoreIncrementally(backupTarget, backupName, backupVolu
 
 	return nil
 }
+
+func (e *Engine) BackupRestoreStatus() ([]*types.RestoreStatus, error) {
+	args := []string{"backup", "restore-status"}
+	output, err := e.ExecuteEngineBinary(args...)
+	if err != nil {
+		return nil, err
+	}
+	restoreStatusList := make([]*types.RestoreStatus, 0)
+	if err := json.Unmarshal([]byte(output), &restoreStatusList); err != nil {
+		return nil, err
+	}
+	return restoreStatusList, nil
+}

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -204,3 +204,11 @@ func (e *EngineSimulator) Info() (*Volume, error) {
 func (e *EngineSimulator) BackupRestoreIncrementally(backupTarget, backupName, backupVolume, lastBackup string) error {
 	return fmt.Errorf("Not implemented")
 }
+
+func (e *EngineSimulator) BackupRestore(url string) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func (e *EngineSimulator) BackupRestoreStatus() ([]*types.RestoreStatus, error) {
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -56,6 +56,8 @@ type EngineClient interface {
 	SnapshotBackupStatus() (map[string]*types.BackupStatus, error)
 
 	BackupRestoreIncrementally(backupTarget, backupName, backupVolume, lastBackup string) error
+	BackupRestore(backup string) error
+	BackupRestoreStatus() ([]*types.RestoreStatus, error)
 }
 
 type EngineClientRequest struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -282,3 +282,9 @@ type BackupStatus struct {
 	BackupError  string `json:"backupError,omitempty"`
 	SnapshotName string `json:"snapshotName"`
 }
+
+type RestoreStatus struct {
+	Progress     int    `json:"progress"`
+	RestoreError string `json:"restoreError,omitempty"`
+	SnapshotName string `json:"snapshotName"`
+}

--- a/types/resource.go
+++ b/types/resource.go
@@ -153,6 +153,7 @@ type EngineSpec struct {
 	UpgradedReplicaAddressMap map[string]string `json:"upgradedReplicaAddressMap"`
 	BackupVolume              string            `json:"backupVolume"`
 	RequestedBackupRestore    string            `json:"requestedBackupRestore"`
+	RestoredFromURL           string            `json:"restoredFromURL"`
 }
 
 type EngineStatus struct {


### PR DESCRIPTION
Earlier, the replica controller was doing restore when bringing up the replicas
but now it's executed by volume controller after all the replicas have come up.
Specifically, as soon as a restoration volume is created, it's automatically
attached and detached and in this window, the backup restore engine command is
executed to restore all the replicas.