### PR TITLE
Update go-iscsi-helper to v0.0.0-20200424013728-e7c199ecb487

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
 	github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405
-	github.com/longhorn/go-iscsi-helper v0.0.0-20200330214004-ab9932015591
+	github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487
 	github.com/longhorn/longhorn-instance-manager v0.0.0-20200226061011-dd95eaa89a05
 	github.com/miekg/dns v1.1.22 // indirect
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/kubernetes-csi/csi-lib-utils v0.6.1 h1:+AZ58SRSRWh2vmMoWAAGcv7x6fIyBM
 github.com/kubernetes-csi/csi-lib-utils v0.6.1/go.mod h1:GVmlUmxZ+SUjVLXicRFjqWUUvWez0g0Y78zNV9t7KfQ=
 github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405 h1:RTgfE4mD8l4wyWROFPKMFQW72TYytVC9Q3ZF/N7yw6s=
 github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
-github.com/longhorn/go-iscsi-helper v0.0.0-20200330214004-ab9932015591 h1:f/x2Ak2vZrB2/la7YphuW/IFdL+jviqTB1DbQ/gPnvQ=
-github.com/longhorn/go-iscsi-helper v0.0.0-20200330214004-ab9932015591/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487 h1:ARgyOW/q9zb2MS5EEX3X9frQhBtpeSX4PVf9DJXTUy4=
+github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/longhorn-instance-manager v0.0.0-20200226061011-dd95eaa89a05 h1:zj0FjrP7SEhpZDunUyWu07WkDsC0Bx2oaV1SIZZHZoo=
 github.com/longhorn/longhorn-instance-manager v0.0.0-20200226061011-dd95eaa89a05/go.mod h1:SfnIsnFj+HdmRiyF2buQ6+CB1WTD1pDQ4zEE6lBLs4s=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
+++ b/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -16,12 +17,19 @@ import (
 )
 
 const (
-	NSBinary = "nsenter"
+	NSBinary    = "nsenter"
+	LSBLKBinary = "lsblk"
 )
 
 var (
 	cmdTimeout = time.Minute // one minute by default
 )
+
+type KernelDevice struct {
+	Name  string
+	Major int
+	Minor int
+}
 
 func getIPFromAddrs(addrs []net.Addr) string {
 	for _, addr := range addrs {
@@ -255,15 +263,50 @@ func RemoveDevice(dev string) error {
 	return nil
 }
 
-func DuplicateDevice(src, dest string) error {
-	stat := unix.Stat_t{}
-	if err := unix.Stat(src, &stat); err != nil {
-		return fmt.Errorf("Cannot duplicate device because cannot find %s: %v", src, err)
+func GetKnownDevices(ne *NamespaceExecutor) (map[string]*KernelDevice, error) {
+	knownDevices := make(map[string]*KernelDevice)
+
+	/* Example command output
+	   $ lsblk -l -n -o NAME,MAJ:MIN
+	   sda           8:0
+	   sdb           8:16
+	   sdc           8:32
+	   nvme0n1     259:0
+	   nvme0n1p1   259:1
+	   nvme0n1p128 259:2
+	   nvme1n1     259:3
+	*/
+
+	opts := []string{
+		"-l", "-n", "-o", "NAME,MAJ:MIN",
 	}
-	major := int(stat.Rdev / 256)
-	minor := int(stat.Rdev % 256)
-	if err := mknod(dest, major, minor); err != nil {
-		return fmt.Errorf("Cannot duplicate device %s to %s", src, dest)
+
+	output, err := ne.Execute(LSBLKBinary, opts)
+	if err != nil {
+		return knownDevices, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+		f := strings.Fields(line)
+		if len(f) == 2 {
+			dev := &KernelDevice{
+				Name: f[0],
+			}
+			if _, err := fmt.Sscanf(f[1], "%d:%d", &dev.Major, &dev.Minor); err != nil {
+				return nil, fmt.Errorf("Invalid major:minor %s for device %s", dev.Name, f[1])
+			}
+			knownDevices[dev.Name] = dev
+		}
+	}
+
+	return knownDevices, nil
+}
+
+func DuplicateDevice(dev *KernelDevice, dest string) error {
+	if err := mknod(dest, dev.Major, dev.Minor); err != nil {
+		return fmt.Errorf("Cannot create device node %s for device %s", dest, dev.Name)
 	}
 	if err := os.Chmod(dest, 0660); err != nil {
 		return fmt.Errorf("Couldn't change permission of the device %s: %s", dest, err)
@@ -274,7 +317,7 @@ func DuplicateDevice(src, dest string) error {
 func mknod(device string, major, minor int) error {
 	var fileMode os.FileMode = 0660
 	fileMode |= unix.S_IFBLK
-	dev := int((major << 8) | (minor & 0xff) | ((minor & 0xfff00) << 12))
+	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
 
 	logrus.Infof("Creating device %s %d:%d", device, major, minor)
 	return unix.Mknod(device, uint32(fileMode), dev)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/kubernetes-csi/csi-lib-utils/protosanitizer
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/logging
 github.com/longhorn/backupstore/util
-# github.com/longhorn/go-iscsi-helper v0.0.0-20200330214004-ab9932015591
+# github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487
 github.com/longhorn/go-iscsi-helper/iscsi
 github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util


### PR DESCRIPTION
This way the manager and engine versions are consistent.

longhorn/longhorn#1223

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>