### PR TITLE
Allowing node deletion when role changes from worker to non-worker

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -37,10 +37,6 @@ var (
 	ownerKindNode = longhorn.SchemeGroupVersion.WithKind("Node").String()
 )
 
-const (
-	nodeRoleWorkerLabel = "node-role.kubernetes.io/worker"
-)
-
 type NodeController struct {
 	// which namespace controller is running with
 	namespace    string
@@ -472,34 +468,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 			return err
 		}
 	} else {
-		// check if the role of the node got changed to non-worker
-		kubeNodeLabels := kubeNode.GetLabels()
-		if len(kubeNodeLabels) != 0 {
-			value, labelPresent := kubeNodeLabels[nodeRoleWorkerLabel]
-			labelValue := false
-			if labelValue, err = strconv.ParseBool(value); err != nil {
-				logrus.Errorf("Error while parsing the value of the label %v in node %v:%v", nodeRoleWorkerLabel,
-					node.Name, err)
-			} else if labelValue == false || labelPresent == false {
-				// role of the node got changed to non-worker
-				condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
-				if condition.Status != types.ConditionStatusFalse {
-					condition.LastTransitionTime = util.Now()
-					nc.eventRecorder.Eventf(node, v1.EventTypeWarning, types.NodeConditionReasonKubernetesNodeGone,
-						"Kubernetes node role changed: node %v is no longer a worker", node.Name)
-				}
-				condition.Status = types.ConditionStatusFalse
-				condition.Reason = string(types.NodeConditionReasonKubernetesNodeGone)
-				condition.Message = fmt.Sprintf("Kubernetes node role changed: node %v is no longer a worker", node.Name)
-				node.Status.Conditions[types.NodeConditionTypeReady] = condition
-				// set node unschedulable
-				node.Spec.AllowScheduling = false
-			}
-
-		} else {
-			logrus.Errorf("Error: Kubernetes node %v does not have any labels", node.Name)
-		}
-
 		kubeConditions := kubeNode.Status.Conditions
 		condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
 		for _, con := range kubeConditions {

--- a/manager/node.go
+++ b/manager/node.go
@@ -190,8 +190,10 @@ func (m *VolumeManager) DeleteNode(name string) error {
 		return err
 	}
 	condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
-	// Only could delete node from longhorn if kubernetes node missing
-	if condition.Status == types.ConditionStatusTrue || condition.Reason != types.NodeConditionReasonKubernetesNodeGone ||
+	// Only could delete node from longhorn if kubernetes node missing or manager pod is missing
+	if condition.Status == types.ConditionStatusTrue ||
+		(condition.Reason != types.NodeConditionReasonKubernetesNodeGone &&
+			condition.Reason != types.NodeConditionReasonManagerPodMissing) ||
 		node.Spec.AllowScheduling || len(replicas) > 0 || len(engines) > 0 {
 		return fmt.Errorf("Could not delete node %v with node ready condition is %v, reason is %v, node schedulable %v, and %v replica, %v engine running on it", name,
 			condition.Status, condition.Reason, node.Spec.AllowScheduling, len(replicas), len(engines))


### PR DESCRIPTION
The following code changes does two things:
1. Reverts the changes where the node controller was looking up the nodeRoleLabel to decide if a node is worker or non-worker. This is introduced by RKE and other clusters wouldn't have it.
2. When the manager pod goes missing in a node, make that node as unschedulable.

Issue: https://github.com/longhorn/longhorn/issues/453