### PR TITLE
controller: Keep syncing IP when IM is running

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -352,9 +352,12 @@ func (imc *InstanceManagerController) syncInstanceManager(key string) (err error
 
 			if im.Status.CurrentState == types.InstanceManagerStateStarting || im.Status.CurrentState == types.InstanceManagerStateUnknown {
 				im.Status.CurrentState = types.InstanceManagerStateRunning
-				im.Status.IP = pod.Status.PodIP
 			} else if im.Status.CurrentState != types.InstanceManagerStateRunning {
 				im.Status.CurrentState = types.InstanceManagerStateError
+			}
+
+			if im.Status.CurrentState == types.InstanceManagerStateRunning {
+				im.Status.IP = pod.Status.PodIP
 			}
 		default:
 			im.Status.CurrentState = types.InstanceManagerStateError


### PR DESCRIPTION
longhorn/longhorn#1880

If somehow the ETCD doesn't work correctly (may due to master reboot) and the instance manager pods are restarted with different IPs during the period, the InstanceManager Controller may miss the instance manager IP sync.