### PR TITLE
Reference correct PodSecurityPolicy name

### DIFF
--- a/examples/rwx/01-security.yaml
+++ b/examples/rwx/01-security.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
-    resourceNames: ["nfs-provisioner"]
+    resourceNames: ["longhorn-nfs-provisioner"]
     verbs: ["use"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Updating ClusterRoleBinding to reference correct name of PodSecurityPolicy. Original yaml referenced a PSP named "nfs-provisioner" but the yaml creates a PSP named "longhorn-nfs-provisioner". Updated to reference correct name.

Signed-off-by: Zachary Bialik <zachbialik1207@gmail.com>