### PR TITLE
scheduler: Introduce node condition Schedulable

### DIFF
--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -168,13 +168,15 @@ func kubeObjStatusSyncTest(testType string) *NodeTestCase {
 		nodeStatus = map[string]types.NodeStatus{
 			TestNode1: {
 				Conditions: map[string]types.Condition{
+					types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 					types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 					types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 				},
 			},
 			TestNode2: {
 				Conditions: map[string]types.Condition{
-					types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				},
 			},
 		}
@@ -182,13 +184,15 @@ func kubeObjStatusSyncTest(testType string) *NodeTestCase {
 		nodeStatus = map[string]types.NodeStatus{
 			TestNode1: {
 				Conditions: map[string]types.Condition{
+					types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 					types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonManagerPodDown),
 					types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusFalse, types.NodeConditionReasonNoMountPropagationSupport),
 				},
 			},
 			TestNode2: {
 				Conditions: map[string]types.Condition{
-					types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				},
 			},
 		}
@@ -196,13 +200,15 @@ func kubeObjStatusSyncTest(testType string) *NodeTestCase {
 		nodeStatus = map[string]types.NodeStatus{
 			TestNode1: {
 				Conditions: map[string]types.Condition{
+					types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 					types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeNotReady),
 					types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 				},
 			},
 			TestNode2: {
 				Conditions: map[string]types.Condition{
-					types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				},
 			},
 		}
@@ -210,13 +216,15 @@ func kubeObjStatusSyncTest(testType string) *NodeTestCase {
 		nodeStatus = map[string]types.NodeStatus{
 			TestNode1: {
 				Conditions: map[string]types.Condition{
+					types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 					types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodePressure),
 					types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 				},
 			},
 			TestNode2: {
 				Conditions: map[string]types.Condition{
-					types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+					types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				},
 			},
 		}
@@ -269,6 +277,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
@@ -288,7 +297,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		},
 		TestNode2: {
 			Conditions: map[string]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
 			DiskStatus: map[string]*types.DiskStatus{
 				TestDiskID1: {
@@ -337,6 +347,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
@@ -355,7 +366,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		},
 		TestNode2: {
 			Conditions: map[string]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
 			DiskStatus: map[string]*types.DiskStatus{
 				TestDiskID1: {
@@ -404,6 +416,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
@@ -422,7 +435,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		},
 		TestNode2: {
 			Conditions: map[string]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
 			DiskStatus: map[string]*types.DiskStatus{
 				TestDiskID1: {
@@ -453,6 +467,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
@@ -497,6 +512,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
@@ -558,6 +574,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[string]types.Condition{
+				types.NodeConditionTypeSchedulable:      newNodeCondition(types.NodeConditionTypeSchedulable, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -863,7 +863,8 @@ func newNode(name, namespace string, allowScheduling bool, status types.Conditio
 		},
 		Status: types.NodeStatus{
 			Conditions: map[string]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, status, reason),
+				types.NodeConditionTypeSchedulable: newNodeCondition(types.NodeConditionTypeSchedulable, status, reason),
+				types.NodeConditionTypeReady:       newNodeCondition(types.NodeConditionTypeReady, status, reason),
 			},
 		},
 	}

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -195,9 +195,18 @@ func (rcs *ReplicaScheduler) getNodeInfo() (map[string]*longhorn.Node, error) {
 		return nil, err
 	}
 	scheduledNode := map[string]*longhorn.Node{}
+
 	for _, node := range nodeInfo {
+		// First check node ready condition
 		nodeReadyCondition := types.GetCondition(node.Status.Conditions, types.NodeConditionTypeReady)
-		if node != nil && node.DeletionTimestamp == nil && nodeReadyCondition.Status == types.ConditionStatusTrue && node.Spec.AllowScheduling {
+		// Get Schedulable condition
+		nodeSchedulableCondition :=
+			types.GetCondition(node.Status.Conditions,
+				types.NodeConditionTypeSchedulable)
+		if node != nil && node.DeletionTimestamp == nil &&
+			nodeReadyCondition.Status == types.ConditionStatusTrue &&
+			nodeSchedulableCondition.Status == types.ConditionStatusTrue &&
+			node.Spec.AllowScheduling {
 			scheduledNode[node.Name] = node
 		}
 	}

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -110,7 +110,8 @@ func newNode(name, namespace string, allowScheduling bool, status types.Conditio
 		},
 		Status: types.NodeStatus{
 			Conditions: map[string]types.Condition{
-				types.NodeConditionTypeReady: newCondition(types.NodeConditionTypeReady, status),
+				types.NodeConditionTypeSchedulable: newCondition(types.NodeConditionTypeSchedulable, status),
+				types.NodeConditionTypeReady:       newCondition(types.NodeConditionTypeReady, status),
 			},
 		},
 	}

--- a/types/resource.go
+++ b/types/resource.go
@@ -269,6 +269,7 @@ type NodeSpec struct {
 const (
 	NodeConditionTypeReady            = "Ready"
 	NodeConditionTypeMountPropagation = "MountPropagation"
+	NodeConditionTypeSchedulable      = "Schedulable"
 )
 
 const (
@@ -279,6 +280,7 @@ const (
 	NodeConditionReasonKubernetesNodePressure    = "KubernetesNodePressure"
 	NodeConditionReasonUnknownNodeConditionTrue  = "UnknownNodeConditionTrue"
 	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
+	NodeConditionReasonKubernetesNodeCordoned    = "KubernetesNodeCordoned"
 )
 
 const (

--- a/types/setting.go
+++ b/types/setting.go
@@ -56,6 +56,7 @@ const (
 	SettingNameCRDAPIVersion                     = SettingName("crd-api-version")
 	SettingNameAutoSalvage                       = SettingName("auto-salvage")
 	SettingNameRegistrySecret                    = SettingName("registry-secret")
+	SettingNameDisableSchedulingOnCordonedNode   = SettingName("disable-scheduling-on-cordoned-node")
 )
 
 var (
@@ -79,6 +80,7 @@ var (
 		SettingNameCRDAPIVersion,
 		SettingNameAutoSalvage,
 		SettingNameRegistrySecret,
+		SettingNameDisableSchedulingOnCordonedNode,
 	}
 )
 
@@ -121,6 +123,7 @@ var (
 		SettingNameCRDAPIVersion:                     SettingDefinitionCRDAPIVersion,
 		SettingNameAutoSalvage:                       SettingDefinitionAutoSalvage,
 		SettingNameRegistrySecret:                    SettingDefinitionRegistrySecret,
+		SettingNameDisableSchedulingOnCordonedNode:   SettingDefinitionDisableSchedulingOnCordonedNode,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -312,6 +315,15 @@ var (
 		ReadOnly:    false,
 		Default:     "",
 	}
+	SettingDefinitionDisableSchedulingOnCordonedNode = SettingDefinition{
+		DisplayName: "Disable Scheduling On Cordoned Node",
+		Description: `Disable Longhorn manager to schedule replica on Kubernetes cordoned node`,
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "true",
+	}
 )
 
 func ValidateInitSetting(name, value string) (err error) {
@@ -340,6 +352,8 @@ func ValidateInitSetting(name, value string) (err error) {
 	case SettingNameCreateDefaultDiskLabeledNodes:
 		fallthrough
 	case SettingNameReplicaSoftAntiAffinity:
+		fallthrough
+	case SettingNameDisableSchedulingOnCordonedNode:
 		fallthrough
 	case SettingNameUpgradeChecker:
 		if value != "true" && value != "false" {


### PR DESCRIPTION
This change introduced "disable-scheduling-on-cordoned-node" setting and
node condition Schedulable.

If the setting is enabled, we will disable the node scheduling when
the Kubernetes Node is cordoned. And it will be reflected in the
Longhorn Node's Schedulable condition.

https://github.com/longhorn/longhorn/issues/1287

Signed-off-by: Bo Tao <bo.tao@rancher.com>