### PR TITLE
Setup environment variables to sub-process only

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -442,7 +442,7 @@ func (ec *EngineController) DeleteInstance(obj interface{}) error {
 	if im.Status.APIVersion == engineapi.IncompatibleInstanceManagerAPIVersion {
 		url := imutil.GetURL(im.Status.IP, engineapi.InstanceManagerDefaultPort)
 		args := []string{"--url", url, "engine", "delete", "--name", e.Name}
-		if _, err := util.ExecuteWithoutTimeout(engineapi.GetDeprecatedInstanceManagerBinary(e.Status.CurrentImage), args...); err != nil && !types.ErrorIsNotFound(err) {
+		if _, err := util.ExecuteWithoutTimeout([]string{}, engineapi.GetDeprecatedInstanceManagerBinary(e.Status.CurrentImage), args...); err != nil && !types.ErrorIsNotFound(err) {
 			return err
 		}
 

--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -53,17 +53,17 @@ func (e *Engine) LonghornEngineBinary() string {
 
 func (e *Engine) ExecuteEngineBinary(args ...string) (string, error) {
 	args = append([]string{"--url", e.cURL}, args...)
-	return util.Execute(e.LonghornEngineBinary(), args...)
+	return util.Execute([]string{}, e.LonghornEngineBinary(), args...)
 }
 
 func (e *Engine) ExecuteEngineBinaryWithTimeout(timeout time.Duration, args ...string) (string, error) {
 	args = append([]string{"--url", e.cURL}, args...)
-	return util.ExecuteWithTimeout(timeout, e.LonghornEngineBinary(), args...)
+	return util.ExecuteWithTimeout(timeout, []string{}, e.LonghornEngineBinary(), args...)
 }
 
-func (e *Engine) ExecuteEngineBinaryWithoutTimeout(args ...string) (string, error) {
+func (e *Engine) ExecuteEngineBinaryWithoutTimeout(envs []string, args ...string) (string, error) {
 	args = append([]string{"--url", e.cURL}, args...)
-	return util.ExecuteWithoutTimeout(e.LonghornEngineBinary(), args...)
+	return util.ExecuteWithoutTimeout(envs, e.LonghornEngineBinary(), args...)
 }
 
 func parseReplica(s string) (*Replica, error) {
@@ -113,7 +113,7 @@ func (e *Engine) ReplicaAdd(url string, isRestoreVolume bool) error {
 	if isRestoreVolume {
 		cmd = append(cmd, "--restore")
 	}
-	if _, err := e.ExecuteEngineBinaryWithoutTimeout(cmd...); err != nil {
+	if _, err := e.ExecuteEngineBinaryWithoutTimeout([]string{}, cmd...); err != nil {
 		return errors.Wrapf(err, "failed to add replica address='%s' to controller '%s'", url, e.name)
 	}
 	return nil
@@ -168,7 +168,7 @@ func (e *Engine) Version(clientOnly bool) (*EngineVersion, error) {
 	} else {
 		cmdline = append([]string{"--url", e.cURL}, cmdline...)
 	}
-	output, err := util.Execute(e.LonghornEngineBinary(), cmdline...)
+	output, err := util.Execute([]string{}, e.LonghornEngineBinary(), cmdline...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get volume version")
 	}
@@ -231,7 +231,7 @@ func (e *Engine) ReplicaRebuildVerify(url string) error {
 		return err
 	}
 	cmd := []string{"verify-rebuild-replica", url}
-	if _, err := e.ExecuteEngineBinaryWithoutTimeout(cmd...); err != nil {
+	if _, err := e.ExecuteEngineBinaryWithoutTimeout([]string{}, cmd...); err != nil {
 		return errors.Wrapf(err, "failed to verify rebuilding for the replica from address %s", url)
 	}
 	return nil

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -70,7 +70,7 @@ func (e *Engine) SnapshotRevert(name string) error {
 }
 
 func (e *Engine) SnapshotPurge() error {
-	if _, err := e.ExecuteEngineBinaryWithoutTimeout("snapshot", "purge", "--skip-if-in-progress"); err != nil {
+	if _, err := e.ExecuteEngineBinaryWithoutTimeout([]string{}, "snapshot", "purge", "--skip-if-in-progress"); err != nil {
 		return errors.Wrapf(err, "error starting snapshot purge")
 	}
 	logrus.Debugf("Volume %v snapshot purge started", e.Name())

--- a/manager/backup.go
+++ b/manager/backup.go
@@ -9,10 +9,9 @@ import (
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
-
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 )
 
 var (
@@ -137,7 +136,7 @@ func GetBackupCredentialConfig(ds *datastore.DataStore) (map[string]string, erro
 	if err != nil {
 		return nil, err
 	}
-	if backupType == util.BackupStoreTypeS3 {
+	if backupType == types.BackupStoreTypeS3 {
 		secretName, err := ds.GetSettingValueExisted(types.SettingNameBackupTargetCredentialSecret)
 		if err != nil {
 			return nil, fmt.Errorf("cannot backup: unable to get settings %v",

--- a/types/types.go
+++ b/types/types.go
@@ -98,6 +98,8 @@ const (
 	EnvPodIP          = "POD_IP"
 	EnvServiceAccount = "SERVICE_ACCOUNT"
 
+	BackupStoreTypeS3 = "s3"
+
 	AWSAccessKey = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
 	AWSEndPoint  = "AWS_ENDPOINTS"

--- a/util/util.go
+++ b/util/util.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -42,18 +42,6 @@ const (
 	VolumeStackPrefix     = "volume-"
 	ControllerServiceName = "controller"
 	ReplicaServiceName    = "replica"
-
-	BackupStoreTypeS3 = "s3"
-	AWSAccessKey      = "AWS_ACCESS_KEY_ID"
-	AWSSecretKey      = "AWS_SECRET_ACCESS_KEY"
-	AWSEndPoint       = "AWS_ENDPOINTS"
-	AWSCert           = "AWS_CERT"
-
-	HTTPSProxy = "HTTPS_PROXY"
-	HTTPProxy  = "HTTP_PROXY"
-	NOProxy    = "NO_PROXY"
-
-	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
 
 	HostProcPath                 = "/host/proc"
 	ReplicaDirectory             = "/replicas/"
@@ -209,13 +197,14 @@ func ParseTime(t string) (time.Time, error) {
 
 }
 
-func Execute(binary string, args ...string) (string, error) {
-	return ExecuteWithTimeout(cmdTimeout, binary, args...)
+func Execute(envs []string, binary string, args ...string) (string, error) {
+	return ExecuteWithTimeout(cmdTimeout, envs, binary, args...)
 }
 
-func ExecuteWithTimeout(timeout time.Duration, binary string, args ...string) (string, error) {
+func ExecuteWithTimeout(timeout time.Duration, envs []string, binary string, args ...string) (string, error) {
 	var err error
 	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), envs...)
 	done := make(chan struct{})
 
 	var output, stderr bytes.Buffer
@@ -247,8 +236,9 @@ func ExecuteWithTimeout(timeout time.Duration, binary string, args ...string) (s
 	return output.String(), nil
 }
 
-func ExecuteWithoutTimeout(binary string, args ...string) (string, error) {
+func ExecuteWithoutTimeout(envs []string, binary string, args ...string) (string, error) {
 	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), envs...)
 
 	var output, stderr bytes.Buffer
 	cmd.Stdout = &output
@@ -375,99 +365,13 @@ func CheckBackupType(backupTarget string) (string, error) {
 	return u.Scheme, nil
 }
 
-func ConfigBackupCredential(backupTarget string, credential map[string]string) error {
-	backupType, err := CheckBackupType(backupTarget)
-	if err != nil {
-		return err
-	}
-	if backupType == BackupStoreTypeS3 {
-		// environment variable has been set in cronjob
-		if credential != nil && credential[AWSAccessKey] != "" && credential[AWSSecretKey] != "" {
-			os.Setenv(AWSAccessKey, credential[AWSAccessKey])
-			os.Setenv(AWSSecretKey, credential[AWSSecretKey])
-			os.Setenv(AWSEndPoint, credential[AWSEndPoint])
-			os.Setenv(AWSCert, credential[AWSCert])
-			os.Setenv(HTTPSProxy, credential[HTTPSProxy])
-			os.Setenv(HTTPProxy, credential[HTTPProxy])
-			os.Setenv(NOProxy, credential[NOProxy])
-			os.Setenv(VirtualHostedStyle, credential[VirtualHostedStyle])
-		} else if os.Getenv(AWSAccessKey) == "" || os.Getenv(AWSSecretKey) == "" {
-			return fmt.Errorf("Could not backup for %s without credential secret", backupType)
-		}
-	}
-	return nil
-}
-
-func ConfigEnvWithCredential(backupTarget string, credentialSecret string, hasEndpoint bool, hasCert bool,
-	container *v1.Container) error {
-	backupType, err := CheckBackupType(backupTarget)
-	if err != nil {
-		return err
-	}
-	if backupType == BackupStoreTypeS3 && credentialSecret != "" {
-		accessKeyEnv := v1.EnvVar{
-			Name: AWSAccessKey,
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: credentialSecret,
-					},
-					Key: AWSAccessKey,
-				},
-			},
-		}
-		container.Env = append(container.Env, accessKeyEnv)
-		secretKeyEnv := v1.EnvVar{
-			Name: AWSSecretKey,
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: credentialSecret,
-					},
-					Key: AWSSecretKey,
-				},
-			},
-		}
-		container.Env = append(container.Env, secretKeyEnv)
-		if hasEndpoint {
-			endpointEnv := v1.EnvVar{
-				Name: AWSEndPoint,
-				ValueFrom: &v1.EnvVarSource{
-					SecretKeyRef: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
-							Name: credentialSecret,
-						},
-						Key: AWSEndPoint,
-					},
-				},
-			}
-			container.Env = append(container.Env, endpointEnv)
-		}
-		if hasCert {
-			certEnv := v1.EnvVar{
-				Name: AWSCert,
-				ValueFrom: &v1.EnvVarSource{
-					SecretKeyRef: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
-							Name: credentialSecret,
-						},
-						Key: AWSCert,
-					},
-				},
-			}
-			container.Env = append(container.Env, certEnv)
-		}
-	}
-	return nil
-}
-
 func GetDiskInfo(directory string) (info *DiskInfo, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "cannot get disk info of directory %v", directory)
 	}()
 	initiatorNSPath := iscsi_util.GetHostNamespacePath(HostProcPath)
 	mountPath := fmt.Sprintf("--mount=%s/mnt", initiatorNSPath)
-	output, err := Execute("nsenter", mountPath, "stat", "-fc", "{\"path\":\"%n\",\"fsid\":\"%i\",\"type\":\"%T\",\"freeBlock\":%f,\"totalBlock\":%b,\"blockSize\":%S}", directory)
+	output, err := Execute([]string{}, "nsenter", mountPath, "stat", "-fc", "{\"path\":\"%n\",\"fsid\":\"%i\",\"type\":\"%T\",\"freeBlock\":%f,\"totalBlock\":%b,\"blockSize\":%S}", directory)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Proposed Changes
Pass S3 specific environment variables to sub-process only.
This could prevent the sub-process environment variables affect the parent process.

For example: if the backup target S3 need to go through proxy server, then pass the additional envs to sub-process by
```go
cmd := exec.Command("backup", "ls", args...)
cmd.Env = append(os.Environ(), "HTTP_PROXY=<http-proxy>", "HTTPS_PROXY=<https-proxy>", "NO_PROXY=<no-proxy>", ...)
```

#### Linked Issues
https://github.com/longhorn/longhorn/issues/2198