### PR TITLE
deploy: remove `/var/run` bind-mount

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -45,9 +45,6 @@ spec:
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
-        - name: varrun
-          mountPath: /var/run/
-          mountPropagation: Bidirectional
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
@@ -76,9 +73,6 @@ spec:
       - name: proc
         hostPath:
           path: /proc/
-      - name: varrun
-        hostPath:
-          path: /var/run/
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/


### PR DESCRIPTION
It caused issue for https://github.com/longhorn/longhorn/issues/2088

Also, frankly speaking, I cannot recall why it's needed. Cannot find
any meaningful references in the code.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>