### PR TITLE
Manager Watch fixes

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -411,10 +411,12 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 				case types.InstanceManagerTypeReplica:
 					watch, err = imc.NewReplicaManagerWatch(im)
 				default:
+					imc.watcherLock.Unlock()
 					return fmt.Errorf("BUG: instance manager %v has invalid type %v", im.Name, im.Spec.Type)
 				}
 
 				if err != nil {
+					imc.watcherLock.Unlock()
 					return err
 				}
 


### PR DESCRIPTION
This PR fixes some random issues with the implementation of the `Watch` functionality used to monitor `Instances` in the `Instance Manager Controller`:
- Ensured that the `watcherLock` of the `InstanceManagerController` is always released after running through the logic to attempt to create a `ManagerWatch`. Previously, any errors creating the `Watch` had the potential to eventually lead to `deadlock`.
- Moved the `Watch` creation logic to be in the same place as the `polling` logic. Previously, this was only run during startup of the `InstanceManager Pod` and in some circumstances could be skipped and result in the `InstanceManagerController` falling back to the slow `resync` period for `Instance` updates.