### PR TITLE
controller: Use EnhancedDefaultControllerRateLimiter() on all controllers

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -92,7 +92,7 @@ func NewEngineImageController(
 		vStoreSynced:  volumeInformer.Informer().HasSynced,
 		dsStoreSynced: dsInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-engine-image"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-engine-image"),
 
 		nowHandler:                util.Now,
 		engineBinaryChecker:       types.EngineBinaryExistOnHostForImage,

--- a/controller/kubernetes_node_controller.go
+++ b/controller/kubernetes_node_controller.go
@@ -69,7 +69,7 @@ func NewKubernetesNodeController(
 		sStoreSynced:  settingInformer.Informer().HasSynced,
 		knStoreSynced: kubeNodeInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-kubernetes-node"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-kubernetes-node"),
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -99,7 +99,7 @@ func NewNodeController(
 		rStoreSynced:  replicaInformer.Informer().HasSynced,
 		knStoreSynced: kubeNodeInformer.Informer().HasSynced,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-node"),
+		queue: workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-node"),
 
 		getDiskInfoHandler:    util.GetDiskInfo,
 		topologyLabelsChecker: util.IsKubernetesVersionAtLeast,

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -107,7 +107,7 @@ func NewSettingController(
 
 		sStoreSynced: settingInformer.Informer().HasSynced,
 
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "longhorn-setting"),
+		queue:   workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), "longhorn-setting"),
 		version: version,
 	}
 


### PR DESCRIPTION
To improve the throughput of the controller.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>