### PR TITLE
Prometheus Support, Part 4

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1041,6 +1041,13 @@ func (s *DataStore) ListNodesRO() ([]*longhorn.Node, error) {
 	return s.nLister.Nodes(s.namespace).List(labels.Everything())
 }
 
+// ListKubeNodesRO returns a list of all Kubernetes Nodes for the given namespace,
+// the list contains direct references to the internal cache objects and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) ListKubeNodesRO() ([]*corev1.Node, error) {
+	return s.knLister.List(labels.Everything())
+}
+
 // ListPodsRO returns a list of all Pods for the given namespace,
 // the list contains direct references to the internal cache objects and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies

--- a/deploy/install/01-prerequisite/02-serviceaccount.yaml
+++ b/deploy/install/01-prerequisite/02-serviceaccount.yaml
@@ -47,7 +47,7 @@ rules:
   resources: ["leases"]
   verbs: ["*"]
 - apiGroups: ["metrics.k8s.io"]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/monitoring/instance_manager_collector.go
+++ b/monitoring/instance_manager_collector.go
@@ -94,16 +94,21 @@ func (imc *InstanceManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	var wg sync.WaitGroup
 
 	wg.Add(1)
-	go imc.collectActualUsage(ch, &wg)
+	go func() {
+		defer wg.Done()
+		imc.collectActualUsage(ch)
+	}()
 
 	wg.Add(1)
-	go imc.collectRequestValues(ch, &wg)
+	go func() {
+		defer wg.Done()
+		imc.collectRequestValues(ch)
+	}()
 
 	wg.Wait()
 }
 
-func (imc *InstanceManagerCollector) collectActualUsage(ch chan<- prometheus.Metric, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (imc *InstanceManagerCollector) collectActualUsage(ch chan<- prometheus.Metric) {
 	defer func() {
 		if err := recover(); err != nil {
 			imc.logger.WithField("error", err).Warn("panic during collecting metrics")
@@ -148,8 +153,7 @@ func getInstanceManagerTypeFromInstanceManagerName(imName string) string {
 	}
 }
 
-func (imc *InstanceManagerCollector) collectRequestValues(ch chan<- prometheus.Metric, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (imc *InstanceManagerCollector) collectRequestValues(ch chan<- prometheus.Metric) {
 	defer func() {
 		if err := recover(); err != nil {
 			imc.logger.WithField("error", err).Warn("panic during collecting metrics")

--- a/monitoring/node_collector.go
+++ b/monitoring/node_collector.go
@@ -2,31 +2,41 @@ package monitoring
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
-
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 )
 
 type NodeCollector struct {
 	*baseCollector
 
+	kubeMetricsClient *metricsclientset.Clientset
+
 	statusMetric             metricInfo
 	totalNumberOfNodesMetric metricInfo
+	cpuUsageMetric           metricInfo
+	cpuCapacityMetric        metricInfo
+	memoryUsageMetric        metricInfo
+	memoryCapacityMetric     metricInfo
 }
 
 func NewNodeCollector(
 	logger logrus.FieldLogger,
 	nodeID string,
-	ds *datastore.DataStore) *NodeCollector {
+	ds *datastore.DataStore,
+	kubeMetricsClient *metricsclientset.Clientset) *NodeCollector {
 
 	nc := &NodeCollector{
-		baseCollector: newBaseCollector(subsystemNode, logger, nodeID, ds),
+		baseCollector:     newBaseCollector(subsystemNode, logger, nodeID, ds),
+		kubeMetricsClient: kubeMetricsClient,
 	}
 
 	nc.statusMetric = metricInfo{
@@ -49,32 +59,100 @@ func NewNodeCollector(
 		Type: prometheus.GaugeValue,
 	}
 
+	nc.cpuUsageMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemNode, "cpu_usage_millicpu"),
+			"The cpu usage on this node",
+			[]string{nodeLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	nc.cpuCapacityMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemNode, "cpu_capacity_millicpu"),
+			"The maximum allocatable cpu on this node",
+			[]string{nodeLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	nc.memoryUsageMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemNode, "memory_usage_bytes"),
+			"The memory usage on this node",
+			[]string{nodeLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	nc.memoryCapacityMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemNode, "memory_capacity_bytes"),
+			"The maximum allocatable memory on this node",
+			[]string{nodeLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
 	return nc
 }
 
 func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.statusMetric.Desc
 	ch <- nc.totalNumberOfNodesMetric.Desc
+	ch <- nc.cpuUsageMetric.Desc
+	ch <- nc.cpuCapacityMetric.Desc
+	ch <- nc.memoryUsageMetric.Desc
+	ch <- nc.memoryCapacityMetric.Desc
 }
 
 func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
-	nodeList, err := nc.ds.ListNodesRO()
-	if err != nil {
-		nc.logger.WithError(err).Warn("error during scrape")
-		return
-	}
+	var wg sync.WaitGroup
 
-	nc.collectNodeStatus(ch, nodeList)
-	nc.collectTotalNumberOfNodes(ch, nodeList)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nc.collectNodeStatus(ch)
+	}()
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nc.collectTotalNumberOfNodes(ch)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nc.collectNodeActualCPUMemoryUsage(ch)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nc.collectNodeCPUMemoryCapacity(ch)
+	}()
+
+	wg.Wait()
 }
 
-func (nc *NodeCollector) collectNodeStatus(ch chan<- prometheus.Metric, nodeList []*longhorn.Node) {
+func (nc *NodeCollector) collectNodeStatus(ch chan<- prometheus.Metric) {
 	defer func() {
 		if err := recover(); err != nil {
 			nc.logger.WithField("error", err).Warn("panic during collecting metrics")
 		}
 	}()
+
+	nodeList, err := nc.ds.ListNodesRO()
+	if err != nil {
+		nc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
 
 	for _, node := range nodeList {
 		if node.Name != nc.currentNodeID {
@@ -98,12 +176,65 @@ func (nc *NodeCollector) collectNodeStatus(ch chan<- prometheus.Metric, nodeList
 	}
 }
 
-func (nc *NodeCollector) collectTotalNumberOfNodes(ch chan<- prometheus.Metric, nodeList []*longhorn.Node) {
+func (nc *NodeCollector) collectTotalNumberOfNodes(ch chan<- prometheus.Metric) {
 	defer func() {
 		if err := recover(); err != nil {
 			nc.logger.WithField("error", err).Warn("panic during collecting metrics")
 		}
 	}()
 
+	nodeList, err := nc.ds.ListNodesRO()
+	if err != nil {
+		nc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
+
 	ch <- prometheus.MustNewConstMetric(nc.totalNumberOfNodesMetric.Desc, nc.totalNumberOfNodesMetric.Type, float64(len(nodeList)))
+}
+
+func (nc *NodeCollector) collectNodeActualCPUMemoryUsage(ch chan<- prometheus.Metric) {
+	defer func() {
+		if err := recover(); err != nil {
+			nc.logger.WithField("error", err).Warn("panic during collecting metrics")
+		}
+	}()
+
+	nodeMetrics, err := nc.kubeMetricsClient.MetricsV1beta1().NodeMetricses().List(metav1.ListOptions{
+		FieldSelector: "metadata.name=" + nc.currentNodeID,
+	})
+	if err != nil {
+		nc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
+
+	for _, nm := range nodeMetrics.Items {
+		cpuUsageMilicpu := float64(nm.Usage.Cpu().MilliValue())
+		memoryUsageBytes := float64(nm.Usage.Memory().Value())
+		ch <- prometheus.MustNewConstMetric(nc.cpuUsageMetric.Desc, nc.cpuUsageMetric.Type, cpuUsageMilicpu, nc.currentNodeID)
+		ch <- prometheus.MustNewConstMetric(nc.memoryUsageMetric.Desc, nc.memoryUsageMetric.Type, memoryUsageBytes, nc.currentNodeID)
+	}
+}
+
+func (nc *NodeCollector) collectNodeCPUMemoryCapacity(ch chan<- prometheus.Metric) {
+	defer func() {
+		if err := recover(); err != nil {
+			nc.logger.WithField("error", err).Warn("panic during collecting metrics")
+		}
+	}()
+
+	kubeNodeList, err := nc.ds.ListKubeNodesRO()
+	if err != nil {
+		nc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
+
+	for _, node := range kubeNodeList {
+		if node.Name != nc.currentNodeID {
+			continue
+		}
+		cpuCapacityMilicpu := float64(node.Status.Allocatable.Cpu().MilliValue())
+		memoryCapacityBytes := float64(node.Status.Allocatable.Memory().Value())
+		ch <- prometheus.MustNewConstMetric(nc.cpuCapacityMetric.Desc, nc.cpuCapacityMetric.Type, cpuCapacityMilicpu, nc.currentNodeID)
+		ch <- prometheus.MustNewConstMetric(nc.memoryCapacityMetric.Desc, nc.memoryCapacityMetric.Type, memoryCapacityBytes, nc.currentNodeID)
+	}
 }

--- a/monitoring/volume_collector.go
+++ b/monitoring/volume_collector.go
@@ -41,8 +41,8 @@ func NewVolumeCollector(
 
 	vc.sizeMetric = metricInfo{
 		Desc: prometheus.NewDesc(
-			prometheus.BuildFQName(longhornName, subsystemVolume, "usage_bytes"),
-			"Used storage space in bytes for this volume",
+			prometheus.BuildFQName(longhornName, subsystemVolume, "actual_size_bytes"),
+			"Actual space used by each replica of the volume on the corresponding node",
 			[]string{nodeLabel, volumeLabel},
 			nil,
 		),


### PR DESCRIPTION
Added the following metrics:
1. longhorn_node_cpu_capacity_millicpu
2. longhorn_node_cpu_usage_millicpu
3. longhorn_node_memory_capacity_bytes
4. longhorn_node_memory_usage_bytes

We use the above metrics to detect when there is cpu/memory high pressure on worker nodes. This will help when debugging cases such as engines die unexpectedly due to cpu pressure. 

Also, change the metric name `longhorn_volume_usage_bytes` to `longhorn_volume_actual_size_bytes` to avoid the confusion between the size of the filesystem (usage_bytes) vs used space by Longhorn block device (actual size)

longhorn/longhorn#1180