### PR TITLE
controller: Engine image pods won't blindly overwriting the engine binary

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -550,7 +550,9 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 	}
 	args := []string{
 		"-c",
-		"cp /usr/local/bin/longhorn* /data/ && echo installed && trap 'rm /data/longhorn* && echo cleaned up' EXIT && sleep infinity",
+		"diff /usr/local/bin/longhorn /data/longhorn > /dev/null 2>&1; " +
+			"if [ $? -ne 0 ]; then cp -p /usr/local/bin/longhorn /data/ && echo installed; fi && " +
+			"trap 'rm /data/longhorn* && echo cleaned up' EXIT && sleep infinity",
 	}
 	maxUnavailable := intstr.FromString(`100%`)
 	d := &appsv1.DaemonSet{


### PR DESCRIPTION
The pods will use command `diff` to check if there is an existing
binary in the destination and if it's the same as the new one.

Besides, engine image pods won't copy the binary
`longhorn-instance-manager` now since it's no longer needed.

longhorn/longhorn#1116