### PR TITLE
Compare recurring job label for backup/snapshot retention calculation

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -49,8 +49,6 @@ var (
 )
 
 const (
-	LabelRecurringJob = "RecurringJob"
-
 	CronJobBackoffLimit = 3
 )
 
@@ -1448,7 +1446,7 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 		"longhorn-manager", "-d",
 		"snapshot", v.Name,
 		"--snapshot-name", job.Name,
-		"--labels", LabelRecurringJob + "=" + job.Name,
+		"--labels", types.RecurringJobLabel + "=" + job.Name,
 		"--retain", strconv.Itoa(job.Retain),
 	}
 	for key, val := range job.Labels {

--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,7 @@ const (
 
 	BaseImageLabel        = "ranchervm-base-image"
 	KubernetesStatusLabel = "KubernetesStatus"
+	RecurringJobLabel     = "RecurringJob"
 
 	LonghornLabelKeyPrefix = "longhorn.io"
 


### PR DESCRIPTION
We no longer compare all the labels, instead we only check against our
retention marker label. This applies to backups as well as snapshots.

longhorn/longhorn#1267

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
