### PR TITLE
Fetch Replica Rebuild Status from Engine

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -735,6 +735,12 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	}
 	engine.Status.Endpoint = endpoint
 
+	replicaRebuildStatus, err := client.ReplicaRebuildStatus()
+	if err != nil {
+		logrus.Errorf("failed to get rebuild status: %v", err)
+	}
+	engine.Status.RebuildStatus = replicaRebuildStatus
+
 	backupStatusList, err := client.SnapshotBackupStatus()
 	if err != nil {
 		logrus.Errorf("engine monitor: engine %v: failed to get backup status: %v", engine.Name, err)
@@ -1048,6 +1054,9 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine) (err error) {
 	e.Status.CurrentImage = e.Spec.EngineImage
 	// reset ReplicaModeMap to reflect the new replicas
 	e.Status.ReplicaModeMap = nil
+	e.Status.BackupStatus = nil
+	e.Status.RestoreStatus = nil
+	e.Status.RebuildStatus = nil
 	e.Spec.ReplicaAddressMap = e.Spec.UpgradedReplicaAddressMap
 	e.Spec.UpgradedReplicaAddressMap = map[string]string{}
 	return nil

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1186,6 +1186,7 @@ func (s *DataStore) ResetEngineMonitoringStatus(e *longhorn.Engine) (*longhorn.E
 	e.Status.ReplicaModeMap = nil
 	e.Status.BackupStatus = nil
 	e.Status.RestoreStatus = nil
+	e.Status.RebuildStatus = nil
 	e.Status.PurgeStatus = nil
 	ret, err := s.UpdateEngine(e)
 	if err != nil {

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -289,3 +289,16 @@ func (e *Engine) BackupRestoreStatus() (map[string]*types.RestoreStatus, error) 
 	}
 	return replicaStatusMap, nil
 }
+
+func (e *Engine) ReplicaRebuildStatus() (map[string]*types.RebuildStatus, error) {
+	args := []string{"replica-rebuild-status"}
+	output, err := e.ExecuteEngineBinary(args...)
+	if err != nil {
+		return nil, err
+	}
+	replicaRebuildStatusMap := make(map[string]*types.RebuildStatus)
+	if err := json.Unmarshal([]byte(output), &replicaRebuildStatusMap); err != nil {
+		return nil, err
+	}
+	return replicaRebuildStatusMap, nil
+}

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -198,3 +198,7 @@ func (e *EngineSimulator) BackupRestore(backupTarget, backupName, backupVolume, 
 func (e *EngineSimulator) BackupRestoreStatus() (map[string]*types.RestoreStatus, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
+
+func (e *EngineSimulator) ReplicaRebuildStatus() (map[string]*types.RebuildStatus, error) {
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -61,6 +61,7 @@ type EngineClient interface {
 
 	BackupRestore(backupTarget, backupName, backupVolume, lastRestored string, credential map[string]string) error
 	BackupRestoreStatus() (map[string]*types.RestoreStatus, error)
+	ReplicaRebuildStatus() (map[string]*types.RebuildStatus, error)
 }
 
 type EngineClientRequest struct {

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -77,6 +77,13 @@ func (e *EngineStatus) DeepCopyInto(to *EngineStatus) {
 			*to.RestoreStatus[key] = *value
 		}
 	}
+	if e.RebuildStatus != nil {
+		to.RebuildStatus = make(map[string]*RebuildStatus)
+		for key, value := range e.RebuildStatus {
+			to.RebuildStatus[key] = &RebuildStatus{}
+			*to.RebuildStatus[key] = *value
+		}
+	}
 	if e.PurgeStatus != nil {
 		to.PurgeStatus = make(map[string]*PurgeStatus)
 		for key, value := range e.PurgeStatus {

--- a/types/resource.go
+++ b/types/resource.go
@@ -167,6 +167,7 @@ type EngineStatus struct {
 	LastRestoredBackup string                    `json:"lastRestoredBackup"`
 	BackupStatus       map[string]*BackupStatus  `json:"backupStatus"`
 	RestoreStatus      map[string]*RestoreStatus `json:"restoreStatus"`
+	RebuildStatus      map[string]*RebuildStatus `json:"rebuildStatus"`
 	PurgeStatus        map[string]*PurgeStatus   `json:"purgeStatus"`
 }
 
@@ -304,6 +305,13 @@ type PurgeStatus struct {
 	IsPurging bool   `json:"isPurging"`
 	Progress  int    `json:"progress"`
 	State     string `json:"state"`
+}
+
+type RebuildStatus struct {
+	IsRebuilding bool   `json:"isRebuilding"`
+	Progress     int    `json:"progress,omitempty"`
+	Error        string `json:"error,omitempty"`
+	State        string `json:"state,omitempty"`
 }
 
 type InstanceType string


### PR DESCRIPTION
The following code changes fetch the replica-rebuild-status from the engine by creating a query command and decode the JSON response. Further, the same response is forwarded to the UI as a part of the corresponding Volume REST API.

Issue: longhorn/longhorn#46