### PR TITLE
Allow for Backup labeling

### DIFF
--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/go-rancher/api"
 
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 )
 
 func (s *Server) SnapshotCreate(w http.ResponseWriter, req *http.Request) (err error) {
@@ -158,7 +159,11 @@ func (s *Server) SnapshotBackup(w http.ResponseWriter, req *http.Request) (err e
 		return fmt.Errorf("cannot create backup for standby volume %v", vol.Name)
 	}
 
-	labels := make(map[string]string)
+	labels, err := util.ValidateSnapshotLabels(input.Labels)
+	if err != nil {
+		return err
+	}
+
 	if vol.Spec.BaseImage != "" {
 		labels[types.BaseImageLabel] = vol.Spec.BaseImage
 	}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1182,6 +1182,9 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 		"--labels", LabelRecurringJob + "=" + job.Name,
 		"--retain", strconv.Itoa(job.Retain),
 	}
+	for key, val := range job.Labels {
+		cmd = append(cmd, "--labels", key+"="+val)
+	}
 	if job.Task == types.RecurringJobTypeBackup {
 		cmd = append(cmd, "--backuptarget", backupTarget)
 	}

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -496,6 +496,11 @@ func (m *VolumeManager) validateRecurringJobs(jobs []types.RecurringJob) error {
 		if len(job.Name) > types.MaximumJobNameSize {
 			return fmt.Errorf("job name %v is too long, must be %v characters or less", job.Name, types.MaximumJobNameSize)
 		}
+		if job.Labels != nil {
+			if _, err := util.ValidateSnapshotLabels(job.Labels); err != nil {
+				return err
+			}
+		}
 	}
 	if err := m.checkDuplicateJobs(jobs); err != nil {
 		return err

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -17,7 +17,14 @@ func (v *VolumeSpec) DeepCopyInto(to *VolumeSpec) {
 	if v.RecurringJobs != nil {
 		to.RecurringJobs = make([]RecurringJob, len(v.RecurringJobs))
 		for i := 0; i < len(v.RecurringJobs); i++ {
-			to.RecurringJobs[i] = v.RecurringJobs[i]
+			toRecurringJob := v.RecurringJobs[i]
+			if v.RecurringJobs[i].Labels != nil {
+				toRecurringJob.Labels = make(map[string]string)
+				for key, value := range v.RecurringJobs[i].Labels {
+					toRecurringJob.Labels[key] = value
+				}
+			}
+			to.RecurringJobs[i] = toRecurringJob
 		}
 	}
 }

--- a/types/resource.go
+++ b/types/resource.go
@@ -112,10 +112,11 @@ const (
 )
 
 type RecurringJob struct {
-	Name   string           `json:"name"`
-	Task   RecurringJobType `json:"task"`
-	Cron   string           `json:"cron"`
-	Retain int              `json:"retain"`
+	Name   string            `json:"name"`
+	Task   RecurringJobType  `json:"task"`
+	Cron   string            `json:"cron"`
+	Retain int               `json:"retain"`
+	Labels map[string]string `json:"labels"`
 }
 
 type InstanceState string

--- a/types/types.go
+++ b/types/types.go
@@ -21,7 +21,8 @@ const (
 
 	NodeCreateDefaultDiskLabel = "node.longhorn.io/create-default-disk"
 
-	BaseImageLabel = "ranchervm-base-image"
+	BaseImageLabel        = "ranchervm-base-image"
+	KubernetesStatusLabel = "KubernetesStatus"
 )
 
 const (

--- a/util/util.go
+++ b/util/util.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	cmdTimeout     = time.Minute // one minute by default
-	reservedLabels = []string{"RecurringJob", "ranchervm-base-image"}
+	reservedLabels = []string{"KubernetesStatus", "RecurringJob", "ranchervm-base-image"}
 
 	ConflictRetryInterval = 20 * time.Millisecond
 	ConflictRetryCounts   = 100

--- a/util/util.go
+++ b/util/util.go
@@ -264,20 +264,24 @@ func GetRequiredEnv(key string) (string, error) {
 	return env, nil
 }
 
+// ParseLabels parses the provided Labels based on longhorn-engine's implementation:
+// https://github.com/longhorn/longhorn-engine/blob/master/util/util.go
 func ParseLabels(labels []string) (map[string]string, error) {
 	result := map[string]string{}
 	for _, label := range labels {
-		kv := strings.Split(label, "=")
+		kv := strings.SplitN(label, "=", 2)
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("Invalid label not in <key>=<value> format %v", label)
+			return nil, fmt.Errorf("invalid label not in <key>=<value> format %v", label)
 		}
 		key := kv[0]
 		value := kv[1]
-		if !ValidateName(key) {
-			return nil, fmt.Errorf("Invalid key %v for label %v", key, label)
+		if errList := validation.IsQualifiedName(key); len(errList) > 0 {
+			return nil, fmt.Errorf("invalid key %v for label: %v", key, errList[0])
 		}
-		if !ValidateName(value) {
-			return nil, fmt.Errorf("Invalid value %v for label %v", value, label)
+		// We don't need to validate the Label value since we're allowing for any form of data to be stored, similar
+		// to Kubernetes Annotations. Of course, we should make sure it isn't empty.
+		if value == "" {
+			return nil, fmt.Errorf("invalid empty value for label with key %v", key)
 		}
 		result[key] = value
 	}


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/563

This PR extends the `longhorn-manager API` to allow users to be able to label `Backups` of `Snapshots`.

Calls to the `snapshotBackup` action on a `Volume` will now properly parse the `Labels` field of a `SnapshotInput` in order to validate them, making sure that every `Label` key conforms to a `Kubernetes Qualified Name` and that every `Label` value is non-empty. Additionally, the validation will ensure that none of the provided `Label` keys are reserved keywords (currently `KubernetesStatus`, `RecurringJobLabel`, and `ranchervm-base-image`). These will be passed to the `Engine API`, which will then make the appropriate calls with the `map` of `Labels` on the `longhorn-engine` to create the `Backup` with those `Labels`.

Additionally, the `snapshot` subcommand of `longhorn-manager`, which is used in `RecurringJobs`, has been modified to read the `KubernetesStatus` property of a `Volume` during a `Snapshot`/`Backup`, marshal that into `JSON`, and then set it as an additional `Label` on the `Snapshot` or `Backup`. That means that `Snapshots` and `Backups` created by the `RecurringJob` functionality will now automatically have `KubernetesStatus` and `RecurringJob` set as `Labels`.

As an aside, because the `BackupSnapshot` method of `VolumeManager` is still calling `SnapshotBackup` of `Engine API` in a `goroutine`, any errors reported on `Backup` initialization by that call will not be passed back to the user during the `Request`, meaning that even if validation passed on the `longhorn-manager` end and the user receives a `200 OK` response from the server, the `Backup` may not be initialized. This should be fixed in a separate PR.