### PR TITLE
types: engine status: Add snapshotsError to stop the error become critical

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -730,9 +730,12 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 
 	snapshots, err := client.SnapshotList()
 	if err != nil {
-		return err
+		engine.Status.Snapshots = map[string]*types.Snapshot{}
+		engine.Status.SnapshotsError = err.Error()
+	} else {
+		engine.Status.Snapshots = snapshots
+		engine.Status.SnapshotsError = ""
 	}
-	engine.Status.Snapshots = snapshots
 
 	// TODO: find a more advanced way to handle invocations for incompatible running engines
 	isOldVersion, err := m.ds.IsEngineImageCLIAPIVersionLessThanThree(engine.Status.CurrentImage)

--- a/types/resource.go
+++ b/types/resource.go
@@ -177,6 +177,7 @@ type EngineStatus struct {
 	PurgeStatus              map[string]*PurgeStatus   `json:"purgeStatus"`
 	RebuildStatus            map[string]*RebuildStatus `json:"rebuildStatus"`
 	Snapshots                map[string]*Snapshot      `json:"snapshots"`
+	SnapshotsError           string                    `json:"snapshotsError"`
 	IsExpanding              bool                      `json:"isExpanding"`
 	LastExpansionError       string                    `json:"lastExpansionError"`
 	LastExpansionFailedAt    string                    `json:"lastExpansionFailedAt"`


### PR DESCRIPTION
For SnapshotList() error.

If a node went down, before we remove the replica from the engine,
snapshot list error might happen.

Notice it won't affect the actual size calcuation in the volume
controller since snapshot list will be cleaned up and actual size
calcuation will be skipped for empty snapshot list.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>