### PR TITLE
controller: Change rate limiter for engine/replica's workqueue

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -111,7 +111,7 @@ func NewEngineController(
 		imStoreSynced: instanceManagerInformer.Informer().HasSynced,
 
 		backoff: flowcontrol.NewBackOff(time.Second*10, time.Minute*5),
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-engine"),
+		queue:   workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-engine"),
 
 		engines:                  engines,
 		engineMonitorMutex:       &sync.RWMutex{},

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -43,7 +43,7 @@ const (
 
 	MaxPollCount = 60
 	MinPollCount = 1
-	PollInterval = 500 * time.Millisecond
+	PollInterval = 1 * time.Second
 )
 
 var (
@@ -135,7 +135,7 @@ func NewInstanceManagerController(
 		imStoreSynced: imInformer.Informer().HasSynced,
 		pStoreSynced:  pInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-instance-manager"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-instance-manager"),
 
 		instanceManagerMonitorMutex:    &sync.RWMutex{},
 		instanceManagerMonitorMap:      map[string]chan struct{}{},

--- a/controller/kubernetes_controller.go
+++ b/controller/kubernetes_controller.go
@@ -99,7 +99,7 @@ func NewKubernetesController(
 		pStoreSynced:   podInformer.Informer().HasSynced,
 		vaStoreSynced:  volumeAttachmentInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Longhorn-Kubernetes"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "Longhorn-Kubernetes"),
 
 		pvToVolumeCache: sync.Map{},
 

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -89,7 +89,7 @@ func NewReplicaController(
 		rStoreSynced:  replicaInformer.Informer().HasSynced,
 		imStoreSynced: instanceManagerInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-replica"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-replica"),
 	}
 	rc.instanceHandler = NewInstanceHandler(ds, rc, rc.eventRecorder)
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -108,7 +108,7 @@ func NewVolumeController(
 		eStoreSynced: engineInformer.Informer().HasSynced,
 		rStoreSynced: replicaInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-volume"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-volume"),
 
 		nowHandler: util.Now,
 	}


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1058

Also, change the polling interval of instance manager to 1 second from
500ms.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>