### PR TITLE
Set uninstaller ServiceAccount and Job namespace

### DIFF
--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: longhorn-uninstall-service-account
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -44,6 +45,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: longhorn-uninstall
+  namespace: default
 spec:
   activeDeadlineSeconds: 900
   backoffLimit: 1


### PR DESCRIPTION
This PR sets the `Namespace` for the `ServiceAccount` and `Job` used for uninstalling `Longhorn` to `default` to match the `Namespace` that is defined in the `ServiceAccount` subject of the `ClusterRoleBinding`. This prevents the possibility of the client creating the uninstall `Resources` but placing them in the incorrect `Namespace` inadvertently, possibly allowing for the uninstall `Job` to fail.