### PR TITLE
allow `kubectl drain` without the --force flag

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1265,12 +1265,16 @@ func (s *DataStore) ListEnginesByNode(name string) ([]*longhorn.Engine, error) {
 // GetOwnerReferencesForInstanceManager returns OwnerReference for the given
 // instance Manager name and UID
 func GetOwnerReferencesForInstanceManager(im *longhorn.InstanceManager) []metav1.OwnerReference {
+	controller := true
 	return []metav1.OwnerReference{
 		{
 			APIVersion: longhorn.SchemeGroupVersion.String(),
 			Kind:       types.LonghornKindInstanceManager,
 			Name:       im.Name,
 			UID:        im.UID,
+			// This field is needed so that `kubectl drain` can work without --force flag
+			// See https://github.com/longhorn/longhorn/issues/1286#issuecomment-623283028 for more details
+			Controller: &controller,
 		},
 	}
 }

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/upgrade/v070to080"
 	"github.com/longhorn/longhorn-manager/upgrade/v100to101"
+	"github.com/longhorn/longhorn-manager/upgrade/v102to110"
 	"github.com/longhorn/longhorn-manager/upgrade/v1alpha1"
 )
 
@@ -231,6 +232,9 @@ func doPodsUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeClient
 		err = errors.Wrap(err, "upgrade Pods failed")
 	}()
 	if err = v100to101.UpgradeInstanceManagerPods(namespace, lhClient, kubeClient); err != nil {
+		return err
+	}
+	if err = v102to110.UpgradeInstanceManagerPods(namespace, lhClient, kubeClient); err != nil {
 		return err
 	}
 	return nil

--- a/upgrade/v102to110/upgrade.go
+++ b/upgrade/v102to110/upgrade.go
@@ -1,0 +1,80 @@
+package v102to110
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	"github.com/longhorn/longhorn-manager/types"
+)
+
+// This upgrade is needed because we add one more field `controller: true`
+// to the ownerReferences of instance manager pods so that `kubectl drain`
+// can work without --force flag.
+// Therefore, we need to updade the field for all existing instance manager pod
+// Link to the original issue: https://github.com/longhorn/longhorn/issues/1286
+
+const (
+	upgradeLogPrefix = "upgrade from v1.0.2 to v1.1.0: "
+)
+
+func UpgradeInstanceManagerPods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager pods failed")
+	}()
+
+	imPodsList, err := kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", types.GetLonghornLabelComponentKey(), types.LonghornLabelInstanceManager),
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing instance manager pods during the instance managers pods upgrade")
+	}
+
+	for _, pod := range imPodsList.Items {
+		if err := upgradeInstanceMangerPodOwnerRef(&pod, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeInstanceMangerPodOwnerRef(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(pod)
+	if err != nil {
+		return err
+	}
+
+	podOwnerRefs := metadata.GetOwnerReferences()
+	isController := true
+	needToUpdate := false
+	for ind, ownerRef := range podOwnerRefs {
+		if ownerRef.Kind == types.LonghornKindInstanceManager &&
+			(ownerRef.Controller == nil || *ownerRef.Controller != true) {
+			ownerRef.Controller = &isController
+			needToUpdate = true
+		}
+		podOwnerRefs[ind] = ownerRef
+	}
+
+	if !needToUpdate {
+		return nil
+	}
+
+	metadata.SetOwnerReferences(podOwnerRefs)
+
+	if _, err = kubeClient.CoreV1().Pods(namespace).Update(pod); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to update the owner reference for instance manager pod %v during the instance managers pods upgrade", pod.GetName())
+	}
+
+	return nil
+}


### PR DESCRIPTION
`kubectl drain` by default is blocked when there is orphan pod on draining the node.

By adding the field `controller: true` to the `ownerReferences` of instance manager pods, we allow the user to run `kubectl drain` without the --force flag

Now users can run something like:
```
kubectl drain phan-cluster-v25-worker-1 --delete-local-data=true --force=false --grace-period=-1 --ignore-daemonsets=true --timeout=120s
```
longhorn/longhorn#1286