### PR TITLE
No need to call attach for shared volumes from the csi driver

### DIFF
--- a/csi/nfs/nsenter_mount.go
+++ b/csi/nfs/nsenter_mount.go
@@ -73,8 +73,10 @@ func (n *Mounter) doNsenterMount(source, target, fstype string, options []string
 	logrus.Debugf("nsenter mount %s %s %s %v", source, target, fstype, options)
 	cmd, args := n.makeNsenterArgs(source, target, fstype, options)
 	outputBytes, err := n.ne.Exec(cmd, args).CombinedOutput()
-	if len(outputBytes) != 0 {
-		logrus.Debugf("Output of mounting %s to %s: %v", source, target, string(outputBytes))
+	logrus.Debugf("Output of mounting %s to %s: %v", source, target, string(outputBytes))
+	if err != nil {
+		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
+			err, cmd, args, string(outputBytes))
 	}
 	return err
 }

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -67,7 +67,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	requiresSharedAccess := requiresSharedAccess(existVol, volumeCapability)
 	if requiresSharedAccess && existVol.AccessMode != string(types.AccessModeReadWriteMany) {
-		return nil, status.Errorf(codes.FailedPrecondition, "The volume requires shared access but is not marked for shared use %s", req.GetVolumeId())
+		return nil, status.Errorf(codes.FailedPrecondition, "The volume %s requires shared access but is not marked for shared use", req.GetVolumeId())
 	}
 
 	if len(existVol.Controllers) != 1 {


### PR DESCRIPTION
Also includes the full error message on a mount failure for shared volumes
We can then add information to the knowledge base to help the user diagnose failures