### PR TITLE
Restart share manager pods, when tolerations/priority class changes

### DIFF
--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -282,17 +282,7 @@ func (s *DataStore) ListManagerPods() ([]*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
-	podList, err := s.pLister.Pods(s.namespace).List(selector)
-	if err != nil {
-		return nil, err
-	}
-
-	pList := []*corev1.Pod{}
-	for _, item := range podList {
-		pList = append(pList, item.DeepCopy())
-	}
-
-	return pList, nil
+	return s.ListPodsBySelector(selector)
 }
 
 func getInstanceManagerComponentSelector() (labels.Selector, error) {
@@ -307,7 +297,24 @@ func (s *DataStore) ListInstanceManagerPods() ([]*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
+	return s.ListPodsBySelector(selector)
+}
 
+func getShareManagerComponentSelector() (labels.Selector, error) {
+	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: types.GetShareManagerComponentLabel(),
+	})
+}
+
+func (s *DataStore) ListShareManagerPods() ([]*corev1.Pod, error) {
+	selector, err := getShareManagerComponentSelector()
+	if err != nil {
+		return nil, err
+	}
+	return s.ListPodsBySelector(selector)
+}
+
+func (s *DataStore) ListPodsBySelector(selector labels.Selector) ([]*corev1.Pod, error) {
 	podList, err := s.pLister.Pods(s.namespace).List(selector)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There is an interesting behavior, that we can only change the toleration settings while all volumes are detached, so the user needs to scale down all rwx volumes, for the sharemanager to detach the volume.

https://github.com/longhorn/longhorn/issues/2049

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
