### PR TITLE
Add missed informers for the uninstaller

### DIFF
--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -94,6 +94,7 @@ func uninstall(c *cli.Context) error {
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -102,6 +103,7 @@ func uninstall(c *cli.Context) error {
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, namespace)
 
 	logger := logrus.StandardLogger()
@@ -121,6 +123,8 @@ func uninstall(c *cli.Context) error {
 		nodeInformer,
 		imInformer,
 		daemonSetInformer,
+		deploymentInformer,
+		csiDriverInformer,
 	)
 	go lhInformerFactory.Start(doneCh)
 	go kubeInformerFactory.Start(doneCh)

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -79,6 +79,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	volumeAttachmentInformer := kubeInformerFactory.Storage().V1beta1().VolumeAttachments()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -87,6 +88,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, namespace)
 	rc := NewReplicaController(logger, ds, scheme,
 		nodeInformer, replicaInformer, imInformer,

--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -63,6 +63,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	// Skip the Lister check that occurs on creation of an Instance Manager.
 	datastore.SkipListerCheck = true
@@ -74,6 +75,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 
 	logger := logrus.StandardLogger()

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -432,6 +432,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -440,6 +441,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 	fakeRecorder := record.NewFakeRecorder(100)
 

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -137,6 +137,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -145,6 +146,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 
 	logger := logrus.StandardLogger()

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -235,6 +235,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 	volumeAttachmentInformer := kubeInformerFactory.Storage().V1beta1().VolumeAttachments()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -243,6 +244,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 
 	logger := logrus.StandardLogger()

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -67,6 +67,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -75,6 +76,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 
 	logger := logrus.StandardLogger()

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -92,6 +92,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -100,6 +101,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 	initSettings(ds)
 

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -6,11 +6,13 @@ import (
 	batchinformers_v1beta1 "k8s.io/client-go/informers/batch/v1beta1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	schedulinginformers "k8s.io/client-go/informers/scheduling/v1"
+	storageinformers "k8s.io/client-go/informers/storage/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	batchlisters_v1beta1 "k8s.io/client-go/listers/batch/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	schedulinglisters "k8s.io/client-go/listers/scheduling/v1"
+	storagelisters "k8s.io/client-go/listers/storage/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
 
@@ -44,23 +46,25 @@ type DataStore struct {
 	imLister      lhlisters.InstanceManagerLister
 	imStoreSynced cache.InformerSynced
 
-	kubeClient     clientset.Interface
-	pLister        corelisters.PodLister
-	pStoreSynced   cache.InformerSynced
-	cjLister       batchlisters_v1beta1.CronJobLister
-	cjStoreSynced  cache.InformerSynced
-	dsLister       appslisters.DaemonSetLister
-	dsStoreSynced  cache.InformerSynced
-	dpLister       appslisters.DeploymentLister
-	dpStoreSynced  cache.InformerSynced
-	pvLister       corelisters.PersistentVolumeLister
-	pvStoreSynced  cache.InformerSynced
-	pvcLister      corelisters.PersistentVolumeClaimLister
-	pvcStoreSynced cache.InformerSynced
-	knLister       corelisters.NodeLister
-	knStoreSynced  cache.InformerSynced
-	pcLister       schedulinglisters.PriorityClassLister
-	pcStoreSynced  cache.InformerSynced
+	kubeClient      clientset.Interface
+	pLister         corelisters.PodLister
+	pStoreSynced    cache.InformerSynced
+	cjLister        batchlisters_v1beta1.CronJobLister
+	cjStoreSynced   cache.InformerSynced
+	dsLister        appslisters.DaemonSetLister
+	dsStoreSynced   cache.InformerSynced
+	dpLister        appslisters.DeploymentLister
+	dpStoreSynced   cache.InformerSynced
+	pvLister        corelisters.PersistentVolumeLister
+	pvStoreSynced   cache.InformerSynced
+	pvcLister       corelisters.PersistentVolumeClaimLister
+	pvcStoreSynced  cache.InformerSynced
+	knLister        corelisters.NodeLister
+	knStoreSynced   cache.InformerSynced
+	pcLister        schedulinglisters.PriorityClassLister
+	pcStoreSynced   cache.InformerSynced
+	csiDriverLister storagelisters.CSIDriverLister
+	csiDriverSynced cache.InformerSynced
 }
 
 // NewDataStore creates new DataStore object
@@ -82,6 +86,7 @@ func NewDataStore(
 	persistentVolumeClaimInformer coreinformers.PersistentVolumeClaimInformer,
 	kubeNodeInformer coreinformers.NodeInformer,
 	priorityClassInformer schedulinginformers.PriorityClassInformer,
+	csiDriverInformer storageinformers.CSIDriverInformer,
 
 	kubeClient clientset.Interface,
 	namespace string) *DataStore {
@@ -105,23 +110,25 @@ func NewDataStore(
 		imLister:      imInformer.Lister(),
 		imStoreSynced: imInformer.Informer().HasSynced,
 
-		kubeClient:     kubeClient,
-		pLister:        podInformer.Lister(),
-		pStoreSynced:   podInformer.Informer().HasSynced,
-		cjLister:       cronJobInformer.Lister(),
-		cjStoreSynced:  cronJobInformer.Informer().HasSynced,
-		dsLister:       daemonSetInformer.Lister(),
-		dsStoreSynced:  daemonSetInformer.Informer().HasSynced,
-		dpLister:       deploymentInformer.Lister(),
-		dpStoreSynced:  deploymentInformer.Informer().HasSynced,
-		pvLister:       persistentVolumeInformer.Lister(),
-		pvStoreSynced:  persistentVolumeInformer.Informer().HasSynced,
-		pvcLister:      persistentVolumeClaimInformer.Lister(),
-		pvcStoreSynced: persistentVolumeClaimInformer.Informer().HasSynced,
-		knLister:       kubeNodeInformer.Lister(),
-		knStoreSynced:  kubeNodeInformer.Informer().HasSynced,
-		pcLister:       priorityClassInformer.Lister(),
-		pcStoreSynced:  priorityClassInformer.Informer().HasSynced,
+		kubeClient:      kubeClient,
+		pLister:         podInformer.Lister(),
+		pStoreSynced:    podInformer.Informer().HasSynced,
+		cjLister:        cronJobInformer.Lister(),
+		cjStoreSynced:   cronJobInformer.Informer().HasSynced,
+		dsLister:        daemonSetInformer.Lister(),
+		dsStoreSynced:   daemonSetInformer.Informer().HasSynced,
+		dpLister:        deploymentInformer.Lister(),
+		dpStoreSynced:   deploymentInformer.Informer().HasSynced,
+		pvLister:        persistentVolumeInformer.Lister(),
+		pvStoreSynced:   persistentVolumeInformer.Informer().HasSynced,
+		pvcLister:       persistentVolumeClaimInformer.Lister(),
+		pvcStoreSynced:  persistentVolumeClaimInformer.Informer().HasSynced,
+		knLister:        kubeNodeInformer.Lister(),
+		knStoreSynced:   kubeNodeInformer.Informer().HasSynced,
+		pcLister:        priorityClassInformer.Lister(),
+		pcStoreSynced:   priorityClassInformer.Informer().HasSynced,
+		csiDriverLister: csiDriverInformer.Lister(),
+		csiDriverSynced: csiDriverInformer.Informer().HasSynced,
 	}
 }
 
@@ -132,7 +139,7 @@ func (s *DataStore) Sync(stopCh <-chan struct{}) bool {
 		s.iStoreSynced, s.nStoreSynced, s.sStoreSynced,
 		s.pStoreSynced, s.cjStoreSynced, s.dsStoreSynced,
 		s.pvStoreSynced, s.pvcStoreSynced, s.imStoreSynced,
-		s.dpStoreSynced, s.knStoreSynced, s.pcStoreSynced)
+		s.dpStoreSynced, s.knStoreSynced, s.pcStoreSynced, s.csiDriverSynced)
 }
 
 // ErrorIsNotFound checks if given error match

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -69,6 +69,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
+	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 
 	ds := datastore.NewDataStore(
 		volumeInformer, engineInformer, replicaInformer,
@@ -77,6 +78,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer,
 		persistentVolumeClaimInformer, kubeNodeInformer, priorityClassInformer,
+		csiDriverInformer,
 		kubeClient, TestNamespace)
 
 	return NewReplicaScheduler(ds)


### PR DESCRIPTION
Sometimes the CSIDriver object or deployments are not cleaned up immediately after the deletion timestamps are set, there is no way to trigger the uninstaller. Then the uninstallation will get stuck.

The root cause of this case is different from the 1st case mentioned in https://github.com/longhorn/longhorn/issues/1820