### PR TITLE
feature: Add AllowVolumeCreationWithDegradedAvailability

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -832,11 +832,13 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 	//      in which case scheduling failure will happen when the volume is detached.
 	//      In other cases, scheduling failure only happens when the volume is attached.
 	//   3. It's faulted.
+	//   4. It's restore pending.
 	ready := true
 	scheduledCondition := types.GetCondition(v.Status.Conditions, types.VolumeConditionTypeScheduled)
 	if (v.Spec.NodeID == "" && v.Status.State != types.VolumeStateDetached) ||
 		(v.Status.State == types.VolumeStateDetached && scheduledCondition.Status != types.ConditionStatusTrue) ||
-		v.Status.Robustness == types.VolumeRobustnessFaulted {
+		v.Status.Robustness == types.VolumeRobustnessFaulted ||
+		v.Status.RestoreRequired {
 		ready = false
 	}
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -864,7 +864,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 		}
 	}
 
-	if err := vc.reconcileVolumeSize(v, e, rs, allScheduled); err != nil {
+	if err := vc.reconcileVolumeSize(v, e, rs); err != nil {
 		return err
 	}
 
@@ -1638,7 +1638,7 @@ func (vc *VolumeController) checkAndInitVolumeRestore(v *longhorn.Volume) error 
 	return nil
 }
 
-func (vc *VolumeController) reconcileVolumeSize(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica, allScheduled bool) error {
+func (vc *VolumeController) reconcileVolumeSize(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) error {
 	log := getLoggerForVolume(vc.logger, v)
 
 	if e == nil || rs == nil {

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -554,6 +554,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		break
 	}
 	for name, r := range tc.replicas {
+		r.Spec.NodeID = TestNode1
 		r.Spec.HealthyAt = getTestNow()
 		r.Spec.DesireState = types.InstanceStateRunning
 		if name != failedReplicaName {

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -32,3 +32,4 @@ data:
     disable-replica-rebuild:
     disable-revision-counter:
     system-managed-pods-image-pull-policy:
+    allow-volume-creation-with-degraded-availability:

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -302,6 +302,10 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool) (v *lo
 		return nil, fmt.Errorf("volume %v is restoring data", name)
 	}
 
+	if v.Status.RestoreRequired {
+		return nil, fmt.Errorf("volume %v is pending restoring", name)
+	}
+
 	// already desired to be attached
 	if v.Spec.NodeID != "" {
 		if v.Spec.NodeID != nodeID {

--- a/types/setting.go
+++ b/types/setting.go
@@ -37,37 +37,38 @@ const (
 type SettingName string
 
 const (
-	SettingNameBackupTarget                         = SettingName("backup-target")
-	SettingNameBackupTargetCredentialSecret         = SettingName("backup-target-credential-secret")
-	SettingNameAllowRecurringJobWhileVolumeDetached = SettingName("allow-recurring-job-while-volume-detached")
-	SettingNameCreateDefaultDiskLabeledNodes        = SettingName("create-default-disk-labeled-nodes")
-	SettingNameDefaultDataPath                      = SettingName("default-data-path")
-	SettingNameDefaultEngineImage                   = SettingName("default-engine-image")
-	SettingNameDefaultInstanceManagerImage          = SettingName("default-instance-manager-image")
-	SettingNameReplicaSoftAntiAffinity              = SettingName("replica-soft-anti-affinity")
-	SettingNameStorageOverProvisioningPercentage    = SettingName("storage-over-provisioning-percentage")
-	SettingNameStorageMinimalAvailablePercentage    = SettingName("storage-minimal-available-percentage")
-	SettingNameUpgradeChecker                       = SettingName("upgrade-checker")
-	SettingNameLatestLonghornVersion                = SettingName("latest-longhorn-version")
-	SettingNameDefaultReplicaCount                  = SettingName("default-replica-count")
-	SettingNameDefaultDataLocality                  = SettingName("default-data-locality")
-	SettingNameGuaranteedEngineCPU                  = SettingName("guaranteed-engine-cpu")
-	SettingNameDefaultLonghornStaticStorageClass    = SettingName("default-longhorn-static-storage-class")
-	SettingNameBackupstorePollInterval              = SettingName("backupstore-poll-interval")
-	SettingNameTaintToleration                      = SettingName("taint-toleration")
-	SettingNameCRDAPIVersion                        = SettingName("crd-api-version")
-	SettingNameAutoSalvage                          = SettingName("auto-salvage")
-	SettingNameRegistrySecret                       = SettingName("registry-secret")
-	SettingNameDisableSchedulingOnCordonedNode      = SettingName("disable-scheduling-on-cordoned-node")
-	SettingNameReplicaZoneSoftAntiAffinity          = SettingName("replica-zone-soft-anti-affinity")
-	SettingNameVolumeAttachmentRecoveryPolicy       = SettingName("volume-attachment-recovery-policy")
-	SettingNameNodeDownPodDeletionPolicy            = SettingName("node-down-pod-deletion-policy")
-	SettingNameAllowNodeDrainWithLastHealthyReplica = SettingName("allow-node-drain-with-last-healthy-replica")
-	SettingNameMkfsExt4Parameters                   = SettingName("mkfs-ext4-parameters")
-	SettingNamePriorityClass                        = SettingName("priority-class")
-	SettingNameDisableRevisionCounter               = SettingName("disable-revision-counter")
-	SettingNameDisableReplicaRebuild                = SettingName("disable-replica-rebuild")
-	SettingNameSystemManagedPodsImagePullPolicy     = SettingName("system-managed-pods-image-pull-policy")
+	SettingNameBackupTarget                                = SettingName("backup-target")
+	SettingNameBackupTargetCredentialSecret                = SettingName("backup-target-credential-secret")
+	SettingNameAllowRecurringJobWhileVolumeDetached        = SettingName("allow-recurring-job-while-volume-detached")
+	SettingNameCreateDefaultDiskLabeledNodes               = SettingName("create-default-disk-labeled-nodes")
+	SettingNameDefaultDataPath                             = SettingName("default-data-path")
+	SettingNameDefaultEngineImage                          = SettingName("default-engine-image")
+	SettingNameDefaultInstanceManagerImage                 = SettingName("default-instance-manager-image")
+	SettingNameReplicaSoftAntiAffinity                     = SettingName("replica-soft-anti-affinity")
+	SettingNameStorageOverProvisioningPercentage           = SettingName("storage-over-provisioning-percentage")
+	SettingNameStorageMinimalAvailablePercentage           = SettingName("storage-minimal-available-percentage")
+	SettingNameUpgradeChecker                              = SettingName("upgrade-checker")
+	SettingNameLatestLonghornVersion                       = SettingName("latest-longhorn-version")
+	SettingNameDefaultReplicaCount                         = SettingName("default-replica-count")
+	SettingNameDefaultDataLocality                         = SettingName("default-data-locality")
+	SettingNameGuaranteedEngineCPU                         = SettingName("guaranteed-engine-cpu")
+	SettingNameDefaultLonghornStaticStorageClass           = SettingName("default-longhorn-static-storage-class")
+	SettingNameBackupstorePollInterval                     = SettingName("backupstore-poll-interval")
+	SettingNameTaintToleration                             = SettingName("taint-toleration")
+	SettingNameCRDAPIVersion                               = SettingName("crd-api-version")
+	SettingNameAutoSalvage                                 = SettingName("auto-salvage")
+	SettingNameRegistrySecret                              = SettingName("registry-secret")
+	SettingNameDisableSchedulingOnCordonedNode             = SettingName("disable-scheduling-on-cordoned-node")
+	SettingNameReplicaZoneSoftAntiAffinity                 = SettingName("replica-zone-soft-anti-affinity")
+	SettingNameVolumeAttachmentRecoveryPolicy              = SettingName("volume-attachment-recovery-policy")
+	SettingNameNodeDownPodDeletionPolicy                   = SettingName("node-down-pod-deletion-policy")
+	SettingNameAllowNodeDrainWithLastHealthyReplica        = SettingName("allow-node-drain-with-last-healthy-replica")
+	SettingNameMkfsExt4Parameters                          = SettingName("mkfs-ext4-parameters")
+	SettingNamePriorityClass                               = SettingName("priority-class")
+	SettingNameDisableRevisionCounter                      = SettingName("disable-revision-counter")
+	SettingNameDisableReplicaRebuild                       = SettingName("disable-replica-rebuild")
+	SettingNameSystemManagedPodsImagePullPolicy            = SettingName("system-managed-pods-image-pull-policy")
+	SettingNameAllowVolumeCreationWithDegradedAvailability = SettingName("allow-volume-creation-with-degraded-availability")
 )
 
 var (
@@ -103,6 +104,7 @@ var (
 		SettingNameDisableRevisionCounter,
 		SettingNameDisableReplicaRebuild,
 		SettingNameSystemManagedPodsImagePullPolicy,
+		SettingNameAllowVolumeCreationWithDegradedAvailability,
 	}
 )
 
@@ -128,37 +130,38 @@ type SettingDefinition struct {
 
 var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
-		SettingNameBackupTarget:                         SettingDefinitionBackupTarget,
-		SettingNameBackupTargetCredentialSecret:         SettingDefinitionBackupTargetCredentialSecret,
-		SettingNameAllowRecurringJobWhileVolumeDetached: SettingDefinitionAllowRecurringJobWhileVolumeDetached,
-		SettingNameCreateDefaultDiskLabeledNodes:        SettingDefinitionCreateDefaultDiskLabeledNodes,
-		SettingNameDefaultDataPath:                      SettingDefinitionDefaultDataPath,
-		SettingNameDefaultEngineImage:                   SettingDefinitionDefaultEngineImage,
-		SettingNameDefaultInstanceManagerImage:          SettingDefinitionDefaultInstanceManagerImage,
-		SettingNameReplicaSoftAntiAffinity:              SettingDefinitionReplicaSoftAntiAffinity,
-		SettingNameStorageOverProvisioningPercentage:    SettingDefinitionStorageOverProvisioningPercentage,
-		SettingNameStorageMinimalAvailablePercentage:    SettingDefinitionStorageMinimalAvailablePercentage,
-		SettingNameUpgradeChecker:                       SettingDefinitionUpgradeChecker,
-		SettingNameLatestLonghornVersion:                SettingDefinitionLatestLonghornVersion,
-		SettingNameDefaultReplicaCount:                  SettingDefinitionDefaultReplicaCount,
-		SettingNameDefaultDataLocality:                  SettingDefinitionDefaultDataLocality,
-		SettingNameGuaranteedEngineCPU:                  SettingDefinitionGuaranteedEngineCPU,
-		SettingNameDefaultLonghornStaticStorageClass:    SettingDefinitionDefaultLonghornStaticStorageClass,
-		SettingNameBackupstorePollInterval:              SettingDefinitionBackupstorePollInterval,
-		SettingNameTaintToleration:                      SettingDefinitionTaintToleration,
-		SettingNameCRDAPIVersion:                        SettingDefinitionCRDAPIVersion,
-		SettingNameAutoSalvage:                          SettingDefinitionAutoSalvage,
-		SettingNameRegistrySecret:                       SettingDefinitionRegistrySecret,
-		SettingNameDisableSchedulingOnCordonedNode:      SettingDefinitionDisableSchedulingOnCordonedNode,
-		SettingNameReplicaZoneSoftAntiAffinity:          SettingDefinitionReplicaZoneSoftAntiAffinity,
-		SettingNameVolumeAttachmentRecoveryPolicy:       SettingDefinitionVolumeAttachmentRecoveryPolicy,
-		SettingNameNodeDownPodDeletionPolicy:            SettingDefinitionNodeDownPodDeletionPolicy,
-		SettingNameAllowNodeDrainWithLastHealthyReplica: SettingDefinitionAllowNodeDrainWithLastHealthyReplica,
-		SettingNameMkfsExt4Parameters:                   SettingDefinitionMkfsExt4Parameters,
-		SettingNamePriorityClass:                        SettingDefinitionPriorityClass,
-		SettingNameDisableRevisionCounter:               SettingDefinitionDisableRevisionCounter,
-		SettingNameDisableReplicaRebuild:                SettingDefinitionDisableReplicaRebuild,
-		SettingNameSystemManagedPodsImagePullPolicy:     SettingDefinitionSystemManagedPodsImagePullPolicy,
+		SettingNameBackupTarget:                                SettingDefinitionBackupTarget,
+		SettingNameBackupTargetCredentialSecret:                SettingDefinitionBackupTargetCredentialSecret,
+		SettingNameAllowRecurringJobWhileVolumeDetached:        SettingDefinitionAllowRecurringJobWhileVolumeDetached,
+		SettingNameCreateDefaultDiskLabeledNodes:               SettingDefinitionCreateDefaultDiskLabeledNodes,
+		SettingNameDefaultDataPath:                             SettingDefinitionDefaultDataPath,
+		SettingNameDefaultEngineImage:                          SettingDefinitionDefaultEngineImage,
+		SettingNameDefaultInstanceManagerImage:                 SettingDefinitionDefaultInstanceManagerImage,
+		SettingNameReplicaSoftAntiAffinity:                     SettingDefinitionReplicaSoftAntiAffinity,
+		SettingNameStorageOverProvisioningPercentage:           SettingDefinitionStorageOverProvisioningPercentage,
+		SettingNameStorageMinimalAvailablePercentage:           SettingDefinitionStorageMinimalAvailablePercentage,
+		SettingNameUpgradeChecker:                              SettingDefinitionUpgradeChecker,
+		SettingNameLatestLonghornVersion:                       SettingDefinitionLatestLonghornVersion,
+		SettingNameDefaultReplicaCount:                         SettingDefinitionDefaultReplicaCount,
+		SettingNameDefaultDataLocality:                         SettingDefinitionDefaultDataLocality,
+		SettingNameGuaranteedEngineCPU:                         SettingDefinitionGuaranteedEngineCPU,
+		SettingNameDefaultLonghornStaticStorageClass:           SettingDefinitionDefaultLonghornStaticStorageClass,
+		SettingNameBackupstorePollInterval:                     SettingDefinitionBackupstorePollInterval,
+		SettingNameTaintToleration:                             SettingDefinitionTaintToleration,
+		SettingNameCRDAPIVersion:                               SettingDefinitionCRDAPIVersion,
+		SettingNameAutoSalvage:                                 SettingDefinitionAutoSalvage,
+		SettingNameRegistrySecret:                              SettingDefinitionRegistrySecret,
+		SettingNameDisableSchedulingOnCordonedNode:             SettingDefinitionDisableSchedulingOnCordonedNode,
+		SettingNameReplicaZoneSoftAntiAffinity:                 SettingDefinitionReplicaZoneSoftAntiAffinity,
+		SettingNameVolumeAttachmentRecoveryPolicy:              SettingDefinitionVolumeAttachmentRecoveryPolicy,
+		SettingNameNodeDownPodDeletionPolicy:                   SettingDefinitionNodeDownPodDeletionPolicy,
+		SettingNameAllowNodeDrainWithLastHealthyReplica:        SettingDefinitionAllowNodeDrainWithLastHealthyReplica,
+		SettingNameMkfsExt4Parameters:                          SettingDefinitionMkfsExt4Parameters,
+		SettingNamePriorityClass:                               SettingDefinitionPriorityClass,
+		SettingNameDisableRevisionCounter:                      SettingDefinitionDisableRevisionCounter,
+		SettingNameDisableReplicaRebuild:                       SettingDefinitionDisableReplicaRebuild,
+		SettingNameSystemManagedPodsImagePullPolicy:            SettingDefinitionSystemManagedPodsImagePullPolicy,
+		SettingNameAllowVolumeCreationWithDegradedAvailability: SettingDefinitionAllowVolumeCreationWithDegradedAvailability,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -490,6 +493,16 @@ var (
 			string(SystemManagedPodsImagePullPolicyAlways),
 		},
 	}
+
+	SettingDefinitionAllowVolumeCreationWithDegradedAvailability = SettingDefinition{
+		DisplayName: "Allow Volume Creation with Degraded Availability",
+		Description: "This setting allows user to create and attach a volume that doesn't have all the replicas scheduled at the time of creation.",
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "true",
+	}
 )
 
 type VolumeAttachmentRecoveryPolicy string
@@ -553,6 +566,8 @@ func ValidateInitSetting(name, value string) (err error) {
 	case SettingNameReplicaZoneSoftAntiAffinity:
 		fallthrough
 	case SettingNameAllowNodeDrainWithLastHealthyReplica:
+		fallthrough
+	case SettingNameAllowVolumeCreationWithDegradedAvailability:
 		fallthrough
 	case SettingNameUpgradeChecker:
 		if value != "true" && value != "false" {


### PR DESCRIPTION
The setting allows user to create a volume with less than specified
number of replicas, so user can use the default Longhorn configuration
without issues in one or two nodes cluster.

It is recommended to disable the feature when using Longhorn in
production environment.

Notice this PR also adds the ability to restore volume/DR volume with degraded availability.

https://github.com/longhorn/longhorn/issues/1701