### PR TITLE
Fix CSI sanity check

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -236,6 +236,10 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	if !cs.waitForVolumeState(req.GetVolumeId(), "deleted", isVolumeDeleted, false, true) {
+		return nil, status.Errorf(codes.Aborted, "Failed to delete volume %s", req.GetVolumeId())
+	}
+
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
@@ -715,6 +719,10 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		CapacityBytes:         req.CapacityRange.GetRequiredBytes(),
 		NodeExpansionRequired: false,
 	}, nil
+}
+
+func isVolumeDeleted(vol *longhornclient.Volume) bool {
+	return vol == nil
 }
 
 func isVolumeDetached(vol *longhornclient.Volume) bool {

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -247,6 +247,17 @@ func (cs *ControllerServer) ControllerGetCapabilities(ctx context.Context, req *
 
 func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	logrus.Infof("ControllerServer ValidateVolumeCapabilities req: %v", req)
+
+	existVol, err := cs.apiClient.Volume.ById(req.GetVolumeId())
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if existVol == nil {
+		msg := fmt.Sprintf("ValidateVolumeCapabilities: the volume %s not exists", req.GetVolumeId())
+		logrus.Warn(msg)
+		return nil, status.Error(codes.NotFound, msg)
+	}
+
 	if err := cs.validateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
 		return nil, err
 	}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -664,7 +664,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if backupVolume != nil {
+	if backupVolume != nil && backupVolume.Name != "" {
 		backupVolume, err = cs.apiClient.BackupVolume.ActionBackupDelete(backupVolume, &longhornclient.BackupInput{Name: backupName})
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -410,6 +410,12 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	logrus.Infof("ControllerServer ControllerUnpublishVolume req: %v", req)
 
+	if req.GetVolumeId() == "" {
+		msg := "ControllerUnpublishVolume: missing volume id in request"
+		logrus.Warn(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+
 	existVol, err := cs.apiClient.Volume.ById(req.GetVolumeId())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -40,7 +40,6 @@ func NewNodeServer(apiClient *longhornclient.RancherClient, nodeID string) *Node
 		nodeID:    nodeID,
 		caps: getNodeServiceCapabilities(
 			[]csi.NodeServiceCapability_RPC_Type{
-				csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 				csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 			}),
 	}

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -295,6 +295,18 @@ func (ns *NodeServer) NodeUnstageVolume(
 }
 
 func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	if req.GetVolumeId() == "" {
+		msg := "NodeGetVolumeStats: missing volume id in request"
+		logrus.Warn(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+
+	if req.GetVolumePath() == "" {
+		msg := "NodeGetVolumeStats: missing volume path in request"
+		logrus.Warn(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+
 	existVol, err := ns.apiClient.Volume.ById(req.GetVolumeId())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -238,7 +238,19 @@ func (ns *NodeServer) nodePublishBlockVolume(volumeName, devicePath, targetPath 
 func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	logrus.Infof("NodeServer NodeUnpublishVolume req: %v", req)
 
+	if req.GetVolumeId() == "" {
+		msg := fmt.Sprint("NodeUnpublishVolume: missing volume id in request")
+		logrus.Warn(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+
 	targetPath := req.GetTargetPath()
+	if targetPath == "" {
+		msg := fmt.Sprint("NodeUnpublishVolume: missing target path in request")
+		logrus.Warn(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
+	}
+
 	mounter := mount.New("")
 	for {
 		if err := mounter.Unmount(targetPath); err != nil {


### PR DESCRIPTION
Fix failures from [csi-sanity](https://github.com/kubernetes-csi/csi-test/tree/master/cmd/csi-sanity) tests.

* Add volume name autocorrection.
* Remove the unimplemented capability to bypass related tests.
* Correct misuse of the error codes.
* Validate resources to fix unexpected returns.
* Address to idempotency of volume life cycle.

Relate to https://github.com/longhorn/longhorn/issues/2076