### PR TITLE
Add disk and node storage metrics

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -927,7 +927,7 @@ func (s *DataStore) CreateNode(node *longhorn.Node) (*longhorn.Node, error) {
 	}
 
 	obj, err := verifyCreation(node.Name, "node", func(name string) (runtime.Object, error) {
-		return s.getNodeRO(name)
+		return s.GetNodeRO(name)
 	})
 	if err != nil {
 		return nil, err
@@ -980,14 +980,14 @@ func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
 	return s.CreateNode(node)
 }
 
-func (s *DataStore) getNodeRO(name string) (*longhorn.Node, error) {
+func (s *DataStore) GetNodeRO(name string) (*longhorn.Node, error) {
 	return s.nLister.Nodes(s.namespace).Get(name)
 }
 
 // GetNode gets Longhorn Node for the given name and namespace
 // Returns a new Node object
 func (s *DataStore) GetNode(name string) (*longhorn.Node, error) {
-	resultRO, err := s.getNodeRO(name)
+	resultRO, err := s.GetNodeRO(name)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1002,7 @@ func (s *DataStore) UpdateNode(node *longhorn.Node) (*longhorn.Node, error) {
 		return nil, err
 	}
 	verifyUpdate(node.Name, obj, func(name string) (runtime.Object, error) {
-		return s.getNodeRO(name)
+		return s.GetNodeRO(name)
 	})
 	return obj, nil
 }
@@ -1014,7 +1014,7 @@ func (s *DataStore) UpdateNodeStatus(node *longhorn.Node) (*longhorn.Node, error
 		return nil, err
 	}
 	verifyUpdate(node.Name, obj, func(name string) (runtime.Object, error) {
-		return s.getNodeRO(name)
+		return s.GetNodeRO(name)
 	})
 	return obj, nil
 }
@@ -1105,7 +1105,7 @@ func (s *DataStore) IsNodeDownOrDeleted(name string) (bool, error) {
 	if name == "" {
 		return false, errors.New("no node name provided to check node down or deleted")
 	}
-	node, err := s.getNodeRO(name)
+	node, err := s.GetNodeRO(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil

--- a/monitoring/disk_collector.go
+++ b/monitoring/disk_collector.go
@@ -1,0 +1,94 @@
+package monitoring
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+)
+
+type DiskCollector struct {
+	*baseCollector
+
+	capacityMetric    metricInfo
+	usageMetric       metricInfo
+	reservationMetric metricInfo
+}
+
+func NewDiskCollector(
+	logger logrus.FieldLogger,
+	nodeID string,
+	ds *datastore.DataStore) *DiskCollector {
+
+	dc := &DiskCollector{
+		baseCollector: newBaseCollector(subsystemDisk, logger, nodeID, ds),
+	}
+
+	dc.capacityMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemDisk, "capacity_bytes"),
+			"The storage capacity of this disk",
+			[]string{nodeLabel, diskLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	dc.usageMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemDisk, "usage_bytes"),
+			"The used storage of this disk",
+			[]string{nodeLabel, diskLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	dc.reservationMetric = metricInfo{
+		Desc: prometheus.NewDesc(
+			prometheus.BuildFQName(longhornName, subsystemDisk, "reservation_bytes"),
+			"The reserved storage for other applications and system on this disk",
+			[]string{nodeLabel, diskLabel},
+			nil,
+		),
+		Type: prometheus.GaugeValue,
+	}
+
+	return dc
+}
+
+func (dc *DiskCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- dc.capacityMetric.Desc
+	ch <- dc.usageMetric.Desc
+	ch <- dc.reservationMetric.Desc
+}
+
+func (dc *DiskCollector) Collect(ch chan<- prometheus.Metric) {
+	dc.collectDiskStorage(ch)
+}
+
+func (dc *DiskCollector) collectDiskStorage(ch chan<- prometheus.Metric) {
+	defer func() {
+		if err := recover(); err != nil {
+			dc.logger.WithField("error", err).Warn("panic during collecting metrics")
+		}
+	}()
+
+	node, err := dc.ds.GetNodeRO(dc.currentNodeID)
+	if err != nil {
+		dc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
+
+	disks := getDiskListFromNode(node)
+
+	for diskName, disk := range disks {
+		storageCapacity := disk.StorageMaximum
+		storageUsage := disk.StorageMaximum - disk.StorageAvailable
+		storageReservation := disk.StorageReserved
+		ch <- prometheus.MustNewConstMetric(dc.capacityMetric.Desc, dc.capacityMetric.Type, float64(storageCapacity), dc.currentNodeID, diskName)
+		ch <- prometheus.MustNewConstMetric(dc.usageMetric.Desc, dc.usageMetric.Type, float64(storageUsage), dc.currentNodeID, diskName)
+		ch <- prometheus.MustNewConstMetric(dc.reservationMetric.Desc, dc.reservationMetric.Type, float64(storageReservation), dc.currentNodeID, diskName)
+	}
+}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -34,9 +34,14 @@ func Handler() http.Handler {
 
 func InitMonitoringSystem(logger logrus.FieldLogger, currentNodeID string, ds *datastore.DataStore, kubeconfigPath string) {
 	vc := NewVolumeCollector(logger, currentNodeID, ds)
+	dc := NewDiskCollector(logger, currentNodeID, ds)
 
 	if err := Register(vc); err != nil {
 		logger.WithField("collector", subsystemVolume).WithError(err).Warn("failed to register collector")
+	}
+
+	if err := Register(dc); err != nil {
+		logger.WithField("collector", subsystemDisk).WithError(err).Warn("failed to register collector")
 	}
 
 	namespace := os.Getenv(types.EnvPodNamespace)


### PR DESCRIPTION
Added metrics:

1. longhorn_node_storage_capacity_bytes
2. longhorn_node_storage_usage_bytes
3. longhorn_node_storage_reservation_bytes
4. longhorn_disk_capacity_bytes
5. longhorn_disk_usage_bytes
6. longhorn_disk_reservation_bytes

longhorn/longhorn#1832