### PR TITLE
Move registry secret setting to outside of  default setting

### DIFF
--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -21,7 +21,6 @@ data:
     backupstore-poll-interval:
     taint-toleration:
     priority-class:
-    registry-secret:
     auto-salvage:
     auto-delete-pod-when-volume-detached-unexpectedly:
     disable-scheduling-on-cordoned-node:

--- a/manager/kubernetes.go
+++ b/manager/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 
 	"github.com/longhorn/longhorn-manager/datastore"
@@ -109,4 +110,8 @@ func (m *VolumeManager) PVCCreate(name, namespace, pvcName string) (v *longhorn.
 
 	logrus.Debugf("Created PVC for volume %v: %+v", v.Name, v.Spec)
 	return v, nil
+}
+
+func (m *VolumeManager) GetDaemonSetRO(name string) (*appsv1.DaemonSet, error) {
+	return m.ds.GetDaemonSet(name)
 }


### PR DESCRIPTION
There are 2 reasons for doing this:
1. To avoid confusing users. In v1.0.2, users have to specify `Private Registry Secret` in the default setting section which is hidden by default. See more at [link](https://github.com/longhorn/longhorn/issues/1670#issuecomment-670723484). With this fix, all the private registry settings are on the same `Private Registry Setting` section. See more at [link](https://github.com/longhorn/longhorn/blob/e020e22913fd3f92c7bfc9d513a5bc86ecd7e0b8/chart/values.yaml#L98)
1. In v1.0.2, when users updating Longhorn deployment and specify a new setting for `registry secret `, it won't be applied because the old `registry secret ` already existed. With this fix, the new value of  `registry secret ` will be applied.

The approach is similar to how we handle the default engine image setting. First, users specify `privateRegistry.registrySecret` in helm chart. Longhorn chart copies  the registry secret setting to ImagePullSecrets field in Longhorn manager daemonset yaml. When manager pod starts, it lookups the field ImagePullSecrets and update the setting SettingNameRegistrySecret to the corresponding value.

longhorn/longhorn#1670