### PR TITLE
controller: Fix unnecessarily restarting instance managers due to GuranteedEngineCPU

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -188,18 +188,12 @@ func EnhancedDefaultControllerRateLimiter() workqueue.RateLimiter {
 }
 
 func IsSameGuaranteedCPURequirement(a, b *corev1.ResourceRequirements) bool {
-	if (a == nil) != (b == nil) {
-		return false
+	var aQ, bQ resource.Quantity
+	if a != nil && a.Requests != nil {
+		aQ = a.Requests[corev1.ResourceCPU]
 	}
-	if a == nil { // means b == nil
-		return true
+	if b != nil && b.Requests != nil {
+		bQ = b.Requests[corev1.ResourceCPU]
 	}
-	if (a.Requests == nil) != (b.Requests == nil) {
-		return false
-	}
-	if a.Requests == nil { // means b.Requests == nil
-		return true
-	}
-	requestA := a.Requests[corev1.ResourceCPU]
-	return (&requestA).Cmp(b.Requests[corev1.ResourceCPU]) == 0
+	return (&aQ).Cmp(bQ) == 0
 }

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -531,6 +531,7 @@ func (sc *SettingController) updateGuaranteedEngineCPU() error {
 		if IsSameGuaranteedCPURequirement(resourceReq, &podResourceReq) {
 			continue
 		}
+		logrus.Infof("Delete instance manager pod %v to refresh GuaranteedEngineCPU option", imPod.Name)
 		if err := sc.ds.DeletePod(imPod.Name); err != nil {
 			return err
 		}


### PR DESCRIPTION
Nil pointer was treated differently from the empty value.

longhorn/longhorn#1384

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>