### PR TITLE
Clean up engine purge status after detaching the volume

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -603,7 +603,7 @@ func getReplicaName(address string, vrs []*longhorn.Replica, volumeName string) 
 			return r.Name
 		}
 	}
-	logrus.Warnf("replica address[%v] received from engine restoreStatus for volume[%v] is not found",
+	logrus.Warnf("Cannot find matching replica by the address[%v] in engine purge/restore status for volume[%v]",
 		address, volumeName)
 	return address
 }

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1173,6 +1173,7 @@ func (s *DataStore) ResetEngineMonitoringStatus(e *longhorn.Engine) (*longhorn.E
 	e.Status.ReplicaModeMap = nil
 	e.Status.BackupStatus = nil
 	e.Status.RestoreStatus = nil
+	e.Status.PurgeStatus = nil
 	ret, err := s.UpdateEngine(e)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to reset engine status for %v", e.Name)


### PR DESCRIPTION
Otherwise, the manager's log will be flooded by the warning messages `"replica address[%v] received from engine restoreStatus for volume[%v] is not found"`.

