### PR TITLE
Refactor volume attach/detach to fix rwx expansion

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -37,6 +37,7 @@ type Volume struct {
 	CurrentImage            string                 `json:"currentImage"`
 	BackingImage            string                 `json:"backingImage"`
 	Created                 string                 `json:"created"`
+	MigrationNodeID         string                 `json:"migrationNodeID"`
 	LastBackup              string                 `json:"lastBackup"`
 	LastBackupAt            string                 `json:"lastBackupAt"`
 	LastAttachedBy          string                 `json:"lastAttachedBy"`
@@ -622,6 +623,12 @@ func volumeSchema(volume *client.Schema) {
 		"engineUpgrade": {
 			Input: "engineUpgradeInput",
 		},
+
+		"migrationStart": {
+			Input: "nodeInput",
+		},
+		"migrationConfirm":  {},
+		"migrationRollback": {},
 	}
 	volume.ResourceFields["controllers"] = client.Field{
 		Type:     "array[controller]",
@@ -999,6 +1006,9 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["pvCreate"] = struct{}{}
 			actions["pvcCreate"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
+			actions["migrationStart"] = struct{}{}
+			actions["migrationConfirm"] = struct{}{}
+			actions["migrationRollback"] = struct{}{}
 		}
 	}
 

--- a/api/model.go
+++ b/api/model.go
@@ -989,12 +989,12 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["detach"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}
 		case types.VolumeStateAttached:
-			// We allow calling attach on an already attached volume in the case
-			// where the volume is migratable, we should consider exposing all the actions
-			// all the time and have the backend deal with when which action is valid
+			// we allow calling attach on an already attached volume in RWX access mode
+			// we should consider exposing all the actions all the time
+			// and have the backend deal with when which action is valid
 			// this would simplify the csi driver down to just being a caller of the api
 			// instead of having all kinds of knowledge about the states itself
-			if r.AccessMode == types.AccessModeReadWriteMany && r.Migratable {
+			if r.AccessMode == types.AccessModeReadWriteMany {
 				actions["attach"] = struct{}{}
 			}
 			actions["detach"] = struct{}{}

--- a/api/model.go
+++ b/api/model.go
@@ -37,7 +37,6 @@ type Volume struct {
 	CurrentImage            string                 `json:"currentImage"`
 	BackingImage            string                 `json:"backingImage"`
 	Created                 string                 `json:"created"`
-	MigrationNodeID         string                 `json:"migrationNodeID"`
 	LastBackup              string                 `json:"lastBackup"`
 	LastBackupAt            string                 `json:"lastBackupAt"`
 	LastAttachedBy          string                 `json:"lastAttachedBy"`
@@ -951,8 +950,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		ShareEndpoint: v.Status.ShareEndpoint,
 		ShareState:    v.Status.ShareState,
 
-		Migratable:      v.Spec.Migratable,
-		MigrationNodeID: v.Spec.MigrationNodeID,
+		Migratable: v.Spec.Migratable,
 
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,

--- a/api/router.go
+++ b/api/router.go
@@ -80,6 +80,10 @@ func NewRouter(s *Server) *mux.Router {
 		"replicaRemove": s.ReplicaRemove,
 		"engineUpgrade": s.EngineUpgrade,
 
+		"migrationStart":    s.MigrationStart,
+		"migrationConfirm":  s.MigrationConfirm,
+		"migrationRollback": s.MigrationRollback,
+
 		"snapshotPurge":  s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotPurge),
 		"snapshotCreate": s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotCreate),
 		"snapshotList":   s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotList),

--- a/api/router.go
+++ b/api/router.go
@@ -80,10 +80,6 @@ func NewRouter(s *Server) *mux.Router {
 		"replicaRemove": s.ReplicaRemove,
 		"engineUpgrade": s.EngineUpgrade,
 
-		"migrationStart":    s.MigrationStart,
-		"migrationConfirm":  s.MigrationConfirm,
-		"migrationRollback": s.MigrationRollback,
-
 		"snapshotPurge":  s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotPurge),
 		"snapshotCreate": s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotCreate),
 		"snapshotList":   s.fwd.Handler(OwnerIDFromVolume(s.m), s.SnapshotList),

--- a/api/volume.go
+++ b/api/volume.go
@@ -209,7 +209,9 @@ func (s *Server) VolumeDetach(rw http.ResponseWriter, req *http.Request) error {
 
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&input); err != nil {
-		return err
+		// HACK: for ui detach requests that don't send a body
+		// This is the same as previous behavior where detach is requested from all nodes
+		input.HostID = ""
 	}
 	id := mux.Vars(req)["name"]
 

--- a/app/volume.go
+++ b/app/volume.go
@@ -221,8 +221,8 @@ func (job *Job) run() (err error) {
 		return errors.Wrapf(err, "could not get volume %v", volumeName)
 	}
 
-	if volume.MigrationNodeID != "" {
-		return fmt.Errorf("cannot run job for volume %v during migration", volume.Name)
+	if len(volume.Controllers) > 1 {
+		return fmt.Errorf("cannot run job for volume %v that is using %v engines", volume.Name, len(volume.Controllers))
 	}
 
 	defer job.handleVolumeDetachment()

--- a/app/volume.go
+++ b/app/volume.go
@@ -221,6 +221,10 @@ func (job *Job) run() (err error) {
 		return errors.Wrapf(err, "could not get volume %v", volumeName)
 	}
 
+	if volume.MigrationNodeID != "" {
+		return fmt.Errorf("cannot run job for volume %v during migration", volume.Name)
+	}
+
 	defer job.handleVolumeDetachment()
 
 	if volume.State != string(types.VolumeStateAttached) && volume.State != string(types.VolumeStateDetached) {

--- a/app/volume.go
+++ b/app/volume.go
@@ -196,8 +196,8 @@ func (job *Job) handleVolumeDetachment() {
 				return
 			}
 			if volume.State == string(types.VolumeStateAttached) {
-				logrus.Infof("Attempting to detach volume %v ", volumeName)
-				if _, err := volumeAPI.ActionDetach(volume); err != nil {
+				logrus.Infof("Attempting to detach volume %v from all nodes", volumeName)
+				if _, err := volumeAPI.ActionDetach(volume, &longhornclient.DetachInput{HostId: ""}); err != nil {
 					logrus.Infof("%v ", err)
 				}
 			}

--- a/client/README.md
+++ b/client/README.md
@@ -19,3 +19,9 @@ Just use cp to copy these code is fine, but you should update package name in `l
 cd longhorn-manager/client
 sed -i -e 's/package longhorn/package client/g' *.go
 ```
+
+## Notes:
+
+The generator currently no longer generates actions, so you need to ensure not to overwrite the `ActionUpdateAccessMode`
+in `generated_volume.go`. I currently don't have the time to look into this and since we are planning on reworking the api
+down the line, this is a low priority issue for now.

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -6,6 +6,7 @@ type RancherClient struct {
 	ApiVersion                ApiVersionOperations
 	Error                     ErrorOperations
 	AttachInput               AttachInputOperations
+	DetachInput               DetachInputOperations
 	SnapshotInput             SnapshotInputOperations
 	Backup                    BackupOperations
 	BackupInput               BackupInputOperations
@@ -22,7 +23,6 @@ type RancherClient struct {
 	Replica                   ReplicaOperations
 	Controller                ControllerOperations
 	DiskUpdate                DiskUpdateOperations
-	NodeInput                 NodeInputOperations
 	UpdateReplicaCountInput   UpdateReplicaCountInputOperations
 	UpdateDataLocalityInput   UpdateDataLocalityInputOperations
 	UpdateAccessModeInput     UpdateAccessModeInputOperations
@@ -61,6 +61,7 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.ApiVersion = newApiVersionClient(client)
 	client.Error = newErrorClient(client)
 	client.AttachInput = newAttachInputClient(client)
+	client.DetachInput = newDetachInputClient(client)
 	client.SnapshotInput = newSnapshotInputClient(client)
 	client.Backup = newBackupClient(client)
 	client.BackupInput = newBackupInputClient(client)
@@ -77,7 +78,6 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.Replica = newReplicaClient(client)
 	client.Controller = newControllerClient(client)
 	client.DiskUpdate = newDiskUpdateClient(client)
-	client.NodeInput = newNodeInputClient(client)
 	client.UpdateReplicaCountInput = newUpdateReplicaCountInputClient(client)
 	client.UpdateDataLocalityInput = newUpdateDataLocalityInputClient(client)
 	client.UpdateAccessModeInput = newUpdateAccessModeInputClient(client)

--- a/client/generated_detach_input.go
+++ b/client/generated_detach_input.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	DETACH_INPUT_TYPE = "detachInput"
+)
+
+type DetachInput struct {
+	Resource `yaml:"-"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+}
+
+type DetachInputCollection struct {
+	Collection
+	Data   []DetachInput `json:"data,omitempty"`
+	client *DetachInputClient
+}
+
+type DetachInputClient struct {
+	rancherClient *RancherClient
+}
+
+type DetachInputOperations interface {
+	List(opts *ListOpts) (*DetachInputCollection, error)
+	Create(opts *DetachInput) (*DetachInput, error)
+	Update(existing *DetachInput, updates interface{}) (*DetachInput, error)
+	ById(id string) (*DetachInput, error)
+	Delete(container *DetachInput) error
+}
+
+func newDetachInputClient(rancherClient *RancherClient) *DetachInputClient {
+	return &DetachInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DetachInputClient) Create(container *DetachInput) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doCreate(DETACH_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DetachInputClient) Update(existing *DetachInput, updates interface{}) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doUpdate(DETACH_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DetachInputClient) List(opts *ListOpts) (*DetachInputCollection, error) {
+	resp := &DetachInputCollection{}
+	err := c.rancherClient.doList(DETACH_INPUT_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *DetachInputCollection) Next() (*DetachInputCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &DetachInputCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *DetachInputClient) ById(id string) (*DetachInput, error) {
+	resp := &DetachInput{}
+	err := c.rancherClient.doById(DETACH_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DetachInputClient) Delete(container *DetachInput) error {
+	return c.rancherClient.doResourceDelete(DETACH_INPUT_TYPE, &container.Resource)
+}

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -41,6 +41,8 @@ type Volume struct {
 
 	LastBackupAt string `json:"lastBackupAt,omitempty" yaml:"last_backup_at,omitempty"`
 
+	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	NodeSelector []string `json:"nodeSelector,omitempty" yaml:"node_selector,omitempty"`

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -41,6 +41,8 @@ type Volume struct {
 
 	LastBackupAt string `json:"lastBackupAt,omitempty" yaml:"last_backup_at,omitempty"`
 
+	Migratable bool `json:"migratable,omitempty" yaml:"migratable,omitempty"`
+
 	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -105,7 +107,7 @@ type VolumeOperations interface {
 
 	ActionCancelExpansion(*Volume) (*Volume, error)
 
-	ActionDetach(*Volume) (*Volume, error)
+	ActionDetach(*Volume, *DetachInput) (*Volume, error)
 
 	ActionExpand(*Volume, *ExpandInput) (*Volume, error)
 
@@ -211,11 +213,11 @@ func (c *VolumeClient) ActionCancelExpansion(resource *Volume) (*Volume, error) 
 	return resp, err
 }
 
-func (c *VolumeClient) ActionDetach(resource *Volume) (*Volume, error) {
+func (c *VolumeClient) ActionDetach(resource *Volume, input *DetachInput) (*Volume, error) {
 
 	resp := &Volume{}
 
-	err := c.rancherClient.doAction(VOLUME_TYPE, "detach", &resource.Resource, nil, resp)
+	err := c.rancherClient.doAction(VOLUME_TYPE, "detach", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -43,8 +43,6 @@ type Volume struct {
 
 	Migratable bool `json:"migratable,omitempty" yaml:"migratable,omitempty"`
 
-	MigrationNodeID string `json:"migrationNodeID,omitempty" yaml:"migration_node_id,omitempty"`
-
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	NodeSelector []string `json:"nodeSelector,omitempty" yaml:"node_selector,omitempty"`

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -148,7 +148,7 @@ func (c *ShareManagerController) enqueueShareManagerForVolume(obj interface{}) {
 		}
 	}
 
-	if volume.Spec.AccessMode == types.AccessModeReadWriteMany {
+	if volume.Spec.AccessMode == types.AccessModeReadWriteMany && !volume.Spec.Migratable {
 		// we can queue the key directly since a share manager only manages a single volume from it's own namespace
 		// and there is no need for us to retrieve the whole object, since we already know the volume name
 		getLoggerForVolume(c.logger, volume).Trace("Enqueuing share manager for volume")

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2318,10 +2318,7 @@ func (vc *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica
 	// delete the volume data on the disk.
 	// Set `active` at last to prevent data loss
 	for _, r := range rs {
-		if activeCondFunc(r, obj) != r.Spec.Active {
-			r.Spec.Active = activeCondFunc(r, obj)
-			rs[r.Name] = r
-		}
+		r.Spec.Active = activeCondFunc(r, obj)
 	}
 	return nil
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -423,6 +423,10 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 		}
 	}
 
+	if err := vc.processMigration(volume, engines, replicas); err != nil {
+		return err
+	}
+
 	if err := vc.ReconcileShareManagerState(volume); err != nil {
 		return err
 	}
@@ -698,7 +702,7 @@ func (vc *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*l
 
 func (vc *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) error {
 	healthyCount := vc.getHealthyReplicaCount(rs)
-	cleanupLeftoverReplicas := !vc.isVolumeUpgrading(v)
+	cleanupLeftoverReplicas := !vc.isVolumeUpgrading(v) && !vc.isVolumeMigrating(v)
 	log := getLoggerForVolume(vc.logger, v)
 
 	for _, r := range rs {
@@ -1432,6 +1436,10 @@ func (vc *VolumeController) replenishReplicas(v *longhorn.Volume, e *longhorn.En
 
 	// If disabled replica rebuild, skip all the rebuild except first time creation.
 	if (len(rs) != 0) && (disableReplicaRebuild == true) {
+		return nil
+	}
+
+	if vc.isVolumeMigrating(v) {
 		return nil
 	}
 
@@ -2252,6 +2260,10 @@ func (vc *VolumeController) isVolumeUpgrading(v *longhorn.Volume) bool {
 	return v.Status.CurrentImage != v.Spec.EngineImage
 }
 
+func (vc *VolumeController) isVolumeMigrating(v *longhorn.Volume) bool {
+	return v.Spec.MigrationNodeID != ""
+}
+
 func (vc *VolumeController) getEngineImage(image string) (*longhorn.EngineImage, error) {
 	name := types.GetEngineImageChecksumName(image)
 	img, err := vc.ds.GetEngineImage(name)
@@ -2338,6 +2350,137 @@ func (vc *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica
 	for _, r := range rs {
 		r.Spec.Active = activeCondFunc(r, obj)
 	}
+	return nil
+}
+
+func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*longhorn.Engine, rs map[string]*longhorn.Replica) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "fail to process migration for %v", v.Name)
+	}()
+	// only process if volume is attached
+	if v.Spec.NodeID == "" {
+		return nil
+	}
+
+	// cannot process migrate when upgrading
+	if vc.isVolumeUpgrading(v) {
+		return nil
+	}
+
+	if len(es) > 2 {
+		return fmt.Errorf("BUG: volume %v: more than two engines exists", v.Name)
+	}
+
+	if !vc.isVolumeMigrating(v) {
+		if len(es) != 2 {
+			return nil
+		}
+
+		// rollback migration
+		if _, err := vc.getCurrentEngineAndCleanupOthers(v, es); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// confirm migration
+	if v.Spec.MigrationNodeID == v.Spec.NodeID {
+		// must be set after migration preparation done
+		currentEngine, err := vc.getCurrentEngineAndCleanupOthers(v, es)
+		if err != nil {
+			return err
+		}
+
+		if err := vc.switchActiveReplicas(rs, func(r *longhorn.Replica, engineName string) bool {
+			return r.Spec.EngineName == engineName
+		}, currentEngine.Name); err != nil {
+			return err
+		}
+
+		v.Status.OwnerID = v.Spec.NodeID
+		v.Spec.MigrationNodeID = ""
+		if _, err := vc.ds.UpdateVolume(v); err != nil {
+			return err
+		}
+
+		// cleanupCorruptedOrStaleReplicas() will take care of old replicas
+		vc.logger.Infof("Migration to node %v has been confirmed", v.Spec.NodeID)
+		return nil
+	}
+
+	currentEngine, migrationEngine, err := vc.getCurrentEngineAndExtra(v, es)
+	if err != nil {
+		return err
+	}
+
+	if migrationEngine == nil {
+		migrationEngine, err = vc.createEngine(v)
+		if err != nil {
+			return err
+		}
+		es[migrationEngine.Name] = migrationEngine
+	}
+
+	currentReplicas := map[string]*longhorn.Replica{}
+	migrationReplicas := map[string]*longhorn.Replica{}
+	unknownReplicas := map[string]*longhorn.Replica{}
+	for _, r := range rs {
+		dataPath := types.GetReplicaDataPath(r.Spec.DiskPath, r.Spec.DataDirectoryName)
+		if r.Spec.FailedAt != "" {
+			continue
+		}
+		if r.Spec.EngineName == currentEngine.Name {
+			currentReplicas[dataPath] = r
+		} else if r.Spec.EngineName == migrationEngine.Name {
+			migrationReplicas[dataPath] = r
+		} else {
+			vc.logger.Warnf("During migration found unknown replica with engine %v", r.Spec.EngineName)
+			unknownReplicas[dataPath] = r
+		}
+	}
+
+	if err := vc.createAndStartMatchingReplicas(v, rs, currentReplicas, migrationReplicas, func(r *longhorn.Replica, engineName string) {
+		r.Spec.EngineName = engineName
+	}, migrationEngine.Name); err != nil {
+		return err
+	}
+
+	if migrationEngine.Spec.DesireState != types.InstanceStateRunning {
+		replicaAddressMap := map[string]string{}
+		for _, r := range migrationReplicas {
+			// wait for all potentially healthy replicas become running
+			if r.Status.CurrentState != types.InstanceStateRunning {
+				return nil
+			}
+			if r.Status.IP == "" {
+				vc.logger.Errorf("BUG: replica %v is running but IP is empty", r.Name)
+				continue
+			}
+			if r.Status.Port == 0 {
+				vc.logger.Errorf("BUG: replica %v is running but Port is empty", r.Name)
+				continue
+			}
+			replicaAddressMap[r.Name] = imutil.GetURL(r.Status.IP, r.Status.Port)
+		}
+		if migrationEngine.Spec.NodeID != "" && migrationEngine.Spec.NodeID != v.Spec.MigrationNodeID {
+			return fmt.Errorf("volume %v: engine is on node %v vs volume migration on %v",
+				v.Name, migrationEngine.Spec.NodeID, v.Spec.NodeID)
+		}
+		migrationEngine.Spec.NodeID = v.Spec.MigrationNodeID
+		migrationEngine.Spec.ReplicaAddressMap = replicaAddressMap
+		migrationEngine.Spec.DesireState = types.InstanceStateRunning
+		migrationEngine, err := vc.ds.UpdateEngine(migrationEngine)
+		if err != nil {
+			return err
+		}
+		es[migrationEngine.Name] = migrationEngine
+	}
+
+	if migrationEngine.Status.CurrentState != types.InstanceStateRunning {
+		return nil
+	}
+
+	vc.logger.Infof("volume migration engine on node %v is ready", v.Spec.MigrationNodeID)
 	return nil
 }
 

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -279,18 +279,38 @@ func (cs *ControllerServer) isNodeReady(nodeID string) bool {
 	return false
 }
 
-// publishSharedVolume doesn't need to call volume.Attach since the underlying rwo volume will be controlled by a share-manager
+// publishVolume sends the actual attach request to the longhorn api and executes the passed waitForResult func
+func (cs *ControllerServer) publishVolume(volume *longhornclient.Volume, nodeID string, waitForResult func() error) (*csi.ControllerPublishVolumeResponse, error) {
+	logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the requested node is %s", volume.Name, nodeID)
+	input := &longhornclient.AttachInput{
+		HostId:          nodeID,
+		DisableFrontend: false,
+	}
+
+	if _, err := cs.apiClient.Volume.ActionAttach(volume, input); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s for node %s", volume.Name, nodeID)
+
+	if err := waitForResult(); err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Volume %s with accessMode %s published to %s", volume.Name, volume.AccessMode, nodeID)
+	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
 func (cs *ControllerServer) publishSharedVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
 	if !volume.Ready || len(volume.Controllers) == 0 || volume.Controllers[0].Endpoint == "" {
 		return nil, status.Errorf(codes.Aborted, "The volume %s is not ready for workloads", req.GetVolumeId())
 	}
 
-	if !cs.waitForVolumeState(volume.Name, "share available", isVolumeShareAvailable, false, false) {
-		return nil, status.Errorf(codes.DeadlineExceeded, "Failed to wait for volume %v share available", req.GetVolumeId())
-	}
-
-	logrus.Infof("Volume %s shared to %s", req.GetVolumeId(), req.GetNodeId())
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return cs.publishVolume(volume, req.NodeId, func() error {
+		if !cs.waitForVolumeState(volume.Name, "share available", isVolumeShareAvailable, false, false) {
+			return status.Errorf(codes.DeadlineExceeded, "Failed to wait for volume %v share available", req.GetVolumeId())
+		}
+		return nil
+	})
 }
 
 func (cs *ControllerServer) publishMigratableVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
@@ -301,23 +321,12 @@ func (cs *ControllerServer) publishMigratableVolume(req *csi.ControllerPublishVo
 		}
 	}
 
-	logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the requested node is %s", req.GetVolumeId(), req.GetNodeId())
-	input := &longhornclient.AttachInput{
-		HostId:          req.GetNodeId(),
-		DisableFrontend: false,
-	}
-
-	if _, err := cs.apiClient.Volume.ActionAttach(volume, input); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s for node %s", req.GetVolumeId(), req.NodeId)
-
-	if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration available", isVolumeMigrationAvailable, false, false) {
-		return nil, status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
-	}
-
-	logrus.Infof("Volume %s attached on %s", req.GetVolumeId(), req.GetNodeId())
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return cs.publishVolume(volume, req.NodeId, func() error {
+		if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration available", isVolumeMigrationAvailable, false, false) {
+			return status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
+		}
+		return nil
+	})
 }
 
 func (cs *ControllerServer) publishReadWriteOnceVolume(req *csi.ControllerPublishVolumeRequest, volume *longhornclient.Volume) (*csi.ControllerPublishVolumeResponse, error) {
@@ -339,23 +348,12 @@ func (cs *ControllerServer) publishReadWriteOnceVolume(req *csi.ControllerPublis
 		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
 
-	logrus.Debugf("ControllerPublishVolume: volume %s is ready to be attached, and the preferred nodeID is %s", req.GetVolumeId(), req.GetNodeId())
-	input := &longhornclient.AttachInput{
-		HostId:          req.GetNodeId(),
-		DisableFrontend: false,
-	}
-
-	if _, err := cs.apiClient.Volume.ActionAttach(volume, input); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	logrus.Debugf("ControllerPublishVolume: succeed to send an attach request for volume %s", req.GetVolumeId())
-
-	if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateAttached), isVolumeAttached, false, false) {
-		return nil, status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
-	}
-
-	logrus.Infof("Volume %s attached on %s", req.GetVolumeId(), req.GetNodeId())
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return cs.publishVolume(volume, req.NodeId, func() error {
+		if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateAttached), isVolumeAttached, false, false) {
+			return status.Errorf(codes.DeadlineExceeded, "Attaching volume %s on node %s failed", req.GetVolumeId(), req.GetNodeId())
+		}
+		return nil
+	})
 }
 
 // ControllerPublishVolume will attach the volume to the specified node
@@ -401,16 +399,9 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	}
 
 	if requiresSharedAccess(existVol, volumeCapability) {
-		if existVol.AccessMode != string(types.AccessModeReadWriteMany) {
-			input := &longhornclient.UpdateAccessModeInput{
-				AccessMode: string(types.AccessModeReadWriteMany),
-			}
-
-			if existVol, err = cs.apiClient.Volume.ActionUpdateAccessMode(existVol, input); err != nil {
-				logrus.WithError(err).Errorf("Failed to change Volume %s access mode to RWX", req.GetVolumeId())
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-			logrus.Infof("Changed Volume %s access mode to RWX", req.GetVolumeId())
+		existVol, err = cs.updateVolumeAccessMode(existVol, types.AccessModeReadWriteMany)
+		if err != nil {
+			return nil, err
 		}
 
 		if !existVol.Migratable {
@@ -421,6 +412,40 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	}
 
 	return cs.publishReadWriteOnceVolume(req, existVol)
+}
+
+func (cs *ControllerServer) updateVolumeAccessMode(volume *longhornclient.Volume, accessMode types.AccessMode) (*longhornclient.Volume, error) {
+	mode := string(accessMode)
+	if volume.AccessMode == mode {
+		return volume, nil
+	}
+
+	volumeName := volume.Name
+	input := &longhornclient.UpdateAccessModeInput{AccessMode: mode}
+	volume, err := cs.apiClient.Volume.ActionUpdateAccessMode(volume, input)
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to change Volume %s access mode to %s", volumeName, mode)
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	logrus.Infof("Changed Volume %s access mode to %s", volumeName, mode)
+	return volume, nil
+}
+
+// unpublishVolume sends the actual detach request to the longhorn api and executes the passed waitForResult func
+func (cs *ControllerServer) unpublishVolume(volume *longhornclient.Volume, nodeID string, waitForResult func() error) (*csi.ControllerUnpublishVolumeResponse, error) {
+	logrus.Debugf("requesting Volume %s detachment for %s", volume.Name, nodeID)
+	_, err := cs.apiClient.Volume.ActionDetach(volume, &longhornclient.DetachInput{HostId: nodeID})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err = waitForResult(); err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("Volume %s unpublished from %s", volume.Name, nodeID)
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 // ControllerUnpublishVolume will detach the volume
@@ -449,28 +474,29 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		return nil, status.Errorf(codes.Aborted, "The volume %s is detaching", req.GetVolumeId())
 	}
 
-	if requiresSharedAccess(existVol, nil) && !existVol.Migratable {
-		logrus.Infof("don't need to detach shared Volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
-		return &csi.ControllerUnpublishVolumeResponse{}, nil
-	}
-
-	logrus.Debugf("requesting Volume %s detachment for %s", req.GetVolumeId(), req.GetNodeId())
-	_, err = cs.apiClient.Volume.ActionDetach(existVol, &longhornclient.DetachInput{HostId: req.NodeId})
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if existVol.Migratable {
-		checkMigrationComplete := func(vol *longhornclient.Volume) bool { return isVolumeMigrationComplete(vol, req.NodeId) }
-		if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration complete", checkMigrationComplete, false, true) {
-			return nil, status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+	if requiresSharedAccess(existVol, nil) {
+		if !existVol.Migratable {
+			return cs.unpublishVolume(existVol, req.NodeId, func() error {
+				logrus.Infof("don't need to detach shared Volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+				return nil
+			})
 		}
-	} else if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateDetached), isVolumeDetached, false, true) {
-		return nil, status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+
+		return cs.unpublishVolume(existVol, req.NodeId, func() error {
+			checkMigrationComplete := func(vol *longhornclient.Volume) bool { return isVolumeMigrationComplete(vol, req.NodeId) }
+			if !cs.waitForVolumeState(req.GetVolumeId(), "volume migration complete", checkMigrationComplete, false, true) {
+				return status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+			}
+			return nil
+		})
 	}
 
-	logrus.Debugf("Volume %s detached on %s", req.GetVolumeId(), req.GetNodeId())
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
+	return cs.unpublishVolume(existVol, req.NodeId, func() error {
+		if !cs.waitForVolumeState(req.GetVolumeId(), string(types.VolumeStateDetached), isVolumeDetached, false, true) {
+			return status.Errorf(codes.DeadlineExceeded, "Failed to detach volume %s from node %s", req.GetVolumeId(), req.GetNodeId())
+		}
+		return nil
+	})
 }
 
 func (cs *ControllerServer) ListVolumes(context.Context, *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -65,7 +65,12 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.InvalidArgument, "Volume capability not provided")
 	}
 
-	if len(existVol.Controllers) != 1 {
+	if len(existVol.Controllers) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "There should be a controller for volume %s", req.GetVolumeId())
+	}
+
+	// For mount volumes, we don't want multiple controllers for a volume, since the filesystem could get messed up
+	if len(existVol.Controllers) > 1 && volumeCapability.GetBlock() == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "There should be only one controller for volume %s", req.GetVolumeId())
 	}
 
@@ -90,7 +95,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	targetPath := req.GetTargetPath()
 	devicePath := existVol.Controllers[0].Endpoint
-	if requiresSharedAccess(existVol, volumeCapability) {
+	if requiresSharedAccess(existVol, volumeCapability) && !existVol.Migratable {
 
 		if existVol.AccessMode != string(types.AccessModeReadWriteMany) {
 			return nil, status.Errorf(codes.FailedPrecondition, "The volume %s requires shared access but is not marked for shared use", req.GetVolumeId())
@@ -107,10 +112,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 		nfsMounter := nfs.NewMounter(nse)
 		return ns.nodePublishSharedVolume(req.GetVolumeId(), existVol.ShareEndpoint, targetPath, nfsMounter)
-	} else if blkCapability := volumeCapability.GetBlock(); blkCapability != nil {
+	} else if volumeCapability.GetBlock() != nil {
 		mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: mount.NewOSExec()}
 		return ns.nodePublishBlockVolume(req.GetVolumeId(), devicePath, targetPath, mounter)
-	} else if mntCapability := volumeCapability.GetMount(); mntCapability != nil {
+	} else if volumeCapability.GetMount() != nil {
 		userExt4Params, _ := ns.apiClient.Setting.ById(string(types.SettingNameMkfsExt4Parameters))
 
 		// mounter assumes ext4 by default

--- a/examples/rwx/storageclass-migratable.yaml
+++ b/examples/rwx/storageclass-migratable.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-migratable
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
+  fromBackup: ""
+  migratable: "true"
+  share: "false"

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -58,6 +58,10 @@ func (m *VolumeManager) CreateSnapshot(snapshotName string, labels map[string]st
 		}
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return nil, err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return nil, err
@@ -82,6 +86,10 @@ func (m *VolumeManager) DeleteSnapshot(snapshotName, volumeName string) error {
 		return fmt.Errorf("volume and snapshot name required")
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return err
@@ -96,6 +104,10 @@ func (m *VolumeManager) DeleteSnapshot(snapshotName, volumeName string) error {
 func (m *VolumeManager) RevertSnapshot(snapshotName, volumeName string) error {
 	if volumeName == "" || snapshotName == "" {
 		return fmt.Errorf("volume and snapshot name required")
+	}
+
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
 	}
 
 	engine, err := m.GetEngineClient(volumeName)
@@ -121,6 +133,10 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 		return fmt.Errorf("volume name required")
 	}
 
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
+	}
+
 	engine, err := m.GetEngineClient(volumeName)
 	if err != nil {
 		return err
@@ -136,6 +152,10 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 func (m *VolumeManager) BackupSnapshot(volumeName, snapshotName, backingImageName, backingImageURL string, labels map[string]string) error {
 	if volumeName == "" || snapshotName == "" {
 		return fmt.Errorf("volume and snapshot name required")
+	}
+
+	if err := m.checkVolumeNotInMigration(volumeName); err != nil {
+		return err
 	}
 
 	backupTarget, err := m.GetSettingValueExisted(types.SettingNameBackupTarget)

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -220,6 +220,17 @@ func (m *VolumeManager) BackupSnapshot(volumeName, snapshotName, backingImageNam
 	return nil
 }
 
+func (m *VolumeManager) checkVolumeNotInMigration(volumeName string) error {
+	v, err := m.ds.GetVolume(volumeName)
+	if err != nil {
+		return err
+	}
+	if v.Spec.MigrationNodeID != "" {
+		return fmt.Errorf("cannot operate during migration")
+	}
+	return nil
+}
+
 func (m *VolumeManager) GetEngineClient(volumeName string) (client engineapi.EngineClient, err error) {
 	var e *longhorn.Engine
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -618,9 +618,13 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 		return nil, fmt.Errorf("cannot expand volume before replica scheduling success")
 	}
 
+	// volume shrinking is not supported the volume is already bigger then the requested size
 	if v.Spec.Size >= size {
-		return nil, fmt.Errorf("cannot expand volume %v with current size %v to a smaller or the same size %v", v.Name, v.Spec.Size, size)
+		logrus.Infof("Volume %v expansion is not necessary since current size %v >= %v", v.Name, v.Spec.Size, size)
+		return v, nil
 	}
+
+	logrus.Infof("Volume %v expandsion from %v to %v requested", v.Name, v.Spec.Size, size)
 	v.Spec.Size = size
 
 	// Support off-line expansion only.
@@ -631,7 +635,6 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 		return nil, err
 	}
 
-	logrus.Debugf("Expanding volume %v to size %v", v.Name, size)
 	return v, nil
 }
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -92,6 +92,7 @@ type VolumeSpec struct {
 	RevisionCounterDisabled bool           `json:"revisionCounterDisabled"`
 	LastAttachedBy          string         `json:"lastAttachedBy"`
 	AccessMode              AccessMode     `json:"accessMode"`
+	Migratable              bool           `json:"migratable"`
 
 	// Deprecated. Rename to BackingImage
 	BaseImage string `json:"baseImage"`

--- a/types/resource.go
+++ b/types/resource.go
@@ -81,6 +81,7 @@ type VolumeSpec struct {
 	DataLocality            DataLocality   `json:"dataLocality"`
 	StaleReplicaTimeout     int            `json:"staleReplicaTimeout"`
 	NodeID                  string         `json:"nodeID"`
+	MigrationNodeID         string         `json:"migrationNodeID"`
 	EngineImage             string         `json:"engineImage"`
 	RecurringJobs           []RecurringJob `json:"recurringJobs"`
 	BackingImage            string         `json:"backingImage"`


### PR DESCRIPTION
The problem is that the expansion call disables the frontend and never enables it again which prohibits the share-manager from controlling the volume. We rely on the attach call to reenable the frontend, this pr reworks the csi + api interaction so that we call attach for each volume type and let the volume-manager do the appropriate stuff :)

depends on this pr https://github.com/longhorn/longhorn-manager/pull/822 for the live migration feature, since there was a lot of overlap in the csi/attach/detach changes.

For the review only the last 2 commits are relevant for the rwx expansion support.
longhorn/longhorn#2181