### PR TITLE
controller: instance manager: Fix high cpu utilization caused by health probe

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -35,11 +35,10 @@ import (
 )
 
 const (
-	managerProbeInitialDelay  = 1
-	managerProbePeriodSeconds = 1
+	managerProbeInitialDelay  = 3
+	managerProbePeriodSeconds = 5
 
-	managerLivenessProbeFailureThreshold  = 60
-	managerReadinessProbeFailureThreshold = 15
+	managerLivenessProbeFailureThreshold = 3
 
 	// MaxPollCount, MinPollCount, PollInterval determines how often we sync instance map
 
@@ -550,16 +549,6 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 						InitialDelaySeconds: managerProbeInitialDelay,
 						PeriodSeconds:       managerProbePeriodSeconds,
 						FailureThreshold:    managerLivenessProbeFailureThreshold,
-					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
-								Command: []string{"/usr/local/bin/grpc_health_probe", "-addr=:8500"},
-							},
-						},
-						InitialDelaySeconds: managerProbeInitialDelay,
-						PeriodSeconds:       managerProbePeriodSeconds,
-						FailureThreshold:    managerReadinessProbeFailureThreshold,
 					},
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &privileged,


### PR DESCRIPTION
The wrong configuration results in skyrocketed CPU usage on instance
manager pods. The liveness and readiness probe set to 1 second interval,
which is too short. Being an `exec` type of probe doesn't help too.

Also remove readiness probe since instance maangers are not behind a
Kubernetes Service.

Set liveness probe interval to 5 seconds, with initial delay of 3
seconds.

https://github.com/longhorn/longhorn/issues/767

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>