### PR TITLE
Fix recurring job scheduling problems

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -250,13 +250,9 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 		return errors.Wrapf(err, "cannot get daemonset for engine image %v", engineImage.Name)
 	}
 	if ds == nil {
-		setting, err := ic.ds.GetSetting(types.SettingNameTaintToleration)
+		tolerations, err := ic.ds.GetSettingTaintToleration()
 		if err != nil {
 			return errors.Wrapf(err, "failed to get taint toleration setting before creating engine image daemonset")
-		}
-		tolerations, err := types.UnmarshalTolerations(setting.Value)
-		if err != nil {
-			return errors.Wrapf(err, "failed to unmarshal taint toleration setting before creating engine image daemonset")
 		}
 
 		priorityClassSetting, err := ic.ds.GetSetting(types.SettingNamePriorityClass)

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -701,13 +701,9 @@ func (imc *InstanceManagerController) cleanupInstanceManager(im *longhorn.Instan
 }
 
 func (imc *InstanceManagerController) createInstanceManagerPod(im *longhorn.InstanceManager) error {
-	setting, err := imc.ds.GetSetting(types.SettingNameTaintToleration)
+	tolerations, err := imc.ds.GetSettingTaintToleration()
 	if err != nil {
 		return errors.Wrapf(err, "failed to get taint toleration setting before creating instance manager pod")
-	}
-	tolerations, err := types.UnmarshalTolerations(setting.Value)
-	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal taint toleration setting before creating instance manager pod")
 	}
 
 	registrySecretSetting, err := imc.ds.GetSetting(types.SettingNameRegistrySecret)

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1258,6 +1258,18 @@ func (s *DataStore) GetSettingImagePullPolicy() (corev1.PullPolicy, error) {
 	return "", fmt.Errorf("invalid image pull policy %v", ipp.Value)
 }
 
+func (s *DataStore) GetSettingTaintToleration() ([]corev1.Toleration, error) {
+	setting, err := s.GetSetting(types.SettingNameTaintToleration)
+	if err != nil {
+		return nil, err
+	}
+	tolerationList, err := types.UnmarshalTolerations(setting.Value)
+	if err != nil {
+		return nil, err
+	}
+	return tolerationList, nil
+}
+
 // ResetMonitoringEngineStatus clean and update Engine status
 func (s *DataStore) ResetMonitoringEngineStatus(e *longhorn.Engine) (*longhorn.Engine, error) {
 	e.Status.Endpoint = ""


### PR DESCRIPTION
This PR does:
1. Remove the hardcoded NodeName in pod's spec of recurring job
2. Set the tolerations for the cronjob pods that are set by the user via the longhorn-settings
3. Reduce SuccessfulJobsHistoryLimit to 1 to reduce total number of pods in the cluster

Previously, we used the engine client binary on the current node to do backup. Therefore, we need to add NodeName: v.Status.CurrentNodeID. Now that we changed to use Longhorn API to do backup, the NodeName field is no longer needed.

Issues:
longhorn/longhorn#1903
longhorn/longhorn#1796
longhorn/longhorn#1793