### PR TITLE
Use default snapshot csi prefix

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -246,8 +246,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 		snapshotterImage,
 		rootDir,
 		[]string{
-			"-v=5",
-			"-snapshot-name-prefix=csi", // unfortunately the prefix cannot be null, so csi snapshots will look different then longhorn snapshots
+			"--v=5",
 			"--csi-address=$(ADDRESS)",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",


### PR DESCRIPTION
By default the csi snapshotter uses snapshot as a prefix, the prefix
cannot be removed only changed, so it's better to just stick with the
default prefix of `snapshot`

Longhorn #304

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>