### PR TITLE
live migration feature

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -37,6 +37,7 @@ type Volume struct {
 	CurrentImage            string                 `json:"currentImage"`
 	BackingImage            string                 `json:"backingImage"`
 	Created                 string                 `json:"created"`
+	MigrationNodeID         string                 `json:"migrationNodeID"`
 	LastBackup              string                 `json:"lastBackup"`
 	LastBackupAt            string                 `json:"lastBackupAt"`
 	LastAttachedBy          string                 `json:"lastAttachedBy"`
@@ -637,6 +638,12 @@ func volumeSchema(volume *client.Schema) {
 		"engineUpgrade": {
 			Input: "engineUpgradeInput",
 		},
+
+		"migrationStart": {
+			Input: "nodeInput",
+		},
+		"migrationConfirm":  {},
+		"migrationRollback": {},
 	}
 	volume.ResourceFields["controllers"] = client.Field{
 		Type:     "array[controller]",
@@ -1014,6 +1021,9 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["pvCreate"] = struct{}{}
 			actions["pvcCreate"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
+			actions["migrationStart"] = struct{}{}
+			actions["migrationConfirm"] = struct{}{}
+			actions["migrationRollback"] = struct{}{}
 		}
 	}
 

--- a/api/model.go
+++ b/api/model.go
@@ -56,6 +56,8 @@ type Volume struct {
 	ShareEndpoint string                  `json:"shareEndpoint"`
 	ShareState    types.ShareManagerState `json:"shareState"`
 
+	Migratable bool `json:"migratable"`
+
 	Replicas      []Replica       `json:"replicas"`
 	Controllers   []Controller    `json:"controllers"`
 	BackupStatus  []BackupStatus  `json:"backupStatus"`
@@ -154,6 +156,10 @@ type AttachInput struct {
 	AttachedBy      string `json:"attachedBy"`
 }
 
+type DetachInput struct {
+	HostID string `json:"hostId"`
+}
+
 type SnapshotInput struct {
 	Name   string            `json:"name"`
 	Labels map[string]string `json:"labels"`
@@ -177,10 +183,6 @@ type SalvageInput struct {
 
 type EngineUpgradeInput struct {
 	Image string `json:"image"`
-}
-
-type NodeInput struct {
-	NodeID string `json:"nodeId"`
 }
 
 type UpdateReplicaCountInput struct {
@@ -340,6 +342,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("schema", client.Schema{})
 	schemas.AddType("error", client.ServerApiError{})
 	schemas.AddType("attachInput", AttachInput{})
+	schemas.AddType("detachInput", DetachInput{})
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("backup", Backup{})
 	schemas.AddType("backupInput", BackupInput{})
@@ -356,7 +359,6 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("replica", Replica{})
 	schemas.AddType("controller", Controller{})
 	schemas.AddType("diskUpdate", types.DiskSpec{})
-	schemas.AddType("nodeInput", NodeInput{})
 	schemas.AddType("UpdateReplicaCountInput", UpdateReplicaCountInput{})
 	schemas.AddType("UpdateDataLocalityInput", UpdateDataLocalityInput{})
 	schemas.AddType("UpdateAccessModeInput", UpdateAccessModeInput{})
@@ -557,6 +559,7 @@ func volumeSchema(volume *client.Schema) {
 			Output: "volume",
 		},
 		"detach": {
+			Input:  "detachInput",
 			Output: "volume",
 		},
 		"salvage": {
@@ -638,12 +641,6 @@ func volumeSchema(volume *client.Schema) {
 		"engineUpgrade": {
 			Input: "engineUpgradeInput",
 		},
-
-		"migrationStart": {
-			Input: "nodeInput",
-		},
-		"migrationConfirm":  {},
-		"migrationRollback": {},
 	}
 	volume.ResourceFields["controllers"] = client.Field{
 		Type:     "array[controller]",
@@ -969,6 +966,9 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		ShareEndpoint: v.Status.ShareEndpoint,
 		ShareState:    v.Status.ShareState,
 
+		Migratable:      v.Spec.Migratable,
+		MigrationNodeID: v.Spec.MigrationNodeID,
+
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,
 
@@ -1004,6 +1004,14 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["detach"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
 		case types.VolumeStateAttached:
+			// We allow calling attach on an already attached volume in the case
+			// where the volume is migratable, we should consider exposing all the actions
+			// all the time and have the backend deal with when which action is valid
+			// this would simplify the csi driver down to just being a caller of the api
+			// instead of having all kinds of knowledge about the states itself
+			if r.AccessMode == types.AccessModeReadWriteMany && r.Migratable {
+				actions["attach"] = struct{}{}
+			}
 			actions["detach"] = struct{}{}
 			actions["activate"] = struct{}{}
 			actions["snapshotPurge"] = struct{}{}
@@ -1021,9 +1029,6 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["pvCreate"] = struct{}{}
 			actions["pvcCreate"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
-			actions["migrationStart"] = struct{}{}
-			actions["migrationConfirm"] = struct{}{}
-			actions["migrationRollback"] = struct{}{}
 		}
 	}
 

--- a/api/model.go
+++ b/api/model.go
@@ -1004,12 +1004,12 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["detach"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
 		case types.VolumeStateAttached:
-			// We allow calling attach on an already attached volume in the case
-			// where the volume is migratable, we should consider exposing all the actions
-			// all the time and have the backend deal with when which action is valid
+			// we allow calling attach on an already attached volume in RWX access mode
+			// we should consider exposing all the actions all the time
+			// and have the backend deal with when which action is valid
 			// this would simplify the csi driver down to just being a caller of the api
 			// instead of having all kinds of knowledge about the states itself
-			if r.AccessMode == types.AccessModeReadWriteMany && r.Migratable {
+			if r.AccessMode == types.AccessModeReadWriteMany {
 				actions["attach"] = struct{}{}
 			}
 			actions["detach"] = struct{}{}

--- a/api/model.go
+++ b/api/model.go
@@ -37,7 +37,6 @@ type Volume struct {
 	CurrentImage            string                 `json:"currentImage"`
 	BackingImage            string                 `json:"backingImage"`
 	Created                 string                 `json:"created"`
-	MigrationNodeID         string                 `json:"migrationNodeID"`
 	LastBackup              string                 `json:"lastBackup"`
 	LastBackupAt            string                 `json:"lastBackupAt"`
 	LastAttachedBy          string                 `json:"lastAttachedBy"`
@@ -966,8 +965,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		ShareEndpoint: v.Status.ShareEndpoint,
 		ShareState:    v.Status.ShareState,
 
-		Migratable:      v.Spec.Migratable,
-		MigrationNodeID: v.Spec.MigrationNodeID,
+		Migratable: v.Spec.Migratable,
 
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,

--- a/api/router.go
+++ b/api/router.go
@@ -80,6 +80,10 @@ func NewRouter(s *Server) *mux.Router {
 		"replicaRemove": s.ReplicaRemove,
 		"engineUpgrade": s.EngineUpgrade,
 
+		"migrationStart":    s.MigrationStart,
+		"migrationConfirm":  s.MigrationConfirm,
+		"migrationRollback": s.MigrationRollback,
+
 		"snapshotPurge":  s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotPurge),
 		"snapshotCreate": s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotCreate),
 		"snapshotList":   s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotList),

--- a/api/router.go
+++ b/api/router.go
@@ -80,10 +80,6 @@ func NewRouter(s *Server) *mux.Router {
 		"replicaRemove": s.ReplicaRemove,
 		"engineUpgrade": s.EngineUpgrade,
 
-		"migrationStart":    s.MigrationStart,
-		"migrationConfirm":  s.MigrationConfirm,
-		"migrationRollback": s.MigrationRollback,
-
 		"snapshotPurge":  s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotPurge),
 		"snapshotCreate": s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotCreate),
 		"snapshotList":   s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotList),

--- a/api/volume.go
+++ b/api/volume.go
@@ -209,7 +209,9 @@ func (s *Server) VolumeDetach(rw http.ResponseWriter, req *http.Request) error {
 
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&input); err != nil {
-		return err
+		// HACK: for ui detach requests that don't send a body
+		// This is the same as previous behavior where detach is requested from all nodes
+		input.HostID = ""
 	}
 	id := mux.Vars(req)["name"]
 

--- a/app/volume.go
+++ b/app/volume.go
@@ -221,8 +221,8 @@ func (job *Job) run() (err error) {
 		return errors.Wrapf(err, "could not get volume %v", volumeName)
 	}
 
-	if volume.MigrationNodeID != "" {
-		return fmt.Errorf("cannot run job for volume %v during migration", volume.Name)
+	if len(volume.Controllers) > 1 {
+		return fmt.Errorf("cannot run job for volume %v that is using %v engines", volume.Name, len(volume.Controllers))
 	}
 
 	defer job.handleVolumeDetachment()

--- a/app/volume.go
+++ b/app/volume.go
@@ -221,6 +221,10 @@ func (job *Job) run() (err error) {
 		return errors.Wrapf(err, "could not get volume %v", volumeName)
 	}
 
+	if volume.MigrationNodeID != "" {
+		return fmt.Errorf("cannot run job for volume %v during migration", volume.Name)
+	}
+
 	defer job.handleVolumeDetachment()
 
 	if volume.State != string(types.VolumeStateAttached) && volume.State != string(types.VolumeStateDetached) {

--- a/app/volume.go
+++ b/app/volume.go
@@ -196,8 +196,8 @@ func (job *Job) handleVolumeDetachment() {
 				return
 			}
 			if volume.State == string(types.VolumeStateAttached) {
-				logrus.Infof("Attempting to detach volume %v ", volumeName)
-				if _, err := volumeAPI.ActionDetach(volume); err != nil {
+				logrus.Infof("Attempting to detach volume %v from all nodes", volumeName)
+				if _, err := volumeAPI.ActionDetach(volume, &longhornclient.DetachInput{HostId: ""}); err != nil {
 					logrus.Infof("%v ", err)
 				}
 			}

--- a/client/README.md
+++ b/client/README.md
@@ -19,3 +19,9 @@ Just use cp to copy these code is fine, but you should update package name in `l
 cd longhorn-manager/client
 sed -i -e 's/package longhorn/package client/g' *.go
 ```
+
+## Notes:
+
+The generator currently no longer generates actions, so you need to ensure not to overwrite the `ActionUpdateAccessMode`
+in `generated_volume.go`. I currently don't have the time to look into this and since we are planning on reworking the api
+down the line, this is a low priority issue for now.

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -6,6 +6,7 @@ type RancherClient struct {
 	ApiVersion                ApiVersionOperations
 	Error                     ErrorOperations
 	AttachInput               AttachInputOperations
+	DetachInput               DetachInputOperations
 	SnapshotInput             SnapshotInputOperations
 	Backup                    BackupOperations
 	BackupInput               BackupInputOperations
@@ -22,7 +23,6 @@ type RancherClient struct {
 	Replica                   ReplicaOperations
 	Controller                ControllerOperations
 	DiskUpdate                DiskUpdateOperations
-	NodeInput                 NodeInputOperations
 	UpdateReplicaCountInput   UpdateReplicaCountInputOperations
 	UpdateDataLocalityInput   UpdateDataLocalityInputOperations
 	UpdateAccessModeInput     UpdateAccessModeInputOperations
@@ -61,6 +61,7 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.ApiVersion = newApiVersionClient(client)
 	client.Error = newErrorClient(client)
 	client.AttachInput = newAttachInputClient(client)
+	client.DetachInput = newDetachInputClient(client)
 	client.SnapshotInput = newSnapshotInputClient(client)
 	client.Backup = newBackupClient(client)
 	client.BackupInput = newBackupInputClient(client)
@@ -77,7 +78,6 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.Replica = newReplicaClient(client)
 	client.Controller = newControllerClient(client)
 	client.DiskUpdate = newDiskUpdateClient(client)
-	client.NodeInput = newNodeInputClient(client)
 	client.UpdateReplicaCountInput = newUpdateReplicaCountInputClient(client)
 	client.UpdateDataLocalityInput = newUpdateDataLocalityInputClient(client)
 	client.UpdateAccessModeInput = newUpdateAccessModeInputClient(client)

--- a/client/generated_detach_input.go
+++ b/client/generated_detach_input.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	DETACH_INPUT_TYPE = "detachInput"
+)
+
+type DetachInput struct {
+	Resource `yaml:"-"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+}
+
+type DetachInputCollection struct {
+	Collection
+	Data   []DetachInput `json:"data,omitempty"`
+	client *DetachInputClient
+}
+
+type DetachInputClient struct {
+	rancherClient *RancherClient
+}
+
+type DetachInputOperations interface {
+	List(opts *ListOpts) (*DetachInputCollection, error)
+	Create(opts *DetachInput) (*DetachInput, error)
+	Update(existing *DetachInput, updates interface{}) (*DetachInput, error)
+	ById(id string) (*DetachInput, error)
+	Delete(container *DetachInput) error
+}
+
+func newDetachInputClient(rancherClient *RancherClient) *DetachInputClient {
+	return &DetachInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DetachInputClient) Create(container *DetachInput) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doCreate(DETACH_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DetachInputClient) Update(existing *DetachInput, updates interface{}) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doUpdate(DETACH_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DetachInputClient) List(opts *ListOpts) (*DetachInputCollection, error) {
+	resp := &DetachInputCollection{}
+	err := c.rancherClient.doList(DETACH_INPUT_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *DetachInputCollection) Next() (*DetachInputCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &DetachInputCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *DetachInputClient) ById(id string) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doById(DETACH_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DetachInputClient) Delete(container *DetachInput) error {
+	return c.rancherClient.doResourceDelete(DETACH_INPUT_TYPE, &container.Resource)
+}

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -41,6 +41,8 @@ type Volume struct {
 
 	LastBackupAt string `json:"lastBackupAt,omitempty" yaml:"last_backup_at,omitempty"`
 
+	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	NodeSelector []string `json:"nodeSelector,omitempty" yaml:"node_selector,omitempty"`

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -41,6 +41,8 @@ type Volume struct {
 
 	LastBackupAt string `json:"lastBackupAt,omitempty" yaml:"last_backup_at,omitempty"`
 
+	Migratable bool `json:"migratable,omitempty" yaml:"migratable,omitempty"`
+
 	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -105,7 +107,7 @@ type VolumeOperations interface {
 
 	ActionCancelExpansion(*Volume) (*Volume, error)
 
-	ActionDetach(*Volume) (*Volume, error)
+	ActionDetach(*Volume, *DetachInput) (*Volume, error)
 
 	ActionExpand(*Volume, *ExpandInput) (*Volume, error)
 
@@ -211,11 +213,11 @@ func (c *VolumeClient) ActionCancelExpansion(resource *Volume) (*Volume, error) 
 	return resp, err
 }
 
-func (c *VolumeClient) ActionDetach(resource *Volume) (*Volume, error) {
+func (c *VolumeClient) ActionDetach(resource *Volume, input *DetachInput) (*Volume, error) {
 
 	resp := &Volume{}
 
-	err := c.rancherClient.doAction(VOLUME_TYPE, "detach", &resource.Resource, nil, resp)
+	err := c.rancherClient.doAction(VOLUME_TYPE, "detach", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -43,8 +43,6 @@ type Volume struct {
 
 	Migratable bool `json:"migratable,omitempty" yaml:"migratable,omitempty"`
 
-	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
-
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	NodeSelector []string `json:"nodeSelector,omitempty" yaml:"node_selector,omitempty"`

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -148,7 +148,7 @@ func (c *ShareManagerController) enqueueShareManagerForVolume(obj interface{}) {
 		}
 	}
 
-	if volume.Spec.AccessMode == types.AccessModeReadWriteMany {
+	if volume.Spec.AccessMode == types.AccessModeReadWriteMany && !volume.Spec.Migratable {
 		// we can queue the key directly since a share manager only manages a single volume from it's own namespace
 		// and there is no need for us to retrieve the whole object, since we already know the volume name
 		getLoggerForVolume(c.logger, volume).Trace("Enqueuing share manager for volume")

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -434,7 +434,7 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 		return err
 	}
 
-	if err := vc.cleanupReplicas(volume, engine, replicas); err != nil {
+	if err := vc.cleanupReplicas(volume, engines, replicas); err != nil {
 		return err
 	}
 
@@ -672,7 +672,19 @@ func (vc *VolumeController) hasReplicaEvictionRequested(rs map[string]*longhorn.
 	return false
 }
 
-func (vc *VolumeController) cleanupReplicas(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) error {
+func (vc *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*longhorn.Engine, rs map[string]*longhorn.Replica) error {
+	// TODO: I don't think it's a good idea to cleanup replicas during a migration or engine image update
+	// 	the healthy replica count doesn't differentiate between replicas of different engines
+	// 	so this can end being really messy
+	if vc.isVolumeMigrating(v) || vc.isVolumeUpgrading(v) {
+		return nil
+	}
+
+	e, err := vc.getCurrentEngine(v, es)
+	if err != nil {
+		return err
+	}
+
 	if err := vc.cleanupCorruptedOrStaleReplicas(v, rs); err != nil {
 		return err
 	}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2330,10 +2330,7 @@ func (vc *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica
 	// delete the volume data on the disk.
 	// Set `active` at last to prevent data loss
 	for _, r := range rs {
-		if activeCondFunc(r, obj) != r.Spec.Active {
-			r.Spec.Active = activeCondFunc(r, obj)
-			rs[r.Name] = r
-		}
+		r.Spec.Active = activeCondFunc(r, obj)
 	}
 	return nil
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2255,17 +2255,14 @@ func (vc *VolumeController) getEngineImage(image string) (*longhorn.EngineImage,
 	return img, nil
 }
 
-func (vc *VolumeController) getCurrentEngineAndExtra(v *longhorn.Volume, es map[string]*longhorn.Engine) (currentEngine, otherEngine *longhorn.Engine, err error) {
-	if len(es) > 2 {
-		return nil, nil, fmt.Errorf("more than two engines exists")
-	}
+func (vc *VolumeController) getCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.Engine) (currentEngine *longhorn.Engine, otherEngines []*longhorn.Engine, err error) {
 	for _, e := range es {
 		if e.Spec.NodeID == v.Status.CurrentNodeID &&
 			e.Spec.DesireState == types.InstanceStateRunning &&
 			e.Status.CurrentState == types.InstanceStateRunning {
 			currentEngine = e
 		} else {
-			otherEngine = e
+			otherEngines = append(otherEngines, e)
 		}
 	}
 	if currentEngine == nil {
@@ -2276,15 +2273,18 @@ func (vc *VolumeController) getCurrentEngineAndExtra(v *longhorn.Volume, es map[
 
 func (vc *VolumeController) getCurrentEngineAndCleanupOthers(v *longhorn.Volume, es map[string]*longhorn.Engine) (current *longhorn.Engine, err error) {
 	defer func() {
-		err = errors.Wrapf(err, "fail to clean up the extra engine for %v", v.Name)
+		err = errors.Wrapf(err, "fail to clean up the extra engines for %v", v.Name)
 	}()
-	current, extra, err := vc.getCurrentEngineAndExtra(v, es)
+	current, extras, err := vc.getCurrentEngineAndExtras(v, es)
 	if err != nil {
 		return nil, err
 	}
-	if extra != nil && extra.DeletionTimestamp == nil {
-		if err := vc.deleteEngine(extra, es); err != nil {
-			return nil, err
+
+	for _, extra := range extras {
+		if extra.DeletionTimestamp == nil {
+			if err := vc.deleteEngine(extra, es); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return current, nil

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -345,8 +345,9 @@ func (cs *ControllerServer) publishMigratableVolume(req *csi.ControllerPublishVo
 		}
 	}
 
+	checkVolumeAttached := func(vol *longhornclient.Volume) bool { return isVolumeAvailableOn(vol, req.NodeId) }
 	return cs.publishVolume(volume, req.NodeId, func() error {
-		if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration available", isVolumeMigrationAvailable, false, false) {
+		if !cs.waitForVolumeState(req.GetVolumeId(), "volume available on", checkVolumeAttached, false, false) {
 			return status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
 		}
 		return nil
@@ -776,12 +777,12 @@ func isVolumeDetached(vol *longhornclient.Volume) bool {
 }
 
 func isVolumeAttached(vol *longhornclient.Volume) bool {
-	return vol.State == string(types.VolumeStateAttached) && vol.Controllers[0].Endpoint != ""
+	return vol.State == string(types.VolumeStateAttached) && len(vol.Controllers) > 0 && vol.Controllers[0].Endpoint != ""
 }
 
-// isVolumeMigrationAvailable checks that the volume is attached and if a migration has been requested whether it has been started
-func isVolumeMigrationAvailable(vol *longhornclient.Volume) bool {
-	return isVolumeAttached(vol) && (vol.MigrationNodeID == "" || isEngineOnNodeAvailable(vol, vol.MigrationNodeID))
+// isVolumeAvailableOn checks that the volume is attached and that an engine is running on the requested node
+func isVolumeAvailableOn(vol *longhornclient.Volume, node string) bool {
+	return isVolumeAttached(vol) && isEngineOnNodeAvailable(vol, node)
 }
 
 // isVolumeMigrationComplete checks that the volume is either detached or is attached on a different node

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -303,6 +303,85 @@ func (cs *ControllerServer) isNodeReady(nodeID string) bool {
 	return false
 }
 
+// publishSharedVolume doesn't need to call volume.Attach since the underlying rwo volume will be controlled by a share-manager
+func (cs *ControllerServer) publishSharedVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
+	if !volume.Ready || len(volume.Controllers) == 0 || volume.Controllers[0].Endpoint == "" {
+		return nil, status.Errorf(codes.Aborted, "The volume %s is not ready for workloads", req.GetVolumeId())
+	}
+
+	if !cs.waitForVolumeState(volume.Name, "share available", isVolumeShareAvailable, false, false) {
+		return nil, status.Errorf(codes.DeadlineExceeded, "Failed to wait for volume %v share available", req.GetVolumeId())
+	}
+
+	logrus.Infof("Volume %s shared to %s", req.GetVolumeId(), req.GetNodeId())
+	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
+func (cs *ControllerServer) publishMigratableVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
+	if volume.State == string(types.VolumeStateAttached) {
+		if !volume.Ready || len(volume.Controllers) == 0 || volume.Controllers[0].Endpoint == "" {
+			return nil, status.Errorf(codes.Aborted,
+				"The volume %s is already attached but it is not ready for workloads", req.GetVolumeId())
+		}
+	}
+
+	logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the requested node is %s", req.GetVolumeId(), req.GetNodeId())
+	input := &longhornclient.AttachInput{
+		HostId:          req.GetNodeId(),
+		DisableFrontend: false,
+	}
+
+	if _, err := cs.apiClient.Volume.ActionAttach(volume, input); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s for node %s", req.GetVolumeId(), req.NodeId)
+
+	if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration available", isVolumeMigrationAvailable, false, false) {
+		return nil, status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
+	}
+
+	logrus.Infof("Volume %s attached on %s", req.GetVolumeId(), req.GetNodeId())
+	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
+func (cs *ControllerServer) publishReadWriteOnceVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
+	// the volume is already attached make sure it's to the same node as this
+	if volume.State == string(types.VolumeStateAttached) {
+		if !volume.Ready || len(volume.Controllers) == 0 || volume.Controllers[0].Endpoint == "" {
+			return nil, status.Errorf(codes.Aborted,
+				"The volume %s is already attached but it is not ready for workloads", req.GetVolumeId())
+		}
+
+		if volume.Controllers[0].HostId != req.GetNodeId() {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"The volume %s cannot be attached to the node %s since it is already attached to the node %s",
+				req.GetVolumeId(), req.GetNodeId(), volume.Controllers[0].HostId)
+		}
+
+		logrus.Infof("ControllerPublishVolume: no need to attach volume %s since it's already attached to the correct node %s",
+			req.GetVolumeId(), req.GetNodeId())
+		return &csi.ControllerPublishVolumeResponse{}, nil
+	}
+
+	logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the preferred nodeID is %s", req.GetVolumeId(), req.GetNodeId())
+	input := &longhornclient.AttachInput{
+		HostId:          req.GetNodeId(),
+		DisableFrontend: false,
+	}
+
+	if _, err := cs.apiClient.Volume.ActionAttach(volume, input); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s", req.GetVolumeId())
+
+	if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateAttached), isVolumeAttached, false, false) {
+		return nil, status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
+	}
+
+	logrus.Infof("Volume %s attached on %s", req.GetVolumeId(), req.GetNodeId())
+	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
 // ControllerPublishVolume will attach the volume to the specified node
 func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	logrus.Infof("ControllerServer ControllerPublishVolume req: %v", req)
@@ -350,14 +429,11 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		return nil, status.Errorf(codes.InvalidArgument, "ControllerPublishVolume: there is no block device frontend for volume %s", req.GetVolumeId())
 	}
 
+	if !existVol.Ready {
+		return nil, status.Errorf(codes.Aborted, "The volume %s is not ready for workloads", req.GetVolumeId())
+	}
+
 	if requiresSharedAccess(existVol, volumeCapability) {
-
-		// we check for volume readiness before potentially messing with the access mode
-		if !existVol.Ready || len(existVol.Controllers) == 0 || existVol.Controllers[0].Endpoint == "" {
-			return nil, status.Errorf(codes.Aborted,
-				"The volume %s is not ready for workloads", req.GetVolumeId())
-		}
-
 		if existVol.AccessMode != string(types.AccessModeReadWriteMany) {
 			input := &longhornclient.UpdateAccessModeInput{
 				AccessMode: string(types.AccessModeReadWriteMany),
@@ -367,56 +443,17 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 				logrus.WithError(err).Errorf("Failed to change Volume %s access mode to RWX", req.GetVolumeId())
 				return nil, status.Error(codes.Internal, err.Error())
 			}
-
 			logrus.Infof("Changed Volume %s access mode to RWX", req.GetVolumeId())
 		}
 
-		if !cs.waitForVolumeState(req.GetVolumeId(), "share available", isVolumeShareAvailable, false, false) {
-			return nil, status.Errorf(codes.DeadlineExceeded, "Failed to wait for volume %v share available", req.GetVolumeId())
+		if !existVol.Migratable {
+			return cs.publishSharedVolume(req, existVol)
 		}
 
-		logrus.Infof("Volume %s shared to %s", req.GetVolumeId(), req.GetNodeId())
-		return &csi.ControllerPublishVolumeResponse{}, nil
+		return cs.publishMigratableVolume(req, existVol)
 	}
 
-	// the volume is already attached make sure it's to the same node as this
-	if existVol.State == string(types.VolumeStateAttached) {
-		if !existVol.Ready || len(existVol.Controllers) == 0 || existVol.Controllers[0].Endpoint == "" {
-			return nil, status.Errorf(codes.Aborted,
-				"The volume %s is already attached but it is not ready for workloads", req.GetVolumeId())
-		}
-
-		if existVol.Controllers[0].HostId != req.GetNodeId() {
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"The volume %s cannot be attached to the node %s since it is already attached to the node %s",
-				req.GetVolumeId(), req.GetNodeId(), existVol.Controllers[0].HostId)
-		}
-
-		// TODO: add comparison for capabilities, to do so we need to pass the volume context
-		//  as part of the volume creation (this is for the Volume published but is incompatible case of the csi spec)
-		logrus.Infof("ControllerPublishVolume: no need to attach volume %s since it's already attached to the correct node %s",
-			req.GetVolumeId(), req.GetNodeId())
-	} else {
-		logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the preferred nodeID is %s", req.GetVolumeId(), req.GetNodeId())
-		// attach longhorn volume with frontend enabled
-		input := &longhornclient.AttachInput{
-			HostId:          req.GetNodeId(),
-			DisableFrontend: false,
-		}
-		existVol, err = cs.apiClient.Volume.ActionAttach(existVol, input)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s", req.GetVolumeId())
-	}
-
-	if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateAttached), isVolumeAttached, false, false) {
-		return nil, status.Errorf(codes.Aborted, "Attaching volume %s on node %s failed",
-			req.GetVolumeId(), req.GetNodeId())
-	}
-	logrus.Infof("Volume %s attached on %s", req.GetVolumeId(), req.GetNodeId())
-
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return cs.publishReadWriteOnceVolume(req, existVol)
 }
 
 // ControllerUnpublishVolume will detach the volume
@@ -437,8 +474,13 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	// VOLUME_NOT_FOUND is no longer the ControllerUnpublishVolume error
 	// See https://github.com/container-storage-interface/spec/issues/382 for details
 	if existVol == nil {
-		msg := fmt.Sprintf("ControllerUnpublishVolume: the volume %s not exists", req.GetVolumeId())
-		logrus.Warn(msg)
+		logrus.Warnf("ControllerUnpublishVolume: the volume %s does not exists", req.GetVolumeId())
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+
+	if existVol.State == string(types.VolumeStateDetached) {
+		logrus.Infof("don't need to detach Volume %s since we are already detached from node %s",
+			req.GetVolumeId(), req.GetNodeId())
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
@@ -446,55 +488,24 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		return nil, status.Errorf(codes.Aborted, "The volume %s is detaching", req.GetVolumeId())
 	}
 
-	needToDetach := false
-	if existVol.State == string(types.VolumeStateAttached) || existVol.State == string(types.VolumeStateAttaching) {
-
-		// try to wait till we are attached, but if we fail to attach we need to process the detach
-		// irregardless of the node we are on otherwise we might end up, allowing a bugged volume to remain in the attaching state forever
-		// NOTE: this is a tradeoff and it would be better if we could verify that we are actually stuck attaching to the requested node
-		if existVol.State == string(types.VolumeStateAttaching) {
-			if cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateAttached), isVolumeAttached, false, true) {
-				existVol, err = cs.apiClient.Volume.ById(req.GetVolumeId())
-				if err != nil {
-					return nil, status.Error(codes.Internal, err.Error())
-				}
-			} else {
-				logrus.Warnf("Volume %s stuck in attaching state, processing detach request for node %s "+
-					"even though we don't know which node we are attaching on", req.GetVolumeId(), req.GetNodeId())
-			}
-		}
-
-		// for shared volumes we don't need to call detach since the share manager handles the volume attachment logic
-		if requiresSharedAccess(existVol, nil) {
-			logrus.Infof("Requesting shared volume %s detach from node %s", req.GetVolumeId(), req.GetNodeId())
-			needToDetach = false
-		} else if existVol.Controllers[0].HostId == req.GetNodeId() {
-			logrus.Infof("Requesting volume %s detach from node %s", req.GetVolumeId(), req.GetNodeId())
-			needToDetach = true
-		} else if len(existVol.Controllers) == 0 || existVol.Controllers[0].HostId == "" {
-			logrus.Warnf("Processing volume %s detach request for node %s "+
-				"even though we don't know which node we are attached on", req.GetVolumeId(), req.GetNodeId())
-			needToDetach = true
-		}
-	}
-
-	if needToDetach {
-		logrus.Debugf("requesting Volume %s detachment for %s", req.GetVolumeId(), req.GetNodeId())
-		_, err = cs.apiClient.Volume.ActionDetach(existVol)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-	} else if requiresSharedAccess(existVol, nil) {
+	if requiresSharedAccess(existVol, nil) && !existVol.Migratable {
 		logrus.Infof("don't need to detach shared Volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
-	} else {
-		logrus.Infof("don't need to detach Volume %s since we are already detached from node %s",
-			req.GetVolumeId(), req.GetNodeId())
-		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
-	if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateDetached), isVolumeDetached, false, true) {
-		return nil, status.Errorf(codes.Aborted, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+	logrus.Debugf("requesting Volume %s detachment for %s", req.GetVolumeId(), req.GetNodeId())
+	_, err = cs.apiClient.Volume.ActionDetach(existVol, &longhornclient.DetachInput{HostId: req.NodeId})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if existVol.Migratable {
+		checkMigrationComplete := func(vol *longhornclient.Volume) bool { return isVolumeMigrationComplete(vol, req.NodeId) }
+		if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration complete", checkMigrationComplete, false, true) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+		}
+	} else if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateDetached), isVolumeDetached, false, true) {
+		return nil, status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
 	}
 
 	logrus.Debugf("Volume %s detached on %s", req.GetVolumeId(), req.GetNodeId())
@@ -740,6 +751,26 @@ func isVolumeDetached(vol *longhornclient.Volume) bool {
 
 func isVolumeAttached(vol *longhornclient.Volume) bool {
 	return vol.State == string(types.VolumeStateAttached) && vol.Controllers[0].Endpoint != ""
+}
+
+// isVolumeMigrationAvailable checks that the volume is attached and if a migration has been requested whether it has been started
+func isVolumeMigrationAvailable(vol *longhornclient.Volume) bool {
+	return isVolumeAttached(vol) && (vol.MigrationNodeID == "" || isEngineOnNodeAvailable(vol, vol.MigrationNodeID))
+}
+
+// isVolumeMigrationComplete checks that the volume is either detached or is attached on a different node
+func isVolumeMigrationComplete(vol *longhornclient.Volume, node string) bool {
+	return isVolumeDetached(vol) || (isVolumeAttached(vol) && !isEngineOnNodeAvailable(vol, node))
+}
+
+func isEngineOnNodeAvailable(vol *longhornclient.Volume, node string) bool {
+	for _, controller := range vol.Controllers {
+		if controller.HostId == node && controller.Endpoint != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isVolumeShareAvailable(vol *longhornclient.Volume) bool {

--- a/examples/rwx/storageclass-migratable.yaml
+++ b/examples/rwx/storageclass-migratable.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-migratable
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
+  fromBackup: ""
+  migratable: "true"
+  share: "false"

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -58,6 +58,10 @@ func (m *VolumeManager) CreateSnapshot(snapshotName string, labels map[string]st
 		}
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return nil, err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return nil, err
@@ -82,6 +86,10 @@ func (m *VolumeManager) DeleteSnapshot(snapshotName, volumeName string) error {
 		return fmt.Errorf("volume and snapshot name required")
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return err
@@ -96,6 +104,10 @@ func (m *VolumeManager) DeleteSnapshot(snapshotName, volumeName string) error {
 func (m *VolumeManager) RevertSnapshot(snapshotName, volumeName string) error {
 	if volumeName == "" || snapshotName == "" {
 		return fmt.Errorf("volume and snapshot name required")
+	}
+
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
 	}
 
 	engine, err := m.GetEngineClient(volumeName)
@@ -121,6 +133,10 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 		return fmt.Errorf("volume name required")
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return err
@@ -136,6 +152,10 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 func (m *VolumeManager) BackupSnapshot(volumeName, snapshotName, backingImageName, backingImageURL string, labels map[string]string) error {
 	if volumeName == "" || snapshotName == "" {
 		return fmt.Errorf("volume and snapshot name required")
+	}
+
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
 	}
 
 	backupTarget, err := m.GetSettingValueExisted(types.SettingNameBackupTarget)

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -220,6 +220,17 @@ func (m *VolumeManager) BackupSnapshot(volumeName, snapshotName, backingImageNam
 	return nil
 }
 
+func (m *VolumeManager) checkVolumeNotInMigration(volumeName string) error {
+	v, err := m.ds.GetVolume(volumeName)
+	if err != nil {
+		return err
+	}
+	if v.Spec.MigrationNodeID != "" {
+		return fmt.Errorf("cannot operate during migration")
+	}
+	return nil
+}
+
 func (m *VolumeManager) GetEngineClient(volumeName string) (client engineapi.EngineClient, err error) {
 	var e *longhorn.Engine
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -736,6 +736,10 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 			v.Name, v.Status.CurrentImage, v.Spec.EngineImage)
 	}
 
+	if v.Spec.MigrationNodeID != "" {
+		return nil, fmt.Errorf("cannot upgrade during migration")
+	}
+
 	// TODO: Rebuild is not supported for old DR volumes and the handling of a degraded DR volume live upgrade will get stuck.
 	//  Hence the live upgrade should be prevented in API level. After all old DR volumes are gone, this check can be removed.
 	if v.Status.State == types.VolumeStateAttached && v.Status.IsStandby && v.Status.Robustness != types.VolumeRobustnessHealthy {
@@ -755,6 +759,120 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 		logrus.Debugf("Rolling back volume %v engine image to %v", v.Name, v.Status.CurrentImage)
 	}
 
+	return v, nil
+}
+
+func (m *VolumeManager) checkVolumeNotInMigration(volumeName string) error {
+	v, err := m.Get(volumeName)
+	if err != nil {
+		return err
+	}
+	if v.Spec.MigrationNodeID != "" {
+		return fmt.Errorf("cannot operate during migration")
+	}
+	return nil
+}
+
+func (m *VolumeManager) MigrationStart(name, nodeID string) (v *longhorn.Volume, err error) {
+	defer func() {
+		err = errors.Wrapf(err, "unable to start migration for volume %v to %v", name, nodeID)
+	}()
+
+	v, err = m.ds.GetVolume(name)
+	if err != nil {
+		return nil, err
+	}
+	if v.Spec.NodeID == "" || v.Status.State != types.VolumeStateAttached {
+		return nil, fmt.Errorf("invalid volume state to start migration %v", v.Status.State)
+	}
+	if v.Status.Robustness != types.VolumeRobustnessHealthy {
+		return nil, fmt.Errorf("volume must be healthy to start migration")
+	}
+	if v.Spec.EngineImage != v.Status.CurrentImage {
+		return nil, fmt.Errorf("upgrading in process for volume, cannot start migration")
+	}
+	if v.Spec.MigrationNodeID != "" {
+		return nil, fmt.Errorf("migration already started")
+	}
+	if v.Spec.NodeID == nodeID {
+		return nil, fmt.Errorf("cannot migrate to the same node as volume currently attached to")
+	}
+
+	if nodeID == "" {
+		return nil, fmt.Errorf("empty migration destination")
+	}
+	if _, err := m.Node2APIAddress(nodeID); err != nil {
+		return nil, err
+	}
+
+	v.Spec.MigrationNodeID = nodeID
+	v, err = m.ds.UpdateVolume(v)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Migration started for volume %v from %v to %v", v.Name, v.Spec.NodeID, nodeID)
+	return v, nil
+}
+
+func (m *VolumeManager) MigrationConfirm(name string) (v *longhorn.Volume, err error) {
+	defer func() {
+		err = errors.Wrapf(err, "unable to confirm migration for volume %v", name)
+	}()
+
+	v, err = m.ds.GetVolume(name)
+	if err != nil {
+		return nil, err
+	}
+	if v.Spec.NodeID == "" || v.Status.State != types.VolumeStateAttached {
+		return nil, fmt.Errorf("invalid volume state to confirm migration %v", v.Status.State)
+	}
+	if v.Spec.MigrationNodeID == "" {
+		return nil, fmt.Errorf("no migration in process to be confirm")
+	}
+
+	// the engine must be running in order to be confirmed
+	es, err := m.ds.ListVolumeEngines(name)
+	attached := false
+	for _, e := range es {
+		if e.Spec.NodeID == v.Spec.MigrationNodeID &&
+			e.Status.CurrentState == types.InstanceStateRunning {
+			attached = true
+			break
+		}
+	}
+	if !attached {
+		return nil, fmt.Errorf("migration is not ready yet")
+	}
+
+	oldNodeID := v.Spec.NodeID
+	v.Spec.NodeID = v.Spec.MigrationNodeID
+	v, err = m.ds.UpdateVolume(v)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Start migration confirming for volume %v from %v to %v", v.Name, oldNodeID, v.Spec.NodeID)
+	return v, nil
+}
+
+func (m *VolumeManager) MigrationRollback(name string) (v *longhorn.Volume, err error) {
+	defer func() {
+		err = errors.Wrapf(err, "unable to rollback migration for volume %v", name)
+	}()
+
+	v, err = m.ds.GetVolume(name)
+	if err != nil {
+		return nil, err
+	}
+	if v.Spec.MigrationNodeID == "" {
+		return nil, fmt.Errorf("no migration in process to be rollback")
+	}
+
+	v.Spec.MigrationNodeID = ""
+	v, err = m.ds.UpdateVolume(v)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Start rolling back migration for volume %v", v.Name)
 	return v, nil
 }
 
@@ -778,6 +896,10 @@ func (m *VolumeManager) UpdateReplicaCount(name string, count int) (v *longhorn.
 	if v.Spec.EngineImage != v.Status.CurrentImage {
 		return nil, fmt.Errorf("upgrading in process, cannot update replica count")
 	}
+	if v.Spec.MigrationNodeID != "" {
+		return nil, fmt.Errorf("migration in process, cannot update replica count")
+	}
+
 	oldCount := v.Spec.NumberOfReplicas
 	v.Spec.NumberOfReplicas = count
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -226,6 +226,10 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 		spec.AccessMode = types.AccessModeReadWriteOnce
 	}
 
+	if spec.Migratable && spec.AccessMode != types.AccessModeReadWriteMany {
+		return nil, fmt.Errorf("migratable volumes are only supported in ReadWriteMany (rwx) access mode")
+	}
+
 	defaultEngineImage, err := m.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
 	if defaultEngineImage == "" {
 		return nil, fmt.Errorf("BUG: Invalid empty Setting.EngineImage")
@@ -261,6 +265,7 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 		Spec: types.VolumeSpec{
 			Size:                    size,
 			AccessMode:              spec.AccessMode,
+			Migratable:              spec.Migratable,
 			Frontend:                spec.Frontend,
 			EngineImage:             defaultEngineImage,
 			FromBackup:              spec.FromBackup,
@@ -296,11 +301,20 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		err = errors.Wrapf(err, "unable to attach volume %v to %v", name, nodeID)
 	}()
 
+	node, err := m.ds.GetNode(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	readyCondition := types.GetCondition(node.Status.Conditions, types.NodeConditionTypeReady)
+	if readyCondition.Status != types.ConditionStatusTrue {
+		return nil, fmt.Errorf("node %v is not ready, couldn't attach volume %v to it", node.Name, name)
+	}
+
 	v, err = m.ds.GetVolume(name)
 	if err != nil {
 		return nil, err
 	}
-	if v.Status.State != types.VolumeStateDetached {
+	if !v.Spec.Migratable && v.Status.State != types.VolumeStateDetached {
 		return nil, fmt.Errorf("invalid state to attach %v: %v", name, v.Status.State)
 	}
 
@@ -324,26 +338,59 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		return nil, fmt.Errorf("volume %v is pending restoring", name)
 	}
 
-	// already desired to be attached
-	if v.Spec.NodeID != "" {
-		if v.Spec.NodeID != nodeID {
-			return nil, fmt.Errorf("Node to be attached %v is different from previous spec %v", nodeID, v.Spec.NodeID)
-		}
+	if v.Spec.NodeID == nodeID {
+		logrus.Debugf("Volume %v is already attached to node %v", v.Name, v.Spec.NodeID)
 		return v, nil
 	}
-	v.Spec.NodeID = nodeID
+
+	if v.Spec.MigrationNodeID == nodeID {
+		logrus.Debugf("Volume %v is already migrating to node %v from node %v", v.Name, nodeID, v.Spec.NodeID)
+		return v, nil
+	}
+
+	if v.Spec.NodeID != "" {
+		if !v.Spec.Migratable {
+			return nil, fmt.Errorf("non migratable volume %v cannot attach to node %v is already attached to node %v", v.Name, nodeID, v.Spec.NodeID)
+		}
+		if v.Spec.MigrationNodeID != "" && v.Spec.MigrationNodeID != nodeID {
+			return nil, fmt.Errorf("unable to migrate volume %v from %v to %v since it's already migrating to %v",
+				v.Name, v.Spec.NodeID, nodeID, v.Spec.MigrationNodeID)
+		}
+		if v.Status.State != types.VolumeStateAttached {
+			return nil, fmt.Errorf("invalid volume state to start migration %v", v.Status.State)
+		}
+		if v.Status.Robustness != types.VolumeRobustnessHealthy {
+			return nil, fmt.Errorf("volume must be healthy to start migration")
+		}
+		if v.Spec.EngineImage != v.Status.CurrentImage {
+			return nil, fmt.Errorf("upgrading in process for volume, cannot start migration")
+		}
+		if v.Spec.Standby || v.Status.IsStandby {
+			return nil, fmt.Errorf("dr volume migration is not supported")
+		}
+		if v.Status.ExpansionRequired {
+			return nil, fmt.Errorf("cannot migrate volume while an expansion is required")
+		}
+
+		v.Spec.MigrationNodeID = nodeID
+		logrus.Infof("Volume %v migration from %v to %v requested", v.Name, v.Spec.NodeID, nodeID)
+	} else {
+		v.Spec.NodeID = nodeID
+		logrus.Infof("Volume %v attachment to %v with disableFrontend %v requested", v.Name, v.Spec.NodeID, disableFrontend)
+	}
+
 	v.Spec.DisableFrontend = disableFrontend
 	v.Spec.LastAttachedBy = attachedBy
-
 	v, err = m.ds.UpdateVolume(v)
 	if err != nil {
 		return nil, err
 	}
-	logrus.Debugf("Attaching volume %v to %v with disableFrontend set %v", v.Name, v.Spec.NodeID, disableFrontend)
 	return v, nil
 }
 
-func (m *VolumeManager) Detach(name string) (v *longhorn.Volume, err error) {
+// Detach will handle regular detachment as well as volume migration confirmation/rollback
+// if nodeID is not specified, the volume will be detached from all nodes
+func (m *VolumeManager) Detach(name, nodeID string) (v *longhorn.Volume, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "unable to detach volume %v", name)
 	}()
@@ -352,24 +399,64 @@ func (m *VolumeManager) Detach(name string) (v *longhorn.Volume, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if v.Status.State != types.VolumeStateAttached && v.Status.State != types.VolumeStateAttaching {
-		return nil, fmt.Errorf("invalid state to detach %v: %v", v.Name, v.Status.State)
+
+	if v.Status.IsStandby {
+		return nil, fmt.Errorf("cannot detach standby volume %v", v.Name)
 	}
 
-	oldNodeID := v.Spec.NodeID
-	if oldNodeID == "" {
+	if v.Spec.NodeID == "" && v.Spec.MigrationNodeID == "" {
+		logrus.Debugf("No need to detach volume %v is already detached from all nodes", v.Name)
 		return v, nil
 	}
 
-	v.Spec.NodeID = ""
-	v.Spec.DisableFrontend = false
+	if nodeID != "" && nodeID != v.Spec.NodeID && nodeID != v.Spec.MigrationNodeID {
+		logrus.Debugf("No need to detach volume %v since it's not attached to node %v", v.Name, nodeID)
+		return v, nil
+	}
 
+	// if the detach request doesn't specify a node to detach from
+	// we detach from all nodes, which is the same behavior as we previously had
+	if nodeID == "" {
+		v.Spec.NodeID = ""
+		v.Spec.MigrationNodeID = ""
+		logrus.Infof("Volume %v detachment from all nodes requested", v.Name)
+	} else if nodeID == v.Spec.NodeID {
+		if v.Spec.MigrationNodeID != "" && v.Spec.Migratable {
+			// migration confirmation, since detach is requested from the old node
+			// the engine must be running on the new node in order to be confirmed
+			if !m.isVolumeAvailableOnNode(name, v.Spec.MigrationNodeID) {
+				return nil, fmt.Errorf("migration is not ready yet")
+			}
+			v.Spec.NodeID = v.Spec.MigrationNodeID
+			v.Spec.MigrationNodeID = ""
+			logrus.Infof("Volume %v migration from %v to %v confirmed", v.Name, nodeID, v.Spec.NodeID)
+		} else {
+			v.Spec.NodeID = ""
+			v.Spec.MigrationNodeID = ""
+			logrus.Infof("Volume %v detachment from node %v requested", v.Name, nodeID)
+		}
+	} else if nodeID == v.Spec.MigrationNodeID {
+		v.Spec.MigrationNodeID = ""
+		logrus.Infof("Volume %v migration from %v to %v rollback", v.Name, nodeID, v.Spec.NodeID)
+	}
+
+	v.Spec.DisableFrontend = false
 	v, err = m.ds.UpdateVolume(v)
 	if err != nil {
 		return nil, err
 	}
-	logrus.Debugf("Detaching volume %v from %v", v.Name, oldNodeID)
 	return v, nil
+}
+
+func (m *VolumeManager) isVolumeAvailableOnNode(volume, node string) bool {
+	es, _ := m.ds.ListVolumeEngines(volume)
+	for _, e := range es {
+		if e.Spec.NodeID == node && e.Status.CurrentState == types.InstanceStateRunning {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *VolumeManager) Salvage(volumeName string, replicaNames []string) (v *longhorn.Volume, err error) {
@@ -759,120 +846,6 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 		logrus.Debugf("Rolling back volume %v engine image to %v", v.Name, v.Status.CurrentImage)
 	}
 
-	return v, nil
-}
-
-func (m *VolumeManager) checkVolumeNotInMigration(volumeName string) error {
-	v, err := m.Get(volumeName)
-	if err != nil {
-		return err
-	}
-	if v.Spec.MigrationNodeID != "" {
-		return fmt.Errorf("cannot operate during migration")
-	}
-	return nil
-}
-
-func (m *VolumeManager) MigrationStart(name, nodeID string) (v *longhorn.Volume, err error) {
-	defer func() {
-		err = errors.Wrapf(err, "unable to start migration for volume %v to %v", name, nodeID)
-	}()
-
-	v, err = m.ds.GetVolume(name)
-	if err != nil {
-		return nil, err
-	}
-	if v.Spec.NodeID == "" || v.Status.State != types.VolumeStateAttached {
-		return nil, fmt.Errorf("invalid volume state to start migration %v", v.Status.State)
-	}
-	if v.Status.Robustness != types.VolumeRobustnessHealthy {
-		return nil, fmt.Errorf("volume must be healthy to start migration")
-	}
-	if v.Spec.EngineImage != v.Status.CurrentImage {
-		return nil, fmt.Errorf("upgrading in process for volume, cannot start migration")
-	}
-	if v.Spec.MigrationNodeID != "" {
-		return nil, fmt.Errorf("migration already started")
-	}
-	if v.Spec.NodeID == nodeID {
-		return nil, fmt.Errorf("cannot migrate to the same node as volume currently attached to")
-	}
-
-	if nodeID == "" {
-		return nil, fmt.Errorf("empty migration destination")
-	}
-	if _, err := m.Node2APIAddress(nodeID); err != nil {
-		return nil, err
-	}
-
-	v.Spec.MigrationNodeID = nodeID
-	v, err = m.ds.UpdateVolume(v)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("Migration started for volume %v from %v to %v", v.Name, v.Spec.NodeID, nodeID)
-	return v, nil
-}
-
-func (m *VolumeManager) MigrationConfirm(name string) (v *longhorn.Volume, err error) {
-	defer func() {
-		err = errors.Wrapf(err, "unable to confirm migration for volume %v", name)
-	}()
-
-	v, err = m.ds.GetVolume(name)
-	if err != nil {
-		return nil, err
-	}
-	if v.Spec.NodeID == "" || v.Status.State != types.VolumeStateAttached {
-		return nil, fmt.Errorf("invalid volume state to confirm migration %v", v.Status.State)
-	}
-	if v.Spec.MigrationNodeID == "" {
-		return nil, fmt.Errorf("no migration in process to be confirm")
-	}
-
-	// the engine must be running in order to be confirmed
-	es, err := m.ds.ListVolumeEngines(name)
-	attached := false
-	for _, e := range es {
-		if e.Spec.NodeID == v.Spec.MigrationNodeID &&
-			e.Status.CurrentState == types.InstanceStateRunning {
-			attached = true
-			break
-		}
-	}
-	if !attached {
-		return nil, fmt.Errorf("migration is not ready yet")
-	}
-
-	oldNodeID := v.Spec.NodeID
-	v.Spec.NodeID = v.Spec.MigrationNodeID
-	v, err = m.ds.UpdateVolume(v)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("Start migration confirming for volume %v from %v to %v", v.Name, oldNodeID, v.Spec.NodeID)
-	return v, nil
-}
-
-func (m *VolumeManager) MigrationRollback(name string) (v *longhorn.Volume, err error) {
-	defer func() {
-		err = errors.Wrapf(err, "unable to rollback migration for volume %v", name)
-	}()
-
-	v, err = m.ds.GetVolume(name)
-	if err != nil {
-		return nil, err
-	}
-	if v.Spec.MigrationNodeID == "" {
-		return nil, fmt.Errorf("no migration in process to be rollback")
-	}
-
-	v.Spec.MigrationNodeID = ""
-	v, err = m.ds.UpdateVolume(v)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("Start rolling back migration for volume %v", v.Name)
 	return v, nil
 }
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -92,6 +92,7 @@ type VolumeSpec struct {
 	RevisionCounterDisabled bool           `json:"revisionCounterDisabled"`
 	LastAttachedBy          string         `json:"lastAttachedBy"`
 	AccessMode              AccessMode     `json:"accessMode"`
+	Migratable              bool           `json:"migratable"`
 
 	// Deprecated. Rename to BackingImage
 	BaseImage string `json:"baseImage"`

--- a/types/resource.go
+++ b/types/resource.go
@@ -81,6 +81,7 @@ type VolumeSpec struct {
 	DataLocality            DataLocality   `json:"dataLocality"`
 	StaleReplicaTimeout     int            `json:"staleReplicaTimeout"`
 	NodeID                  string         `json:"nodeID"`
+	MigrationNodeID         string         `json:"migrationNodeID"`
 	EngineImage             string         `json:"engineImage"`
 	RecurringJobs           []RecurringJob `json:"recurringJobs"`
 	BackingImage            string         `json:"backingImage"`


### PR DESCRIPTION
The live migration function works like this:

- n1 | vm1 has the volume attached (v.spec.nodeID = n1)
- n2 | vm2 requests attachment (v.spec.migrationNodeID = n2) [migrationStart]
- volume-controller brings up new engine on n2, with inactive matching replicas (same as live engine upgrade)
- csi driver polls for existence of second engine on n2 before acknowledging attach

The following detach decides whether a migration is successful or a migration rollback on the longhorn side.
- n1 | vm1 requests detach of n1 (v.spec.nodeID = n2, v.spec.migrationNodeID = "") [migrationComplete]
- n2 | vm2 requests detach of n2 (v.spec.NodeID = n1, v.spec.migrationNodeID = "") [migrationRollback]

The volume controller then cleans up the second engine and switches the active replicas to be the current engine ones.

longhorn/longhorn#2127