### PR TITLE
Translating Replica address to Replica Name

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1143,6 +1143,8 @@ func (s *DataStore) UpdateVolumeAndOwner(v *longhorn.Volume) (*longhorn.Volume, 
 func (s *DataStore) ResetEngineMonitoringStatus(e *longhorn.Engine) (*longhorn.Engine, error) {
 	e.Status.Endpoint = ""
 	e.Status.ReplicaModeMap = nil
+	e.Status.BackupStatus = nil
+	e.Status.RestoreStatus = nil
 	ret, err := s.UpdateEngine(e)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to reset engine status for %v", e.Name)


### PR DESCRIPTION
As it's hard for UI to identify the replica based on it's IP, we are
translating the replica address to it's name instead