### PR TITLE
Fix Node checks during Volume reconciliation

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -727,6 +727,10 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 
 		replicaUpdated := false
 		for _, r := range rs {
+			// Don't attempt to start the replica or do anything else if it hasn't been scheduled.
+			if r.Spec.NodeID == "" {
+				continue
+			}
 			nodeDown, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID)
 			if err != nil {
 				return errors.Wrapf(err, "cannot find node %v", r.Spec.NodeID)

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -973,6 +973,9 @@ func (s *DataStore) RemoveFinalizerForNode(obj *longhorn.Node) error {
 }
 
 func (s *DataStore) IsNodeDownOrDeleted(name string) (bool, error) {
+	if name == "" {
+		return false, errors.New("no node name provided to check node down or deleted")
+	}
 	node, err := s.getNodeRO(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
This PR mades some changes to how the `NodeID` fields is handled on unscheduled `Replicas`.

The first change fixes a bug in how the `IsNodeDownOrDeleted` function works so that if an empty `string` is provided, it returns an `error`. Previously, it would return `true`, which would imply a `Node` was down or deleted even though none was specified, which was problematic for certain checks.

The second change adds a check in `ReconcileVolumeState` to skip over `Replica` handling on a live `Volume` if that `Replica` is unscheduled. This prevents a `Replica` from having a `Pod` launched since it's unscheduled, and will also prevent the `Replica` from needlessly being marked as failed and constantly having to be recreated. As a side effect, this change reduces the rate at which an attempt at scheduling down to three times at most every thirty seconds (the current rescheduling rate when a `Volume` is first created and cannot be scheduled) and alleviates some of the load costs described in longhorn/longhorn#599.

Of the top off my head, there is at least one integration test that should be modified in response to this change. In `test_scheduling.py::test_hard_anti_affinity_scheduling` and `test_scheduling.py::test_hard_anti_affinity_detach`, the assertions check for a number of `Replicas` between two and four due to the `Volume Controller` constantly attempting to create new `Replicas` to replace the ones that were being marked as failed and deleted. Since this change retains the unscheduled `Replica`, we should change this check to assert that there are only three `Replicas`. I will open a separate PR for this in longhorn/longhorn-tests later.