### PR TITLE
Fix csi driver problems

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -800,9 +800,12 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 	if v.Status.Robustness == types.VolumeRobustnessFaulted {
 		actions["salvage"] = struct{}{}
 	} else {
+		// attach/detach actions should always be exposed
+		// it's the managers job to determine whether an attach/detach action is valid
+		actions["attach"] = struct{}{}
+		actions["detach"] = struct{}{}
 		switch v.Status.State {
 		case types.VolumeStateDetached:
-			actions["attach"] = struct{}{}
 			actions["recurringUpdate"] = struct{}{}
 			actions["activate"] = struct{}{}
 			actions["expand"] = struct{}{}
@@ -812,7 +815,6 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["pvCreate"] = struct{}{}
 			actions["pvcCreate"] = struct{}{}
 		case types.VolumeStateAttaching:
-			actions["detach"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
 		case types.VolumeStateAttached:
 			actions["detach"] = struct{}{}


### PR DESCRIPTION
Previously the csi driver decided whether attachment/detachment was
necessary, but it didn't actually have all required information to make
this choice. This could then lead to a situation in which the csi driver
told kubernetes that attachment was successful but in reality longhorn
never attached the volume. Once that case happens the Node.PublishVolume
will continuously fail, but because kubernetes thinks the volume is
already attached it will not try to call Controller.PublishVolume again.

After this change we will always let the longhorn manager make the
decision whether attach/detachment is necessary so that the csi driver
(kubernetes) and longhorn cannot end up in a situation where they are
out of sync in regard to a volume attachment.

The longhorn manager will now also return successfully when a volume
attach/detachment is requested for a volume that is already in the
correct requested state.

longhorn/longhorn#820
longhorn/longhorn#159

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>