### PR TITLE
types: Use checksum instead of full image name for the instance manager labels

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -103,7 +103,8 @@ const (
 	// DefaultStaleReplicaTimeout in minutes. 48h by default
 	DefaultStaleReplicaTimeout = "2880"
 
-	EngineImageChecksumNameLength = 8
+	EngineImageChecksumNameLength          = 8
+	InstanceManagerImageChecksumNameLength = 8
 )
 
 type NotFoundError struct {
@@ -127,7 +128,8 @@ const (
 	// 5. Dash and buffer for 2
 	MaximumJobNameSize = 8
 
-	engineImagePrefix = "ei-"
+	engineImagePrefix          = "ei-"
+	instanceManagerImagePrefix = "imi-"
 
 	instanceManagerPrefix = "instance-manager-"
 	engineManagerPrefix   = instanceManagerPrefix + "e-"
@@ -202,7 +204,7 @@ func GetInstanceManagerLabels(node, instanceManagerImage string, managerType Ins
 		labels[GetLonghornLabelKey(LonghornLabelNode)] = node
 	}
 	if instanceManagerImage != "" {
-		labels[GetLonghornLabelKey(LonghornLabelInstanceManagerImage)] = GetImageCanonicalName(instanceManagerImage)
+		labels[GetLonghornLabelKey(LonghornLabelInstanceManagerImage)] = GetInstanceManagerImageChecksumName(GetImageCanonicalName(instanceManagerImage))
 	}
 
 	return labels
@@ -243,6 +245,10 @@ func GetRegionAndZone(labels map[string]string, isUsingTopologyLabels bool) (str
 
 func GetEngineImageChecksumName(image string) string {
 	return engineImagePrefix + util.GetStringChecksum(strings.TrimSpace(image))[:EngineImageChecksumNameLength]
+}
+
+func GetInstanceManagerImageChecksumName(image string) string {
+	return instanceManagerImagePrefix + util.GetStringChecksum(strings.TrimSpace(image))[:InstanceManagerImageChecksumNameLength]
 }
 
 func ValidateEngineImageChecksumName(name string) bool {


### PR DESCRIPTION
Use checksum instead of full image name for the instance manager labels. Similar to how we make the engine image labels.

Issue: [1323](https://github.com/longhorn/longhorn/issues/1323)