### PR TITLE
Add Pod Security Policy to deploy

### DIFF
--- a/deploy/install/01-prerequisite/05-podsecuritypolicy.yaml
+++ b/deploy/install/01-prerequisite/05-podsecuritypolicy.yaml
@@ -1,0 +1,61 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: longhorn-psp
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+    - NET_RAW
+  allowedCapabilities:
+    - SYS_ADMIN
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - secret
+    - projected
+    - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-psp-role
+  namespace: longhorn-system
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - longhorn-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-psp-binding
+  namespace: longhorn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-psp-role
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-service-account
+    namespace: longhorn-system
+  - kind: ServiceAccount
+    name: default
+    namespace: longhorn-system


### PR DESCRIPTION
This PR adds an additional file to `deploy/` that creates the necessary resources for Longhorn to be deployed with Pod Security Policy. This file creates a Pod Security Policy with the necessary privileges for Longhorn to operate correctly, along with the necessary Role and Role Binding for Longhorn's Service Accounts to use this policy.

This PR is based off of the Pod Security Policy that is proposed in longhorn/longhorn#1634.