### PR TITLE
upgrade, upgrade/v100to101: do not update IM label if it is up to date, add retry logic when doing CRDs update

### DIFF
--- a/upgrade/v100to101/upgrade.go
+++ b/upgrade/v100to101/upgrade.go
@@ -92,7 +92,8 @@ func doInstanceManagerUpgrade(namespace string, lhClient *lhclientset.Clientset)
 	}
 
 	for _, im := range imList.Items {
-		if im.Spec.Image != "" {
+		newInstanceManagerLabels := types.GetInstanceManagerLabels(im.Spec.NodeID, im.Spec.Image, im.Spec.Type)
+		if im.Labels[types.LonghornLabelInstanceManagerImage] != newInstanceManagerLabels[types.LonghornLabelInstanceManagerImage] {
 			if err := upgradeInstanceManagersLabels(&im, lhClient, namespace); err != nil {
 				return err
 			}


### PR DESCRIPTION
1. To reduce the number of conflicts when doing CRDs upgrade, we do not update IM's label if it is up to date. This fix alone solves the issue.
2. Adding retry logic when doing CRDs update so that one API conflict does not block Longhorn upgrading. This fix alone also solves the issue.

We combine both of the above fixes to achieve fast (reduce the number of conflicts) and safe (adding retry logic).

longhorn/longhorn#1646