### PR TITLE
Clean up Kubernetes resources on Volume deletion

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -283,6 +283,25 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 				}
 			}
 		}
+
+		kubeStatus := volume.Status.KubernetesStatus
+
+		if kubeStatus.PVName != "" {
+			if err := vc.ds.DeletePersisentVolume(kubeStatus.PVName); err != nil {
+				if !datastore.ErrorIsNotFound(err) {
+					return err
+				}
+			}
+		}
+
+		if kubeStatus.PVCName != "" && kubeStatus.LastPVCRefAt == "" {
+			if err := vc.ds.DeletePersisentVolumeClaim(kubeStatus.Namespace, kubeStatus.PVCName); err != nil {
+				if !datastore.ErrorIsNotFound(err) {
+					return err
+				}
+			}
+		}
+
 		// now replicas and engines have been marked for deletion
 
 		if engines, err := vc.ds.ListVolumeEngines(volume.Name); err != nil {


### PR DESCRIPTION
This PR adds logic to the `Volume Controller` that reads the `Kubernetes Status` as part of the `Volume` deletion process to check for `Kubernetes` resources to clean up. If the `Kubernetes Status` indicates the existence a `Persistent Volume` and possibly a `Persistent Volume Claim` associated with the `Volume`, those resources will be cleaned up as part of the deletion process as requested in longhorn/longhorn#520.