### PR TITLE
Add 'node.Status.OwnerID' field to bind the node object to a node controller

### DIFF
--- a/types/resource.go
+++ b/types/resource.go
@@ -321,6 +321,7 @@ type NodeStatus struct {
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
 	Region     string                 `json:"region"`
 	Zone       string                 `json:"zone"`
+	OwnerID    string                 `json:"ownerID"`
 }
 
 type DiskSpec struct {


### PR DESCRIPTION
This new field will prevent multiple node controllers to update the same
node object.

https://github.com/longhorn/longhorn/issues/1449

Signed-off-by: Bo Tao <bo.tao@rancher.com>