### PR TITLE
Update default share-manager image to v1_20210106

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20201216
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20201204
+        - longhornio/longhorn-share-manager:v1_20210106
         - --manager-image
         - longhornio/longhorn-manager:master
         - --service-account

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20201204
+longhornio/longhorn-share-manager:v1_20210106
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
 longhornio/csi-attacher:v2.2.1-lh1

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20201204
+longhornio/longhorn-share-manager:v1_20210106
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
 longhornio/csi-attacher:v2.2.1-lh1


### PR DESCRIPTION
We switched from fedora to an ubuntu base image, to support the security
scanner.

longhorn/longhorn#2111

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
