### PR TITLE
Upgrade longhorn.io CRDs from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -14,31 +14,42 @@ spec:
     - lhe
     singular: engine
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The current state of the engine
-    JSONPath: .status.currentState
-  - name: Node
-    type: string
-    description: The node that the engine is on
-    JSONPath: .spec.nodeID
-  - name: InstanceManager
-    type: string
-    description: The instance manager of the engine
-    JSONPath: .status.instanceManagerName
-  - name: Image
-    type: string
-    description: The current image of the engine
-    JSONPath: .status.currentImage
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the engine
+      jsonPath: .status.currentState
+    - name: Node
+      type: string
+      description: The node that the engine is on
+      jsonPath: .spec.nodeID
+    - name: InstanceManager
+      type: string
+      description: The instance manager of the engine
+      jsonPath: .status.instanceManagerName
+    - name: Image
+      type: string
+      description: The current image of the engine
+      jsonPath: .status.currentImage
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -54,35 +65,46 @@ spec:
     - lhr
     singular: replica
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The current state of the replica
-    JSONPath: .status.currentState
-  - name: Node
-    type: string
-    description: The node that the replica is on
-    JSONPath: .spec.nodeID
-  - name: Disk
-    type: string
-    description: The disk that the replica is on
-    JSONPath: .spec.diskID
-  - name: InstanceManager
-    type: string
-    description: The instance manager of the replica
-    JSONPath: .status.instanceManagerName
-  - name: Image
-    type: string
-    description: The current image of the replica
-    JSONPath: .status.currentImage
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the replica
+      jsonPath: .status.currentState
+    - name: Node
+      type: string
+      description: The node that the replica is on
+      jsonPath: .spec.nodeID
+    - name: Disk
+      type: string
+      description: The disk that the replica is on
+      jsonPath: .spec.diskID
+    - name: InstanceManager
+      type: string
+      description: The instance manager of the replica
+      jsonPath: .status.instanceManagerName
+    - name: Image
+      type: string
+      description: The current image of the replica
+      jsonPath: .status.currentImage
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -98,17 +120,23 @@ spec:
     - lhs
     singular: setting
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: Value
-    type: string
-    description: The value of the setting
-    JSONPath: .value
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Value
+      type: string
+      description: The value of the setting
+      jsonPath: .value
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -124,35 +152,46 @@ spec:
     - lhv
     singular: volume
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the volume
-    JSONPath: .status.state
-  - name: Robustness
-    type: string
-    description: The robustness of the volume
-    JSONPath: .status.robustness
-  - name: Scheduled
-    type: string
-    description: The scheduled condition of the volume
-    JSONPath: .status.conditions['scheduled']['status']
-  - name: Size
-    type: string
-    description: The size of the volume
-    JSONPath: .spec.size
-  - name: Node
-    type: string
-    description: The node that the volume is currently attaching to
-    JSONPath: .status.currentNodeID
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The state of the volume
+      jsonPath: .status.state
+    - name: Robustness
+      type: string
+      description: The robustness of the volume
+      jsonPath: .status.robustness
+    - name: Scheduled
+      type: string
+      description: The scheduled condition of the volume
+      jsonPath: .status.conditions['scheduled']['status']
+    - name: Size
+      type: string
+      description: The size of the volume
+      jsonPath: .spec.size
+    - name: Node
+      type: string
+      description: The node that the volume is currently attaching to
+      jsonPath: .status.currentNodeID
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -168,31 +207,42 @@ spec:
     - lhei
     singular: engineimage
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: State of the engine image
-    JSONPath: .status.state
-  - name: Image
-    type: string
-    description: The Longhorn engine image
-    JSONPath: .spec.image
-  - name: RefCount
-    type: integer
-    description: Number of volumes are using the engine image
-    JSONPath: .status.refCount
-  - name: BuildDate
-    type: date
-    description: The build date of the engine image
-    JSONPath: .status.buildDate
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: State of the engine image
+      jsonPath: .status.state
+    - name: Image
+      type: string
+      description: The Longhorn engine image
+      jsonPath: .spec.image
+    - name: RefCount
+      type: integer
+      description: Number of volumes are using the engine image
+      jsonPath: .status.refCount
+    - name: BuildDate
+      type: date
+      description: The build date of the engine image
+      jsonPath: .status.buildDate
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -208,27 +258,38 @@ spec:
     - lhn
     singular: node
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    description: Indicate whether the node is ready
-    JSONPath: .status.conditions['Ready']['status']
-  - name: AllowScheduling
-    type: boolean
-    description: Indicate whether the user disabled/enabled replica scheduling for the node
-    JSONPath: .spec.allowScheduling
-  - name: Schedulable
-    type: string
-    description: Indicate whether Longhorn can schedule replicas on the node
-    JSONPath: .status.conditions['Schedulable']['status']
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      description: Indicate whether the node is ready
+      jsonPath: .status.conditions['Ready']['status']
+    - name: AllowScheduling
+      type: boolean
+      description: Indicate whether the user disabled/enabled replica scheduling for the node
+      jsonPath: .spec.allowScheduling
+    - name: Schedulable
+      type: string
+      description: Indicate whether Longhorn can schedule replicas on the node
+      jsonPath: .status.conditions['Schedulable']['status']
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -244,22 +305,33 @@ spec:
     - lhim
     singular: instancemanager
   scope: Namespaced
-  version: v1beta1
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the instance manager
-    JSONPath: .status.currentState
-  - name: Type
-    type: string
-    description: The type of the instance manager (engine or replica)
-    JSONPath: .spec.type
-  - name: Node
-    type: string
-    description: The node that the instance manager is running on
-    JSONPath: .spec.nodeID
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The state of the instance manager
+      jsonPath: .status.currentState
+    - name: Type
+      type: string
+      description: The type of the instance manager (engine or replica)
+      jsonPath: .spec.type
+    - name: Node
+      type: string
+      description: The node that the instance manager is running on
+      jsonPath: .spec.nodeID
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
We need to upgrade because `apiextensions.k8s.io/v1beta1` is being deprecated. It will be unavailable in Kubernetes v1.22+.

In this PR, we disable pruning for Longhorn CRDs for the ease of implementation by setting `x-kubernetes-preserve-unknown-fields: true`. In the future, we can turn it on by having a full description of `schema. openAPIV3Schema`; removing the field `x-kubernetes-preserve-unknown-fields: true `; and set `preserveUnknownFields : false`. By doing that, it allows us to turn on the schema validation feature of Kubernetes on both the API server-side and client-side (kubectl, client-go, etc,..). 

This also servers as a preparation for the upgrade from `longhorn.io/v1beta1` to `longhorn.io/v1`. The idea is that we can deploy both `v1` and `v1beta1` versions at the same time (by adding `v1` version into `spec.versions`). Set both `v1` and `v1beta1` as served version ; set  `v1` as storage and unset `v1beta1`. Finally, in the upgrade code read all the existing crds and re-update them to force Kubernetes to save the crds in `v1` format. If everything went well, in the release after that release, we can remove `v1beta1` from the crds. More detail at https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
Of course, we also need to re-generate the `longhorn-manager/k8s` package which contains Longhorn client-set to talk to Kube API server at the new endpoint, `/apis/longhorn.io/v1`. 

longhorn/longhorn#1813