### PR TITLE
Update default deployment in manager to use master version

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: longhorn-manager
-        image: longhornio/longhorn-manager:5b29b03
+        image: longhornio/longhorn-manager:master
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -25,9 +25,9 @@ spec:
         - -d
         - daemon
         - --engine-image
-        - longhornio/longhorn-engine:0f79e7a
+        - longhornio/longhorn-engine:master
         - --manager-image
-        - longhornio/longhorn-manager:5b29b03
+        - longhornio/longhorn-manager:master
         - --service-account
         - longhorn-service-account
         ports:

--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: longhorn-ui
-        image: longhornio/longhorn-ui:v0.5.0
+        image: longhornio/longhorn-ui:master
         ports:
         - containerPort: 8000
         env:

--- a/deploy/install/02-components/04-driver.yaml
+++ b/deploy/install/02-components/04-driver.yaml
@@ -15,18 +15,18 @@ spec:
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: longhornio/longhorn-manager:5b29b03
+          image: longhornio/longhorn-manager:master
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: longhornio/longhorn-manager:5b29b03
+          image: longhornio/longhorn-manager:master
           imagePullPolicy: Always
           command:
           - longhorn-manager
           - -d
           - deploy-driver
           - --manager-image
-          - longhornio/longhorn-manager:5b29b03
+          - longhornio/longhorn-manager:master
           - --manager-url
           - http://longhorn-backend:9500/v1
           # manually choose "flexvolume" or "csi"

--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: longhorn-uninstall
-        image: longhornio/longhorn-manager:5b29b03
+        image: longhornio/longhorn-manager:master
         imagePullPolicy: Always
         command:
         - longhorn-manager


### PR DESCRIPTION
`master` tag has been used for all up to date developing version
Longhorn components.

The tag will be updated during the official releases, includes release
candidate.

Issue: #664