### PR TITLE
Apply QoS to Instance Manager Pods

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -190,12 +190,17 @@ var (
 
 	SettingDefinitionGuaranteedEngineCPU = SettingDefinition{
 		DisplayName: "Guaranteed Engine CPU",
-		Description: "(EXPERIMENTAL FEATURE) Allow Longhorn Engine to have guaranteed CPU allocation. The value is how many CPUs should be reserved for one Longhorn engine or replica. For example, 0.1 means one-tenth of a CPU. This will help the engine stability during the high node workload. It only applies to the volumes attached after the setting took effect. WARNING: Attaching of the volume may fail or stuck while using this feature due to the resource constraint. Disabled (\"0\") by default.",
-		Category:    SettingCategoryGeneral,
-		Type:        SettingTypeInt,
-		Required:    true,
-		ReadOnly:    false,
-		Default:     "0",
+		Description: "(EXPERIMENTAL FEATURE) Allow Longhorn Engine to have guaranteed CPU allocation. The value is " +
+			"how many CPUs should be reserved for each Engine/Replica Manager Pod created by Longhorn. For example, " +
+			"0.1 means one-tenth of a CPU. This will help maintain engine stability during high node workload. It " +
+			"only applies to the Engine/Replica Manager Pods created after the setting took effect. WARNING: " +
+			"Attaching of the volume may fail or stuck while using this feature due to the resource constraint. " +
+			"Disabled (\"0\") by default.",
+		Category: SettingCategoryGeneral,
+		Type:     SettingTypeInt,
+		Required: true,
+		ReadOnly: false,
+		Default:  "0",
 	}
 
 	SettingDefinitionDefaultLonghornStaticStorageClass = SettingDefinition{


### PR DESCRIPTION
This PR allows for us to guarantee CPU resources for the new `Engine Manager Pods` and `Replica Manager Pods` that we are creating as part of the `InstanceManager` refactor. On creation of an `Instance Manager Pod`, the `InstanceManagerController` will check to see if a `Resource Requirement` has been set, and if set, will apply this requirement to the `Pod` specification as it is created. This means that all `Engine` and `Replica` processes running on the `Pod` will share this requirement.

Note that since `QoS` cannot be modified after `Pod` creation, the user will have to manually delete an `Instance Manager Pod` during maintenance time in order for a new `Pod` to be created after a new `QoS` value has been set.