### PR TITLE
Add role/cluster binding for nfs-provisioner

### DIFF
--- a/deploy/install/01-prerequisite/02-serviceaccount.yaml
+++ b/deploy/install/01-prerequisite/02-serviceaccount.yaml
@@ -56,3 +56,59 @@ subjects:
 - kind: ServiceAccount
   name: longhorn-service-account
   namespace: longhorn-system
+- kind: ServiceAccount
+  name: longhorn-nfs-provisioner
+  namespace: longhorn-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-nfs-provisioner
+  namespace: longhorn-system
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: longhorn-nfs-provisioner
+  namespace: longhorn-system
+  labels:
+    app: longhorn-nfs-provisioner
+spec:
+  # hardcode a cluster ip for the service
+  # so that on delete & recreate of the service the previous pv's still point
+  # to this nfs-provisioner, pick a new ip for each new nfs provisioner
+  clusterIP: 10.43.111.111
+  ports:
+    - name: nfs
+      port: 2049
+    - name: nfs-udp
+      port: 2049
+      protocol: UDP
+    - name: nlockmgr
+      port: 32803
+    - name: nlockmgr-udp
+      port: 32803
+      protocol: UDP
+    - name: mountd
+      port: 20048
+    - name: mountd-udp
+      port: 20048
+      protocol: UDP
+    - name: rquotad
+      port: 875
+    - name: rquotad-udp
+      port: 875
+      protocol: UDP
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+    - name: statd
+      port: 662
+    - name: statd-udp
+      port: 662
+      protocol: UDP
+  selector:
+    app: longhorn-nfs-provisioner
+---

--- a/deploy/install/01-prerequisite/05-podsecuritypolicy.yaml
+++ b/deploy/install/01-prerequisite/05-podsecuritypolicy.yaml
@@ -9,6 +9,8 @@ spec:
     - NET_RAW
   allowedCapabilities:
     - SYS_ADMIN
+    - DAC_READ_SEARCH
+    - SYS_RESOURCE
   hostNetwork: false
   hostIPC: false
   hostPID: true
@@ -27,6 +29,7 @@ spec:
     - secret
     - projected
     - hostPath
+    - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -42,6 +45,9 @@ rules:
       - use
     resourceNames:
       - longhorn-psp
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -58,4 +64,7 @@ subjects:
     namespace: longhorn-system
   - kind: ServiceAccount
     name: default
+    namespace: longhorn-system
+  - kind: ServiceAccount
+    name: longhorn-nfs-provisioner
     namespace: longhorn-system


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1606

I'm not sure about ```service``` ```longhorn-nfs-provisioner``` that it should be included here or not.

Signed-off-by: khushboo-rancher <60111667+khushboo-rancher@users.noreply.github.com>