### PR TITLE
Disable BaseImage in longhorn-manager API for now

### DIFF
--- a/api/volume.go
+++ b/api/volume.go
@@ -107,6 +107,10 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 
+	if volume.BaseImage != "" {
+		return fmt.Errorf("BaseImage feature is currently unsupported")
+	}
+
 	if volume.Standby {
 		if volume.Frontend != "" {
 			return fmt.Errorf("cannot set frontend for standby volume: %v", volume.Name)


### PR DESCRIPTION
This PR modifies the `longhorn-manager REST API` input to reject any `Volume` creation requests that have the `BaseImage` specified, effectively disabling the `Base Image` feature since it is currently unimplemented as part of the `Instance Manager` refactor. This implements the `longhorn-manager` portion of longhorn/longhorn#650.

Note that `Volume` listings still contain the `Base Image` field and that this field still appears in the `Kubernetes API` definition.