### PR TITLE
The script longhorn-engine-exec will handle the case that instance manager is empty or not found

### DIFF
--- a/deploy/scripts/longhorn-engine-exec
+++ b/deploy/scripts/longhorn-engine-exec
@@ -37,7 +37,7 @@ do
     if [[ "$1" == "${engineVolume}" ]]
     then
         enginePort=$(echo "${engineInfo}" | grep "port:" | sed "s/ *port: *//")
-        instanceManager=$(echo "${engineInfo}" | grep "instanceManagerName:" | sed "s/ *instanceManagerName: *//")
+        instanceManager=$(echo "${engineInfo}" | grep "instanceManagerName:" | sed "s/ *instanceManagerName: *//" | sed "s/\"//g")
         if [[ "${enginePort}" == "" ]]
         then
             echo "Cannot find related port"
@@ -45,7 +45,7 @@ do
         fi
         if [[ "${instanceManager}" == "" ]]
         then
-            echo "Cannot find related instance manager"
+            echo "Cannot find related instance manager. Or the volume is not running and the instance manager is empty."
             exit 1
         fi
 

--- a/deploy/scripts/longhorn-engine-exec
+++ b/deploy/scripts/longhorn-engine-exec
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-cat << EOF
+function usage() {
+    cat << EOF
+
 USAGE:
   # Must have Longhorn installed in "longhorn-system" namespace and have access to "kubectl" and the namespace
+  # The volume should be state "attached"
   ./longhorn-engine-exec [volume-name] [longhorn-command-args]
 
 EXAMPLE:
@@ -11,17 +14,19 @@ EXAMPLE:
 
 EOF
 
+}
 
 if [[ $# -lt 2 ]]
 then
-    echo "Require at least 2 parameters: [volume-name] and [longhorn-command-args]"
+    echo "Error: Require at least 2 parameters: [volume-name] and [longhorn-command-args]"
+    usage
     exit 1
 fi
 
 kubectl -n longhorn-system get lhv $1 > /dev/null
 if [[ $? -ne 0 ]]
 then
-    echo "Volume $1 is not found in Longhorn system"
+    echo "Error: Volume $1 is not found in Longhorn system"
     exit 1
 fi
 
@@ -40,24 +45,24 @@ do
         instanceManager=$(echo "${engineInfo}" | grep "instanceManagerName:" | sed "s/ *instanceManagerName: *//" | sed "s/\"//g")
         if [[ "${enginePort}" == "" ]]
         then
-            echo "Cannot find related port"
+            echo "Error: Cannot find related port"
             exit 1
         fi
         if [[ "${instanceManager}" == "" ]]
         then
-            echo "Cannot find related instance manager. Or the volume is not running and the instance manager is empty."
+            echo "Error: Cannot find related instance manager, or the volume is not running and the instance manager is empty."
+            usage
             exit 1
         fi
 
         array=( $@ )
         args=( ${array[@]:1} )
 
-        echo -e "\"longhorn\" command output: \n"
         kubectl -n longhorn-system exec -it ${instanceManager} -- bash -c "longhorn --url localhost:${enginePort} ${args[@]}"
 
         exit 0
     fi
 done
 
-echo "Cannot find related engine for volume $1, exit"
+echo "Error: Cannot find related engine for volume $1"
 exit 1


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/655

If the field `instanceManagerName` of the engine object is empty, this field will be `instanceManagerName: ""` rather than `instanceManagerName: `.