### PR TITLE
Adding backup and restore state

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -210,6 +210,7 @@ type BackupStatus struct {
 	Progress  int    `json:"progress"`
 	BackupURL string `json:"backupURL"`
 	Error     string `json:"error"`
+	State     string `json:"state"`
 }
 
 type RestoreStatus struct {
@@ -220,6 +221,7 @@ type RestoreStatus struct {
 	Progress     int    `json:"progress"`
 	Error        string `json:"error"`
 	Filename     string `json:"filename"`
+	State        string `json:"state"`
 }
 
 func NewSchema() *client.Schemas {
@@ -572,6 +574,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 					Progress:  status.Progress,
 					BackupURL: status.BackupURL,
 					Error:     status.Error,
+					State:     status.State,
 				})
 			}
 		}
@@ -586,6 +589,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 					Progress:     status.Progress,
 					Error:        status.Error,
 					Filename:     status.Filename,
+					State:        status.State,
 				})
 			}
 		}

--- a/types/resource.go
+++ b/types/resource.go
@@ -283,6 +283,7 @@ type BackupStatus struct {
 	BackupURL    string `json:"backupURL,omitempty"`
 	Error        string `json:"error,omitempty"`
 	SnapshotName string `json:"snapshotName"`
+	State        string `json:"state"`
 }
 
 type RestoreStatus struct {
@@ -291,4 +292,5 @@ type RestoreStatus struct {
 	Progress     int    `json:"progress,omitempty"`
 	Error        string `json:"error,omitempty"`
 	Filename     string `json:"filename,omitempty"`
+	State        string `json:"state"`
 }


### PR DESCRIPTION
The following changes adds the state field to BackupStatus and RestoreStatus so that when UI queries for the volume, these fields are available with the right state values.