### PR TITLE
controller, deploy: change imagePullPolicy to IfNotPresent for Engine Image daemonset, Manager daemonset, UI deployment, Driver Deployer deployment

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -602,7 +602,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 							Image:           image,
 							Command:         cmd,
 							Args:            args,
-							ImagePullPolicy: v1.PullAlways,
+							ImagePullPolicy: v1.PullIfNotPresent,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "data",

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -523,7 +523,8 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 			PriorityClassName:  priorityClass.Value,
 			Containers: []v1.Container{
 				{
-					Image: im.Spec.Image,
+					Image:           im.Spec.Image,
+					ImagePullPolicy: v1.PullIfNotPresent,
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{
 							Exec: &v1.ExecAction{

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -283,7 +283,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 									Value: GetInContainerCSISocketFilePath(),
 								},
 							},
-							//ImagePullPolicy: v1.PullAlways,
+							ImagePullPolicy: v1.PullIfNotPresent,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "socket-dir",

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -78,10 +78,10 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 					PriorityClassName:  priorityClass,
 					Containers: []v1.Container{
 						{
-							Name:  commonName,
-							Image: image,
-							Args:  args,
-							//ImagePullPolicy: v1.PullAlways,
+							Name:            commonName,
+							Image:           image,
+							Args:            args,
+							ImagePullPolicy: v1.PullIfNotPresent,
 							Env: []v1.EnvVar{
 								{
 									Name:  "ADDRESS",

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: longhorn-manager
         image: longhornio/longhorn-manager:master
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         command:

--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: longhorn-ui
         image: longhornio/longhorn-ui:master
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
         ports:

--- a/deploy/install/02-components/04-driver.yaml
+++ b/deploy/install/02-components/04-driver.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: longhorn-driver-deployer
           image: longhornio/longhorn-manager:master
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command:
           - longhorn-manager
           - -d


### PR DESCRIPTION
We change the imagePullPolicy from Always to IfNotPresent so that users who do air-gap installation don't have to set up a registry to install Longhorn.
Also, provided a script for developers to quickly change it back to Always located inside `longhorn/dev/scripts` repo.

longhorn/longhorn#1491