### PR TITLE
Run Engine Image Pods as Privileged

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -565,6 +565,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 			"trap 'rm /data/longhorn* && echo cleaned up' EXIT && sleep infinity",
 	}
 	maxUnavailable := intstr.FromString(`100%`)
+	privileged := true
 	d := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dsName,
@@ -611,6 +612,9 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 								},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
+							},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &privileged,
 							},
 						},
 					},


### PR DESCRIPTION
This PR modifies the `Daemon Set` spec used for deploying `Engine Images` in order to run them with as `Privileged`. This allows the `Pods` that run as part of this `Daemon Set` to be able to succeed even when running with `SELinux` (which normally blocks containers from being able to write to `/var/lib`).

longhorn/longhorn#1273