### PR TITLE
controller: Automatically recover the restoring/DR volumes on the down node

### DIFF
--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -263,6 +263,8 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.volume.Spec.Standby = false
 	tc.volume.Status.InitialRestorationRequired = true
 	tc.volume.Status.RestoreInitiated = true
+	tc.volume.Status.CurrentNodeID = TestNode1
+	tc.volume.Status.State = types.VolumeStateAttaching
 	tc.volume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.volume.Status.Conditions,
 		types.VolumeConditionTypeRestore, types.ConditionStatusTrue, types.VolumeConditionReasonRestoreInProgress, "")
 	tc.copyCurrentToExpect()
@@ -284,7 +286,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.engines = nil
 	// Set replica node soft anti-affinity
 	tc.replicaNodeSoftAntiAffinity = "true"
-	testCases["restored volume is automatically attaching after creation"] = tc
+	testCases["restored volume keeps automatically attaching after creation"] = tc
 
 	// Newly restored volume changed from attaching to attached
 	tc = generateVolumeTestCaseTemplate()
@@ -559,6 +561,8 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.volume.Spec.DisableFrontend = false
 	tc.volume.Status.InitialRestorationRequired = true
 	tc.volume.Status.RestoreInitiated = true
+	tc.volume.Status.CurrentNodeID = TestNode1
+	tc.volume.Status.State = types.VolumeStateAttaching
 	tc.volume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.volume.Status.Conditions,
 		types.VolumeConditionTypeRestore, types.ConditionStatusTrue, types.VolumeConditionReasonRestoreInProgress, "")
 	for _, r := range tc.replicas {
@@ -575,7 +579,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for _, r := range tc.expectReplicas {
 		r.Spec.DesireState = types.InstanceStateRunning
 	}
-	testCases["new standby volume automatically attaching"] = tc
+	testCases["new standby volume keeps automatically attaching"] = tc
 
 	// New standby volume changed from attaching to attached, and it's not automatically detached
 	tc = generateVolumeTestCaseTemplate()


### PR DESCRIPTION
longhorn/longhorn#1355
longhorn/longhorn#1366

The modifications of this commit:
1. Automatically unset volume.Status.CurrentNodeID for the
   restoring/DR volumes on the down node.
   It means the restore/DR volumes will be detached once the node is
   down. Then Longhorn can reattach it and restart restoring later.
2. Set volume.Status.CurrentNodeID only if the volume is
   detached/newly created.
   This modification guarantees that the auto detachment mentioned
   above won't be intervened by this auto attachment logic, and the
   restore/DR volumes can be reattached after the node down and the
   auto detachment complete.
3. Fix a bug in the unit test: When restore already starts and the
   field `RestoreInitiated` is true, the volume current state should
   not be Detached.