### PR TITLE
Fix: volume remains attaching to the wrong node during a recurring backup

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -39,6 +39,7 @@ type Volume struct {
 	Created                 string                 `json:"created"`
 	LastBackup              string                 `json:"lastBackup"`
 	LastBackupAt            string                 `json:"lastBackupAt"`
+	LastAttachedBy          string                 `json:"lastAttachedBy"`
 	Standby                 bool                   `json:"standby"`
 	RestoreRequired         bool                   `json:"restoreRequired"`
 	RevisionCounterDisabled bool                   `json:"revisionCounterDisabled"`
@@ -130,6 +131,7 @@ type EngineImage struct {
 type AttachInput struct {
 	HostID          string `json:"hostId"`
 	DisableFrontend bool   `json:"disableFrontend"`
+	AttachedBy      string `json:"attachedBy"`
 }
 
 type SnapshotInput struct {
@@ -855,6 +857,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		Size:                strconv.FormatInt(v.Spec.Size, 10),
 		Frontend:            v.Spec.Frontend,
 		DisableFrontend:     v.Spec.DisableFrontend,
+		LastAttachedBy:      v.Spec.LastAttachedBy,
 		FromBackup:          v.Spec.FromBackup,
 		NumberOfReplicas:    v.Spec.NumberOfReplicas,
 		DataLocality:        v.Spec.DataLocality,

--- a/api/volume.go
+++ b/api/volume.go
@@ -203,7 +203,7 @@ func (s *Server) VolumeAttach(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
-		return s.m.Attach(id, input.HostID, input.DisableFrontend)
+		return s.m.Attach(id, input.HostID, input.DisableFrontend, input.AttachedBy)
 	})
 	if err != nil {
 		return err

--- a/client/generated_attach_input.go
+++ b/client/generated_attach_input.go
@@ -7,6 +7,8 @@ const (
 type AttachInput struct {
 	Resource `yaml:"-"`
 
+	AttachedBy string `json:"attachedBy,omitempty" yaml:"attached_by,omitempty"`
+
 	DisableFrontend bool `json:"disableFrontend,omitempty" yaml:"disable_frontend,omitempty"`
 
 	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -33,6 +33,8 @@ type Volume struct {
 
 	KubernetesStatus KubernetesStatus `json:"kubernetesStatus,omitempty" yaml:"kubernetes_status,omitempty"`
 
+	LastAttachedBy string `json:"lastAttachedBy,omitempty" yaml:"last_attached_by,omitempty"`
+
 	LastBackup string `json:"lastBackup,omitempty" yaml:"last_backup,omitempty"`
 
 	LastBackupAt string `json:"lastBackupAt,omitempty" yaml:"last_backup_at,omitempty"`

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -277,7 +277,7 @@ func (m *VolumeManager) Delete(name string) error {
 	return nil
 }
 
-func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool) (v *longhorn.Volume, err error) {
+func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attachedBy string) (v *longhorn.Volume, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "unable to attach volume %v to %v", name, nodeID)
 	}()
@@ -315,6 +315,7 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool) (v *lo
 	}
 	v.Spec.NodeID = nodeID
 	v.Spec.DisableFrontend = disableFrontend
+	v.Spec.LastAttachedBy = attachedBy
 
 	v, err = m.ds.UpdateVolume(v)
 	if err != nil {

--- a/types/resource.go
+++ b/types/resource.go
@@ -82,6 +82,7 @@ type VolumeSpec struct {
 	NodeSelector            []string       `json:"nodeSelector"`
 	DisableFrontend         bool           `json:"disableFrontend"`
 	RevisionCounterDisabled bool           `json:"revisionCounterDisabled"`
+	LastAttachedBy          string         `json:"lastAttachedBy"`
 }
 
 type KubernetesStatus struct {


### PR DESCRIPTION
We have discussed the option of removing the auto-reattachment feature entirely. However, I think that we shouldn't do it because:
1. We need the auto-reattachment feature in some cases. For example, when the volume is in the restoring process, if it is detached unexpectedly, Longhorn should auto-reattach the volume and continue doing the restoration. 

1. Removing the auto-reattachment feature doesn't solve the problem in this issue. The root cause of this problem is that when the volume is detached unexpectedly during a recurring backup job, the `volume.Spec.NodeID` field is not cleared (therefore, workload pod cannot uses the volume). The auto-reattachment feature lives inside VolumeController and VolumeController never changes volume's spec.

This PR proposes another approach:
1. We add a new field to the volume's spec: `LastAttachedBy`. This field indicates who is the last one that attached the volume. If the last attachment doesn't set this set field, it will be empty.
1. Change the logic of recurring backup job so that when the job automatically attaches the volume to a node, it also sets volume's `LastAttachedBy` field to be the job's name.
1. At the end of the recurring backup job, it will check to see if the volume was attached by the job's name. If so, the job tries to detach the volume.

This approach has another advantage: It doesn't only solve the problem when the volume is detached unexpectedly, but also solve the problem when the recurring job dies unexpectedly in the middle of a backup. 
Currently, if the recurring job dies unexpectedly in the middle of a backup, it cannot detach the volume that was attached by the job. The next time, the job runs, it sees that volume already attached so it will not detach the volume at the end. The end result is that the workload pod cannot use the volume forever. 


 longhorn/longhorn#1922