### PR TITLE
controller: engine: monitor shouldn't treat progress error as blocker

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -603,8 +603,7 @@ func getReplicaName(address string, vrs []*longhorn.Replica, volumeName string) 
 			return r.Name
 		}
 	}
-	logrus.Warnf("Cannot find matching replica by the address[%v] in engine purge/restore status for volume[%v]",
-		address, volumeName)
+	//Cannot find matching replica by the address, replica may be removed already. Use address instead
 	return address
 }
 


### PR DESCRIPTION
Otherwise intermediate errors can block the engine status update

Also, remove the unnecessary warning of `cannot find the replica with
address` since it's likely due to the replica has been removed.

https://github.com/longhorn/longhorn/issues/715

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>