### PR TITLE
Restore Progress in Longhorn Manager

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -44,9 +44,10 @@ type Volume struct {
 	Conditions       map[types.VolumeConditionType]types.Condition `json:"conditions"`
 	KubernetesStatus types.KubernetesStatus                        `json:"kubernetesStatus"`
 
-	Replicas     []Replica      `json:"replicas"`
-	Controllers  []Controller   `json:"controllers"`
-	BackupStatus []BackupStatus `json:"backupStatus"`
+	Replicas      []Replica       `json:"replicas"`
+	Controllers   []Controller    `json:"controllers"`
+	BackupStatus  []BackupStatus  `json:"backupStatus"`
+	RestoreStatus []RestoreStatus `json:"restoreStatus"`
 }
 
 type Snapshot struct {
@@ -209,6 +210,16 @@ type BackupStatus struct {
 	BackupError string `json:"backupError"`
 }
 
+type RestoreStatus struct {
+	client.Resource
+	Replica      string `json:"replica"`
+	IsRestoring  bool   `json:"isRestoring"`
+	LastRestored string `json:"lastRestored"`
+	Progress     int    `json:"progress"`
+	Error        string `json:"error"`
+	Filename     string `json:"filename"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -221,6 +232,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("backup", Backup{})
 	schemas.AddType("backupInput", BackupInput{})
 	schemas.AddType("backupStatus", BackupStatus{})
+	schemas.AddType("restoreStatus", RestoreStatus{})
 	schemas.AddType("recurringJob", types.RecurringJob{})
 	schemas.AddType("replicaRemoveInput", ReplicaRemoveInput{})
 	schemas.AddType("salvageInput", SalvageInput{})
@@ -518,6 +530,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 	var ve *longhorn.Engine
 	controllers := []Controller{}
 	backups := []BackupStatus{}
+	restoreStatus := []RestoreStatus{}
 	for _, e := range ves {
 		controllers = append(controllers, Controller{
 			Instance: Instance{
@@ -545,6 +558,20 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 					Progress:    status.Progress,
 					BackupURL:   status.BackupURL,
 					BackupError: status.BackupError,
+				})
+			}
+		}
+		rs := e.Status.RestoreStatus
+		if rs != nil {
+			for replica, status := range rs {
+				restoreStatus = append(restoreStatus, RestoreStatus{
+					Resource:     client.Resource{},
+					Replica:      replica,
+					IsRestoring:  status.IsRestoring,
+					LastRestored: status.LastRestored,
+					Progress:     status.Progress,
+					Error:        status.Error,
+					Filename:     status.Filename,
 				})
 			}
 		}
@@ -603,9 +630,10 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,
 
-		Controllers:  controllers,
-		Replicas:     replicas,
-		BackupStatus: backups,
+		Controllers:   controllers,
+		Replicas:      replicas,
+		BackupStatus:  backups,
+		RestoreStatus: restoreStatus,
 	}
 
 	actions := map[string]struct{}{}

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -677,6 +677,7 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		logrus.Errorf("failed to get Backup Restore Status: %v", err)
 		return err
 	}
+	engine.Status.RestoreStatus = rsMap
 
 	isRestoring := false
 	lastRestored := ""

--- a/types/resource.go
+++ b/types/resource.go
@@ -158,10 +158,11 @@ type EngineSpec struct {
 
 type EngineStatus struct {
 	InstanceStatus
-	ReplicaModeMap     map[string]ReplicaMode   `json:"replicaModeMap"`
-	Endpoint           string                   `json:"endpoint"`
-	LastRestoredBackup string                   `json:"lastRestoredBackup"`
-	BackupStatus       map[string]*BackupStatus `json:"backupStatus"`
+	ReplicaModeMap     map[string]ReplicaMode    `json:"replicaModeMap"`
+	Endpoint           string                    `json:"endpoint"`
+	LastRestoredBackup string                    `json:"lastRestoredBackup"`
+	BackupStatus       map[string]*BackupStatus  `json:"backupStatus"`
+	RestoreStatus      map[string]*RestoreStatus `json:"restoreStatus"`
 }
 
 type ReplicaSpec struct {
@@ -285,4 +286,7 @@ type BackupStatus struct {
 type RestoreStatus struct {
 	IsRestoring  bool   `json:"isRestoring"`
 	LastRestored string `json:"lastRestored"`
+	Progress     int    `json:"progress,omitempty"`
+	Error        string `json:"error,omitempty"`
+	Filename     string `json:"filename,omitempty"`
 }


### PR DESCRIPTION
The following code changes adds Progress, RestoreError and the filename that's being restored into the RestoreStatus structure. This information is fetched every 5 seconds from engine.
Further, the code changes also includes exporting the restore status into the volume API so that when UI requests for the volume details, restore status is included in it for every replica.

Issue: https://github.com/longhorn/longhorn/issues/49