### PR TITLE
app, controller: allow recurring backup for detached volumes

### DIFF
--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -7,6 +7,7 @@ data:
   default-setting.yaml: |-
     backup-target:
     backup-target-credential-secret:
+    allow-recurring-job-while-volume-detached:
     create-default-disk-labeled-nodes:
     default-data-path:
     replica-soft-anti-affinity:

--- a/types/setting.go
+++ b/types/setting.go
@@ -37,39 +37,41 @@ const (
 type SettingName string
 
 const (
-	SettingNameBackupTarget                      = SettingName("backup-target")
-	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
-	SettingNameCreateDefaultDiskLabeledNodes     = SettingName("create-default-disk-labeled-nodes")
-	SettingNameDefaultDataPath                   = SettingName("default-data-path")
-	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
-	SettingNameDefaultInstanceManagerImage       = SettingName("default-instance-manager-image")
-	SettingNameReplicaSoftAntiAffinity           = SettingName("replica-soft-anti-affinity")
-	SettingNameStorageOverProvisioningPercentage = SettingName("storage-over-provisioning-percentage")
-	SettingNameStorageMinimalAvailablePercentage = SettingName("storage-minimal-available-percentage")
-	SettingNameUpgradeChecker                    = SettingName("upgrade-checker")
-	SettingNameLatestLonghornVersion             = SettingName("latest-longhorn-version")
-	SettingNameDefaultReplicaCount               = SettingName("default-replica-count")
-	SettingNameDefaultDataLocality               = SettingName("default-data-locality")
-	SettingNameGuaranteedEngineCPU               = SettingName("guaranteed-engine-cpu")
-	SettingNameDefaultLonghornStaticStorageClass = SettingName("default-longhorn-static-storage-class")
-	SettingNameBackupstorePollInterval           = SettingName("backupstore-poll-interval")
-	SettingNameTaintToleration                   = SettingName("taint-toleration")
-	SettingNameCRDAPIVersion                     = SettingName("crd-api-version")
-	SettingNameAutoSalvage                       = SettingName("auto-salvage")
-	SettingNameRegistrySecret                    = SettingName("registry-secret")
-	SettingNameDisableSchedulingOnCordonedNode   = SettingName("disable-scheduling-on-cordoned-node")
-	SettingNameReplicaZoneSoftAntiAffinity       = SettingName("replica-zone-soft-anti-affinity")
-	SettingNameVolumeAttachmentRecoveryPolicy    = SettingName("volume-attachment-recovery-policy")
-	SettingNameNodeDownPodDeletionPolicy         = SettingName("node-down-pod-deletion-policy")
-	SettingNameMkfsExt4Parameters                = SettingName("mkfs-ext4-parameters")
-	SettingNamePriorityClass                     = SettingName("priority-class")
-	SettingNameDisableRevisionCounter            = SettingName("disable-revision-counter")
+	SettingNameBackupTarget                         = SettingName("backup-target")
+	SettingNameBackupTargetCredentialSecret         = SettingName("backup-target-credential-secret")
+	SettingNameAllowRecurringJobWhileVolumeDetached = SettingName("allow-recurring-job-while-volume-detached")
+	SettingNameCreateDefaultDiskLabeledNodes        = SettingName("create-default-disk-labeled-nodes")
+	SettingNameDefaultDataPath                      = SettingName("default-data-path")
+	SettingNameDefaultEngineImage                   = SettingName("default-engine-image")
+	SettingNameDefaultInstanceManagerImage          = SettingName("default-instance-manager-image")
+	SettingNameReplicaSoftAntiAffinity              = SettingName("replica-soft-anti-affinity")
+	SettingNameStorageOverProvisioningPercentage    = SettingName("storage-over-provisioning-percentage")
+	SettingNameStorageMinimalAvailablePercentage    = SettingName("storage-minimal-available-percentage")
+	SettingNameUpgradeChecker                       = SettingName("upgrade-checker")
+	SettingNameLatestLonghornVersion                = SettingName("latest-longhorn-version")
+	SettingNameDefaultReplicaCount                  = SettingName("default-replica-count")
+	SettingNameDefaultDataLocality                  = SettingName("default-data-locality")
+	SettingNameGuaranteedEngineCPU                  = SettingName("guaranteed-engine-cpu")
+	SettingNameDefaultLonghornStaticStorageClass    = SettingName("default-longhorn-static-storage-class")
+	SettingNameBackupstorePollInterval              = SettingName("backupstore-poll-interval")
+	SettingNameTaintToleration                      = SettingName("taint-toleration")
+	SettingNameCRDAPIVersion                        = SettingName("crd-api-version")
+	SettingNameAutoSalvage                          = SettingName("auto-salvage")
+	SettingNameRegistrySecret                       = SettingName("registry-secret")
+	SettingNameDisableSchedulingOnCordonedNode      = SettingName("disable-scheduling-on-cordoned-node")
+	SettingNameReplicaZoneSoftAntiAffinity          = SettingName("replica-zone-soft-anti-affinity")
+	SettingNameVolumeAttachmentRecoveryPolicy       = SettingName("volume-attachment-recovery-policy")
+	SettingNameNodeDownPodDeletionPolicy            = SettingName("node-down-pod-deletion-policy")
+	SettingNameMkfsExt4Parameters                   = SettingName("mkfs-ext4-parameters")
+	SettingNamePriorityClass                        = SettingName("priority-class")
+	SettingNameDisableRevisionCounter               = SettingName("disable-revision-counter")
 )
 
 var (
 	SettingNameList = []SettingName{
 		SettingNameBackupTarget,
 		SettingNameBackupTargetCredentialSecret,
+		SettingNameAllowRecurringJobWhileVolumeDetached,
 		SettingNameCreateDefaultDiskLabeledNodes,
 		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
@@ -120,33 +122,34 @@ type SettingDefinition struct {
 
 var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
-		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
-		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
-		SettingNameCreateDefaultDiskLabeledNodes:     SettingDefinitionCreateDefaultDiskLabeledNodes,
-		SettingNameDefaultDataPath:                   SettingDefinitionDefaultDataPath,
-		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
-		SettingNameDefaultInstanceManagerImage:       SettingDefinitionDefaultInstanceManagerImage,
-		SettingNameReplicaSoftAntiAffinity:           SettingDefinitionReplicaSoftAntiAffinity,
-		SettingNameStorageOverProvisioningPercentage: SettingDefinitionStorageOverProvisioningPercentage,
-		SettingNameStorageMinimalAvailablePercentage: SettingDefinitionStorageMinimalAvailablePercentage,
-		SettingNameUpgradeChecker:                    SettingDefinitionUpgradeChecker,
-		SettingNameLatestLonghornVersion:             SettingDefinitionLatestLonghornVersion,
-		SettingNameDefaultReplicaCount:               SettingDefinitionDefaultReplicaCount,
-		SettingNameDefaultDataLocality:               SettingDefinitionDefaultDataLocality,
-		SettingNameGuaranteedEngineCPU:               SettingDefinitionGuaranteedEngineCPU,
-		SettingNameDefaultLonghornStaticStorageClass: SettingDefinitionDefaultLonghornStaticStorageClass,
-		SettingNameBackupstorePollInterval:           SettingDefinitionBackupstorePollInterval,
-		SettingNameTaintToleration:                   SettingDefinitionTaintToleration,
-		SettingNameCRDAPIVersion:                     SettingDefinitionCRDAPIVersion,
-		SettingNameAutoSalvage:                       SettingDefinitionAutoSalvage,
-		SettingNameRegistrySecret:                    SettingDefinitionRegistrySecret,
-		SettingNameDisableSchedulingOnCordonedNode:   SettingDefinitionDisableSchedulingOnCordonedNode,
-		SettingNameReplicaZoneSoftAntiAffinity:       SettingDefinitionReplicaZoneSoftAntiAffinity,
-		SettingNameVolumeAttachmentRecoveryPolicy:    SettingDefinitionVolumeAttachmentRecoveryPolicy,
-		SettingNameNodeDownPodDeletionPolicy:         SettingDefinitionNodeDownPodDeletionPolicy,
-		SettingNameMkfsExt4Parameters:                SettingDefinitionMkfsExt4Parameters,
-		SettingNamePriorityClass:                     SettingDefinitionPriorityClass,
-		SettingNameDisableRevisionCounter:            SettingDefinitionDisableRevisionCounter,
+		SettingNameBackupTarget:                         SettingDefinitionBackupTarget,
+		SettingNameBackupTargetCredentialSecret:         SettingDefinitionBackupTargetCredentialSecret,
+		SettingNameAllowRecurringJobWhileVolumeDetached: SettingDefinitionAllowRecurringJobWhileVolumeDetached,
+		SettingNameCreateDefaultDiskLabeledNodes:        SettingDefinitionCreateDefaultDiskLabeledNodes,
+		SettingNameDefaultDataPath:                      SettingDefinitionDefaultDataPath,
+		SettingNameDefaultEngineImage:                   SettingDefinitionDefaultEngineImage,
+		SettingNameDefaultInstanceManagerImage:          SettingDefinitionDefaultInstanceManagerImage,
+		SettingNameReplicaSoftAntiAffinity:              SettingDefinitionReplicaSoftAntiAffinity,
+		SettingNameStorageOverProvisioningPercentage:    SettingDefinitionStorageOverProvisioningPercentage,
+		SettingNameStorageMinimalAvailablePercentage:    SettingDefinitionStorageMinimalAvailablePercentage,
+		SettingNameUpgradeChecker:                       SettingDefinitionUpgradeChecker,
+		SettingNameLatestLonghornVersion:                SettingDefinitionLatestLonghornVersion,
+		SettingNameDefaultReplicaCount:                  SettingDefinitionDefaultReplicaCount,
+		SettingNameDefaultDataLocality:                  SettingDefinitionDefaultDataLocality,
+		SettingNameGuaranteedEngineCPU:                  SettingDefinitionGuaranteedEngineCPU,
+		SettingNameDefaultLonghornStaticStorageClass:    SettingDefinitionDefaultLonghornStaticStorageClass,
+		SettingNameBackupstorePollInterval:              SettingDefinitionBackupstorePollInterval,
+		SettingNameTaintToleration:                      SettingDefinitionTaintToleration,
+		SettingNameCRDAPIVersion:                        SettingDefinitionCRDAPIVersion,
+		SettingNameAutoSalvage:                          SettingDefinitionAutoSalvage,
+		SettingNameRegistrySecret:                       SettingDefinitionRegistrySecret,
+		SettingNameDisableSchedulingOnCordonedNode:      SettingDefinitionDisableSchedulingOnCordonedNode,
+		SettingNameReplicaZoneSoftAntiAffinity:          SettingDefinitionReplicaZoneSoftAntiAffinity,
+		SettingNameVolumeAttachmentRecoveryPolicy:       SettingDefinitionVolumeAttachmentRecoveryPolicy,
+		SettingNameNodeDownPodDeletionPolicy:            SettingDefinitionNodeDownPodDeletionPolicy,
+		SettingNameMkfsExt4Parameters:                   SettingDefinitionMkfsExt4Parameters,
+		SettingNamePriorityClass:                        SettingDefinitionPriorityClass,
+		SettingNameDisableRevisionCounter:               SettingDefinitionDisableRevisionCounter,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -165,6 +168,18 @@ var (
 		Type:        SettingTypeString,
 		Required:    false,
 		ReadOnly:    false,
+	}
+
+	SettingDefinitionAllowRecurringJobWhileVolumeDetached = SettingDefinition{
+		DisplayName: "Allow Recurring Job While Volume Is Detached",
+		Description: "If this setting is enabled, Longhorn will automatically attaches the volume and takes snapshot/backup when it is the time to do recurring snapshot/backup. \n\n" +
+			"Note that during the time the volume was attached automatically, the volume is not ready for workload. " +
+			"Workload will have to wait until the recurring job finishes.",
+		Category: SettingCategoryBackup,
+		Type:     SettingTypeBool,
+		Required: true,
+		ReadOnly: false,
+		Default:  "false",
 	}
 
 	SettingDefinitionBackupstorePollInterval = SettingDefinition{
@@ -472,6 +487,8 @@ func ValidateInitSetting(name, value string) (err error) {
 			return fmt.Errorf("value %s, contains %v", value, strings.Join(findStr, " or "))
 		}
 	case SettingNameCreateDefaultDiskLabeledNodes:
+		fallthrough
+	case SettingNameAllowRecurringJobWhileVolumeDetached:
 		fallthrough
 	case SettingNameReplicaSoftAntiAffinity:
 		fallthrough


### PR DESCRIPTION
In the current Longhorn implementation, users cannot do recurring backup when volumes are detached. 
This PR gives the users an option to do recurring backup even when volumes are detached.

The design overview is documented at the PR https://github.com/longhorn/longhorn/pull/1851

longhorn/longhorn#1509