### PR TITLE
Avoid setting duplicated tolerations for IM pods and cronjob

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions/longhorn/v1beta1"
-	"github.com/longhorn/longhorn-manager/types"
 )
 
 const (
@@ -817,7 +819,7 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 		},
 		Spec: v1.PodSpec{
 			ServiceAccountName: imc.serviceAccount,
-			Tolerations:        tolerations,
+			Tolerations:        util.GetDistinctTolerations(tolerations),
 			PriorityClassName:  priorityClass.Value,
 			Containers: []v1.Container{
 				{

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2053,7 +2053,7 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 							},
 							ServiceAccountName: vc.ServiceAccount,
 							RestartPolicy:      v1.RestartPolicyOnFailure,
-							Tolerations:        tolerations,
+							Tolerations:        util.GetDistinctTolerations(tolerations),
 						},
 					},
 				},

--- a/util/util.go
+++ b/util/util.go
@@ -716,6 +716,15 @@ func SetAnnotation(obj runtime.Object, annotationKey, annotationValue string) er
 	return nil
 }
 
+func GetDistinctTolerations(tolerationList []v1.Toleration) []v1.Toleration {
+	res := []v1.Toleration{}
+	tolerationMap := TolerationListToMap(tolerationList)
+	for _, t := range tolerationMap {
+		res = append(res, t)
+	}
+	return res
+}
+
 func TolerationListToMap(tolerationList []v1.Toleration) map[string]v1.Toleration {
 	res := map[string]v1.Toleration{}
 	for _, t := range tolerationList {


### PR DESCRIPTION
When users enter duplicated tolerations (same key, operation, value, and effect) in Longhorn UI setting, make sure Longhorn doesn't set duplicated tolerations for IM pods and cronjob.

Related to this comment https://github.com/longhorn/longhorn/issues/1977#issuecomment-733396340

longhorn/longhorn#1977