### PR TITLE
Don't use the Ready flag for share availability signal

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -848,9 +848,6 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		})
 	}
 
-	requiresSharedAccess := v.Spec.AccessMode == types.AccessModeReadWriteMany
-	isShareReady := v.Status.ShareState == types.ShareManagerStateRunning && v.Status.ShareEndpoint != ""
-
 	// The volume is not ready for workloads if:
 	//   1. It's auto attached.
 	//   2. It fails to schedule replicas during the volume creation,
@@ -858,14 +855,12 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 	//      In other cases, scheduling failure only happens when the volume is attached.
 	//   3. It's faulted.
 	//   4. It's restore pending.
-	//   5. It's a shared volume, where the share is not yet available
 	ready := true
 	scheduledCondition := types.GetCondition(v.Status.Conditions, types.VolumeConditionTypeScheduled)
 	if (v.Spec.NodeID == "" && v.Status.State != types.VolumeStateDetached) ||
 		(v.Status.State == types.VolumeStateDetached && scheduledCondition.Status != types.ConditionStatusTrue) ||
 		v.Status.Robustness == types.VolumeRobustnessFaulted ||
-		v.Status.RestoreRequired ||
-		(requiresSharedAccess && !isShareReady) {
+		v.Status.RestoreRequired {
 		ready = false
 	}
 


### PR DESCRIPTION
Instead the user of a shared volume needs to check for shareEndpoint
availability directly via shareState == running and shareEndpoint != ""

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
