### PR TITLE
Fix missing return err

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -435,6 +435,7 @@ func (nc *NodeController) syncNode(key string) (err error) {
 			nc.ds.GetSettingAsBool(types.SettingNameDisableSchedulingOnCordonedNode)
 		if err != nil {
 			logrus.Errorf("error getting disable scheduling on cordoned node setting: %v", err)
+			return err
 		}
 
 		// Update node condition based on


### PR DESCRIPTION
This is for getting `Disable Scheduling On Cordoned Node` setting error,
we return error.

Signed-off-by: Bo Tao <bo.tao@rancher.com>