### PR TITLE
Set LeaderDurationSeconds on LeaderElectionRecord

### DIFF
--- a/patch/vendor-add-duration-seconds-to-election-record.patch
+++ b/patch/vendor-add-duration-seconds-to-election-record.patch
@@ -1,0 +1,33 @@
+From a7a87cf0cc127caa8811128b21640140711cf593 Mon Sep 17 00:00:00 2001
+From: Michael William Le Nguyen <michael@mail.ttp.codes>
+Date: Mon, 3 Aug 2020 15:04:11 -0700
+Subject: vendor: add duration seconds to election record
+
+This fixes the underlying cause of #1379 in client-go since this fix
+has yet to be merged upstream. This patch can be dropped on our end once
+one of these PRs gets merged into upstream:
+
+- kubernetes/kubernetes#88192
+- kubernetes/kubernetes#91942
+- kubernetes/kubernetes#91966
+
+Signed-off-by: Michael William Le Nguyen <michael@mail.ttp.codes>
+---
+ vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+index 02bdebd1..f8a3b81d 100644
+--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
++++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+@@ -276,6 +276,7 @@ func (le *LeaderElector) release() bool {
+ 		return true
+ 	}
+ 	leaderElectionRecord := rl.LeaderElectionRecord{
++		LeaseDurationSeconds: le.observedRecord.LeaseDurationSeconds,
+ 		LeaderTransitions: le.observedRecord.LeaderTransitions,
+ 	}
+ 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {
+-- 
+2.28.0
+

--- a/patch/vendor-fix-nil-pointer-for-Leader-Election-Record.patch
+++ b/patch/vendor-fix-nil-pointer-for-Leader-Election-Record.patch
@@ -1,0 +1,64 @@
+From 33357268774c2891c846bf68237e742bd5bb3f86 Mon Sep 17 00:00:00 2001
+From: Michael William Le Nguyen <michael@mail.ttp.codes>
+Date: Mon, 3 Aug 2020 15:05:09 -0700
+Subject: vendor: fix nil pointer for Leader Election Record
+
+This merges in a fix for the LeaseSpecToLeaderElectionRecord function
+which isn't available until Kubernetes v1.17 which helps prevent a nil
+pointer reference when LeaseDurationSeconds is set. This fix is based on
+the changes in this commit:
+
+kubernetes/kubernetes@7907b29551c7ef87bbe398ac02836b4c87246d3d
+
+This patch can be dropped once Longhorn Manager switches to using the
+Kubernetes v1.17 API, which contains this fix.
+
+Signed-off-by: Michael William Le Nguyen <michael@mail.ttp.codes>
+---
+ .../leaderelection/resourcelock/leaselock.go  | 23 +++++++++----------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+index 285f9440..75492fe6 100644
+--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
++++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+@@ -90,25 +90,24 @@ func (ll *LeaseLock) Identity() string {
+ }
+ 
+ func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
+-	holderIdentity := ""
++	var r LeaderElectionRecord
+ 	if spec.HolderIdentity != nil {
+-		holderIdentity = *spec.HolderIdentity
++		r.HolderIdentity = *spec.HolderIdentity
+ 	}
+-	leaseDurationSeconds := 0
+ 	if spec.LeaseDurationSeconds != nil {
+-		leaseDurationSeconds = int(*spec.LeaseDurationSeconds)
++		r.LeaseDurationSeconds = int(*spec.LeaseDurationSeconds)
+ 	}
+-	leaseTransitions := 0
+ 	if spec.LeaseTransitions != nil {
+-		leaseTransitions = int(*spec.LeaseTransitions)
++		r.LeaderTransitions = int(*spec.LeaseTransitions)
+ 	}
+-	return &LeaderElectionRecord{
+-		HolderIdentity:       holderIdentity,
+-		LeaseDurationSeconds: leaseDurationSeconds,
+-		AcquireTime:          metav1.Time{spec.AcquireTime.Time},
+-		RenewTime:            metav1.Time{spec.RenewTime.Time},
+-		LeaderTransitions:    leaseTransitions,
++	if spec.AcquireTime != nil {
++		r.AcquireTime = metav1.Time{spec.AcquireTime.Time}
+ 	}
++	if spec.RenewTime != nil {
++		r.RenewTime = metav1.Time{spec.RenewTime.Time}
++	}
++	return &r
++
+ }
+ 
+ func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.LeaseSpec {
+-- 
+2.28.0
+

--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -276,6 +276,7 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
+		LeaseDurationSeconds: le.observedRecord.LeaseDurationSeconds,
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -90,25 +90,24 @@ func (ll *LeaseLock) Identity() string {
 }
 
 func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
-	holderIdentity := ""
+	var r LeaderElectionRecord
 	if spec.HolderIdentity != nil {
-		holderIdentity = *spec.HolderIdentity
+		r.HolderIdentity = *spec.HolderIdentity
 	}
-	leaseDurationSeconds := 0
 	if spec.LeaseDurationSeconds != nil {
-		leaseDurationSeconds = int(*spec.LeaseDurationSeconds)
+		r.LeaseDurationSeconds = int(*spec.LeaseDurationSeconds)
 	}
-	leaseTransitions := 0
 	if spec.LeaseTransitions != nil {
-		leaseTransitions = int(*spec.LeaseTransitions)
+		r.LeaderTransitions = int(*spec.LeaseTransitions)
 	}
-	return &LeaderElectionRecord{
-		HolderIdentity:       holderIdentity,
-		LeaseDurationSeconds: leaseDurationSeconds,
-		AcquireTime:          metav1.Time{spec.AcquireTime.Time},
-		RenewTime:            metav1.Time{spec.RenewTime.Time},
-		LeaderTransitions:    leaseTransitions,
+	if spec.AcquireTime != nil {
+		r.AcquireTime = metav1.Time{spec.AcquireTime.Time}
 	}
+	if spec.RenewTime != nil {
+		r.RenewTime = metav1.Time{spec.RenewTime.Time}
+	}
+	return &r
+
 }
 
 func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.LeaseSpec {


### PR DESCRIPTION
This PR patches the `client-go` dependency in order to fix a bug in which the `LeaderDurationSeconds` is not properly set on the `LeaderElectionRecord` created in the `release()` function. This fixes the bug in longhorn/longhorn#1379 in which the `LeaderDurationSeconds` field is set to 0, leading to a failure to release the upgrade lock and delaying the upgrade process while the other Longhorn Managers wait for the lock to expire.

This PR contains an additional fix to the `LeaseSpecToLeaderElectionRecord()` function, which prevents a panic resulting from a nil pointer occurring when `LeaderDurationSeconds` is set, which is necessary for the above patch to work properly in the current version of the Kubernetes API we are using.

If the `vendor/` is overwritten, these patches can be applied again using `git am --signoff <name of patch file>`, with `vendor-add-duration-seconds-to-election-record.patch` containing the first fix and `vendor-fix-nil-pointer-for-Leader-Election-Record.patch` containing the second fix.

These patches should eventually be removed from the repository once the issues have been fixed upstream. The first patch does not have a timeline for removal, as upstream has yet to merge the PRs necessary to fix this issue:
- kubernetes/kubernetes#88192
- kubernetes/kubernetes#91942
- kubernetes/kubernetes#91966

The second patch can be removed once we upgrade to v1.17 of the Kubernetes API which contains the fix for the nil pointer issue. The code for this fix is contained in this commit: kubernetes/kubernetes@7907b29551c7ef87bbe398ac02836b4c87246d3d