### PR TITLE
Engine monitor will update endpoint after checking replica mode

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -585,12 +585,6 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	}
 	engine.Status.BackupStatus = backupStatusList
 
-	endpoint, err := engineapi.Endpoint(engine.Status.IP, engine.Name)
-	if err != nil {
-		return err
-	}
-	engine.Status.Endpoint = endpoint
-
 	replicaURLModeMap, err := client.ReplicaList()
 	if err != nil {
 		return err
@@ -632,6 +626,12 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	if !reflect.DeepEqual(engine.Status.ReplicaModeMap, currentReplicaModeMap) {
 		engine.Status.ReplicaModeMap = currentReplicaModeMap
 	}
+
+	endpoint, err := engineapi.Endpoint(engine.Status.IP, engine.Name)
+	if err != nil {
+		return err
+	}
+	engine.Status.Endpoint = endpoint
 
 	rsMap, err := client.BackupRestoreStatus()
 	if err != nil {


### PR DESCRIPTION
To prevent the following corner case:
1. Engine monitor updates field `Endpoint` with empty string
2. Engine's frontend is started and the endpint is suddenly set
3. Engine's all replicas are state `running` with mode `RW`
4. Engine monitor updates field `ReplicaModeMap`
5. Volume controller checks `ReplicaModeMap` then updates the volume
to state`Healthy`

In this case, field `Endpoint` is out of date. Then the volume is `Healthy`
but with empty `Endpoint`.
