### PR TITLE
settings: Change default setting for storage related options

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -208,7 +208,7 @@ var (
 		Type:        SettingTypeInt,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "500",
+		Default:     "200",
 	}
 
 	SettingDefinitionStorageMinimalAvailablePercentage = SettingDefinition{
@@ -218,7 +218,7 @@ var (
 		Type:        SettingTypeInt,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "10",
+		Default:     "25",
 	}
 
 	SettingDefinitionUpgradeChecker = SettingDefinition{


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1068

Overprovision factor to 200.
Minimal available disk to 25%.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>