### PR TITLE
Allow user to set all kind of taint tolerations

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -56,7 +56,7 @@ type AttacherDeployment struct {
 }
 
 func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *AttacherDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *AttacherDeployment {
 
 	service := getCommonService(types.CSIAttacherName, namespace)
 
@@ -74,6 +74,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 		},
 		int32(replicaCount),
 		tolerations,
+		tolerationsString,
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
@@ -119,7 +120,7 @@ type ProvisionerDeployment struct {
 }
 
 func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ProvisionerDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ProvisionerDeployment {
 
 	service := getCommonService(types.CSIProvisionerName, namespace)
 
@@ -138,6 +139,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 		},
 		int32(replicaCount),
 		tolerations,
+		tolerationsString,
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
@@ -183,7 +185,7 @@ type ResizerDeployment struct {
 }
 
 func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ResizerDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ResizerDeployment {
 
 	service := getCommonService(types.CSIResizerName, namespace)
 
@@ -201,6 +203,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		},
 		int32(replicaCount),
 		tolerations,
+		tolerationsString,
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
@@ -246,7 +249,7 @@ type SnapshotterDeployment struct {
 }
 
 func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *SnapshotterDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *SnapshotterDeployment {
 	service := getCommonService(types.CSISnapshotterName, namespace)
 
 	deployment := getCommonDeployment(
@@ -263,6 +266,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 		},
 		int32(replicaCount),
 		tolerations,
+		tolerationsString,
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
@@ -307,12 +311,13 @@ type PluginDeployment struct {
 }
 
 func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, managerImage, managerURL, rootDir string,
-	tolerations []v1.Toleration, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *PluginDeployment {
+	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *PluginDeployment {
 
 	daemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      types.CSIPluginName,
-			Namespace: namespace,
+			Name:        types.CSIPluginName,
+			Namespace:   namespace,
+			Annotations: map[string]string{types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix): tolerationsString},
 		},
 
 		Spec: appsv1.DaemonSetSpec{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -55,7 +55,7 @@ func getCommonService(commonName, namespace string) *v1.Service {
 }
 
 func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir string, args []string, replicaCount int32,
-	tolerations []v1.Toleration, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *appsv1.Deployment {
+	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *appsv1.Deployment {
 
 	labels := map[string]string{
 		"app": commonName,
@@ -63,8 +63,9 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 
 	commonDeploymentSpec := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      commonName,
-			Namespace: namespace,
+			Name:        commonName,
+			Namespace:   namespace,
+			Annotations: map[string]string{types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix): tolerationsString},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,8 @@ const (
 	KubeNodeDefaultDiskConfigAnnotationKey    = "node.longhorn.io/default-disks-config"
 	KubeNodeDefaultNodeTagConfigAnnotationKey = "node.longhorn.io/default-node-tags"
 
+	LastAppliedTolerationAnnotationKeySuffix = "last-applied-tolerations"
+
 	BaseImageLabel        = "ranchervm-base-image"
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -243,5 +243,8 @@ func doPodsUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeClient
 	if err = v102to110.UpgradeReplicas(namespace, lhClient); err != nil {
 		return err
 	}
+	if err = v102to110.UpdateDeploymentAndDaemonset(namespace, kubeClient); err != nil {
+		return err
+	}
 	return nil
 }

--- a/upgrade/v102to110/upgrade.go
+++ b/upgrade/v102to110/upgrade.go
@@ -1,6 +1,7 @@
 package v102to110
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
@@ -46,6 +48,9 @@ func UpgradeInstanceManagerPods(namespace string, lhClient *lhclientset.Clientse
 
 	for _, pod := range imPodsList.Items {
 		if err := upgradeInstanceMangerPodOwnerRef(&pod, kubeClient, namespace); err != nil {
+			return err
+		}
+		if err := updateIMPodLastAppliedTolerationsAnnotation(&pod, kubeClient, namespace); err != nil {
 			return err
 		}
 	}
@@ -162,4 +167,134 @@ func UpgradeReplicas(namespace string, lhClient *lhclientset.Clientset) (err err
 		}
 	}
 	return nil
+}
+
+func UpdateDeploymentAndDaemonset(namespace string, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"UpdateLastAppliedTolerationsAnnotation failed")
+	}()
+
+	if err := updateDeploymentLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
+		return err
+	}
+	if err := updateDaemonsetLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateDaemonsetLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	daemonsetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list Longhorn daemonsets for toleration annotation update")
+	}
+	for _, ds := range daemonsetList.Items {
+		dsp := &ds
+		needToUpdate, err := needToUpdateTolerationAnnotation(dsp)
+		if err != nil {
+			return err
+		}
+		if !needToUpdate {
+			continue
+		}
+		appliedTolerations := getNonDefaultTolerationList(dsp.Spec.Template.Spec.Tolerations)
+		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+		if err != nil {
+			return err
+		}
+		if err := util.SetAnnotation(dsp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+			return err
+		}
+		if _, err := kubeClient.AppsV1().DaemonSets(namespace).Update(dsp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateDeploymentLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	deploymentList, err := kubeClient.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list Longhorn deployments for toleration annotation update")
+	}
+
+	for _, dp := range deploymentList.Items {
+		dpp := &dp
+		needToUpdate, err := needToUpdateTolerationAnnotation(dpp)
+		if err != nil {
+			return err
+		}
+		if !needToUpdate {
+			continue
+		}
+		appliedTolerations := getNonDefaultTolerationList(dpp.Spec.Template.Spec.Tolerations)
+		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+		if err != nil {
+			return err
+		}
+		if err := util.SetAnnotation(dpp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+			return err
+		}
+		if _, err := kubeClient.AppsV1().Deployments(namespace).Update(dpp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateIMPodLastAppliedTolerationsAnnotation(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
+	needToUpdate, err := needToUpdateTolerationAnnotation(pod)
+	if err != nil {
+		return err
+	}
+	if !needToUpdate {
+		return nil
+	}
+	appliedTolerations := getNonDefaultTolerationList(pod.Spec.Tolerations)
+	appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+	if err != nil {
+		return err
+	}
+	if err := util.SetAnnotation(pod, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+		return err
+	}
+	if _, err = kubeClient.CoreV1().Pods(namespace).Update(pod); err != nil {
+		return errors.Wrapf(err, "failed to update toleration annotation for instance manager pod %v", pod.GetName())
+	}
+	return nil
+}
+
+func getNonDefaultTolerationList(tolerations []v1.Toleration) []v1.Toleration {
+	result := []v1.Toleration{}
+	for _, t := range tolerations {
+		if !util.IsKubernetesDefaultToleration(t) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func needToUpdateTolerationAnnotation(obj runtime.Object) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	annos := objMeta.GetAnnotations()
+	if annos == nil {
+		return true, nil
+	}
+
+	_, ok := annos[types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix)]
+	if ok {
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
We allow the user to set all kinds of taint tolerations including the ones that contain `kubernetes.io` substring. This allows users to run Longhorn on control/etcd nodes.

We remember which tolerations applied by us in the annotation `longhorn.io/last-applied-tolerations`

Also, allow empty effect to enable 2 special cases for tolerations:

>An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
An empty effect matches all effects with key key.

Also, fix the bug to allow multiple tolerations with the same key

longhorn/longhorn#1874 
longhorn/longhorn#1977