### PR TITLE
fix nil pointer cause longhorn-manager pods crushloopbackoff (#2208)

### DIFF
--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -587,11 +587,9 @@ func (rc *ReplicaController) enqueueNodeChange(obj interface{}) {
 	for _, diskName := range evictionDisks {
 		if diskStatus, existed := node.Status.DiskStatus[diskName]; existed {
 			for replicaName := range diskStatus.ScheduledReplica {
-				replica, err := rc.ds.GetReplica(replicaName)
-				if err != nil {
-					return
+				if replica, err := rc.ds.GetReplica(replicaName); err == nil {
+					rc.enqueueReplica(replica)
 				}
-				rc.enqueueReplica(replica)
 			}
 		}
 	}

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -585,12 +585,14 @@ func (rc *ReplicaController) enqueueNodeChange(obj interface{}) {
 
 	// Add eviction requested replicas to the workqueue
 	for _, diskName := range evictionDisks {
-		for replicaName := range node.Status.DiskStatus[diskName].ScheduledReplica {
-			replica, err := rc.ds.GetReplica(replicaName)
-			if err != nil {
-				return
+		if diskStatus, existed := node.Status.DiskStatus[diskName]; existed {
+			for replicaName := range diskStatus.ScheduledReplica {
+				replica, err := rc.ds.GetReplica(replicaName)
+				if err != nil {
+					return
+				}
+				rc.enqueueReplica(replica)
 			}
-			rc.enqueueReplica(replica)
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

fix nil pointer cause longhorn-manager pods crushloopbackoff to resolve ticket '[BUG] All longhorn-manager pods crushloopbackoff' (#2208)

#### Types of Changes ####

Fixed Bug.

#### Verification ####

It seems that during creating, diskStatus is nil. Need to check if diskstatus existed.

time="2021-02-18T08:41:05Z" level=info msg=disk-1
time="2021-02-18T08:41:06Z" level=info msg=disk-1
time="2021-02-18T08:41:06Z" level=info msg="Diskname disk-1 has status %!b(bool=true)"

NOTE: this was sample print during implementation/verification.

#### Linked Issues ####

Refs: https://github.com/longhorn/longhorn/issues/2208

#### Further Comments ####

None

Signed-off-by: cclhsu <clark.hsu@suse.com>