### PR TITLE
skip adding ImagePullSecrets if not specified

### DIFF
--- a/app/get_proc_arg.go
+++ b/app/get_proc_arg.go
@@ -156,7 +156,7 @@ func getProcCmdline(kubeClient *clientset.Clientset, managerImage, serviceAccoun
 
 func deployDetectionPod(kubeClient *clientset.Clientset, namespace, managerImage, serviceAccountName, name, script string, tolerations []v1.Toleration, registrySecret string) error {
 	privileged := true
-	_, err := kubeClient.CoreV1().Pods(namespace).Create(&v1.Pod{
+	detectionPodSpec := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -176,13 +176,18 @@ func deployDetectionPod(kubeClient *clientset.Clientset, namespace, managerImage
 			},
 			RestartPolicy: v1.RestartPolicyNever,
 			HostPID:       true,
-			ImagePullSecrets: []v1.LocalObjectReference{
-				{
-					Name: registrySecret,
-				},
-			},
 		},
-	})
+	}
+
+	if registrySecret != "" {
+		detectionPodSpec.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
+	}
+
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(detectionPodSpec)
 
 	return err
 }

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -614,11 +614,6 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 							},
 						},
 					},
-					ImagePullSecrets: []v1.LocalObjectReference{
-						{
-							Name: registrySecret,
-						},
-					},
 					Volumes: []v1.Volume{
 						{
 							Name: "data",
@@ -633,5 +628,14 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 			},
 		},
 	}
+
+	if registrySecret != "" {
+		d.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
+	}
+
 	return d
 }

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -554,14 +554,17 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 					},
 				},
 			},
-			ImagePullSecrets: []v1.LocalObjectReference{
-				{
-					Name: registrySecret,
-				},
-			},
 			NodeName:      imc.controllerID,
 			RestartPolicy: v1.RestartPolicyNever,
 		},
+	}
+
+	if registrySecret != "" {
+		podSpec.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
 	}
 
 	// Apply resource requirements to newly created Instance Manager Pods.

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -476,11 +476,6 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 							},
 						},
 					},
-					ImagePullSecrets: []v1.LocalObjectReference{
-						{
-							Name: registrySecret,
-						},
-					},
 					Volumes: []v1.Volume{
 						{
 							Name: "kubernetes-csi-dir",
@@ -555,6 +550,14 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 				},
 			},
 		},
+	}
+
+	if registrySecret != "" {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
 	}
 
 	return &PluginDeployment{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -57,7 +57,8 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 	labels := map[string]string{
 		"app": commonName,
 	}
-	return &appsv1.Deployment{
+
+	commonDeploymentSpec := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      commonName,
 			Namespace: namespace,
@@ -102,11 +103,6 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 							},
 						},
 					},
-					ImagePullSecrets: []v1.LocalObjectReference{
-						{
-							Name: registrySecret,
-						},
-					},
 					Volumes: []v1.Volume{
 						{
 							Name: "socket-dir",
@@ -122,6 +118,16 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 			},
 		},
 	}
+
+	if registrySecret != "" {
+		commonDeploymentSpec.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
+	}
+
+	return commonDeploymentSpec
 }
 
 type resourceCreateFunc func(kubeClient *clientset.Clientset, obj runtime.Object) error


### PR DESCRIPTION
longhorn/longhorn#1288
Always deploying Longhorn components with ImagePullSecrets spec, kubelet logs will report
`Unable retrieve pull secret longhorn-system/ for longhorn-system`


Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>