### PR TITLE
Revert "Add 'node.Status.OwnerID' field to bind the node object to a node controller"

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -269,10 +269,6 @@ func getLoggerForNode(logger logrus.FieldLogger, n *longhorn.Node) logrus.FieldL
 	return logger.WithField("node", n.Name)
 }
 
-func (nc *NodeController) isResponsibleFor(n *longhorn.Node) bool {
-	return isControllerResponsibleFor(nc.controllerID, nc.ds, n.Name, n.Name, n.Status.OwnerID)
-}
-
 func (nc *NodeController) syncNode(key string) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "fail to sync node for %v", key)
@@ -293,23 +289,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 			return nil
 		}
 		return err
-	}
-
-	if node.Status.OwnerID != nc.controllerID {
-		if !nc.isResponsibleFor(node) {
-			// Not ours
-			return nil
-		}
-		node.Status.OwnerID = nc.controllerID
-		node, err = nc.ds.UpdateNodeStatus(node)
-		if err != nil {
-			// we don't mind others coming first
-			if apierrors.IsConflict(errors.Cause(err)) {
-				return nil
-			}
-			return err
-		}
-		logrus.Infof("Node got new owner %v", nc.controllerID)
 	}
 
 	if node.DeletionTimestamp != nil {

--- a/types/resource.go
+++ b/types/resource.go
@@ -321,7 +321,6 @@ type NodeStatus struct {
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
 	Region     string                 `json:"region"`
 	Zone       string                 `json:"zone"`
-	OwnerID    string                 `json:"ownerID"`
 }
 
 type DiskSpec struct {


### PR DESCRIPTION
Reverts longhorn/longhorn-manager#749

It broke the Longhorn node down detection.

Ref: https://github.com/longhorn/longhorn/issues/1449