### PR TITLE
Refactor to add support for instance based logging

### DIFF
--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -104,8 +104,11 @@ func uninstall(c *cli.Context) error {
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
 		kubeClient, namespace)
 
+	logger := logrus.StandardLogger()
+
 	doneCh := make(chan struct{})
 	ctrl := controller.NewUninstallController(
+		logger,
 		namespace,
 		c.Bool(FlagForce),
 		ds,

--- a/controller/base_controller.go
+++ b/controller/base_controller.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+type baseController struct {
+	name   string
+	logger logrus.FieldLogger
+	queue  workqueue.RateLimitingInterface
+}
+
+func newBaseController(name string, logger logrus.FieldLogger) *baseController {
+	return newBaseControllerWithQueue(name, logger,
+		workqueue.NewNamedRateLimitingQueue(EnhancedDefaultControllerRateLimiter(), name))
+}
+
+func newBaseControllerWithQueue(name string, logger logrus.FieldLogger,
+	queue workqueue.RateLimitingInterface) *baseController {
+	c := &baseController{
+		name:   name,
+		logger: logger.WithField("controller", name),
+		queue:  queue,
+	}
+
+	return c
+}

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -80,7 +80,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 	volumeAttachmentInformer := kubeInformerFactory.Storage().V1beta1().VolumeAttachments()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 
-	logger := logrus.StandardLogger()
+	logger := logrus.StandardLogger().WithField("node", controllerID)
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,

--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
+
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -73,7 +76,9 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
 		kubeClient, TestNamespace)
 
+	logger := logrus.StandardLogger()
 	ic := NewEngineImageController(
+		logger,
 		ds, scheme.Scheme,
 		engineImageInformer, volumeInformer, daemonSetInformer,
 		kubeClient, TestNamespace, TestNode1, TestServiceAccount)

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	. "gopkg.in/check.v1"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +20,8 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 	lhinformerfactory "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions"
+
+	. "gopkg.in/check.v1"
 )
 
 const (

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -145,7 +147,9 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
 		kubeClient, TestNamespace)
 
-	imc := NewInstanceManagerController(ds, scheme.Scheme, imInformer, podInformer, kubeClient, TestNamespace,
+	logger := logrus.StandardLogger()
+	imc := NewInstanceManagerController(logger,
+		ds, scheme.Scheme, imInformer, podInformer, kubeClient, TestNamespace,
 		controllerID, TestServiceAccount)
 	fakeRecorder := record.NewFakeRecorder(100)
 	imc.eventRecorder = fakeRecorder

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
+
 	apiv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -242,8 +245,11 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
 		kubeClient, TestNamespace)
 
-	kc := NewKubernetesPVController(ds, scheme.Scheme, volumeInformer, persistentVolumeInformer,
-		persistentVolumeClaimInformer, podInformer, volumeAttachmentInformer, kubeClient, TestNode1)
+	logger := logrus.StandardLogger()
+	kc := NewKubernetesPVController(logger,
+		ds, scheme.Scheme,
+		volumeInformer, persistentVolumeInformer, persistentVolumeClaimInformer, podInformer, volumeAttachmentInformer,
+		kubeClient, TestNode1)
 
 	fakeRecorder := record.NewFakeRecorder(100)
 	kc.eventRecorder = fakeRecorder

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -75,7 +77,11 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
 		kubeClient, TestNamespace)
 
-	nc := NewNodeController(ds, scheme.Scheme, nodeInformer, settingInformer, podInformer, replicaInformer, kubeNodeInformer, kubeClient, TestNamespace, controllerID)
+	logger := logrus.StandardLogger()
+	nc := NewNodeController(logger,
+		ds, scheme.Scheme,
+		nodeInformer, settingInformer, podInformer, replicaInformer, kubeNodeInformer,
+		kubeClient, TestNamespace, controllerID)
 	fakeRecorder := record.NewFakeRecorder(100)
 	nc.eventRecorder = fakeRecorder
 	nc.getDiskInfoHandler = fakeGetDiskInfo

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -101,7 +103,11 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 		kubeClient, TestNamespace)
 	initSettings(ds)
 
-	vc := NewVolumeController(ds, scheme.Scheme, volumeInformer, engineInformer, replicaInformer, kubeClient, TestNamespace, controllerID, TestServiceAccount, TestManagerImage)
+	logger := logrus.StandardLogger()
+	vc := NewVolumeController(logger,
+		ds, scheme.Scheme,
+		volumeInformer, engineInformer, replicaInformer,
+		kubeClient, TestNamespace, controllerID, TestServiceAccount, TestManagerImage)
 
 	fakeRecorder := record.NewFakeRecorder(100)
 	vc.eventRecorder = fakeRecorder

--- a/controller/websocket_controller.go
+++ b/controller/websocket_controller.go
@@ -32,6 +32,7 @@ func (w *Watcher) Close() {
 }
 
 type WebsocketController struct {
+	*baseController
 	volumeSynced      cache.InformerSynced
 	engineSynced      cache.InformerSynced
 	replicaSynced     cache.InformerSynced
@@ -44,6 +45,7 @@ type WebsocketController struct {
 }
 
 func NewWebsocketController(
+	logger logrus.FieldLogger,
 	volumeInformer lhinformers.VolumeInformer,
 	engineInformer lhinformers.EngineInformer,
 	replicaInformer lhinformers.ReplicaInformer,
@@ -53,6 +55,7 @@ func NewWebsocketController(
 ) *WebsocketController {
 
 	wc := &WebsocketController{
+		baseController:    newBaseController("longhorn-websocket", logger),
 		volumeSynced:      volumeInformer.Informer().HasSynced,
 		engineSynced:      engineInformer.Informer().HasSynced,
 		replicaSynced:     replicaInformer.Informer().HasSynced,


### PR DESCRIPTION
This adds a base controller that takes care of setting up the initial instance based logger so that we always have the controller name and node fields.

longhorn/longhorn#1724
longhorn/longhorn#1736