### PR TITLE
controller: mark replica failed when we detect a bad replica while doing SnapshotPurge

### DIFF
--- a/controller/events.go
+++ b/controller/events.go
@@ -15,6 +15,7 @@ const (
 	EventReasonFailedRebuilding = "FailedRebuilding"
 
 	EventReasonFailedStartingSnapshotPurge = "FailedStartingSnapshotPurge"
+	EventReasonFailedSnapshotPurge         = "FailedSnapshotPurge"
 
 	EventReasonFailedRestore = "FailedRestore"
 


### PR DESCRIPTION
For the error during the SnapshotPurge progress, it will be recorded by
the engine/replica process automatically. Then once there is an error
in the engine's purgeStatus, the volume controller will mark the replica
as failed.

longhorn/longhorn#1895