### PR TITLE
Additional "Default Data Path" changes

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -125,7 +125,7 @@ var (
 
 	SettingDefinitionDefaultDataPath = SettingDefinition{
 		DisplayName: "Default Data Path",
-		Description: "Default path to use for mounting data on a host",
+		Description: "Default path to use for storing data on a host",
 		Category:    SettingCategoryGeneral,
 		Type:        SettingTypeString,
 		Required:    true,

--- a/types/setting.go
+++ b/types/setting.go
@@ -17,6 +17,7 @@ type SettingName string
 const (
 	SettingNameBackupTarget                      = SettingName("backup-target")
 	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
+	SettingNameCreateDefaultDisk                 = SettingName("create-default-disk")
 	SettingNameDefaultDataPath                   = SettingName("default-data-path")
 	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
 	SettingNameReplicaSoftAntiAffinity           = SettingName("replica-soft-anti-affinity")
@@ -34,6 +35,7 @@ var (
 	SettingNameList = []SettingName{
 		SettingNameBackupTarget,
 		SettingNameBackupTargetCredentialSecret,
+		SettingNameCreateDefaultDisk,
 		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
 		SettingNameReplicaSoftAntiAffinity,
@@ -69,6 +71,7 @@ var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
 		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
 		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
+		SettingNameCreateDefaultDisk:                 SettingDefinitionCreateDefaultDisk,
 		SettingNameDefaultDataPath:                   SettingDefinitionDefaultDataPath,
 		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
 		SettingNameReplicaSoftAntiAffinity:           SettingDefinitionReplicaSoftAntiAffinity,
@@ -108,6 +111,16 @@ var (
 		Required:    true,
 		ReadOnly:    false,
 		Default:     "300",
+	}
+
+	SettingDefinitionCreateDefaultDisk = SettingDefinition{
+		DisplayName: "Create Default Disk",
+		Description: "Create default disk automatically on newly added Nodes. Configure path with Default Data Path",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "true",
 	}
 
 	SettingDefinitionDefaultDataPath = SettingDefinition{


### PR DESCRIPTION
This PR makes some additional changes to the implementation of the `Default Data Path Setting` that were discussed in longhorn/longhorn#582:
- The default value of the `Setting` is now `/var/lib/longhorn`.
- There is a new `boolean Setting` titled `create-default-disk` that allows users to specify whether or not they'd like to have the default `Disk` automatically created.
- The description of the `Default Data Path Setting` has been fixed to use the verb `storing` instead of `mounting`.
- On `Node` creation, the `longhorn-manager` will attempt to enter the host `namespace` to create the directory specified by `Default Data Path`. This will create the directory if it doesn't already exist, and do nothing if it does already exist. Of course, if this fails, the `longhorn-manager` will still `panic`.