### PR TITLE
datastore, types, util: add HTTP_PROXY, HTTPS_PROXY, and NO_PROXY fie…

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -211,6 +211,9 @@ func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]strin
 		credentialSecret[types.AWSSecretKey] = string(secret.Data[types.AWSSecretKey])
 		credentialSecret[types.AWSEndPoint] = string(secret.Data[types.AWSEndPoint])
 		credentialSecret[types.AWSCert] = string(secret.Data[types.AWSCert])
+		credentialSecret[types.HTTPSProxy] = string(secret.Data[types.HTTPSProxy])
+		credentialSecret[types.HTTPProxy] = string(secret.Data[types.HTTPProxy])
+		credentialSecret[types.NOProxy] = string(secret.Data[types.NOProxy])
 	}
 	return credentialSecret, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -92,6 +92,10 @@ const (
 	AWSEndPoint  = "AWS_ENDPOINTS"
 	AWSCert      = "AWS_CERT"
 
+	HTTPSProxy = "HTTPS_PROXY"
+	HTTPProxy  = "HTTP_PROXY"
+	NOProxy    = "NO_PROXY"
+
 	OptionFromBackup          = "fromBackup"
 	OptionNumberOfReplicas    = "numberOfReplicas"
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"

--- a/util/util.go
+++ b/util/util.go
@@ -48,6 +48,10 @@ const (
 	AWSEndPoint       = "AWS_ENDPOINTS"
 	AWSCert           = "AWS_CERT"
 
+	HTTPSProxy = "HTTPS_PROXY"
+	HTTPProxy  = "HTTP_PROXY"
+	NOProxy    = "NO_PROXY"
+
 	HostProcPath                 = "/host/proc"
 	ReplicaDirectory             = "/replicas/"
 	DeviceDirectory              = "/dev/longhorn/"
@@ -379,6 +383,9 @@ func ConfigBackupCredential(backupTarget string, credential map[string]string) e
 			os.Setenv(AWSSecretKey, credential[AWSSecretKey])
 			os.Setenv(AWSEndPoint, credential[AWSEndPoint])
 			os.Setenv(AWSCert, credential[AWSCert])
+			os.Setenv(HTTPSProxy, credential[HTTPSProxy])
+			os.Setenv(HTTPProxy, credential[HTTPProxy])
+			os.Setenv(NOProxy, credential[NOProxy])
 		} else if os.Getenv(AWSAccessKey) == "" || os.Getenv(AWSSecretKey) == "" {
 			return fmt.Errorf("Could not backup for %s without credential secret", backupType)
 		}


### PR DESCRIPTION
…ld to s3-secret. We use those information to setup http_proxy in Longhorn manager and engine

This fix is needed for users who are running a cluster behind a http_proxy and wish to use AWS S3 as the `backupstore`. First, we add 3 new fields in `s3-secret` (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY) to get the information about the http_proxy from user. Then we use the information to setup environment variables in Longhorn `manager` and `engine`. This will allow the `manager` and `engine` to send the outbound traffic to AWS S3 `backupstore` through the Http Proxy. 

longhorn/longhorn#1540