### PR TITLE
Add Setting Replica Rebuild Concurrent Limit

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -990,7 +990,7 @@ func (ec *EngineController) ReconcileEngineState(e *longhorn.Engine) error {
 	if err := ec.removeUnknownReplica(e); err != nil {
 		return err
 	}
-	if err := ec.rebuildingNewReplica(e); err != nil {
+	if err := ec.rebuildNewReplica(e); err != nil {
 		return err
 	}
 	return nil
@@ -1050,7 +1050,7 @@ func (ec *EngineController) removeUnknownReplica(e *longhorn.Engine) error {
 	return nil
 }
 
-func (ec *EngineController) rebuildingNewReplica(e *longhorn.Engine) error {
+func (ec *EngineController) rebuildNewReplica(e *longhorn.Engine) error {
 	rebuildingInProgress := false
 	replicaExists := make(map[string]bool)
 	for replica, mode := range e.Status.ReplicaModeMap {

--- a/types/setting.go
+++ b/types/setting.go
@@ -58,6 +58,7 @@ const (
 	SettingNameRegistrySecret                    = SettingName("registry-secret")
 	SettingNameDisableSchedulingOnCordonedNode   = SettingName("disable-scheduling-on-cordoned-node")
 	SettingNameReplicaZoneSoftAntiAffinity       = SettingName("replica-zone-soft-anti-affinity")
+	SettingNameReplicaRebuildConcurrentLimit     = SettingName("replica-rebuild-concurrent-limit")
 )
 
 var (
@@ -83,6 +84,7 @@ var (
 		SettingNameRegistrySecret,
 		SettingNameDisableSchedulingOnCordonedNode,
 		SettingNameReplicaZoneSoftAntiAffinity,
+		SettingNameReplicaRebuildConcurrentLimit,
 	}
 )
 
@@ -127,6 +129,7 @@ var (
 		SettingNameRegistrySecret:                    SettingDefinitionRegistrySecret,
 		SettingNameDisableSchedulingOnCordonedNode:   SettingDefinitionDisableSchedulingOnCordonedNode,
 		SettingNameReplicaZoneSoftAntiAffinity:       SettingDefinitionReplicaZoneSoftAntiAffinity,
+		SettingNameReplicaRebuildConcurrentLimit:     SettingDefinitionReplicaRebuildConcurrentLimit,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -336,6 +339,15 @@ var (
 		ReadOnly:    false,
 		Default:     "true",
 	}
+	SettingDefinitionReplicaRebuildConcurrentLimit = SettingDefinition{
+		DisplayName: "Replica Rebuild Concurrent Limit",
+		Description: "The maximum number of replica build allowed to happen at the same time",
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeInt,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "10",
+	}
 )
 
 func ValidateInitSetting(name, value string) (err error) {
@@ -414,6 +426,14 @@ func ValidateInitSetting(name, value string) (err error) {
 	case SettingNameTaintToleration:
 		if _, err = UnmarshalTolerations(value); err != nil {
 			return fmt.Errorf("the value of %v is invalid: %v", sName, err)
+		}
+	case SettingNameReplicaRebuildConcurrentLimit:
+		if _, err := strconv.Atoi(value); err != nil {
+			return fmt.Errorf("value %v is not a number", value)
+		}
+		value, err := util.ConvertSize(value)
+		if err != nil || value < 0 {
+			return fmt.Errorf("value %v should be at least 0", value)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR allows the user to set a limit for how many replicas can be rebuilt at any given time across the cluster. The limit can be set to 0, to disable the replica rebuild across the cluster.

The limit will have no impact on the replicas that already in the process of rebuilding.

The limit was implemented by checking all the existing running engines when a replica is due for scheduling for the rebuild purpose. The data is read from the cache (implemented by Kubernetes informer), so there should be a minimal performance impact.

Moreover, we no longer schedule all the replicas first then start rebuilding. In the past, if there are two or more replicas missing from the volume, we will pre-schedule the space for all the replicas, then start rebuilding one by one. Now we only schedule one replica for each volume at one time, then rebuild that one, then schedule another one, and so on. This can avoid unnecessary scheduling failure for other volumes when they need to rebuild replicas as well.

longhorn/longhorn#307