### PR TITLE
Clean up status.InstanceManagerName for detaching error instance only

### DIFF
--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -288,7 +288,9 @@ func (h *InstanceHandler) ReconcileInstanceState(obj interface{}, spec *types.In
 				}
 			}
 		}
-		status.InstanceManagerName = ""
+		if spec.DesireState == types.InstanceStateStopped {
+			status.InstanceManagerName = ""
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If instance handler directly cleans up the field for the error process with spec.DesireStatus running, then there is no way to find the correct instance manager and clean up the
corresponding error process for the subsequent detachment.
