### PR TITLE
Manager fetching restore status attributes

### DIFF
--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -228,3 +228,16 @@ func (e *Engine) BackupRestoreIncrementally(backupTarget, backupName, backupVolu
 
 	return nil
 }
+
+func (e *Engine) BackupRestoreStatus() (map[string]*types.RestoreStatus, error) {
+	args := []string{"backup", "restore-status"}
+	output, err := e.ExecuteEngineBinary(args...)
+	if err != nil {
+		return nil, err
+	}
+	replicaStatusMap := make(map[string]*types.RestoreStatus)
+	if err := json.Unmarshal([]byte(output), &replicaStatusMap); err != nil {
+		return nil, err
+	}
+	return replicaStatusMap, nil
+}

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -204,3 +204,7 @@ func (e *EngineSimulator) Info() (*Volume, error) {
 func (e *EngineSimulator) BackupRestoreIncrementally(backupTarget, backupName, backupVolume, lastBackup string) error {
 	return fmt.Errorf("Not implemented")
 }
+
+func (e *EngineSimulator) BackupRestoreStatus() (map[string]*types.RestoreStatus, error) {
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -56,6 +56,7 @@ type EngineClient interface {
 	SnapshotBackupStatus() (map[string]*types.BackupStatus, error)
 
 	BackupRestoreIncrementally(backupTarget, backupName, backupVolume, lastBackup string) error
+	BackupRestoreStatus() (map[string]*types.RestoreStatus, error)
 }
 
 type EngineClientRequest struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -282,3 +282,8 @@ type BackupStatus struct {
 	BackupError  string `json:"backupError,omitempty"`
 	SnapshotName string `json:"snapshotName"`
 }
+
+type RestoreStatus struct {
+	IsRestoring  bool   `json:"isRestoring"`
+	LastRestored string `json:"lastRestored"`
+}


### PR DESCRIPTION
Earlier engine controller was executing controller info command to fetch
the isRestoring and lastRestored values from engine. Now that it's moved
to sync-agent-server, it's querying backup restore-status to fetch the
same.

Essentially, The following code changes implements the following: 
1. Add an interface for engine client to execute backup restore-status
2. Use the above interface to determine if incremental restore is required or not.