### PR TITLE
Create Replica directory for new Disks

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -20,8 +20,6 @@ import (
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
-
-	iscsi_util "github.com/longhorn/go-iscsi-helper/util"
 )
 
 const (
@@ -850,14 +848,8 @@ func (s *DataStore) CreateDefaultDisk(node *longhorn.Node) error {
 		return err
 	}
 
-	// Attempt to create the specified Default Data Path on the disk, in case it doesn't exist.
-	nsPath := iscsi_util.GetHostNamespacePath(util.HostProcPath)
-	nsExec, err := iscsi_util.NewNamespaceExecutor(nsPath)
-	if err != nil {
+	if err := util.CreateDiskPath(pathSetting.Value); err != nil {
 		return err
-	}
-	if _, err := nsExec.Execute("mkdir", []string{"-p", pathSetting.Value}); err != nil {
-		return errors.Wrapf(err, "error creating data path %v on host", pathSetting.Value)
 	}
 
 	diskInfo, err := util.GetDiskInfo(pathSetting.Value)

--- a/manager/node.go
+++ b/manager/node.go
@@ -140,6 +140,9 @@ func (m *VolumeManager) DiskUpdate(name string, updateDisks []types.DiskSpec) (*
 				diskUpdateMap[diskInfo.Fsid] = uDisk
 			} else {
 				// add disks
+				if err := util.CreateDiskPath(uDisk.Path); err != nil {
+					return nil, err
+				}
 				diskUpdateMap[diskInfo.Fsid] = uDisk
 			}
 

--- a/util/util.go
+++ b/util/util.go
@@ -44,7 +44,8 @@ const (
 	AWSSecretKey      = "AWS_SECRET_ACCESS_KEY"
 	AWSEndPoint       = "AWS_ENDPOINTS"
 
-	HostProcPath = "/host/proc"
+	HostProcPath     = "/host/proc"
+	ReplicaDirectory = "/replicas/"
 )
 
 var (
@@ -550,4 +551,17 @@ func ValidateTags(inputTags []string) ([]string, error) {
 	sort.Strings(tags)
 
 	return tags, nil
+}
+
+func CreateDiskPath(path string) error {
+	nsPath := iscsi_util.GetHostNamespacePath(HostProcPath)
+	nsExec, err := iscsi_util.NewNamespaceExecutor(nsPath)
+	if err != nil {
+		return err
+	}
+	if _, err := nsExec.Execute("mkdir", []string{"-p", filepath.Join(path + ReplicaDirectory)}); err != nil {
+		return errors.Wrapf(err, "error creating data path %v on host", path)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR modifies the logic used to handle new `Disks` created on a `Node` to additionally create the `replicas/` subdirectory, which is needed to actually store the `Replicas`.

This subdirectory of a `Disk` was previously created by the `Instance Pod` of a `Replica`, since the `HostPath` would create this directory if it didn't exist. However, the new `Instance Manager` refactor did not handle creation of this directory automatically, and on all new installations of `Longhorn`, all new `Replicas` would fail with the error `No such file or directory`.