### PR TITLE
Add volume data migration example job

### DIFF
--- a/examples/data_migration.yaml
+++ b/examples/data_migration.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default  # namespace where the pvc's exist
+  name: volume-migration
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    metadata:
+      name: volume-migration
+      labels:
+        name: volume-migration
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: volume-migration
+          image: ubuntu:xenial
+          tty: true
+          command: [ "/bin/sh" ]
+          args: [ "-c", "cp -r -v /mnt/old /mnt/new" ]
+          volumeMounts:
+            - name: old-vol
+              mountPath: /mnt/old
+            - name: new-vol
+              mountPath: /mnt/new
+      volumes:
+        - name: old-vol
+          persistentVolumeClaim:
+            claimName: data-source-pvc # change to data source pvc
+        - name: new-vol
+          persistentVolumeClaim:
+            claimName: data-target-pvc # change to data target pvc


### PR DESCRIPTION
This can be used to migrate data from other storage systems or the old nfs
provisioner. The job will restart up to 3 times in the case of failure of
the copy operation.

After successful completion the list of files, can be viewed in the logs
of the job pod. The job can be deleted once the operation succeeded.

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
