### PR TITLE
Set service account for all pods creation in Longhorn 

### DIFF
--- a/app/driver.go
+++ b/app/driver.go
@@ -237,7 +237,7 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 	rootDir := c.String(FlagKubeletRootDir)
 	if rootDir == "" {
 		var err error
-		rootDir, err = getProcArg(kubeClient, managerImage, ArgKubeletRootDir)
+		rootDir, err = getProcArg(kubeClient, managerImage, serviceAccountName, ArgKubeletRootDir)
 		if err != nil {
 			logrus.Error(err)
 			return err
@@ -314,10 +314,11 @@ func handleCSIUpgrade(kubeClient *clientset.Clientset, namespace string) error {
 }
 
 func deployFlexvolumeDriver(kubeClient *clientset.Clientset, c *cli.Context, managerImage, managerURL string) error {
+	serviceAccountName := os.Getenv(types.EnvServiceAccount)
 	flexvolumeDir := c.String(FlagFlexvolumeDir)
 	if flexvolumeDir == "" {
 		var err error
-		flexvolumeDir, err = getProcArg(kubeClient, managerImage, ArgFlexvolumePluginDir)
+		flexvolumeDir, err = getProcArg(kubeClient, managerImage, serviceAccountName, ArgFlexvolumePluginDir)
 		if err != nil {
 			logrus.Error(err)
 			return err

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -96,7 +96,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		serviceAccount, managerImage)
 	ic := NewEngineImageController(ds, scheme,
 		engineImageInformer, volumeInformer, daemonSetInformer,
-		kubeClient, namespace, controllerID)
+		kubeClient, namespace, controllerID, serviceAccount)
 	nc := NewNodeController(ds, scheme,
 		engineImageInformer, nodeInformer, settingInformer, podInformer, replicaInformer, imInformer, kubeNodeInformer,
 		kubeClient, namespace, controllerID)
@@ -107,7 +107,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		kubeClient, version)
 	kc := NewKubernetesController(ds, scheme, volumeInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, podInformer, volumeAttachmentInformer, kubeClient)
-	imc := NewInstanceManagerController(ds, scheme, imInformer, podInformer, kubeClient, namespace, controllerID)
+	imc := NewInstanceManagerController(ds, scheme, imInformer, podInformer, kubeClient, namespace, controllerID, serviceAccount)
 
 	go kubeInformerFactory.Start(stopCh)
 	go lhInformerFactory.Start(stopCh)

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -49,8 +49,9 @@ const (
 )
 
 type InstanceManagerController struct {
-	namespace    string
-	controllerID string
+	namespace      string
+	controllerID   string
+	serviceAccount string
 
 	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
@@ -114,15 +115,16 @@ func NewInstanceManagerController(
 	imInformer lhinformers.InstanceManagerInformer,
 	pInformer coreinformers.PodInformer,
 	kubeClient clientset.Interface,
-	namespace, controllerID string) *InstanceManagerController {
+	namespace, controllerID, serviceAccount string) *InstanceManagerController {
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(logrus.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 
 	imc := &InstanceManagerController{
-		namespace:    namespace,
-		controllerID: controllerID,
+		namespace:      namespace,
+		controllerID:   controllerID,
+		serviceAccount: serviceAccount,
 
 		kubeClient:    kubeClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "longhorn-instance-manager-controller"}),
@@ -537,7 +539,8 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 			},
 		},
 		Spec: v1.PodSpec{
-			Tolerations: tolerations,
+			ServiceAccountName: imc.serviceAccount,
+			Tolerations:        tolerations,
 			Containers: []v1.Container{
 				{
 					Image: image.Spec.Image,

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -118,7 +118,8 @@ func newPod(phase v1.PodPhase, name, namespace, nodeID string) *v1.Pod {
 			Namespace: namespace,
 		},
 		Spec: v1.PodSpec{
-			NodeName: nodeID,
+			ServiceAccountName: TestServiceAccount,
+			NodeName:           nodeID,
 		},
 		Status: v1.PodStatus{
 			Phase: phase,
@@ -155,7 +156,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 		kubeClient, TestNamespace)
 
 	imc := NewInstanceManagerController(ds, scheme.Scheme, imInformer, podInformer, kubeClient, TestNamespace,
-		controllerID)
+		controllerID, TestServiceAccount)
 	fakeRecorder := record.NewFakeRecorder(100)
 	imc.eventRecorder = fakeRecorder
 	imc.imStoreSynced = alwaysReady

--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -23,6 +23,7 @@ spec:
         env:
           - name: LONGHORN_MANAGER_IP
             value: "http://longhorn-backend:9500"
+      serviceAccountName: longhorn-service-account
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/603

Now longhorn service account will be applied to all Longhorn components. Then as long as the Longhorn service account is using correct pod security policy, Longhorn will work fine in the cluster enabling pod security policy.