### PR TITLE
Indicate Node readiness based on Instance Manager status

### DIFF
--- a/api/misc.go
+++ b/api/misc.go
@@ -112,3 +112,28 @@ func (s *Server) NodeTagList(rw http.ResponseWriter, req *http.Request) error {
 	apiContext.Write(toTagCollection(tags, "node", apiContext))
 	return nil
 }
+
+func (s *Server) InstanceManagerGet(rw http.ResponseWriter, req *http.Request) error {
+	id := mux.Vars(req)["name"]
+	apiContext := api.GetApiContext(req)
+
+	im, err := s.m.GetInstanceManager(id)
+	if err != nil {
+		return err
+	}
+
+	apiContext.Write(toInstanceManagerResource(im))
+	return nil
+}
+
+func (s *Server) InstanceManagerList(rw http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	instanceManagers, err := s.m.ListInstanceManagers()
+	if err != nil {
+		return errors.Wrap(err, "failed to list instance managers")
+	}
+
+	apiContext.Write(toInstanceManagerCollection(instanceManagers))
+	return nil
+}

--- a/api/model.go
+++ b/api/model.go
@@ -241,6 +241,14 @@ func generateTimestamp() string {
 	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
+type InstanceManager struct {
+	client.Resource
+	CurrentState types.InstanceManagerState `json:"currentState"`
+	EngineImage  string                     `json:"engineImage"`
+	Name         string                     `json:"name"`
+	NodeID       string                     `json:"nodeID"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -279,6 +287,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("supportBundle", SupportBundle{})
 	schemas.AddType("supportBundleInitateInput", SupportBundleInitateInput{})
 
+	schemas.AddType("instanceManager", InstanceManager{})
 	schemas.AddType("tag", Tag{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
@@ -953,4 +962,25 @@ func toTagCollection(tags []string, tagType string, apiContext *api.ApiContext) 
 		data = append(data, toTagResource(tag, tagType, apiContext))
 	}
 	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "tag"}}
+}
+
+func toInstanceManagerResource(im *longhorn.InstanceManager) *InstanceManager {
+	return &InstanceManager{
+		Resource: client.Resource{
+			Id:   im.Name,
+			Type: "instanceManager",
+		},
+		CurrentState: im.Status.CurrentState,
+		EngineImage:  im.Spec.EngineImage,
+		Name:         im.Name,
+		NodeID:       im.Spec.NodeID,
+	}
+}
+
+func toInstanceManagerCollection(instanceManagers map[string]*longhorn.InstanceManager) *client.GenericCollection {
+	var data []interface{}
+	for _, im := range instanceManagers {
+		data = append(data, toInstanceManagerResource(im))
+	}
+	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "instanceManager"}}
 }

--- a/api/router.go
+++ b/api/router.go
@@ -125,6 +125,9 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/disktags").Handler(f(schemas, s.DiskTagList))
 	r.Methods("GET").Path("/v1/nodetags").Handler(f(schemas, s.NodeTagList))
 
+	r.Methods("GET").Path("/v1/instancemanagers").Handler(f(schemas, s.InstanceManagerList))
+	r.Methods("GET").Path("/v1/instancemanagers/{name}").Handler(f(schemas, s.InstanceManagerGet))
+
 	r.Methods("POST").Path("/v1/supportbundles").Handler(f(schemas, s.InitiateSupportBundle))
 	r.Methods("GET").Path("/v1/supportbundles/{name}/{bundleName}").Handler(f(schemas,
 		s.fwd.Handler(OwnerIDFromNode(s.m), s.QuerySupportBundle)))

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -97,7 +97,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		engineImageInformer, volumeInformer, daemonSetInformer,
 		kubeClient, namespace, controllerID)
 	nc := NewNodeController(ds, scheme,
-		engineImageInformer, nodeInformer, settingInformer, podInformer, replicaInformer, kubeNodeInformer,
+		engineImageInformer, nodeInformer, settingInformer, podInformer, replicaInformer, imInformer, kubeNodeInformer,
 		kubeClient, namespace, controllerID)
 	ws := NewWebsocketController(volumeInformer, engineInformer, replicaInformer,
 		settingInformer, engineImageInformer, nodeInformer)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -31,7 +31,8 @@ const (
 	TestManagerImage   = "longhorn-manager:latest"
 	TestServiceAccount = "longhorn-service-account"
 
-	TestInstanceManagerName = "instance-manager-engine-image-name"
+	TestInstanceManagerName1 = "instance-manager-engine-image-name-1"
+	TestInstanceManagerName2 = "instance-manager-engine-image-name-2"
 
 	TestPod1 = "test-pod-name-1"
 	TestPod2 = "test-pod-name-2"

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -115,7 +115,7 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 		// 1. keep stopped
 		"engine keeps stopped": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			false,
@@ -123,167 +123,167 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 		// 2. desire state becomes stopped
 		"engine desire state becomes start": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
-			newEngine(NonExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
+			newEngine(NonExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
 			false,
 		},
 		// 3. wait for im update
 		"starting engine waits for im update": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
-			newEngine(NonExistingInstance, TestInstanceManagerName, "", "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
-			newEngine(NonExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newEngine(NonExistingInstance, TestInstanceManagerName1, "", "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
+			newEngine(NonExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
 			false,
 		},
 
 		// 4.1.1. become starting
 		"engine becomes starting": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateStarting,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
 			false,
 		},
 		// 4.1.2. still starting
 		"engine is still starting": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateStarting,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
 			false,
 		},
 		// 4.1.3. become started from starting
 		"engine becomes running from starting state": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStarting, types.InstanceStateRunning),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
 			false,
 		},
 		// 4.2. become started from stopped
 		"engine becomes running from stopped state": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopped, types.InstanceStateRunning),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
 			false,
 		},
 		// 5. keep running
 		"engine keeps running": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
 			false,
 		},
 		// 6. desire state becomes stopped
 		"engine desire state becomes stopped": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateStopped),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateStopped),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
 			false,
 		},
 		// 7. wait for update
 		"stopping engine waits for im update": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
 			false,
 		},
 
 		// 8.1.1. become stopping
 		"engine becomes stopping": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateStopping,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
+			newEngine(ExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, false, types.InstanceStateRunning, types.InstanceStateStopped),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
 			false,
 		},
 		// 8.1.2. still stopping
 		"engine is still stopping": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateStopping,
 						PortStart: TestPort1,
 					},
 				}, false),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
-			newEngine(ExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
+			newEngine(ExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
 			false,
 		},
 		// 8.1.3. become stopped from stopping
 		"engine becomes stopped from stopping state": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
-			newEngine(NonExistingInstance, "", TestInstanceManagerName, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newEngine(NonExistingInstance, "", TestInstanceManagerName1, "", 0, false, types.InstanceStateStopping, types.InstanceStateStopped),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			false,
 		},
 		// 8.2. become stopped from running
 		"engine becomes stopped from running state": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
-			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateStopped),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateStopped),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			false,
 		},
 		// corner case1: invalid desireState
 		"engine gets invalid desire state": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopping),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopping),
 			true,
@@ -291,21 +291,21 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 		// corner case2: the instance currentState is running but the related instance manager is being deleting
 		"engine keeps running but instance manager is being deleting": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1,
 				map[string]types.InstanceProcessStatus{
 					ExistingInstance: types.InstanceProcessStatus{
 						State:     types.InstanceStateRunning,
 						PortStart: TestPort1,
 					},
 				}, true),
-			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
 			newEngine(NonExistingInstance, "", "", "", 0, true, types.InstanceStateError, types.InstanceStateRunning),
 			false,
 		},
 		// corner case3: the instance is stopped and the related instance manager is being deleting
 		"engine keeps stopped and instance manager is being deleting": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, true),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, true),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			newEngine(NonExistingInstance, "", "", "", 0, false, types.InstanceStateStopped, types.InstanceStateStopped),
 			false,
@@ -313,8 +313,8 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 		// corner case4: the instance currentState is running but the related instance manager is starting
 		"engine keeps running but instance manager somehow is starting": {
 			types.InstanceManagerTypeEngine,
-			newInstanceManager(types.InstanceManagerTypeEngine, types.InstanceManagerStateStarting, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
-			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
+			newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateStarting, TestOwnerID1, TestNode1, TestIP1, map[string]types.InstanceProcessStatus{}, false),
+			newEngine(NonExistingInstance, TestEngineImage, TestInstanceManagerName1, TestIP1, TestPort1, true, types.InstanceStateRunning, types.InstanceStateRunning),
 			newEngine(NonExistingInstance, "", "", "", 0, true, types.InstanceStateError, types.InstanceStateRunning),
 			false,
 		},
@@ -330,7 +330,7 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 
 		h := newTestInstanceHandler(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient)
 
-		ei, err := lhClient.LonghornV1alpha1().EngineImages(TestNamespace).Create(newEngineImage())
+		ei, err := lhClient.LonghornV1alpha1().EngineImages(TestNamespace).Create(newEngineImage(types.EngineImageStateReady))
 		c.Assert(err, IsNil)
 		eiIndexer := lhInformerFactory.Longhorn().V1alpha1().EngineImages().Informer().GetIndexer()
 		err = eiIndexer.Add(ei)

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -38,7 +38,7 @@ type InstanceManagerTestCase struct {
 	expectedType     types.InstanceManagerType
 }
 
-func newEngineImage() *longhorn.EngineImage {
+func newEngineImage(state types.EngineImageState) *longhorn.EngineImage {
 	return &longhorn.EngineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getTestEngineImageName(),
@@ -49,12 +49,13 @@ func newEngineImage() *longhorn.EngineImage {
 			Image: TestEngineImage,
 		},
 		Status: types.EngineImageStatus{
-			State: types.EngineImageStateReady,
+			State: state,
 		},
 	}
 }
 
 func newInstanceManager(
+	name string,
 	imType types.InstanceManagerType,
 	currentState types.InstanceManagerState,
 	currentOwnerID, nodeID, ip string,
@@ -63,7 +64,7 @@ func newInstanceManager(
 
 	im := &longhorn.InstanceManager{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TestInstanceManagerName,
+			Name:      name,
 			Namespace: TestNamespace,
 			UID:       uuid.NewUUID(),
 			Labels: map[string]string{
@@ -238,7 +239,7 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 			tc.controllerID)
 
 		// Controller logic depends on the Instance Manager's Engine Image existing.
-		ei := newEngineImage()
+		ei := newEngineImage(types.EngineImageStateReady)
 		err = eiIndexer.Add(ei)
 		c.Assert(err, IsNil)
 		_, err = lhClient.LonghornV1alpha1().EngineImages(ei.Namespace).Create(ei)
@@ -270,7 +271,7 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 		_, err = lhClient.LonghornV1alpha1().Nodes(lhNode2.Namespace).Create(lhNode2)
 		c.Assert(err, IsNil)
 
-		im := newInstanceManager(tc.expectedType, tc.currentState, tc.currentOwnerID, tc.nodeID, "", nil, false)
+		im := newInstanceManager(TestInstanceManagerName1, tc.expectedType, tc.currentState, tc.currentOwnerID, tc.nodeID, "", nil, false)
 		err = imIndexer.Add(im)
 		c.Assert(err, IsNil)
 		_, err = lhClient.LonghornV1alpha1().InstanceManagers(im.Namespace).Create(im)

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -945,7 +945,6 @@ func (nc *NodeController) createInstanceManager(ei *longhorn.EngineImage, imType
 
 	instanceManager := &longhorn.InstanceManager{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: generateName,
 			// Even though the labels duplicate information already in the spec, spec cannot be used for
 			// Field Selectors in CustomResourceDefinitions:
 			// https://github.com/kubernetes/kubernetes/issues/53459
@@ -954,6 +953,7 @@ func (nc *NodeController) createInstanceManager(ei *longhorn.EngineImage, imType
 				"nodeID":      nc.controllerID,
 				"type":        string(imType),
 			},
+			Name: generateName + util.RandomID(),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: longhorn.SchemeGroupVersion.String(),

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -409,29 +409,27 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	}
 	testCases["test disable disk when file system changed"] = tc
 
-	// TODO: Test doesn't work because GenerateName isn't handled by the fake Kubernetes implementation, so there are
-	//  two conflicting Instance Managers with a Name of empty string.
-	//tc = &NodeTestCase{}
-	//tc.engineImages = []*longhorn.EngineImage{
-	//	newEngineImage(types.EngineImageStateReady),
-	//}
-	//tc.kubeNodes = generateKubeNodes(ManagerPodUp)
-	//tc.pods = generateManagerPod(ManagerPodUp)
-	//node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
-	//tc.nodes = map[string]*longhorn.Node{
-	//	TestNode1: node1,
-	//}
-	//tc.expectInstanceManagers = 2
-	//tc.expectNodeStatus = map[string]types.NodeStatus{
-	//	TestNode1: {
-	//		Conditions: map[types.NodeConditionType]types.Condition{
-	//			types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
-	//			types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
-	//		},
-	//		Readiness: types.NodeReadinessDeploying,
-	//	},
-	//}
-	//testCases["test create instance managers"] = tc
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateReady),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectInstanceManagers = 2
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessDeploying,
+		},
+	}
+	testCases["test create instance managers"] = tc
 
 	tc = &NodeTestCase{}
 	tc.engineImages = []*longhorn.EngineImage{

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -65,7 +65,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		persistentVolumeInformer, persistentVolumeClaimInformer,
 		kubeClient, TestNamespace)
 
-	nc := NewNodeController(ds, scheme.Scheme, engineImageInformer, nodeInformer, settingInformer, podInformer, replicaInformer, kubeNodeInformer, kubeClient, TestNamespace, controllerID)
+	nc := NewNodeController(ds, scheme.Scheme, engineImageInformer, nodeInformer, settingInformer, podInformer, replicaInformer, imInformer, kubeNodeInformer, kubeClient, TestNamespace, controllerID)
 	fakeRecorder := record.NewFakeRecorder(100)
 	nc.eventRecorder = fakeRecorder
 	nc.getDiskInfoHandler = fakeGetDiskInfo

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -32,12 +32,15 @@ const (
 var MountPropagationBidirectional = v1.MountPropagationBidirectional
 
 type NodeTestCase struct {
-	nodes     map[string]*longhorn.Node
-	pods      map[string]*v1.Pod
-	replicas  []*longhorn.Replica
-	kubeNodes map[string]*v1.Node
+	engineImages     []*longhorn.EngineImage
+	instanceManagers []*longhorn.InstanceManager
+	nodes            map[string]*longhorn.Node
+	pods             map[string]*v1.Pod
+	replicas         []*longhorn.Replica
+	kubeNodes        map[string]*v1.Node
 
-	expectNodeStatus map[string]types.NodeStatus
+	expectInstanceManagers int
+	expectNodeStatus       map[string]types.NodeStatus
 }
 
 func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
@@ -202,6 +205,9 @@ func kubeObjStatusSyncTest(testType string) *NodeTestCase {
 }
 
 func (s *TestSuite) TestSyncNode(c *C) {
+	// Skip the Lister check that occurs on creation of an Instance Manager.
+	datastore.SkipListerCheck = true
+
 	testCases := map[string]*NodeTestCase{}
 	testCases["manager pod up"] = kubeObjStatusSyncTest(ManagerPodUp)
 	testCases["manager pod down"] = kubeObjStatusSyncTest(ManagerPodDown)
@@ -403,6 +409,176 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	}
 	testCases["test disable disk when file system changed"] = tc
 
+	// TODO: Test doesn't work because GenerateName isn't handled by the fake Kubernetes implementation, so there are
+	//  two conflicting Instance Managers with a Name of empty string.
+	//tc = &NodeTestCase{}
+	//tc.engineImages = []*longhorn.EngineImage{
+	//	newEngineImage(types.EngineImageStateReady),
+	//}
+	//tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	//tc.pods = generateManagerPod(ManagerPodUp)
+	//node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	//tc.nodes = map[string]*longhorn.Node{
+	//	TestNode1: node1,
+	//}
+	//tc.expectInstanceManagers = 2
+	//tc.expectNodeStatus = map[string]types.NodeStatus{
+	//	TestNode1: {
+	//		Conditions: map[types.NodeConditionType]types.Condition{
+	//			types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+	//			types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+	//		},
+	//		Readiness: types.NodeReadinessDeploying,
+	//	},
+	//}
+	//testCases["test create instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateIncompatible),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessReady,
+		},
+	}
+	testCases["test incompatible engine image without instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateDeploying),
+	}
+	tc.instanceManagers = []*longhorn.InstanceManager{
+		newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning,
+			TestNode1, TestNode1, TestIP1, nil, false),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessDeploying,
+		},
+	}
+	testCases["test deploying engine image with instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateDeploying),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessDeploying,
+		},
+	}
+	testCases["test deploying engine image without instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateReady),
+	}
+	tc.instanceManagers = []*longhorn.InstanceManager{
+		newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine,
+			types.InstanceManagerStateStarting, TestNode1, TestNode1, TestIP1, nil, false),
+		newInstanceManager(TestInstanceManagerName2, types.InstanceManagerTypeReplica,
+			types.InstanceManagerStateStarting, TestNode1, TestNode1, TestIP1, nil, false),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectInstanceManagers = 2
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessDeploying,
+		},
+	}
+	testCases["test unready instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateReady),
+	}
+	tc.instanceManagers = []*longhorn.InstanceManager{
+		newInstanceManager(TestInstanceManagerName1, types.InstanceManagerTypeEngine, types.InstanceManagerStateRunning,
+			TestNode1, TestNode1, TestIP1, nil, false),
+		newInstanceManager(TestInstanceManagerName2, types.InstanceManagerTypeReplica,
+			types.InstanceManagerStateRunning, TestNode1, TestNode1, TestIP1, nil, false),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectInstanceManagers = 2
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessReady,
+		},
+	}
+	testCases["test ready instance managers"] = tc
+
+	tc = &NodeTestCase{}
+	tc.engineImages = []*longhorn.EngineImage{
+		newEngineImage(types.EngineImageStateReady),
+	}
+	tc.kubeNodes = generateKubeNodes(ManagerPodUp)
+	tc.pods = generateManagerPod(ManagerPodUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	node1.Spec.Disks = map[string]types.DiskSpec{}
+	tc.nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+	}
+	tc.expectInstanceManagers = 1
+	tc.expectNodeStatus = map[string]types.NodeStatus{
+		TestNode1: {
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
+			},
+			Readiness: types.NodeReadinessDeploying,
+		},
+	}
+	testCases["test no replica instance manager"] = tc
+
 	for name, tc := range testCases {
 		fmt.Printf("testing %v\n", name)
 		kubeClient := fake.NewSimpleClientset()
@@ -411,6 +587,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformerfactory.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
 
+		eiIndexer := lhInformerFactory.Longhorn().V1alpha1().EngineImages().Informer().GetIndexer()
+		imIndexer := lhInformerFactory.Longhorn().V1alpha1().InstanceManagers().Informer().GetIndexer()
 		nIndexer := lhInformerFactory.Longhorn().V1alpha1().Nodes().Informer().GetIndexer()
 		pIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 
@@ -430,6 +608,20 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(pod)
 			c.Assert(err, IsNil)
 			pIndexer.Add(p)
+		}
+		// create engine images
+		for _, ei := range tc.engineImages {
+			ei, err := lhClient.LonghornV1alpha1().EngineImages(TestNamespace).Create(ei)
+			c.Assert(err, IsNil)
+			err = eiIndexer.Add(ei)
+			c.Assert(err, IsNil)
+		}
+		// create instance managers
+		for _, im := range tc.instanceManagers {
+			im, err := lhClient.LonghornV1alpha1().InstanceManagers(TestNamespace).Create(im)
+			c.Assert(err, IsNil)
+			err = imIndexer.Add(im)
+			c.Assert(err, IsNil)
 		}
 		// create node
 		for _, node := range tc.nodes {
@@ -480,6 +672,15 @@ func (s *TestSuite) TestSyncNode(c *C) {
 					n.Status.DiskStatus[fsid] = diskStatus
 				}
 				c.Assert(n.Status.DiskStatus, DeepEquals, tc.expectNodeStatus[nodeName].DiskStatus)
+			}
+
+			// Assertions related to the Instance Manager logic.
+			imList, err := lhClient.LonghornV1alpha1().InstanceManagers(TestNamespace).List(metav1.ListOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(imList.Items, HasLen, tc.expectInstanceManagers)
+
+			if tc.expectNodeStatus[nodeName].Readiness != "" {
+				c.Assert(n.Status.Readiness, Equals, tc.expectNodeStatus[nodeName].Readiness)
 			}
 		}
 

--- a/manager/node.go
+++ b/manager/node.go
@@ -11,6 +11,14 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
 )
 
+func (m *VolumeManager) GetInstanceManager(name string) (*longhorn.InstanceManager, error) {
+	return m.ds.GetInstanceManager(name)
+}
+
+func (m *VolumeManager) ListInstanceManagers() (map[string]*longhorn.InstanceManager, error) {
+	return m.ds.ListInstanceManagers()
+}
+
 func (m *VolumeManager) GetNode(name string) (*longhorn.Node, error) {
 	return m.ds.GetNode(name)
 }

--- a/types/resource.go
+++ b/types/resource.go
@@ -247,6 +247,13 @@ const (
 	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
 )
 
+type NodeReadiness string
+
+const (
+	NodeReadinessDeploying = NodeReadiness("deploying")
+	NodeReadinessReady     = NodeReadiness("ready")
+)
+
 type DiskConditionType string
 
 const (
@@ -263,6 +270,7 @@ const (
 type NodeStatus struct {
 	Conditions map[NodeConditionType]Condition `json:"conditions"`
 	DiskStatus map[string]DiskStatus           `json:"diskStatus"`
+	Readiness  NodeReadiness                   `json:"readiness"`
 }
 
 type DiskSpec struct {


### PR DESCRIPTION
This PR adds a new field to the `NodeStatus` titled `Readiness`, meant to indicate the state of the `Node` in relation to the `Engine Images` and `Instance Managers` to indicate whether or not the `Node` is ready for deploying `Volumes`.

As part of the reconciliation process, the `Node Controller` will obtain a listing of the `Engine Images`, and as it attempts to create and delete the appropriate `Instance Managers`, it will set the `Readiness` as either `Deploying` or `Ready`. For the `Node` to be `Ready`, the `Node Controller` will ensure that these conditions are met for the `Engine Images` and the related `Instance Managers`:
- If the `Engine Image` is `Incompatible` or `Deploying`, there must not be any `Instance Managers` that exist for that `Engine Image`.
- All `Engine Images` must either be `Ready` or `Incompatible` and not be in `Deploying` status.
- If the `Engine Image` is `Ready`, there must be matching `Instance Managers` for that `Engine Image` that are in `Running` state.

Any of these conditions failing will set the `Node` to be `Deploying`.

Because the `Node` depends on the `Instance Manager` for determining its `Readiness`, the `Node Controller` logic has been modified to also track updates from the `Instance Manager Informer` and will enqueue `Nodes` from `Instance Manager` changes if the `Instance Manager` is related to the `Node` and the `Controller`.

The `Instance Manager` object has also been exposed via the `Longhorn HTTP API` for use in `longhorn-ui` for generating a matrix showing the state of an `Engine Image` deployment status on a `Node`.

Additional unit tests have been added for the `Node Controller` in order to test this new logic.