### PR TITLE
Modify SnapshotPurge logic in longhorn-manager

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -667,6 +667,13 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		}
 	}
 
+	purgeStatus, err := client.SnapshotPurgeStatus()
+	if err != nil {
+		logrus.Errorf("failed to get snapshot purge status: %v", err)
+		return err
+	}
+	engine.Status.PurgeStatus = purgeStatus
+
 	engine, err = m.ds.UpdateEngine(engine)
 	if err != nil {
 		return err

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -171,6 +171,10 @@ func (e *EngineSimulator) SnapshotPurge() error {
 	return fmt.Errorf("Not implemented")
 }
 
+func (e *EngineSimulator) SnapshotPurgeStatus() (map[string]*types.PurgeStatus, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (e *EngineSimulator) SnapshotBackup(snapName, backupTarget string, labels map[string]string, credential map[string]string) error {
 	return fmt.Errorf("Not implemented")
 }

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -69,8 +69,8 @@ func (e *Engine) SnapshotRevert(name string) error {
 
 func (e *Engine) SnapshotPurge() error {
 	if _, err := e.ExecuteEngineBinaryWithoutTimeout("snapshot", "purge"); err != nil {
-		return errors.Wrapf(err, "error purging snapshots")
+		return errors.Wrapf(err, "error starting snapshot purge")
 	}
-	logrus.Debugf("Volume %v snapshot purge completed", e.Name())
+	logrus.Debugf("Volume %v snapshot purge started", e.Name())
 	return nil
 }

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/longhorn/longhorn-manager/types"
 )
 
 const (
@@ -73,4 +75,18 @@ func (e *Engine) SnapshotPurge() error {
 	}
 	logrus.Debugf("Volume %v snapshot purge started", e.Name())
 	return nil
+}
+
+func (e *Engine) SnapshotPurgeStatus() (map[string]*types.PurgeStatus, error) {
+	output, err := e.ExecuteEngineBinary("snapshot", "purge-status")
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting snapshot purge status")
+	}
+
+	data := map[string]*types.PurgeStatus{}
+	if err := json.Unmarshal([]byte(output), &data); err != nil {
+		return nil, errors.Wrapf(err, "error parsing snapshot purge status")
+	}
+
+	return data, nil
 }

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -70,7 +70,7 @@ func (e *Engine) SnapshotRevert(name string) error {
 }
 
 func (e *Engine) SnapshotPurge() error {
-	if _, err := e.ExecuteEngineBinaryWithoutTimeout("snapshot", "purge"); err != nil {
+	if _, err := e.ExecuteEngineBinaryWithoutTimeout("snapshot", "purge", "--skip-if-in-progress"); err != nil {
 		return errors.Wrapf(err, "error starting snapshot purge")
 	}
 	logrus.Debugf("Volume %v snapshot purge started", e.Name())

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -51,6 +51,7 @@ type EngineClient interface {
 	SnapshotDelete(name string) error
 	SnapshotRevert(name string) error
 	SnapshotPurge() error
+	SnapshotPurgeStatus() (map[string]*types.PurgeStatus, error)
 	SnapshotBackup(snapName, backupTarget string, labels map[string]string, credential map[string]string) error
 	SnapshotBackupStatus() (map[string]*types.BackupStatus, error)
 

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -137,11 +137,11 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 	if err != nil {
 		return err
 	}
-	//TODO time consuming operation, move it out of API server path
+
 	if err := engine.SnapshotPurge(); err != nil {
 		return err
 	}
-	logrus.Debugf("Purged snapshots for volume %v", volumeName)
+	logrus.Debugf("Started snapshot purge for volume %v", volumeName)
 	return nil
 }
 

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -57,12 +57,32 @@ func (e *EngineSpec) DeepCopyInto(to *EngineSpec) {
 
 func (e *EngineStatus) DeepCopyInto(to *EngineStatus) {
 	*to = *e
-	if e.ReplicaModeMap == nil {
-		return
+	if e.BackupStatus != nil {
+		to.BackupStatus = make(map[string]*BackupStatus)
+		for key, value := range e.BackupStatus {
+			to.BackupStatus[key] = &BackupStatus{}
+			*to.BackupStatus[key] = *value
+		}
 	}
-	to.ReplicaModeMap = make(map[string]ReplicaMode)
-	for key, value := range e.ReplicaModeMap {
-		to.ReplicaModeMap[key] = value
+	if e.ReplicaModeMap != nil {
+		to.ReplicaModeMap = make(map[string]ReplicaMode)
+		for key, value := range e.ReplicaModeMap {
+			to.ReplicaModeMap[key] = value
+		}
+	}
+	if e.RestoreStatus != nil {
+		to.RestoreStatus = make(map[string]*RestoreStatus)
+		for key, value := range e.RestoreStatus {
+			to.RestoreStatus[key] = &RestoreStatus{}
+			*to.RestoreStatus[key] = *value
+		}
+	}
+	if e.PurgeStatus != nil {
+		to.PurgeStatus = make(map[string]*PurgeStatus)
+		for key, value := range e.PurgeStatus {
+			to.PurgeStatus[key] = &PurgeStatus{}
+			*to.PurgeStatus[key] = *value
+		}
 	}
 }
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -167,6 +167,7 @@ type EngineStatus struct {
 	LastRestoredBackup string                    `json:"lastRestoredBackup"`
 	BackupStatus       map[string]*BackupStatus  `json:"backupStatus"`
 	RestoreStatus      map[string]*RestoreStatus `json:"restoreStatus"`
+	PurgeStatus        map[string]*PurgeStatus   `json:"purgeStatus"`
 }
 
 type ReplicaSpec struct {
@@ -304,6 +305,13 @@ type RestoreStatus struct {
 	Filename     string `json:"filename,omitempty"`
 	State        string `json:"state"`
 	BackupURL    string `json:"backupURL"`
+}
+
+type PurgeStatus struct {
+	Error     string `json:"error"`
+	IsPurging bool   `json:"isPurging"`
+	Progress  int    `json:"progress"`
+	State     string `json:"state"`
 }
 
 type InstanceType string


### PR DESCRIPTION
This PR makes changes to the `SnapshotPurge` logic to account for the `SnapshotPurge` operation being moved to the `SyncAgentServer` in `longhorn-engine` as part of longhorn/longhorn-engine#402:
- Various comments and logs have been modified to indicate the `asynchronous` nature of the `SnapshotPurge` operation.
- The `EngineStatus` now stores the `SnapshotPurgeStatus` of the `Volume` during the `refresh` operation.
- The `SnapshotPurge` call during the `RecurringJob` now waits for the `SnapshotPurge` operation to complete before finishing.

This PR implements the `longhorn-manager` portion of longhorn/longhorn#665.