### PR TITLE
Run Recurring Jobs via longhorn-manager API

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -96,5 +96,11 @@ func (s *Server) BackupDelete(w http.ResponseWriter, req *http.Request) error {
 		return errors.Wrapf(err, "error deleting backup %v of volume %v", input.Name, volName)
 	}
 	logrus.Debugf("Removed backup %v of volume %v", input.Name, volName)
+
+	bv, err := s.m.GetBackupVolume(volName)
+	if err != nil {
+		return errors.Wrapf(err, "error get backup volume '%s'", volName)
+	}
+	apiContext.Write(toBackupVolumeResource(bv, apiContext))
 	return nil
 }

--- a/api/model.go
+++ b/api/model.go
@@ -484,7 +484,9 @@ func volumeSchema(volume *client.Schema) {
 			Output: "volume",
 		},
 
-		"snapshotPurge": {},
+		"snapshotPurge": {
+			Output: "volume",
+		},
 		"snapshotCreate": {
 			Input:  "snapshotInput",
 			Output: "snapshot",
@@ -498,14 +500,15 @@ func volumeSchema(volume *client.Schema) {
 		},
 		"snapshotDelete": {
 			Input:  "snapshotInput",
-			Output: "snapshot",
+			Output: "volume",
 		},
 		"snapshotRevert": {
 			Input:  "snapshotInput",
 			Output: "snapshot",
 		},
 		"snapshotBackup": {
-			Input: "snapshotInput",
+			Input:  "snapshotInput",
+			Output: "volume",
 		},
 
 		"recurringUpdate": {

--- a/api/model.go
+++ b/api/model.go
@@ -301,7 +301,6 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("apiVersion", client.Resource{})
 	schemas.AddType("schema", client.Schema{})
 	schemas.AddType("error", client.ServerApiError{})
-	schemas.AddType("snapshot", Snapshot{})
 	schemas.AddType("attachInput", AttachInput{})
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("backup", Backup{})
@@ -342,6 +341,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("instanceProcess", types.InstanceProcess{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
+	snapshotSchema(schemas.AddType("snapshot", Snapshot{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))
 	settingSchema(schemas.AddType("setting", Setting{}))
 	recurringSchema(schemas.AddType("recurringInput", RecurringInput{}))
@@ -624,6 +624,12 @@ func volumeSchema(volume *client.Schema) {
 	rebuildStatus := volume.ResourceFields["rebuildStatus"]
 	rebuildStatus.Type = "array[rebuildStatus]"
 	volume.ResourceFields["rebuildStatus"] = rebuildStatus
+}
+
+func snapshotSchema(snapshot *client.Schema) {
+	children := snapshot.ResourceFields["children"]
+	children.Type = "map[bool]"
+	snapshot.ResourceFields["children"] = children
 }
 
 func backupListOutputSchema(backupList *client.Schema) {

--- a/api/model.go
+++ b/api/model.go
@@ -285,6 +285,16 @@ type InstanceManager struct {
 	Instances    map[string]types.InstanceProcess `json:"instances"`
 }
 
+type BackupListOutput struct {
+	Data []Backup `json:"data"`
+	Type string   `json:"type"`
+}
+
+type SnapshotListOutput struct {
+	Data []Snapshot `json:"data"`
+	Type string     `json:"type"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -340,6 +350,8 @@ func NewSchema() *client.Schemas {
 	diskSchema(schemas.AddType("diskUpdateInput", DiskUpdateInput{}))
 	diskInfoSchema(schemas.AddType("diskInfo", DiskInfo{}))
 	kubernetesStatusSchema(schemas.AddType("kubernetesStatus", types.KubernetesStatus{}))
+	backupListOutputSchema(schemas.AddType("backupListOutput", BackupListOutput{}))
+	snapshotListOutputSchema(schemas.AddType("snapshotListOutput", SnapshotListOutput{}))
 
 	return schemas
 }
@@ -411,7 +423,9 @@ func backupVolumeSchema(backupVolume *client.Schema) {
 	backupVolume.CollectionMethods = []string{"GET"}
 	backupVolume.ResourceMethods = []string{"GET", "DELETE"}
 	backupVolume.ResourceActions = map[string]client.Action{
-		"backupList": {},
+		"backupList": {
+			Output: "backupListOutput",
+		},
 		"backupGet": {
 			Input:  "backupInput",
 			Output: "backup",
@@ -479,7 +493,9 @@ func volumeSchema(volume *client.Schema) {
 			Input:  "snapshotInput",
 			Output: "snapshot",
 		},
-		"snapshotList": {},
+		"snapshotList": {
+			Output: "snapshotListOutput",
+		},
 		"snapshotDelete": {
 			Input:  "snapshotInput",
 			Output: "snapshot",
@@ -605,6 +621,18 @@ func volumeSchema(volume *client.Schema) {
 	rebuildStatus := volume.ResourceFields["rebuildStatus"]
 	rebuildStatus.Type = "array[rebuildStatus]"
 	volume.ResourceFields["rebuildStatus"] = rebuildStatus
+}
+
+func backupListOutputSchema(backupList *client.Schema) {
+	data := backupList.ResourceFields["data"]
+	data.Type = "array[backup]"
+	backupList.ResourceFields["data"] = data
+}
+
+func snapshotListOutputSchema(snapshotList *client.Schema) {
+	data := snapshotList.ResourceFields["data"]
+	data.Type = "array[snapshot]"
+	snapshotList.ResourceFields["data"] = data
 }
 
 func toSettingResource(setting *longhorn.Setting) *Setting {

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -106,7 +106,7 @@ func (s *Server) SnapshotDelete(w http.ResponseWriter, req *http.Request) (err e
 	if err := s.m.DeleteSnapshot(input.Name, volName); err != nil {
 		return err
 	}
-	return nil
+	return s.responseWithVolume(w, req, volName, nil)
 }
 
 func (s *Server) SnapshotRevert(w http.ResponseWriter, req *http.Request) (err error) {
@@ -183,7 +183,11 @@ func (s *Server) SnapshotBackup(w http.ResponseWriter, req *http.Request) (err e
 		labels[types.KubernetesStatusLabel] = string(kubeStatus)
 	}
 
-	return s.m.BackupSnapshot(input.Name, labels, volName)
+	if err := s.m.BackupSnapshot(input.Name, labels, volName); err != nil {
+		return err
+	}
+
+	return s.responseWithVolume(w, req, volName, nil)
 }
 
 func (s *Server) SnapshotPurge(w http.ResponseWriter, req *http.Request) (err error) {
@@ -192,6 +196,9 @@ func (s *Server) SnapshotPurge(w http.ResponseWriter, req *http.Request) (err er
 	}()
 
 	volName := mux.Vars(req)["name"]
+	if err := s.m.PurgeSnapshot(volName); err != nil {
+		return err
+	}
 
-	return s.m.PurgeSnapshot(volName)
+	return s.responseWithVolume(w, req, volName, nil)
 }

--- a/client/generated_backup_list_output.go
+++ b/client/generated_backup_list_output.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	BACKUP_LIST_OUTPUT_TYPE = "backupListOutput"
+)
+
+type BackupListOutput struct {
+	Resource `yaml:"-"`
+
+	Data []Backup `json:"data,omitempty" yaml:"data,omitempty"`
+}
+
+type BackupListOutputCollection struct {
+	Collection
+	Data   []BackupListOutput `json:"data,omitempty"`
+	client *BackupListOutputClient
+}
+
+type BackupListOutputClient struct {
+	rancherClient *RancherClient
+}
+
+type BackupListOutputOperations interface {
+	List(opts *ListOpts) (*BackupListOutputCollection, error)
+	Create(opts *BackupListOutput) (*BackupListOutput, error)
+	Update(existing *BackupListOutput, updates interface{}) (*BackupListOutput, error)
+	ById(id string) (*BackupListOutput, error)
+	Delete(container *BackupListOutput) error
+}
+
+func newBackupListOutputClient(rancherClient *RancherClient) *BackupListOutputClient {
+	return &BackupListOutputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *BackupListOutputClient) Create(container *BackupListOutput) (*BackupListOutput, error) {
+	resp := &BackupListOutput{}
+	err := c.rancherClient.doCreate(BACKUP_LIST_OUTPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *BackupListOutputClient) Update(existing *BackupListOutput, updates interface{}) (*BackupListOutput, error) {
+	resp := &BackupListOutput{}
+	err := c.rancherClient.doUpdate(BACKUP_LIST_OUTPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *BackupListOutputClient) List(opts *ListOpts) (*BackupListOutputCollection, error) {
+	resp := &BackupListOutputCollection{}
+	err := c.rancherClient.doList(BACKUP_LIST_OUTPUT_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *BackupListOutputCollection) Next() (*BackupListOutputCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &BackupListOutputCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *BackupListOutputClient) ById(id string) (*BackupListOutput, error) {
+	resp := &BackupListOutput{}
+	err := c.rancherClient.doById(BACKUP_LIST_OUTPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *BackupListOutputClient) Delete(container *BackupListOutput) error {
+	return c.rancherClient.doResourceDelete(BACKUP_LIST_OUTPUT_TYPE, &container.Resource)
+}

--- a/client/generated_backup_volume.go
+++ b/client/generated_backup_volume.go
@@ -46,6 +46,8 @@ type BackupVolumeOperations interface {
 	ActionBackupDelete(*BackupVolume, *BackupInput) (*BackupVolume, error)
 
 	ActionBackupGet(*BackupVolume, *BackupInput) (*Backup, error)
+
+	ActionBackupList(*BackupVolume) (*BackupListOutput, error)
 }
 
 func newBackupVolumeClient(rancherClient *RancherClient) *BackupVolumeClient {
@@ -112,6 +114,15 @@ func (c *BackupVolumeClient) ActionBackupGet(resource *BackupVolume, input *Back
 	resp := &Backup{}
 
 	err := c.rancherClient.doAction(BACKUP_VOLUME_TYPE, "backupGet", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *BackupVolumeClient) ActionBackupList(resource *BackupVolume) (*BackupListOutput, error) {
+
+	resp := &BackupListOutput{}
+
+	err := c.rancherClient.doAction(BACKUP_VOLUME_TYPE, "backupList", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -5,7 +5,6 @@ type RancherClient struct {
 
 	ApiVersion                ApiVersionOperations
 	Error                     ErrorOperations
-	Snapshot                  SnapshotOperations
 	AttachInput               AttachInputOperations
 	SnapshotInput             SnapshotInputOperations
 	Backup                    BackupOperations
@@ -35,7 +34,9 @@ type RancherClient struct {
 	SupportBundle             SupportBundleOperations
 	SupportBundleInitateInput SupportBundleInitateInputOperations
 	Tag                       TagOperations
+	InstanceManager           InstanceManagerOperations
 	Volume                    VolumeOperations
+	Snapshot                  SnapshotOperations
 	BackupVolume              BackupVolumeOperations
 	Setting                   SettingOperations
 	RecurringInput            RecurringInputOperations
@@ -44,6 +45,8 @@ type RancherClient struct {
 	DiskUpdateInput           DiskUpdateInputOperations
 	DiskInfo                  DiskInfoOperations
 	KubernetesStatus          KubernetesStatusOperations
+	BackupListOutput          BackupListOutputOperations
+	SnapshotListOutput        SnapshotListOutputOperations
 }
 
 func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
@@ -53,7 +56,6 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 
 	client.ApiVersion = newApiVersionClient(client)
 	client.Error = newErrorClient(client)
-	client.Snapshot = newSnapshotClient(client)
 	client.AttachInput = newAttachInputClient(client)
 	client.SnapshotInput = newSnapshotInputClient(client)
 	client.Backup = newBackupClient(client)
@@ -83,7 +85,9 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.SupportBundle = newSupportBundleClient(client)
 	client.SupportBundleInitateInput = newSupportBundleInitateInputClient(client)
 	client.Tag = newTagClient(client)
+	client.InstanceManager = newInstanceManagerClient(client)
 	client.Volume = newVolumeClient(client)
+	client.Snapshot = newSnapshotClient(client)
 	client.BackupVolume = newBackupVolumeClient(client)
 	client.Setting = newSettingClient(client)
 	client.RecurringInput = newRecurringInputClient(client)
@@ -92,6 +96,8 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.DiskUpdateInput = newDiskUpdateInputClient(client)
 	client.DiskInfo = newDiskInfoClient(client)
 	client.KubernetesStatus = newKubernetesStatusClient(client)
+	client.BackupListOutput = newBackupListOutputClient(client)
+	client.SnapshotListOutput = newSnapshotListOutputClient(client)
 
 	return client
 }

--- a/client/generated_instance_manager.go
+++ b/client/generated_instance_manager.go
@@ -1,0 +1,89 @@
+package client
+
+const (
+	INSTANCE_MANAGER_TYPE = "instanceManager"
+)
+
+type InstanceManager struct {
+	Resource `yaml:"-"`
+
+	CurrentState string `json:"currentState,omitempty" yaml:"current_state,omitempty"`
+
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	Instances map[string]string `json:"instances,omitempty" yaml:"instances,omitempty"`
+
+	ManagerType string `json:"managerType,omitempty" yaml:"manager_type,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	NodeID string `json:"nodeID,omitempty" yaml:"node_id,omitempty"`
+}
+
+type InstanceManagerCollection struct {
+	Collection
+	Data   []InstanceManager `json:"data,omitempty"`
+	client *InstanceManagerClient
+}
+
+type InstanceManagerClient struct {
+	rancherClient *RancherClient
+}
+
+type InstanceManagerOperations interface {
+	List(opts *ListOpts) (*InstanceManagerCollection, error)
+	Create(opts *InstanceManager) (*InstanceManager, error)
+	Update(existing *InstanceManager, updates interface{}) (*InstanceManager, error)
+	ById(id string) (*InstanceManager, error)
+	Delete(container *InstanceManager) error
+}
+
+func newInstanceManagerClient(rancherClient *RancherClient) *InstanceManagerClient {
+	return &InstanceManagerClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InstanceManagerClient) Create(container *InstanceManager) (*InstanceManager, error) {
+	resp := &InstanceManager{}
+	err := c.rancherClient.doCreate(INSTANCE_MANAGER_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InstanceManagerClient) Update(existing *InstanceManager, updates interface{}) (*InstanceManager, error) {
+	resp := &InstanceManager{}
+	err := c.rancherClient.doUpdate(INSTANCE_MANAGER_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InstanceManagerClient) List(opts *ListOpts) (*InstanceManagerCollection, error) {
+	resp := &InstanceManagerCollection{}
+	err := c.rancherClient.doList(INSTANCE_MANAGER_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *InstanceManagerCollection) Next() (*InstanceManagerCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &InstanceManagerCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *InstanceManagerClient) ById(id string) (*InstanceManager, error) {
+	resp := &InstanceManager{}
+	err := c.rancherClient.doById(INSTANCE_MANAGER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InstanceManagerClient) Delete(container *InstanceManager) error {
+	return c.rancherClient.doResourceDelete(INSTANCE_MANAGER_TYPE, &container.Resource)
+}

--- a/client/generated_setting_definition.go
+++ b/client/generated_setting_definition.go
@@ -15,6 +15,8 @@ type SettingDefinition struct {
 
 	DisplayName string `json:"displayName,omitempty" yaml:"display_name,omitempty"`
 
+	Options []string `json:"options,omitempty" yaml:"options,omitempty"`
+
 	ReadOnly bool `json:"readOnly,omitempty" yaml:"read_only,omitempty"`
 
 	Required bool `json:"required,omitempty" yaml:"required,omitempty"`

--- a/client/generated_snapshot.go
+++ b/client/generated_snapshot.go
@@ -7,7 +7,7 @@ const (
 type Snapshot struct {
 	Resource `yaml:"-"`
 
-	Children map[string]string `json:"children,omitempty" yaml:"children,omitempty"`
+	Children map[string]interface{} `json:"children,omitempty" yaml:"children,omitempty"`
 
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`
 

--- a/client/generated_snapshot_list_output.go
+++ b/client/generated_snapshot_list_output.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	SNAPSHOT_LIST_OUTPUT_TYPE = "snapshotListOutput"
+)
+
+type SnapshotListOutput struct {
+	Resource `yaml:"-"`
+
+	Data []Snapshot `json:"data,omitempty" yaml:"data,omitempty"`
+}
+
+type SnapshotListOutputCollection struct {
+	Collection
+	Data   []SnapshotListOutput `json:"data,omitempty"`
+	client *SnapshotListOutputClient
+}
+
+type SnapshotListOutputClient struct {
+	rancherClient *RancherClient
+}
+
+type SnapshotListOutputOperations interface {
+	List(opts *ListOpts) (*SnapshotListOutputCollection, error)
+	Create(opts *SnapshotListOutput) (*SnapshotListOutput, error)
+	Update(existing *SnapshotListOutput, updates interface{}) (*SnapshotListOutput, error)
+	ById(id string) (*SnapshotListOutput, error)
+	Delete(container *SnapshotListOutput) error
+}
+
+func newSnapshotListOutputClient(rancherClient *RancherClient) *SnapshotListOutputClient {
+	return &SnapshotListOutputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *SnapshotListOutputClient) Create(container *SnapshotListOutput) (*SnapshotListOutput, error) {
+	resp := &SnapshotListOutput{}
+	err := c.rancherClient.doCreate(SNAPSHOT_LIST_OUTPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *SnapshotListOutputClient) Update(existing *SnapshotListOutput, updates interface{}) (*SnapshotListOutput, error) {
+	resp := &SnapshotListOutput{}
+	err := c.rancherClient.doUpdate(SNAPSHOT_LIST_OUTPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *SnapshotListOutputClient) List(opts *ListOpts) (*SnapshotListOutputCollection, error) {
+	resp := &SnapshotListOutputCollection{}
+	err := c.rancherClient.doList(SNAPSHOT_LIST_OUTPUT_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *SnapshotListOutputCollection) Next() (*SnapshotListOutputCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &SnapshotListOutputCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *SnapshotListOutputClient) ById(id string) (*SnapshotListOutput, error) {
+	resp := &SnapshotListOutput{}
+	err := c.rancherClient.doById(SNAPSHOT_LIST_OUTPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *SnapshotListOutputClient) Delete(container *SnapshotListOutput) error {
+	return c.rancherClient.doResourceDelete(SNAPSHOT_LIST_OUTPUT_TYPE, &container.Resource)
+}

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -103,11 +103,17 @@ type VolumeOperations interface {
 
 	ActionSalvage(*Volume, *SalvageInput) (*Volume, error)
 
+	ActionSnapshotBackup(*Volume, *SnapshotInput) (*Volume, error)
+
 	ActionSnapshotCreate(*Volume, *SnapshotInput) (*Snapshot, error)
 
-	ActionSnapshotDelete(*Volume, *SnapshotInput) (*Snapshot, error)
+	ActionSnapshotDelete(*Volume, *SnapshotInput) (*Volume, error)
 
 	ActionSnapshotGet(*Volume, *SnapshotInput) (*Snapshot, error)
+
+	ActionSnapshotList(*Volume) (*SnapshotListOutput, error)
+
+	ActionSnapshotPurge(*Volume) (*Volume, error)
 
 	ActionSnapshotRevert(*Volume, *SnapshotInput) (*Snapshot, error)
 }
@@ -243,6 +249,15 @@ func (c *VolumeClient) ActionSalvage(resource *Volume, input *SalvageInput) (*Vo
 	return resp, err
 }
 
+func (c *VolumeClient) ActionSnapshotBackup(resource *Volume, input *SnapshotInput) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshotBackup", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
 func (c *VolumeClient) ActionSnapshotCreate(resource *Volume, input *SnapshotInput) (*Snapshot, error) {
 
 	resp := &Snapshot{}
@@ -252,9 +267,9 @@ func (c *VolumeClient) ActionSnapshotCreate(resource *Volume, input *SnapshotInp
 	return resp, err
 }
 
-func (c *VolumeClient) ActionSnapshotDelete(resource *Volume, input *SnapshotInput) (*Snapshot, error) {
+func (c *VolumeClient) ActionSnapshotDelete(resource *Volume, input *SnapshotInput) (*Volume, error) {
 
-	resp := &Snapshot{}
+	resp := &Volume{}
 
 	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshotDelete", &resource.Resource, input, resp)
 
@@ -266,6 +281,24 @@ func (c *VolumeClient) ActionSnapshotGet(resource *Volume, input *SnapshotInput)
 	resp := &Snapshot{}
 
 	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshotGet", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionSnapshotList(resource *Volume) (*SnapshotListOutput, error) {
+
+	resp := &SnapshotListOutput{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshotList", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VolumeClient) ActionSnapshotPurge(resource *Volume) (*Volume, error) {
+
+	resp := &Volume{}
+
+	err := c.rancherClient.doAction(VOLUME_TYPE, "snapshotPurge", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/types/types.go
+++ b/types/types.go
@@ -150,6 +150,10 @@ func GetAPIServerAddressFromIP(ip string) string {
 	return ip + ":" + strconv.Itoa(DefaultAPIPort)
 }
 
+func GetDefaultManagerURL() string {
+	return "http://longhorn-backend:" + strconv.Itoa(DefaultAPIPort) + "/v1"
+}
+
 func GetImageCanonicalName(image string) string {
 	return strings.Replace(strings.Replace(image, ":", "-", -1), "/", "-", -1)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -62,7 +62,7 @@ const (
 
 var (
 	cmdTimeout     = time.Minute // one minute by default
-	reservedLabels = []string{"KubernetesStatus", "RecurringJob", "ranchervm-base-image"}
+	reservedLabels = []string{"KubernetesStatus", "ranchervm-base-image"}
 
 	ConflictRetryInterval = 20 * time.Millisecond
 	ConflictRetryCounts   = 100


### PR DESCRIPTION
This PR refactors the logic responsible for running `Recurring Jobs` as per longhorn/longhorn#1406 such that instead of using the `Engine API` directly in order to make `Snapshot` and `Backup` calls, the `Recurring Job` calls the `longhorn-manager` in order to make requests instead. 

This means that the actual `Backup` or `Snapshot` calls will go through the same code that a user-created `Backup` or `Snapshot` would go through, and the `Backup` and `Snapshot` operations will be visible from the `longhorn-manager` log.