### PR TITLE
csi driver: Remove compatible CSI deployment

### DIFF
--- a/app/driver.go
+++ b/app/driver.go
@@ -245,6 +245,26 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 		return err
 	}
 
+	// TODO: Remove This after v1.1.0
+	// Longhorn #1365, remove compatible CSI deployment
+	compatCSIAttacherName := "compatible-csi-attacher"
+	compatCSIAttacherDeployment, err :=
+		kubeClient.AppsV1().Deployments(namespace).Get(
+			compatCSIAttacherName, metav1.GetOptions{})
+
+	// Delete compatible-csi-attacher deployment if it exists
+	if err == nil {
+		logrus.Debugf("Deleting %v deployment",
+			compatCSIAttacherDeployment.Name)
+
+		err = kubeClient.AppsV1().Deployments(namespace).Delete(
+			compatCSIAttacherName, &metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Warnf("Failed to delete %v deployment with err %v",
+				compatCSIAttacherDeployment.Name, err)
+		}
+	}
+
 	logrus.Debug("CSI deployment done")
 
 	done := make(chan struct{})

--- a/app/driver.go
+++ b/app/driver.go
@@ -240,14 +240,8 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 			return err
 		}
 	}
-
 	pluginDeployment := csi.NewPluginDeployment(namespace, serviceAccountName, csiNodeDriverRegistrarImage, managerImage, managerURL, rootDir, tolerations, registrySecret)
 	if err := pluginDeployment.Deploy(kubeClient); err != nil {
-		return err
-	}
-
-	compatibleAttacherDeployment := csi.NewCompatibleAttacherDeployment(namespace, serviceAccountName, csiAttacherImage, rootDir, tolerations, registrySecret)
-	if err := compatibleAttacherDeployment.Deploy(kubeClient); err != nil {
 		return err
 	}
 

--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -517,7 +517,6 @@ func (c *UninstallController) deleteDriver() (bool, error) {
 		types.CSIAttacherName,
 		types.CSIProvisionerName,
 		types.CSIResizerName,
-		types.CompatibleCSIAttacherName,
 	}
 	wait := false
 	for _, name := range deploymentsToClean {

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1beta "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -399,24 +399,4 @@ func GetOnHostObseletedPluginsDir(kubeletRootDir string) string {
 
 func GetCSIEndpoint() string {
 	return "unix://" + GetInContainerCSISocketFilePath()
-}
-
-func GetOldInContainerCSISocketDir() string {
-	return filepath.Join(GetInContainerPluginsDir(), types.DepracatedDriverName)
-}
-
-func GetOldInContainerCSISocketFilePath() string {
-	return filepath.Join(GetOldInContainerCSISocketDir(), DefaultCSISocketFileName)
-}
-
-func GetOldOnHostCSISocketDir(kubeletRootDir string) string {
-	return filepath.Join(GetOnHostObseletedPluginsDir(kubeletRootDir), types.DepracatedDriverName)
-}
-
-func GetOldOnHostCSISocketFilePath(kubeletRootDir string) string {
-	return filepath.Join(GetOldOnHostCSISocketDir(kubeletRootDir), DefaultCSISocketFileName)
-}
-
-func GetOldCSIEndpoint() string {
-	return "unix://" + GetOldInContainerCSISocketFilePath()
 }

--- a/types/deploy.go
+++ b/types/deploy.go
@@ -3,10 +3,9 @@ package types
 const (
 	LonghornManagerDaemonSetName = "longhorn-manager"
 
-	DriverDeployerName        = "longhorn-driver-deployer"
-	CSIAttacherName           = "csi-attacher"
-	CSIProvisionerName        = "csi-provisioner"
-	CSIResizerName            = "csi-resizer"
-	CSIPluginName             = "longhorn-csi-plugin"
-	CompatibleCSIAttacherName = "compatible-csi-attacher"
+	DriverDeployerName = "longhorn-driver-deployer"
+	CSIAttacherName    = "csi-attacher"
+	CSIProvisionerName = "csi-provisioner"
+	CSIResizerName     = "csi-resizer"
+	CSIPluginName      = "longhorn-csi-plugin"
 )


### PR DESCRIPTION
This commit revertes commit f88d71c1fae0a21057724e2290d07f0a3103c66b.
It's to remove compatible CSI deployment 'io.rancher.longhorn'.

https://github.com/longhorn/longhorn/issues/1365