### PR TITLE
Log fixes

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -198,7 +198,7 @@ func (ec *EngineController) handleErr(err error, key interface{}) {
 	ec.queue.Forget(key)
 }
 
-func getLoggerForEngine(logger logrus.FieldLogger, e *longhorn.Engine) logrus.FieldLogger {
+func getLoggerForEngine(logger logrus.FieldLogger, e *longhorn.Engine) *logrus.Entry {
 	return logger.WithField("engine", e.Name)
 }
 

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -175,7 +175,7 @@ func (ic *EngineImageController) handleErr(err error, key interface{}) {
 	ic.queue.Forget(key)
 }
 
-func getLoggerForEngineImage(logger logrus.FieldLogger, ei *longhorn.EngineImage) logrus.FieldLogger {
+func getLoggerForEngineImage(logger logrus.FieldLogger, ei *longhorn.EngineImage) *logrus.Entry {
 	return logger.WithField("engineImage", ei.Name)
 }
 

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -247,7 +247,7 @@ func (imc *InstanceManagerController) handleErr(err error, key interface{}) {
 	imc.queue.Forget(key)
 }
 
-func getLoggerForInstanceManager(logger logrus.FieldLogger, im *longhorn.InstanceManager) logrus.FieldLogger {
+func getLoggerForInstanceManager(logger logrus.FieldLogger, im *longhorn.InstanceManager) *logrus.Entry {
 	return logger.WithField("instanceManager", im.Name)
 }
 

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -264,7 +264,7 @@ func (nc *NodeController) handleErr(err error, key interface{}) {
 	nc.queue.Forget(key)
 }
 
-func getLoggerForNode(logger logrus.FieldLogger, n *longhorn.Node) logrus.FieldLogger {
+func getLoggerForNode(logger logrus.FieldLogger, n *longhorn.Node) *logrus.Entry {
 	return logger.WithField("node", n.Name)
 }
 

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -171,7 +171,7 @@ func (rc *ReplicaController) handleErr(err error, key interface{}) {
 	rc.queue.Forget(key)
 }
 
-func getLoggerForReplica(logger logrus.FieldLogger, r *longhorn.Replica) logrus.FieldLogger {
+func getLoggerForReplica(logger logrus.FieldLogger, r *longhorn.Replica) *logrus.Entry {
 	return logger.WithField("replica", r.Name)
 }
 

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -110,7 +110,7 @@ func NewShareManagerController(
 	return c
 }
 
-func getLoggerForShareManager(logger logrus.FieldLogger, sm *longhorn.ShareManager) logrus.FieldLogger {
+func getLoggerForShareManager(logger logrus.FieldLogger, sm *longhorn.ShareManager) *logrus.Entry {
 	return logger.WithFields(
 		logrus.Fields{
 			"shareManager": sm.Name,

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -149,7 +149,7 @@ func (c *ShareManagerController) enqueueShareManagerForVolume(obj interface{}) {
 	if volume.Spec.AccessMode == types.AccessModeReadWriteMany {
 		// we can queue the key directly since a share manager only manages a single volume from it's own namespace
 		// and there is no need for us to retrieve the whole object, since we already know the volume name
-		getLoggerForVolume(c.logger, volume).Debug("Enqueuing share manager for volume")
+		getLoggerForVolume(c.logger, volume).Trace("Enqueuing share manager for volume")
 		key := volume.Namespace + "/" + volume.Name
 		c.queue.AddRateLimited(key)
 		return
@@ -176,7 +176,7 @@ func (c *ShareManagerController) enqueueShareManagerForPod(obj interface{}) {
 	// we can queue the key directly since a share manager only manages pods from it's own namespace
 	// and there is no need for us to retrieve the whole object, since the share manager name is stored in the label
 	smName := pod.Labels[types.GetLonghornLabelKey(types.LonghornLabelShareManager)]
-	c.logger.WithField("pod", pod.Name).WithField("shareManager", smName).Debug("Enqueuing share manager for pod")
+	c.logger.WithField("pod", pod.Name).WithField("shareManager", smName).Trace("Enqueuing share manager for pod")
 	key := pod.Namespace + "/" + smName
 	c.queue.AddRateLimited(key)
 	return

--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -209,15 +209,15 @@ func (c *UninstallController) handleErr(err error, key interface{}) {
 	c.queue.AddRateLimited(key)
 }
 
-func getLoggerForUninstallCSIDriver(logger logrus.FieldLogger, name string) logrus.FieldLogger {
+func getLoggerForUninstallCSIDriver(logger logrus.FieldLogger, name string) *logrus.Entry {
 	return logger.WithField("CSIDriver", name)
 }
 
-func getLoggerForUninstallDaemonSet(logger logrus.FieldLogger, name string) logrus.FieldLogger {
+func getLoggerForUninstallDaemonSet(logger logrus.FieldLogger, name string) *logrus.Entry {
 	return logger.WithField("daemonSet", name)
 }
 
-func getLoggerForUninstallDeployment(logger logrus.FieldLogger, name string) logrus.FieldLogger {
+func getLoggerForUninstallDeployment(logger logrus.FieldLogger, name string) *logrus.Entry {
 	return logger.WithField("deployment", name)
 }
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -204,7 +204,7 @@ func (vc *VolumeController) handleErr(err error, key interface{}) {
 	vc.queue.Forget(key)
 }
 
-func getLoggerForVolume(logger logrus.FieldLogger, v *longhorn.Volume) logrus.FieldLogger {
+func getLoggerForVolume(logger logrus.FieldLogger, v *longhorn.Volume) *logrus.Entry {
 	log := logger.WithFields(
 		logrus.Fields{
 			"volume":     v.Name,

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2264,7 +2264,7 @@ func (vc *VolumeController) createAndStartMatchingReplicas(v *longhorn.Volume,
 	}
 
 	if len(pathToOldRunnngRs) != v.Spec.NumberOfReplicas {
-		log.Debug("Volume old healthy replica count %v doesn't match the desired replica count %v",
+		log.Debugf("Volume old healthy replica count %v doesn't match the desired replica count %v",
 			len(pathToOldRunnngRs), v.Spec.NumberOfReplicas)
 		return nil
 	}


### PR DESCRIPTION
Changed the enqueue logs from the informers for the share manager to Trace level.
The 30s log even though there is no activity is caused by the 30s resync period.

https://github.com/longhorn/longhorn/issues/2089