### PR TITLE
Fix bugs in instance handler

### DIFF
--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -236,7 +236,13 @@ func (h *InstanceHandler) ReconcileInstanceState(obj interface{}, spec *types.In
 		return fmt.Errorf("BUG: unknown instance desire state: desire %v", spec.DesireState)
 	}
 
+	oldState := status.CurrentState
+
 	h.syncStatusWithInstanceManager(im, instanceName, spec, status)
+
+	if oldState != status.CurrentState {
+		logrus.Debugf("Instance handler updated instance %v state, old state %v, new state %v", instanceName, oldState, status.CurrentState)
+	}
 
 	if status.CurrentState == types.InstanceStateRunning {
 		// If `spec.DesireState` is `types.InstanceStateStopped`, `spec.NodeID` has been unset by volume controller.


### PR DESCRIPTION
1. Wrongly update instance state to `error` when its current state is `running` and `desire state is `stopped`.

2. Cannot print log for error instance