### PR TITLE
Consolidate for loops in switchActiveReplicas

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1790,14 +1790,8 @@ func (vc *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica
 	// delete the volume data on the disk.
 	// Set `active` at last to prevent data loss
 	for _, r := range rs {
-		if !activeCondFunc(r, obj) && r.Spec.Active != false {
-			r.Spec.Active = false
-			rs[r.Name] = r
-		}
-	}
-	for _, r := range rs {
-		if activeCondFunc(r, obj) && r.Spec.Active != true {
-			r.Spec.Active = true
+		if activeCondFunc(r, obj) != r.Spec.Active {
+			r.Spec.Active = activeCondFunc(r, obj)
 			rs[r.Name] = r
 		}
 	}


### PR DESCRIPTION
Seems reasonable to consolidate the two for loops.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>