### PR TITLE
Fix missed deletion events crash the longhorn-manager

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -87,18 +87,9 @@ func NewKubernetesPodController(
 	}
 
 	kubePodInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			pod := obj.(*v1.Pod)
-			kc.enqueuePodChange(pod)
-		},
-		UpdateFunc: func(old, cur interface{}) {
-			curPod := cur.(*v1.Pod)
-			kc.enqueuePodChange(curPod)
-		},
-		DeleteFunc: func(obj interface{}) {
-			pod := obj.(*v1.Pod)
-			kc.enqueuePodChange(pod)
-		},
+		AddFunc:    kc.enqueuePodChange,
+		UpdateFunc: func(old, cur interface{}) { kc.enqueuePodChange(cur) },
+		DeleteFunc: kc.enqueuePodChange,
 	})
 
 	return kc
@@ -297,11 +288,27 @@ func isOwnedByDeployment(pod *v1.Pod) bool {
 }
 
 // enqueuePodChange determines if the pod requires processing based on whether the pod has a PV created by us (driver.longhorn.io)
-func (kc *KubernetesPodController) enqueuePodChange(pod *v1.Pod) {
-	key, err := controller.KeyFunc(pod)
+func (kc *KubernetesPodController) enqueuePodChange(obj interface{}) {
+	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", pod, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
 		return
+	}
+
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
+			return
+		}
+
+		// use the last known state, to enqueue, dependent objects
+		pod, ok = deletedState.Obj.(*v1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("DeletedFinalStateUnknown contained invalid object: %#v", deletedState.Obj))
+			return
+		}
 	}
 
 	for _, v := range pod.Spec.Volumes {
@@ -331,7 +338,6 @@ func (kc *KubernetesPodController) enqueuePodChange(pod *v1.Pod) {
 			kc.queue.AddRateLimited(key)
 			break
 		}
-
 	}
 }
 


### PR DESCRIPTION
If an informer misses a deletion event, the final state of the object
will be unknown and instead the event will be a marker object of type
cache.DeletedFinalStateUnknown with a sub Obj that contains the last
cached state.

Previously we didn't handle the cache.DeletedFinalStateUnkown object and instead always used a type assertion for the corresponding longhorn object.

longhorn/longhorn#1900
related: #1877