### PR TITLE
controller: Add poll interval if the instance manager monitor fails to receive the info

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -859,6 +859,7 @@ func (m *InstanceManagerMonitor) Run() {
 
 			if _, err := notifier.Recv(); err != nil {
 				logrus.Errorf("error receiving next item in engine watch: %v", err)
+				time.Sleep(MinPollCount * PollInterval)
 			} else {
 				m.lock.Lock()
 				m.updateNotification = true


### PR DESCRIPTION
During toleration setting update, the instance manager pod will be
deleted temporarily. And the receive function of instance manager
monitor will error out. If there is no wait interval for retrying
the receive function, the longhorn manager's log will be flooded
by the following message:

```
[longhorn-manager-thcvm] time="2019-09-17T21:49:43Z" level=error msg="error receiving next item in engine watch: rpc error: code = Unavailable desc = transport is closing"
```