### PR TITLE
Flip Anti-Affinity setting

### DIFF
--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -97,12 +97,12 @@ func (rcs *ReplicaScheduler) chooseDiskCandidates(nodeInfo map[string]*longhorn.
 	// If there's no disk fit for replica on other nodes,
 	// try to schedule to node that has been scheduled replicas.
 	// Avoid this if Replica Hard Anti-Affinity is enabled.
-	hardAntiAffinity, err := rcs.ds.GetSettingAsBool(types.SettingNameReplicaHardAntiAffinity)
+	softAntiAffinity, err := rcs.ds.GetSettingAsBool(types.SettingNameReplicaSoftAntiAffinity)
 	if err != nil {
 		logrus.Errorf("error getting replica hard anti-affinity setting: %v", err)
 	}
 	// Defaulting to soft anti-affinity if we can't get the hard anti-affinity setting.
-	if err != nil || !hardAntiAffinity {
+	if err != nil || softAntiAffinity {
 		for _, node := range filterdNode {
 			diskCandidates = rcs.filterNodeDisksForReplica(node, replica, replicas, volume)
 		}

--- a/types/setting.go
+++ b/types/setting.go
@@ -19,7 +19,7 @@ const (
 	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
 	SettingNameDefaultDataPath                   = SettingName("default-data-path")
 	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
-	SettingNameReplicaHardAntiAffinity           = SettingName("replica-hard-anti-affinity")
+	SettingNameReplicaSoftAntiAffinity           = SettingName("replica-soft-anti-affinity")
 	SettingNameStorageOverProvisioningPercentage = SettingName("storage-over-provisioning-percentage")
 	SettingNameStorageMinimalAvailablePercentage = SettingName("storage-minimal-available-percentage")
 	SettingNameUpgradeChecker                    = SettingName("upgrade-checker")
@@ -36,7 +36,7 @@ var (
 		SettingNameBackupTargetCredentialSecret,
 		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
-		SettingNameReplicaHardAntiAffinity,
+		SettingNameReplicaSoftAntiAffinity,
 		SettingNameStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage,
 		SettingNameUpgradeChecker,
@@ -71,7 +71,7 @@ var (
 		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
 		SettingNameDefaultDataPath:                   SettingDefinitionDefaultDataPath,
 		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
-		SettingNameReplicaHardAntiAffinity:           SettingDefinitionReplicaHardAntiAffinity,
+		SettingNameReplicaSoftAntiAffinity:           SettingDefinitionReplicaSoftAntiAffinity,
 		SettingNameStorageOverProvisioningPercentage: SettingDefinitionStorageOverProvisioningPercentage,
 		SettingNameStorageMinimalAvailablePercentage: SettingDefinitionStorageMinimalAvailablePercentage,
 		SettingNameUpgradeChecker:                    SettingDefinitionUpgradeChecker,
@@ -129,14 +129,14 @@ var (
 		ReadOnly:    true,
 	}
 
-	SettingDefinitionReplicaHardAntiAffinity = SettingDefinition{
-		DisplayName: "Replica Hard Anti Affinity",
-		Description: "Prevent scheduling on nodes with existing healthy replicas of the same volume",
+	SettingDefinitionReplicaSoftAntiAffinity = SettingDefinition{
+		DisplayName: "Replica Soft Anti-Affinity",
+		Description: "Allow scheduling on nodes with existing healthy replicas of the same volume",
 		Category:    SettingCategoryScheduling,
 		Type:        SettingTypeBool,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "false",
+		Default:     "true",
 	}
 
 	SettingDefinitionStorageOverProvisioningPercentage = SettingDefinition{


### PR DESCRIPTION
This PR changes the `Anti-Affinity Setting` to be `Soft Anti-Affinity` instead. The language of the setting has been modified to avoid using negative keywords, and the default for this `Setting` has been flipped to true, as suggested in longhorn/longhorn#607.

The tests relating to this `Setting` have been modified in longhorn/longhorn-tests#163.