### PR TITLE
Add support for DR volumes in RWX mode

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -388,6 +388,12 @@ func (c *ShareManagerController) syncShareManagerPod(sm *longhorn.ShareManager) 
 		return err
 	}
 
+	// no need to expose standby volumes via a share manager
+	if volume.Spec.Standby || volume.Status.IsStandby {
+		sm.Status.State = types.ShareManagerStateStopped
+		return c.cleanupShareManagerPod(sm)
+	}
+
 	// no active workload, there is no need to keep the share manager around and the volume can be detached
 	if volume.Status.KubernetesStatus.LastPodRefAt != "" || volume.Status.KubernetesStatus.LastPVCRefAt != "" {
 		isVolumeAttached := volume.Status.State == types.VolumeStateAttached || volume.Status.State == types.VolumeStateAttaching


### PR DESCRIPTION
While a volume is in standby mode there is no need for the volume to be
controlled by a share manager, since the user needs to activate a volume
before it can be used by workloads.

https://github.com/longhorn/longhorn/issues/2048

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
