### PR TITLE
Update CSI component images

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	DefaultCSIAttacherImage            = "longhornio/csi-attacher:lh-10142020"
-	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:lh-10132020"
-	DefaultCSIResizerImage             = "longhornio/csi-resizer:lh-10152020"
-	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:lh-10132020"
-	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:lh-10132020"
+	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v2.2.1-lh1"
+	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v1.6.0-lh1"
+	DefaultCSIResizerImage             = "longhornio/csi-resizer:v0.5.1-lh1"
+	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v2.1.1-lh1"
+	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v1.2.0-lh1"
 
 	DefaultCSIAttacherReplicaCount    = 3
 	DefaultCSIProvisionerReplicaCount = 3

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -2,8 +2,8 @@ longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20200514
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
-longhornio/csi-attacher:v2.0.0
-longhornio/csi-node-driver-registrar:v1.2.0
-longhornio/csi-provisioner:v1.6.0
-longhornio/csi-resizer:v0.3.0
-longhornio/csi-snapshotter:v2.1.1
+longhornio/csi-attacher:v2.2.1-lh1
+longhornio/csi-provisioner:v1.6.0-lh1
+longhornio/csi-resizer:v0.5.1-lh1
+longhornio/csi-snapshotter:v2.1.1-lh1
+longhornio/csi-node-driver-registrar:v1.2.0-lh1

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -2,8 +2,8 @@ longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20200514
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
-quay.io/k8scsi/csi-attacher:v2.0.0
-quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-quay.io/k8scsi/csi-provisioner:v1.6.0
-quay.io/k8scsi/csi-resizer:v0.3.0
-quay.io/k8scsi/csi-snapshotter:v2.1.1
+longhornio/csi-attacher:v2.2.1-lh1
+longhornio/csi-provisioner:v1.6.0-lh1
+longhornio/csi-resizer:v0.5.1-lh1
+longhornio/csi-snapshotter:v2.1.1-lh1
+longhornio/csi-node-driver-registrar:v1.2.0-lh1


### PR DESCRIPTION
```
longhornio/csi-attacher:v2.2.1-lh1
longhornio/csi-provisioner:v1.6.0-lh1
longhornio/csi-resizer:v0.5.1-lh1
longhornio/csi-snapshotter:v2.1.1-lh1
longhornio/csi-node-driver-registrar:v1.2.0-lh1
```

https://github.com/longhorn/longhorn/issues/1886