### PR TITLE
controller: Clean up the instance manager when the node is disconnected

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -316,6 +316,9 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 	// that the Node it belongs to went down, or its newly scheduled.
 	if im.Spec.NodeID != imc.controllerID {
 		im.Status.CurrentState = types.InstanceManagerStateUnknown
+		if err := imc.cleanupInstanceManager(im); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -323,6 +326,10 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 	if pod == nil {
 		if im.Status.CurrentState != types.InstanceManagerStateError {
 			im.Status.CurrentState = types.InstanceManagerStateStopped
+		}
+	} else if pod.DeletionTimestamp != nil {
+		if im.Status.CurrentState != types.InstanceManagerStateError {
+			im.Status.CurrentState = types.InstanceManagerStateError
 		}
 	} else {
 		// TODO: Will remove this reference kind correcting after all Longhorn components having used the new kinds
@@ -336,15 +343,7 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 
 		switch pod.Status.Phase {
 		case v1.PodPending:
-			if im.Status.CurrentState == types.InstanceManagerStateUnknown {
-				if len(pod.Status.ContainerStatuses) != 0 && pod.Status.ContainerStatuses[0].State.Terminated != nil {
-					im.Status.CurrentState = types.InstanceManagerStateError
-					logrus.Errorf("Instance Manager %v pod terminated. Details %+v. Set state to Error.", im.Name,
-						pod.Status.ContainerStatuses[0].State.Terminated)
-				} else {
-					im.Status.CurrentState = types.InstanceManagerStateStarting
-				}
-			} else if im.Status.CurrentState != types.InstanceManagerStateStarting {
+			if im.Status.CurrentState != types.InstanceManagerStateStarting {
 				im.Status.CurrentState = types.InstanceManagerStateError
 				logrus.Errorf("Instance Manager %v is state %v but the related pod is pending.", im.Name, im.Status.CurrentState)
 			}

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -188,7 +188,7 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 		"instance manager node down": {
 			TestNode2, true, TestNode1,
 			v1.PodRunning, TestNode1, types.InstanceManagerStateRunning,
-			TestNode2, 1,
+			TestNode2, 0,
 			types.InstanceManagerStatus{
 				OwnerID:       TestNode2,
 				CurrentState:  types.InstanceManagerStateUnknown,


### PR DESCRIPTION
Fix the 1st scenario in longhorn/longhorn#1545