### PR TITLE
Fix Label description for Create Default Disk on Labeled Nodes

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -116,8 +116,8 @@ var (
 	SettingDefinitionCreateDefaultDiskLabeledNodes = SettingDefinition{
 		DisplayName: "Create Default Disk on Labeled Nodes",
 		Description: "Create default Disk automatically only on Nodes with the label " +
-			"\"node.longhorn.io/role: storage\" if no other Disks exist. If disabled, default Disk will be created on " +
-			"all new Nodes (only on first add).",
+			"\"node.longhorn.io/create-default-disk=true\" if no other Disks exist. If disabled, default Disk will " +
+			"be created on all new Nodes (only on first add).",
 		Category: SettingCategoryGeneral,
 		Type:     SettingTypeBool,
 		Required: true,


### PR DESCRIPTION
This PR modifies the description for `Setting: Create Default Disk on Labeled Nodes` such that it now refers to the `Label` that we're looking for to determine initial `Disk` creation, which is `node.longhorn.io/create-default-disk=true`. This value was previously still referring to the old value from when the feature was still being developed, which was `node.longhorn.io/role=storage`.