### PR TITLE
Add volumeattachments to the support bundle

### DIFF
--- a/datastore/uncached.go
+++ b/datastore/uncached.go
@@ -56,3 +56,7 @@ func (s *DataStore) GetAllEventsList() (runtime.Object, error) {
 func (s *DataStore) GetAllConfigMaps() (runtime.Object, error) {
 	return s.kubeClient.CoreV1().ConfigMaps(s.namespace).List(metav1.ListOptions{})
 }
+
+func (s *DataStore) GetAllVolumeAttachments() (runtime.Object, error) {
+	return s.kubeClient.StorageV1().VolumeAttachments().List(metav1.ListOptions{})
+}

--- a/manager/misc.go
+++ b/manager/misc.go
@@ -212,6 +212,8 @@ func (m *VolumeManager) generateSupportBundleYAMLsForKubernetes(dir string, errL
 	getListAndEncodeToYAML("cronjobs", m.ds.GetAllCronJobsList, dir, errLog)
 	getListAndEncodeToYAML("nodes", m.ds.GetAllNodesList, dir, errLog)
 	getListAndEncodeToYAML("configmaps", m.ds.GetAllConfigMaps, dir, errLog)
+	getListAndEncodeToYAML("volumeattachments",
+		m.ds.GetAllVolumeAttachments, dir, errLog)
 }
 
 func getListAndEncodeToYAML(name string, getListFunc GetRuntimeObjectListFunc, yamlsDir string, errLog io.Writer) {


### PR DESCRIPTION
If volumeattachment object is available in kubernetes, we add it to the
support bundle yamls/kubernetes directory.

https://github.com/longhorn/longhorn/issues/1369

Signed-off-by: Bo Tao <bo.tao@rancher.com>