### PR TITLE
Set minAvailable to 0 for instance-manager-e pods

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -627,6 +627,14 @@ func (imc *InstanceManagerController) createInstanceManagerPDB(im *longhorn.Inst
 }
 
 func (imc *InstanceManagerController) generateInstanceManagerPDBManifest(im *longhorn.InstanceManager) *policyv1beta1.PodDisruptionBudget {
+	var minAvailable int32
+	switch im.Spec.Type {
+	case types.InstanceManagerTypeEngine:
+		minAvailable = 0
+	case types.InstanceManagerTypeReplica:
+		minAvailable = 1
+	}
+
 	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      imc.getPDBName(im),
@@ -636,7 +644,7 @@ func (imc *InstanceManagerController) generateInstanceManagerPDBManifest(im *lon
 			Selector: &metav1.LabelSelector{
 				MatchLabels: types.GetInstanceManagerLabels(imc.controllerID, im.Spec.Image, im.Spec.Type),
 			},
-			MinAvailable: &intstr.IntOrString{IntVal: 1},
+			MinAvailable: &intstr.IntOrString{IntVal: minAvailable},
 		},
 	}
 }


### PR DESCRIPTION
* Allows for compatibility with Cluster Autoscaler

Signed-off-by: Andrew Hemming <andrew@footprintmedia.net>