### PR TITLE
Cleanup volume attachment on terminating pods

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,7 @@ const (
 
 	BaseImageLabel        = "ranchervm-base-image"
 	KubernetesStatusLabel = "KubernetesStatus"
+	KubernetesReplicaSet  = "ReplicaSet"
 	RecurringJobLabel     = "RecurringJob"
 
 	LonghornLabelKeyPrefix = "longhorn.io"


### PR DESCRIPTION
When a pod resides on an offline node kubernetes will by default wait
forever to delete the pod resource from the api server. The kubernetes
volume attach/detach controller will not remove the volume attachment
till the pod is deleted. This leads to the replacement pod not being
able to start since it will forever wait for the volume attachment.

longhorn/longhorn#820

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
