### PR TITLE
Setting creation conflicts

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -54,7 +54,7 @@ func (s *DataStore) InitSettings() error {
 						Value: definition.Default,
 					},
 				}
-				if _, err := s.CreateSetting(setting); err != nil {
+				if _, err := s.CreateSetting(setting); err != nil && !apierrors.IsAlreadyExists(err) {
 					return err
 				}
 			} else {


### PR DESCRIPTION
Inside `InitSettings()`, don't return error when creating a setting and the setting already exists.

longhorn/longhorn#2077