### PR TITLE
Don't restore Persistent Volume status from Backup

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -182,6 +182,10 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 				if len(kubeStatus.WorkloadsStatus) != 0 && kubeStatus.LastPodRefAt == "" {
 					kubeStatus.LastPodRefAt = backup.SnapshotCreated
 				}
+
+				// Do not restore the PersistentVolume fields.
+				kubeStatus.PVName = ""
+				kubeStatus.PVStatus = ""
 			}
 		}
 


### PR DESCRIPTION
This PR modifies the restoration logic on the `longhorn-manager` such that it sets the `KubernetesStatus` fields `PVName` and `PVStatus` to `empty string`, preventing `longhorn-manager` from having a `Volume` that is stuck with a reference to a nonexistent `PersistentVolume` as described in longhorn/longhorn#638.

The other mitigation described in that issue has been dropped due to the possible fixes requiring either conflicting with the existing logic in the `KubernetesController` or requiring that the `VolumeController` also modify the `KubernetesStatus` and potentially cause conflicts.