### PR TITLE
Fix Instance Manager deepcopy

### DIFF
--- a/k8s/pkg/apis/longhorn/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s/pkg/apis/longhorn/v1alpha1/zz_generated.deepcopy.go
@@ -152,7 +152,7 @@ func (in *InstanceManager) DeepCopyInto(out *InstanceManager) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
-	out.Status = in.Status
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -86,3 +86,13 @@ func (n *DiskStatus) DeepCopyInto(to *DiskStatus) {
 		to.Conditions[key] = value
 	}
 }
+
+func (n *InstanceManagerStatus) DeepCopyInto(to *InstanceManagerStatus) {
+	*to = *n
+	if n.Instances != nil {
+		to.Instances = make(map[string]InstanceProcessStatus)
+		for key, value := range n.Instances {
+			to.Instances[key] = value
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an error in the `Kubernetes` generated `API` for the new `InstanceManager CRD`. The `API` is now properly regenerated to account for the new `Instances map` that exists on the `InstanceManagerStatus`, and implements the required `DeepCopyInto` function needed for the `DeepCopy` to work properly.