### PR TITLE
Update longhorn-instance-manager vendor

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -31,7 +31,7 @@ github.com/kubernetes-csi/drivers       v0.4.1
 
 github.com/longhorn/backupstore                 ff219ef1a30b47aaae0aab2f683e2391e682a00b
 github.com/longhorn/go-iscsi-helper             7f2d6582326a514dda5fd60eb2a84ae33f744d9c
-github.com/longhorn/longhorn-instance-manager   master
+github.com/longhorn/longhorn-instance-manager   3e573d294759af29c18daae037ba8a2bd0cb85fb
 
 github.com/golang/protobuf       v1.3.1
 google.golang.org/grpc           v1.22.0

--- a/vendor/github.com/longhorn/longhorn-instance-manager/client/engine_manager.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/client/engine_manager.go
@@ -174,12 +174,9 @@ func (cli *EngineManagerClient) EngineLog(volumeName string) (*api.LogStream, er
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to EngineManager Service %v: %v", cli.Address, err)
 	}
-	defer conn.Close()
+
 	client := rpc.NewEngineManagerServiceClient(conn)
-
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
-	defer cancel()
-
 	stream, err := client.EngineLog(ctx, &rpc.LogRequest{
 		Name: volumeName,
 	})
@@ -187,7 +184,7 @@ func (cli *EngineManagerClient) EngineLog(volumeName string) (*api.LogStream, er
 		return nil, fmt.Errorf("failed to get engine log of volume %v: %v", volumeName, err)
 	}
 
-	return api.NewLogStream(stream), nil
+	return api.NewLogStream(conn, cancel, stream), nil
 }
 
 func (cli *EngineManagerClient) EngineWatch() (*api.EngineStream, error) {

--- a/vendor/github.com/longhorn/longhorn-instance-manager/client/process_manager.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/client/process_manager.go
@@ -128,19 +128,16 @@ func (cli *ProcessManagerClient) ProcessLog(name string) (*api.LogStream, error)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
 	}
-	defer conn.Close()
 
 	client := rpc.NewProcessManagerServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
-	defer cancel()
-
 	stream, err := client.ProcessLog(ctx, &rpc.LogRequest{
 		Name: name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get process log of %v: %v", name, err)
 	}
-	return api.NewLogStream(stream), nil
+	return api.NewLogStream(conn, cancel, stream), nil
 }
 
 func (cli *ProcessManagerClient) ProcessWatch() (*api.ProcessStream, error) {


### PR DESCRIPTION
This PR updates the `longhorn-instance-manager` dependency in `vendor.conf` to the latest version (currently `3e573d294759af29c18daae037ba8a2bd0cb85fb`) instead of the branch `master`.