### PR TITLE
setting: Set GuaranteedEngineCPU to 0.25 by default

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -262,16 +262,16 @@ var (
 	SettingDefinitionGuaranteedEngineCPU = SettingDefinition{
 		DisplayName: "Guaranteed Engine CPU",
 		Description: "(EXPERIMENTAL) Allow Longhorn Engine to have guaranteed CPU allocation. The value is " +
-			"how many CPUs should be reserved for each Engine/Replica Manager Pod created by Longhorn. For example, " +
+			"how many CPUs should be reserved for each Engine/Replica Instance Manager Pod created by Longhorn. For example, " +
 			"0.1 means one-tenth of a CPU. This will help maintain engine stability during high node workload. It " +
 			"only applies to the Engine/Replica Manager Pods created after the setting took effect. WARNING: " +
 			"After this setting is changed, the instance manager needs to be manually restarted." +
-			"Disabled (\"0\") by default.",
+			"0.25 by default.",
 		Category: SettingCategoryGeneral,
 		Type:     SettingTypeInt,
 		Required: true,
 		ReadOnly: false,
-		Default:  "0",
+		Default:  "0.25",
 	}
 
 	SettingDefinitionDefaultLonghornStaticStorageClass = SettingDefinition{


### PR DESCRIPTION
This will help with the stability of the engine.

0.25 was chosen because as long as the user has one 1 vcpu, the upgrade
of the instance manager can be performed, since both engine and replica
instance manager of the old and new version needs 1/4 of one vcpu.

https://github.com/longhorn/longhorn/issues/1345

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>