### PR TITLE
Add Node labeling support

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -30,6 +30,8 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
 	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions/longhorn/v1alpha1"
+
+	iscsi_util "github.com/longhorn/go-iscsi-helper/util"
 )
 
 var (
@@ -481,6 +483,11 @@ func (nc *NodeController) syncNode(key string) (err error) {
 		return nil
 	}
 
+	// sync default Disk on labeled Nodes
+	if err := nc.syncDefaultDisk(node); err != nil {
+		return err
+	}
+
 	// sync disks status on current node
 	if err := nc.syncDiskStatus(node); err != nil {
 		return err
@@ -555,6 +562,59 @@ func (nc *NodeController) enqueueKubernetesNode(n *v1.Node) {
 		return
 	}
 	nc.enqueueNode(node)
+}
+
+// syncDefaultDisk handles creation of the default Disk if Create Default Disk on Labeled Nodes is enabled. This allows
+// for the default Disk to be created even if the Node has been labeled after initial registration with Longhorn,
+// provided that there are no existing Disks remaining on the Node.
+func (nc *NodeController) syncDefaultDisk(node *longhorn.Node) error {
+	requireLabel, err := nc.ds.GetSettingAsBool(types.SettingNameCreateDefaultDiskLabeledNodes)
+	if err != nil {
+		return err
+	}
+	if requireLabel && len(node.Spec.Disks) == 0 {
+		kubeNode, err := nc.ds.GetKubernetesNode(node.Name)
+		if err != nil {
+			return err
+		}
+		if val, ok := kubeNode.Labels[types.NodeCreateDefaultDiskLabel]; ok {
+			createDisk, err := strconv.ParseBool(val)
+			if err != nil {
+				logrus.Errorf("unable to parse label %v, value %v as bool: %v",
+					types.NodeCreateDefaultDiskLabel, val, err)
+			} else if createDisk {
+				pathSetting, err := nc.ds.GetSetting(types.SettingNameDefaultDataPath)
+				if err != nil {
+					return err
+				}
+
+				// Attempt to create the specified Default Data Path on the disk, in case it doesn't exist.
+				nsPath := iscsi_util.GetHostNamespacePath(util.HostProcPath)
+				nsExec, err := iscsi_util.NewNamespaceExecutor(nsPath)
+				if err != nil {
+					return err
+				}
+				if _, err := nsExec.Execute("mkdir", []string{"-p", pathSetting.Value}); err != nil {
+					return errors.Wrapf(err, "error creating data path %v on host", pathSetting.Value)
+				}
+
+				diskInfo, err := util.GetDiskInfo(pathSetting.Value)
+				if err != nil {
+					return err
+				}
+
+				defaultDisk := map[string]types.DiskSpec{
+					diskInfo.Fsid: {
+						Path:            diskInfo.Path,
+						AllowScheduling: true,
+						StorageReserved: diskInfo.StorageMaximum * 30 / 100,
+					},
+				}
+				node.Spec.Disks = defaultDisk
+			}
+		}
+	}
+	return nil
 }
 
 func (nc *NodeController) syncDiskStatus(node *longhorn.Node) error {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -846,11 +846,10 @@ func (s *DataStore) CreateNode(node *longhorn.Node) (*longhorn.Node, error) {
 	return ret, nil
 }
 
-// CreateDefaultNode will set the default directory to the value of the DefaultDataPath setting, which is initially
-// the Node Replica mount path. However, if the CreateDefaultDisk setting is set to false, the creation of the default
-// disk will be skipped.
+// CreateDefaultNode will create the default Disk at the value of the DefaultDataPath Setting only if Create Default
+// Disk on Labeled Nodes has been disabled.
 func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
-	createDisk, err := s.GetSettingAsBool(types.SettingNameCreateDefaultDisk)
+	requireLabel, err := s.GetSettingAsBool(types.SettingNameCreateDefaultDiskLabeledNodes)
 	if err != nil {
 		return nil, err
 	}
@@ -863,7 +862,7 @@ func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
 			AllowScheduling: true,
 		},
 	}
-	if createDisk {
+	if !requireLabel {
 		pathSetting, err := s.GetSetting(types.SettingNameDefaultDataPath)
 		if err != nil {
 			return nil, err

--- a/types/setting.go
+++ b/types/setting.go
@@ -17,7 +17,7 @@ type SettingName string
 const (
 	SettingNameBackupTarget                      = SettingName("backup-target")
 	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
-	SettingNameCreateDefaultDisk                 = SettingName("create-default-disk")
+	SettingNameCreateDefaultDiskLabeledNodes     = SettingName("create-default-disk-labeled-nodes")
 	SettingNameDefaultDataPath                   = SettingName("default-data-path")
 	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
 	SettingNameReplicaSoftAntiAffinity           = SettingName("replica-soft-anti-affinity")
@@ -35,7 +35,7 @@ var (
 	SettingNameList = []SettingName{
 		SettingNameBackupTarget,
 		SettingNameBackupTargetCredentialSecret,
-		SettingNameCreateDefaultDisk,
+		SettingNameCreateDefaultDiskLabeledNodes,
 		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
 		SettingNameReplicaSoftAntiAffinity,
@@ -71,7 +71,7 @@ var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
 		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
 		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
-		SettingNameCreateDefaultDisk:                 SettingDefinitionCreateDefaultDisk,
+		SettingNameCreateDefaultDiskLabeledNodes:     SettingDefinitionCreateDefaultDiskLabeledNodes,
 		SettingNameDefaultDataPath:                   SettingDefinitionDefaultDataPath,
 		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
 		SettingNameReplicaSoftAntiAffinity:           SettingDefinitionReplicaSoftAntiAffinity,
@@ -113,14 +113,16 @@ var (
 		Default:     "300",
 	}
 
-	SettingDefinitionCreateDefaultDisk = SettingDefinition{
-		DisplayName: "Create Default Disk",
-		Description: "Create default disk automatically on newly added Nodes. Configure path with Default Data Path",
-		Category:    SettingCategoryGeneral,
-		Type:        SettingTypeBool,
-		Required:    true,
-		ReadOnly:    false,
-		Default:     "true",
+	SettingDefinitionCreateDefaultDiskLabeledNodes = SettingDefinition{
+		DisplayName: "Create Default Disk on Labeled Nodes",
+		Description: "Create default Disk automatically only on Nodes with the label " +
+			"\"node.longhorn.io/role: storage\" if no other Disks exist. If disabled, default Disk will be created on " +
+			"all new Nodes (only on first add).",
+		Category: SettingCategoryGeneral,
+		Type:     SettingTypeBool,
+		Required: true,
+		ReadOnly: false,
+		Default:  "false",
 	}
 
 	SettingDefinitionDefaultDataPath = SettingDefinition{

--- a/types/types.go
+++ b/types/types.go
@@ -19,6 +19,8 @@ const (
 
 	LonghornNodeKey = "longhornnode"
 
+	NodeCreateDefaultDiskLabel = "node.longhorn.io/create-default-disk"
+
 	BaseImageLabel = "ranchervm-base-image"
 )
 


### PR DESCRIPTION
This PR implements the ability to specify which `Nodes` should be used for storage by default as described in longhorn/longhorn#583. To implement this, the recently introduced `Setting: create-default-disk` has been changed to `create-default-disk-labeled-nodes`, which, when enabled, will only create the default `Disk` on `Nodes` with `Label: longhorn=storage-node` on it. Other `Nodes` will not have this `Disk` created if the `Setting` is enabled, and will thus be disabled for scheduling as a result.

The default value for this switch is `false`, meaning that by default, the default `Disks` will still be created on all `Nodes`. Regardless of whether or not this `Setting` has been enabled, the path of the default `Disk` can still be set in the `Setting: default-data-path`.