### PR TITLE
Fix failed to wait for engine image start

### DIFF
--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -29,8 +29,8 @@ func (c *EngineCollection) NewEngineClient(request *EngineClientRequest) (Engine
 	if request.EngineImage == "" {
 		return nil, fmt.Errorf("Invalid empty engine image from request")
 	}
-	if request.IP == "" || request.Port == 0 {
-		return nil, fmt.Errorf("Invalid empty IP or port from request")
+	if request.IP != "" && request.Port == 0 {
+		return nil, fmt.Errorf("Invalid empty port from request with valid IP")
 	}
 	return &Engine{
 		name:  request.VolumeName,


### PR DESCRIPTION
Due to the port and IP check.

```
Error syncing Longhorn engine image longhorn-system/ei-605a0f3e: fail to
sync engine image for longhorn-system/ei-605a0f3e: cannot get engine
client to check engine version: Invalid empty IP or port from request
```