### PR TITLE
Fixes to Instance Handler implementation

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -246,9 +246,12 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 	}
 
 	if engine.DeletionTimestamp != nil {
-		// don't go through state transition because it can go wrong
-		if _, err := ec.DeleteInstance(engine); err != nil {
-			return err
+		// Only attempt Instance deletion if it's assigned to an InstanceManager.
+		if engine.Status.InstanceManagerName != "" {
+			// don't go through state transition because it can go wrong
+			if _, err := ec.DeleteInstance(engine); err != nil {
+				return err
+			}
 		}
 		return ec.ds.RemoveFinalizerForEngine(engine)
 	}

--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -165,13 +165,15 @@ func (h *InstanceHandler) ReconcileInstanceState(obj interface{}, spec *types.In
 		return err
 	}
 
-	im, err := h.ds.GetInstanceManager(status.InstanceManagerName)
-	if err != nil {
-		if datastore.ErrorIsNotFound(err) {
-			logrus.Debugf("cannot find instance manager %v", status.InstanceManagerName)
-			im = nil
-		} else {
-			return err
+	var im *longhorn.InstanceManager
+	if status.InstanceManagerName != "" {
+		im, err = h.ds.GetInstanceManager(status.InstanceManagerName)
+		if err != nil {
+			if datastore.ErrorIsNotFound(err) {
+				logrus.Debugf("cannot find instance manager %v", status.InstanceManagerName)
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -233,8 +233,11 @@ func (rc *ReplicaController) syncReplica(key string) (err error) {
 		}
 
 		if replica.Spec.NodeID == rc.controllerID {
-			if _, err := rc.DeleteInstance(replica); err != nil {
-				return err
+			// Only attempt Instance deletion if it's assigned to an InstanceManager.
+			if replica.Status.InstanceManagerName != "" {
+				if _, err := rc.DeleteInstance(replica); err != nil {
+					return err
+				}
 			}
 			if replica.Spec.Active {
 				// prevent accidentally deletion

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -384,6 +384,10 @@ func (rc *ReplicaController) LogInstance(obj interface{}) (*imapi.LogStream, err
 	}
 
 	c, err := rc.getProcessManagerClient(r.Status.InstanceManagerName)
+	if err != nil {
+		return nil, err
+	}
+
 	stream, err := c.ProcessLog(r.Name)
 	if err != nil {
 		return nil, err

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -400,9 +400,6 @@ func (rc *ReplicaController) LogInstance(obj interface{}) (*imapi.LogStream, err
 }
 
 func (rc *ReplicaController) enqueueInstanceManagerChange(im *longhorn.InstanceManager) {
-	if im.Spec.OwnerID != rc.controllerID {
-		return
-	}
 	imType, ok := im.Labels["type"]
 	if !ok || imType != string(types.InstanceManagerTypeReplica) {
 		return
@@ -414,7 +411,9 @@ func (rc *ReplicaController) enqueueInstanceManagerChange(im *longhorn.InstanceM
 	}
 	for _, rList := range rs {
 		for _, r := range rList {
-			rc.enqueueReplica(r)
+			if r.Spec.OwnerID == rc.controllerID {
+				rc.enqueueReplica(r)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
This PR makes various changes to the implementations of the `InstanceHandler` (the `EngineController` and `ReplicaController`) to fix several bugs that currently exist in their logic:
- A call to `getProcessManagerClient` in the `ReplicaController` now has the proper `error` check in order to avoid a `panic` from a `nil pointer dereference`.
- When handling deletion, the `EngineController` and `ReplicaController` will only attempt deletion of the associated `Instance` if `InstanceManagerName` is set to indicate that an associated `Instance` does exist. This avoids issues with being unable to delete `Volumes`, `Engines`, and `Replicas` due to the `InstanceHandler` not being able to find a nonexistent `Instance`.
- `enqueueInstanceManagerChange` has been modified to avoid filtering `InstanceManagers` by `Node` and filtering the `Replicas` individually, ensuring that any `Replicas` that are updated by the live streaming updates from the `InstanceManagerController` are able to be handled on the correct `ReplicaController`.