### PR TITLE
Renaming BackupError to Error in Manager

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -202,11 +202,11 @@ type Tag struct {
 
 type BackupStatus struct {
 	client.Resource
-	Name        string `json:"id"`
-	Snapshot    string `json:"snapshot"`
-	Progress    int    `json:"progress"`
-	BackupURL   string `json:"backupURL"`
-	BackupError string `json:"backupError"`
+	Name      string `json:"id"`
+	Snapshot  string `json:"snapshot"`
+	Progress  int    `json:"progress"`
+	BackupURL string `json:"backupURL"`
+	Error     string `json:"error"`
 }
 
 func NewSchema() *client.Schemas {
@@ -539,12 +539,12 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		if backupStatus != nil {
 			for id, status := range backupStatus {
 				backups = append(backups, BackupStatus{
-					Resource:    client.Resource{},
-					Name:        id,
-					Snapshot:    status.SnapshotName,
-					Progress:    status.Progress,
-					BackupURL:   status.BackupURL,
-					BackupError: status.BackupError,
+					Resource:  client.Resource{},
+					Name:      id,
+					Snapshot:  status.SnapshotName,
+					Progress:  status.Progress,
+					BackupURL: status.BackupURL,
+					Error:     status.Error,
 				})
 			}
 		}

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -193,8 +193,8 @@ func (m *VolumeManager) BackupSnapshot(snapshotName string, labels map[string]st
 					}
 				}
 			}
-			if bks.BackupError != "" {
-				logrus.Errorf("Failed to updated volume LastBackup for %v due to backup error %v", volumeName, bks.BackupError)
+			if bks.Error != "" {
+				logrus.Errorf("Failed to updated volume LastBackup for %v due to backup error %v", volumeName, bks.Error)
 				break
 			}
 			if bks.Progress == 100 {

--- a/types/resource.go
+++ b/types/resource.go
@@ -278,7 +278,7 @@ type DiskStatus struct {
 type BackupStatus struct {
 	Progress     int    `json:"progress"`
 	BackupURL    string `json:"backupURL,omitempty"`
-	BackupError  string `json:"backupError,omitempty"`
+	Error        string `json:"error,omitempty"`
 	SnapshotName string `json:"snapshotName"`
 }
 


### PR DESCRIPTION
The following code changes modify the name `backupError` to `error`