### PR TITLE
Make daemon support IPv6 adresses

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -154,7 +155,7 @@ func GetCronJobNameForVolumeAndJob(vName, job string) string {
 }
 
 func GetAPIServerAddressFromIP(ip string) string {
-	return ip + ":" + strconv.Itoa(DefaultAPIPort)
+	return net.JoinHostPort(ip, strconv.Itoa(DefaultAPIPort))
 }
 
 func GetDefaultManagerURL() string {


### PR DESCRIPTION
Actually the longhorn manager doesn't support well IPv6 adresses. For
example, in an IPv6-only k8s cluster we can see the following logs:

>  level=info msg="Listening on 2001:db8:caca:8273:187:4:ffff:4f5a:9500

which is missing brackets. The pod fails its readiness probe and never
becomes available.

PS: please excuse me for any fuckups. It's actually my first time writing a line in Go.
Cheers