### PR TITLE
Checking CSI driver before binding with k8s PV

### DIFF
--- a/controller/kubernetes_controller.go
+++ b/controller/kubernetes_controller.go
@@ -33,6 +33,10 @@ import (
 	"github.com/longhorn/longhorn-manager/util"
 )
 
+const (
+	LonghornCSIDriver = "io.rancher.longhorn"
+)
+
 type KubernetesController struct {
 	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
@@ -219,6 +223,11 @@ func (kc *KubernetesController) syncKubernetesStatus(key string) (err error) {
 		}
 		return errors.Wrapf(err, "Error getting Persistent Volume %s", name)
 	}
+
+	if pv.Spec.CSI.Driver != LonghornCSIDriver {
+		return nil
+	}
+
 	volumeName := kc.getCSIVolumeHandleFromPV(pv)
 	if volumeName == "" {
 		return nil


### PR DESCRIPTION
If the volume name and the `volumeHandle` of the PV are same, then
longhorn was blindly attaching the volume with the PV. Now, it checks
the driver for the value `io.rancher.longhorn` before doing so.

Issue: https://github.com/longhorn/longhorn/issues/639