### PR TITLE
Update go client

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -224,7 +224,6 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("backupInput", BackupInput{})
 	schemas.AddType("backupStatus", BackupStatus{})
 	schemas.AddType("recurringJob", types.RecurringJob{})
-	schemas.AddType("kubernetesStatus", types.KubernetesStatus{})
 	schemas.AddType("replicaRemoveInput", ReplicaRemoveInput{})
 	schemas.AddType("salvageInput", SalvageInput{})
 	schemas.AddType("activateInput", ActivateInput{})
@@ -234,6 +233,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("diskUpdate", types.DiskSpec{})
 	schemas.AddType("nodeInput", NodeInput{})
 	schemas.AddType("UpdateReplicaCountInput", UpdateReplicaCountInput{})
+	schemas.AddType("workloadStatus", types.WorkloadStatus{})
 
 	schemas.AddType("PVCreateInput", PVCreateInput{})
 	schemas.AddType("PVCCreateInput", PVCCreateInput{})
@@ -258,6 +258,7 @@ func NewSchema() *client.Schemas {
 	nodeSchema(schemas.AddType("node", Node{}))
 	diskSchema(schemas.AddType("diskUpdateInput", DiskUpdateInput{}))
 	diskInfoSchema(schemas.AddType("diskInfo", DiskInfo{}))
+	kubernetesStatusSchema(schemas.AddType("kubernetesStatus", types.KubernetesStatus{}))
 
 	return schemas
 }
@@ -317,6 +318,12 @@ func recurringSchema(recurring *client.Schema) {
 	jobs := recurring.ResourceFields["jobs"]
 	jobs.Type = "array[recurringJob]"
 	recurring.ResourceFields["jobs"] = jobs
+}
+
+func kubernetesStatusSchema(status *client.Schema) {
+	workloadsStatus := status.ResourceFields["workloadsStatus"]
+	workloadsStatus.Type = "array[workloadStatus]"
+	status.ResourceFields["workloadsStatus"] = workloadsStatus
 }
 
 func backupVolumeSchema(backupVolume *client.Schema) {
@@ -495,6 +502,7 @@ func volumeSchema(volume *client.Schema) {
 	volume.ResourceFields["nodeSelector"] = nodeSelector
 
 	kubernetesStatus := volume.ResourceFields["kubernetesStatus"]
+	kubernetesStatus.Type = "kubernetesStatus"
 	volume.ResourceFields["kubernetesStatus"] = kubernetesStatus
 }
 

--- a/client/generated_backup_status.go
+++ b/client/generated_backup_status.go
@@ -7,9 +7,9 @@ const (
 type BackupStatus struct {
 	Resource `yaml:"-"`
 
-	BackupError string `json:"backupError,omitempty" yaml:"backup_error,omitempty"`
-
 	BackupURL string `json:"backupURL,omitempty" yaml:"backup_url,omitempty"`
+
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 
 	Progress int64 `json:"progress,omitempty" yaml:"progress,omitempty"`
 

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -12,7 +12,6 @@ type RancherClient struct {
 	BackupInput               BackupInputOperations
 	BackupStatus              BackupStatusOperations
 	RecurringJob              RecurringJobOperations
-	KubernetesStatus          KubernetesStatusOperations
 	ReplicaRemoveInput        ReplicaRemoveInputOperations
 	SalvageInput              SalvageInputOperations
 	ActivateInput             ActivateInputOperations
@@ -22,6 +21,7 @@ type RancherClient struct {
 	DiskUpdate                DiskUpdateOperations
 	NodeInput                 NodeInputOperations
 	UpdateReplicaCountInput   UpdateReplicaCountInputOperations
+	WorkloadStatus            WorkloadStatusOperations
 	PVCreateInput             PVCreateInputOperations
 	PVCCreateInput            PVCCreateInputOperations
 	SettingDefinition         SettingDefinitionOperations
@@ -39,6 +39,7 @@ type RancherClient struct {
 	Node                      NodeOperations
 	DiskUpdateInput           DiskUpdateInputOperations
 	DiskInfo                  DiskInfoOperations
+	KubernetesStatus          KubernetesStatusOperations
 }
 
 func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
@@ -55,7 +56,6 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.BackupInput = newBackupInputClient(client)
 	client.BackupStatus = newBackupStatusClient(client)
 	client.RecurringJob = newRecurringJobClient(client)
-	client.KubernetesStatus = newKubernetesStatusClient(client)
 	client.ReplicaRemoveInput = newReplicaRemoveInputClient(client)
 	client.SalvageInput = newSalvageInputClient(client)
 	client.ActivateInput = newActivateInputClient(client)
@@ -65,6 +65,7 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.DiskUpdate = newDiskUpdateClient(client)
 	client.NodeInput = newNodeInputClient(client)
 	client.UpdateReplicaCountInput = newUpdateReplicaCountInputClient(client)
+	client.WorkloadStatus = newWorkloadStatusClient(client)
 	client.PVCreateInput = newPVCreateInputClient(client)
 	client.PVCCreateInput = newPVCCreateInputClient(client)
 	client.SettingDefinition = newSettingDefinitionClient(client)
@@ -82,6 +83,7 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.Node = newNodeClient(client)
 	client.DiskUpdateInput = newDiskUpdateInputClient(client)
 	client.DiskInfo = newDiskInfoClient(client)
+	client.KubernetesStatus = newKubernetesStatusClient(client)
 
 	return client
 }

--- a/client/generated_kubernetes_status.go
+++ b/client/generated_kubernetes_status.go
@@ -19,7 +19,7 @@ type KubernetesStatus struct {
 
 	PvcName string `json:"pvcName,omitempty" yaml:"pvc_name,omitempty"`
 
-	WorkloadsStatus []string `json:"workloadsStatus,omitempty" yaml:"workloads_status,omitempty"`
+	WorkloadsStatus []WorkloadStatus `json:"workloadsStatus,omitempty" yaml:"workloads_status,omitempty"`
 }
 
 type KubernetesStatusCollection struct {

--- a/client/generated_workload_status.go
+++ b/client/generated_workload_status.go
@@ -1,0 +1,85 @@
+package client
+
+const (
+	WORKLOAD_STATUS_TYPE = "workloadStatus"
+)
+
+type WorkloadStatus struct {
+	Resource `yaml:"-"`
+
+	PodName string `json:"podName,omitempty" yaml:"pod_name,omitempty"`
+
+	PodStatus string `json:"podStatus,omitempty" yaml:"pod_status,omitempty"`
+
+	WorkloadName string `json:"workloadName,omitempty" yaml:"workload_name,omitempty"`
+
+	WorkloadType string `json:"workloadType,omitempty" yaml:"workload_type,omitempty"`
+}
+
+type WorkloadStatusCollection struct {
+	Collection
+	Data   []WorkloadStatus `json:"data,omitempty"`
+	client *WorkloadStatusClient
+}
+
+type WorkloadStatusClient struct {
+	rancherClient *RancherClient
+}
+
+type WorkloadStatusOperations interface {
+	List(opts *ListOpts) (*WorkloadStatusCollection, error)
+	Create(opts *WorkloadStatus) (*WorkloadStatus, error)
+	Update(existing *WorkloadStatus, updates interface{}) (*WorkloadStatus, error)
+	ById(id string) (*WorkloadStatus, error)
+	Delete(container *WorkloadStatus) error
+}
+
+func newWorkloadStatusClient(rancherClient *RancherClient) *WorkloadStatusClient {
+	return &WorkloadStatusClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *WorkloadStatusClient) Create(container *WorkloadStatus) (*WorkloadStatus, error) {
+	resp := &WorkloadStatus{}
+	err := c.rancherClient.doCreate(WORKLOAD_STATUS_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *WorkloadStatusClient) Update(existing *WorkloadStatus, updates interface{}) (*WorkloadStatus, error) {
+	resp := &WorkloadStatus{}
+	err := c.rancherClient.doUpdate(WORKLOAD_STATUS_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *WorkloadStatusClient) List(opts *ListOpts) (*WorkloadStatusCollection, error) {
+	resp := &WorkloadStatusCollection{}
+	err := c.rancherClient.doList(WORKLOAD_STATUS_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *WorkloadStatusCollection) Next() (*WorkloadStatusCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &WorkloadStatusCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *WorkloadStatusClient) ById(id string) (*WorkloadStatus, error) {
+	resp := &WorkloadStatus{}
+	err := c.rancherClient.doById(WORKLOAD_STATUS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *WorkloadStatusClient) Delete(container *WorkloadStatus) error {
+	return c.rancherClient.doResourceDelete(WORKLOAD_STATUS_TYPE, &container.Resource)
+}


### PR DESCRIPTION
Right now Kubernetes cannot attach Longhorn volume via csi handler. Because the generated Longhorn go client code is incorrect, the volume object cannot be parsed into go struct hence `ControllerPublishVolume()` always errors out.