### PR TITLE
Fix: uninstallation takes long time to finish

### DIFF
--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -338,18 +338,18 @@ func (c *UninstallController) deleteCRDs() (bool, error) {
 		return true, c.deleteEngineImages(engineImages)
 	}
 
-	if nodes, err := c.ds.ListNodes(); err != nil {
-		return true, err
-	} else if len(nodes) > 0 {
-		c.logger.Infof("Found %d nodes remaining", len(nodes))
-		return true, c.deleteNodes(nodes)
-	}
-
 	if instanceManagers, err := c.ds.ListInstanceManagers(); err != nil {
 		return true, err
 	} else if len(instanceManagers) > 0 {
 		c.logger.Infof("Found %d instance managers remaining", len(instanceManagers))
 		return true, c.deleteInstanceManagers(instanceManagers)
+	}
+
+	if nodes, err := c.ds.ListNodes(); err != nil {
+		return true, err
+	} else if len(nodes) > 0 {
+		c.logger.Infof("Found %d nodes remaining", len(nodes))
+		return true, c.deleteNodes(nodes)
 	}
 
 	return false, nil


### PR DESCRIPTION
Previously, we delete node resources before deleting instance manager resources. This leads to a chaotic situation in which the ownership of instance manager resources gets transferred constantly between Longhorn managers ([see the log](https://github.com/longhorn/longhorn/issues/1653#issuecomment-670109463)). There are always conflicts when updating the instance manager resources in `etcd` and the Longhorn managers cannot remove the `finalizer` for the instance manager resources.

Now, we delete instance manager resources, then delete node resources. The problem is gone.

longhorn/longhorn#1653