### PR TITLE
Clearn up the lease object longhorn-manager-upgrade-lock when uninstall Longhorn

### DIFF
--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -193,6 +193,11 @@ func (s *DataStore) DeletePod(name string) error {
 	return s.kubeClient.CoreV1().Pods(s.namespace).Delete(name, nil)
 }
 
+// DeleteLease deletes Lease with the given name in s.namespace
+func (s *DataStore) DeleteLease(name string) error {
+	return s.kubeClient.CoordinationV1().Leases(s.namespace).Delete(name, nil)
+}
+
 // GetStorageClassRO gets StorageClass with the given name
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies

--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: ["longhorn.io"]
     resources: ["volumes", "engines", "replicas", "settings", "engineimages", "nodes", "instancemanagers"]
     verbs: ["*"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	leaseLockName = "longhorn-manager-upgrade-lock"
+	LeaseLockName = "longhorn-manager-upgrade-lock"
 )
 
 func Upgrade(kubeconfigPath, currentNodeID string) error {
@@ -79,7 +79,7 @@ func upgrade(currentNodeID, namespace string, config *restclient.Config, lhClien
 
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
-			Name:      leaseLockName,
+			Name:      LeaseLockName,
 			Namespace: namespace,
 		},
 		Client: kubeClient.CoordinationV1(),


### PR DESCRIPTION
Clearn up the lease object longhorn-manager-upgrade-lock in the longhorn-system namespace as a part of uninstallation, so the NPE can be avoided

longhorn/longhorn#1779