### PR TITLE
fixed the bug: Longhorn always delelte PDB of replica instance manager pod

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1129,8 +1129,7 @@ func getNodeSelector(nodeName string) (labels.Selector, error) {
 	})
 }
 
-// ListReplicasByNode gets a list of Node by LonghornNodeKey name for the given
-// namespace. Returns an object maps to the DiskID
+// ListReplicasByNode gets a map of Replicas on the node Name for the given namespace.
 func (s *DataStore) ListReplicasByNode(name string) (map[string][]*longhorn.Replica, error) {
 	nodeSelector, err := getNodeSelector(name)
 	if err != nil {
@@ -1149,6 +1148,17 @@ func (s *DataStore) ListReplicasByNode(name string) (map[string][]*longhorn.Repl
 		replicaDiskMap[replica.Spec.DiskID] = append(replicaDiskMap[replica.Spec.DiskID], replica.DeepCopy())
 	}
 	return replicaDiskMap, nil
+}
+
+// ListReplicasByNodeRO returns a list of all Replicas on node Name for the given namespace,
+// the list contains direct references to the internal cache objects and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) ListReplicasByNodeRO(name string) ([]*longhorn.Replica, error) {
+	nodeSelector, err := getNodeSelector(name)
+	if err != nil {
+		return nil, err
+	}
+	return s.rLister.Replicas(s.namespace).List(nodeSelector)
 }
 
 func tagNodeLabel(nodeID string, obj runtime.Object) error {


### PR DESCRIPTION
Fix the bug: Longhorn always deletes PDB of replica instance manager pod when the current node is draining eventhough the node contains the last replica of a volume and user set `Allow Node Drain with the Last Healthy Replica` to false.

The reason was that after the the volume is detached, the `im.Status.Instance` map  is empty and the loop https://github.com/longhorn/longhorn-manager/blob/12ab9ef33ef043b230c11e28ef2e4505fb650e82/controller/instance_manager_controller.go#L532
is never executed

longhorn/longhorn #1631