### PR TITLE
controller: Use `Args` instead of `Command` to respect image's entrypoint

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -575,7 +575,7 @@ func (imc *InstanceManagerController) createEngineManagerPodSpec(im *longhorn.In
 
 	podSpec.ObjectMeta.Labels = types.GetInstanceManagerLabels(imc.controllerID, image.Name, types.InstanceManagerTypeEngine)
 	podSpec.Spec.Containers[0].Name = "engine-manager"
-	podSpec.Spec.Containers[0].Command = []string{
+	podSpec.Spec.Containers[0].Args = []string{
 		"engine-manager", "--debug", "daemon", "--listen", "0.0.0.0:8500",
 	}
 	podSpec.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
@@ -632,7 +632,7 @@ func (imc *InstanceManagerController) createReplicaManagerPodSpec(im *longhorn.I
 
 	podSpec.ObjectMeta.Labels = types.GetInstanceManagerLabels(imc.controllerID, image.Name, types.InstanceManagerTypeReplica)
 	podSpec.Spec.Containers[0].Name = "replica-manager"
-	podSpec.Spec.Containers[0].Command = []string{
+	podSpec.Spec.Containers[0].Args = []string{
 		"longhorn-instance-manager", "daemon", "--listen", "0.0.0.0:8500",
 	}
 	podSpec.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{


### PR DESCRIPTION
We need `tini` to handle reaping the children properly.

This approach can avoid breaking the images without `tini` packaged.

https://github.com/longhorn/longhorn/issues/795

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>