### PR TITLE
types: Enable Replica Node Level Hard Anti-Affinity By Default

### DIFF
--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -207,6 +207,7 @@ type ReplicaSchedulerTestCase struct {
 	nodes                             map[string]*longhorn.Node
 	storageOverProvisioningPercentage string
 	storageMinimalAvailablePercentage string
+	replicaNodeSoftAntiAffinity       string
 
 	// schedule state
 	expectedNodes map[string]*longhorn.Node
@@ -293,6 +294,8 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 	tc.expectedNodes = expectedNodes
 	tc.err = false
 	tc.isNilReplica = false
+	// Set replica node soft anti-affinity
+	tc.replicaNodeSoftAntiAffinity = "true"
 	testCases["nodes could not schedule"] = tc
 
 	// Test no disks on each nodes, volume should not schedule to any node
@@ -573,6 +576,16 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 
 			s = initSettings(string(types.SettingNameStorageMinimalAvailablePercentage), tc.storageMinimalAvailablePercentage)
 			setting, err = lhClient.LonghornV1beta1().Settings(TestNamespace).Create(s)
+			c.Assert(err, IsNil)
+			sIndexer.Add(setting)
+		}
+		// Set replica node soft anti-affinity setting
+		if tc.replicaNodeSoftAntiAffinity != "" {
+			s := initSettings(
+				string(types.SettingNameReplicaSoftAntiAffinity),
+				tc.replicaNodeSoftAntiAffinity)
+			setting, err :=
+				lhClient.LonghornV1beta1().Settings(TestNamespace).Create(s)
 			c.Assert(err, IsNil)
 			sIndexer.Add(setting)
 		}

--- a/types/setting.go
+++ b/types/setting.go
@@ -207,7 +207,7 @@ var (
 		Type:        SettingTypeBool,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "true",
+		Default:     "false",
 	}
 
 	SettingDefinitionStorageOverProvisioningPercentage = SettingDefinition{


### PR DESCRIPTION
This change enables replica node level hard anti-affinity by default.

Also adjust some test cases setting with enabling replica node level soft
anti-affinity.

https://github.com/longhorn/longhorn/issues/1282

Signed-off-by: Bo Tao <bo.tao@rancher.com>