### PR TITLE
Upgrade fixes

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -322,11 +322,6 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 		return err
 	}
 
-	// TODO: Will remove this reference kind correcting after all Longhorn components having used the new kinds
-	if len(im.OwnerReferences) < 1 || im.OwnerReferences[0].Kind != types.LonghornKindEngineImage {
-		im.OwnerReferences = datastore.GetOwnerReferencesForEngineImage(image)
-	}
-
 	pod, err := imc.ds.GetInstanceManagerPod(im.Name)
 	if err != nil {
 		return errors.Wrapf(err, "cannot get pod for instance manager %v", im.Name)

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -606,15 +606,6 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 		newVolume = true
 	}
 
-	// TODO: Will remove this reference kind correcting after all Longhorn components having used the new kinds
-	if len(e.OwnerReferences) < 1 || e.OwnerReferences[0].Kind != types.LonghornKindVolume {
-		e.OwnerReferences = datastore.GetOwnerReferencesForVolume(v)
-		e, err = vc.ds.UpdateEngine(e)
-		if err != nil {
-			return err
-		}
-	}
-
 	if len(rs) == 0 {
 		// first time creation
 		if err = vc.replenishReplicas(v, e, rs); err != nil {
@@ -659,15 +650,6 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 
 	allScheduled := true
 	for _, r := range rs {
-		// TODO: Will remove this reference kind correcting after all Longhorn components having used the new kinds
-		if len(r.OwnerReferences) < 1 || r.OwnerReferences[0].Kind != types.LonghornKindVolume {
-			r.OwnerReferences = datastore.GetOwnerReferencesForVolume(v)
-			r, err = vc.ds.UpdateReplica(r)
-			if err != nil {
-				return err
-			}
-		}
-
 		// check whether the replica need to be scheduled
 		if r.Spec.NodeID != "" {
 			continue

--- a/hack/cleancrds.sh
+++ b/hack/cleancrds.sh
@@ -4,9 +4,9 @@ set -x
 
 namespace=longhorn-system
 
-clean_crs() {
+clean_crds() {
 	crd=$1
-	kubectl -n $namespace get $crd --no-headers|cut -f1 -d" "| xargs kubectl -n $namespace patch $crd --type='merge' -p '{"metadata":{"finalizers": null}}'
+	kubectl -n $namespace get $crd --no-headers|cut -f1 -d" "| xargs kubectl -n $namespace patch $crd --type='merge' -p '{"metadata":{"finalizers": null, "ownerReferences":null}}'
 	kubectl -n $namespace delete $crd --all
 	kubectl -n $namespace delete crd $crd
 }
@@ -46,7 +46,5 @@ esac
 
 for crd in "${list[@]}"
 do
-	clean_crs $crd
+	clean_crds $crd
 done
-
-#kubectl -n longhorn-system get instancemanagers.longhorn.rancher.io --no-headers|cut -f1 -d" "| xargs kubectl -n longhorn-system patch instancemanagers.longhorn.rancher.io --type='merge' -p '{"metadata":{"finalizers": null}}'


### PR DESCRIPTION
Now upgrade following the YAML path in  https://github.com/longhorn/longhorn/blob/v0.7.0/docs/upgrade-from-v0.6.2-to-v0.7.0.md works. Previously due to the owner reference, the instance manager will be deleted when v0.6.2 CRD object removed.