### PR TITLE
Add 'OwnerID field in 'NodeStatus' to bind node object to a node controller

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1394,5 +1394,5 @@ func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine) error {
 }
 
 func (ec *EngineController) isResponsibleFor(e *longhorn.Engine) bool {
-	return isControllerResponsibleFor(ec.controllerID, ec.ds, e.Name, e.Spec.NodeID, e.Status.OwnerID)
+	return isControllerResponsibleFor(ec.controllerID, ec.ds, e.Name, e.Spec.NodeID, e.Status.OwnerID, false)
 }

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1089,5 +1089,5 @@ func (m *InstanceManagerMonitor) pollAndUpdateInstanceMap() error {
 }
 
 func (imc *InstanceManagerController) isResponsibleFor(im *longhorn.InstanceManager) bool {
-	return isControllerResponsibleFor(imc.controllerID, imc.ds, im.Name, im.Spec.NodeID, im.Status.OwnerID)
+	return isControllerResponsibleFor(imc.controllerID, imc.ds, im.Name, im.Spec.NodeID, im.Status.OwnerID, false)
 }

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -269,6 +269,10 @@ func getLoggerForNode(logger logrus.FieldLogger, n *longhorn.Node) logrus.FieldL
 	return logger.WithField("node", n.Name)
 }
 
+func (nc *NodeController) isResponsibleFor(n *longhorn.Node) bool {
+	return isControllerResponsibleFor(nc.controllerID, nc.ds, n.Name, n.Name, n.Status.OwnerID, true)
+}
+
 func (nc *NodeController) syncNode(key string) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "fail to sync node for %v", key)
@@ -289,6 +293,23 @@ func (nc *NodeController) syncNode(key string) (err error) {
 			return nil
 		}
 		return err
+	}
+
+	if node.Status.OwnerID != nc.controllerID {
+		if !nc.isResponsibleFor(node) {
+			// Not ours
+			return nil
+		}
+		node.Status.OwnerID = nc.controllerID
+		node, err = nc.ds.UpdateNodeStatus(node)
+		if err != nil {
+			// we don't mind others coming first
+			if apierrors.IsConflict(errors.Cause(err)) {
+				return nil
+			}
+			return err
+		}
+		logrus.Infof("Node %v got new owner %v", node.Name, nc.controllerID)
 	}
 
 	if node.DeletionTimestamp != nil {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -596,5 +596,5 @@ func (rc *ReplicaController) enqueueNodeChange(obj interface{}) {
 }
 
 func (rc *ReplicaController) isResponsibleFor(r *longhorn.Replica) bool {
-	return isControllerResponsibleFor(rc.controllerID, rc.ds, r.Name, r.Spec.NodeID, r.Status.OwnerID)
+	return isControllerResponsibleFor(rc.controllerID, rc.ds, r.Name, r.Spec.NodeID, r.Status.OwnerID, false)
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2205,7 +2205,7 @@ func (vc *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica
 }
 
 func (vc *VolumeController) isResponsibleFor(v *longhorn.Volume) bool {
-	return isControllerResponsibleFor(vc.controllerID, vc.ds, v.Name, v.Spec.NodeID, v.Status.OwnerID)
+	return isControllerResponsibleFor(vc.controllerID, vc.ds, v.Name, v.Spec.NodeID, v.Status.OwnerID, false)
 }
 
 func (vc *VolumeController) deleteReplica(r *longhorn.Replica, rs map[string]*longhorn.Replica) error {

--- a/types/resource.go
+++ b/types/resource.go
@@ -321,6 +321,7 @@ type NodeStatus struct {
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
 	Region     string                 `json:"region"`
 	Zone       string                 `json:"zone"`
+	OwnerID    string                 `json:"ownerID"`
 }
 
 type DiskSpec struct {


### PR DESCRIPTION
Add 'OwnerID' to 'NodeStatus' and add logic to
'isControllerResponsibleFor' to get Kubernetes node condition for node
controller.

https://github.com/longhorn/longhorn/issues/1449

Signed-off-by: Bo Tao <bo.tao@rancher.com>