### PR TITLE
Fix the issue that engine image may be wrongly marked as incompatible

### DIFF
--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -186,6 +186,11 @@ func generateEngineImageControllerTestCases() map[string]*EngineImageControllerT
 	tc.copyCurrentToExpected()
 	tc.expectedEngineImage.Status.State = types.EngineImageStateDeploying
 	tc.expectedDaemonSet = nil
+	tc.expectedEngineImage.Status.Conditions[types.EngineImageConditionTypeReady] = types.Condition{
+		Type:   types.EngineImageConditionTypeReady,
+		Status: types.ConditionStatusFalse,
+		Reason: types.EngineImageConditionTypeReadyReasonDaemonSet,
+	}
 	testCases["DaemonSet with deprecated labels is found"] = tc
 
 	tc = getEngineImageControllerTestTemplate()


### PR DESCRIPTION
1. The sync function should error out if the version check command
execution fails.
2. Check the binary executability in the daemonset readiness probe.
3. Make sure the engine image state can be updated/corrected later
even if it is wrongly marked as incompatible.

longhorn/longhorn#1663