### PR TITLE
Change from checking engine image's availability on all nodes to checking the engine image's availability on required nodes

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -63,7 +63,7 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/volumes").Handler(f(schemas, s.VolumeList))
 	r.Methods("GET").Path("/v1/volumes/{name}").Handler(f(schemas, s.VolumeGet))
 	r.Methods("DELETE").Path("/v1/volumes/{name}").Handler(f(schemas, s.VolumeDelete))
-	r.Methods("POST").Path("/v1/volumes").Handler(f(schemas, s.VolumeCreate))
+	r.Methods("POST").Path("/v1/volumes").Handler(f(schemas, s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.VolumeCreate)))
 
 	volumeActions := map[string]func(http.ResponseWriter, *http.Request) error{
 		"attach":             s.VolumeAttach,
@@ -95,13 +95,13 @@ func NewRouter(s *Server) *mux.Router {
 		r.Methods("POST").Path("/v1/volumes/{name}").Queries("action", name).Handler(f(schemas, action))
 	}
 
-	r.Methods("GET").Path("/v1/backupvolumes").Handler(f(schemas, s.BackupVolumeList))
-	r.Methods("GET").Path("/v1/backupvolumes/{volName}").Handler(f(schemas, s.BackupVolumeGet))
-	r.Methods("DELETE").Path("/v1/backupvolumes/{volName}").Handler(f(schemas, s.BackupVolumeDelete))
+	r.Methods("GET").Path("/v1/backupvolumes").Handler(f(schemas, s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupVolumeList)))
+	r.Methods("GET").Path("/v1/backupvolumes/{volName}").Handler(f(schemas, s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupVolumeGet)))
+	r.Methods("DELETE").Path("/v1/backupvolumes/{volName}").Handler(f(schemas, s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupVolumeDelete)))
 	backupActions := map[string]func(http.ResponseWriter, *http.Request) error{
-		"backupList":   s.BackupList,
-		"backupGet":    s.BackupGet,
-		"backupDelete": s.BackupDelete,
+		"backupList":   s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupList),
+		"backupGet":    s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupGet),
+		"backupDelete": s.fwd.Handler(NodeHasDefaultEngineImage(s.m), s.BackupDelete),
 	}
 	for name, action := range backupActions {
 		r.Methods("POST").Path("/v1/backupvolumes/{volName}").Queries("action", name).Handler(f(schemas, action))

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -165,7 +165,7 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
-	if err := m.DeployAndWaitForEngineImage(engineImage); err != nil {
+	if err := m.DeployEngineImage(engineImage); err != nil {
 		return err
 	}
 

--- a/client/generated_engine_image.go
+++ b/client/generated_engine_image.go
@@ -13,7 +13,7 @@ type EngineImage struct {
 
 	CliAPIVersion int64 `json:"cliAPIVersion,omitempty" yaml:"cli_apiversion,omitempty"`
 
-	Conditions map[string]string `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Conditions map[string]interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 
 	ControllerAPIMinVersion int64 `json:"controllerAPIMinVersion,omitempty" yaml:"controller_apimin_version,omitempty"`
 
@@ -32,6 +32,8 @@ type EngineImage struct {
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	NoRefSince string `json:"noRefSince,omitempty" yaml:"no_ref_since,omitempty"`
+
+	NodeDeploymentMap map[string]bool `json:"nodeDeploymentMap,omitempty" yaml:"node_deployment_map,omitempty"`
 
 	OwnerID string `json:"ownerID,omitempty" yaml:"owner_id,omitempty"`
 

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -242,27 +242,20 @@ func GetInstanceManagerCPURequirement(ds *datastore.DataStore, imName string) (*
 }
 
 func isControllerResponsibleFor(controllerID string, ds *datastore.DataStore, name, preferredOwnerID, currentOwnerID string) bool {
-	var err error
-	responsible := false
-
-	ownerDown := false
-	if currentOwnerID != "" {
-		ownerDown, err = ds.IsNodeDownOrDeleted(currentOwnerID)
-		if err != nil {
-			logrus.Warnf("Error while checking if object %v owner is down or deleted: %v", name, err)
+	// we use this approach so that if there is an issue with the data store
+	// we don't accidentally transfer ownership
+	isOwnerUnavailable := func(node string) bool {
+		nodeDown, err := ds.IsNodeDownOrDeleted(node)
+		if node != "" && err != nil {
+			logrus.Errorf("Error while checking if object %v node %v is down or deleted: %v", name, node, err)
 		}
+		return node == "" || nodeDown
 	}
 
-	if controllerID == preferredOwnerID {
-		responsible = true
-	} else if currentOwnerID == "" {
-		responsible = true
-	} else { // currentOwnerID != ""
-		if ownerDown {
-			responsible = true
-		}
-	}
-	return responsible
+	isPreferredOwner := controllerID == preferredOwnerID
+	continueToBeOwner := currentOwnerID == controllerID && isOwnerUnavailable(preferredOwnerID)
+	requiresNewOwner := isOwnerUnavailable(currentOwnerID) && isOwnerUnavailable(preferredOwnerID)
+	return isPreferredOwner || continueToBeOwner || requiresNewOwner
 }
 
 // EnhancedDefaultControllerRateLimiter is an enhanced version of workqueue.DefaultControllerRateLimiter()

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -142,6 +142,7 @@ func newEngineImage(image string, state types.EngineImageState) *longhorn.Engine
 					Status: types.ConditionStatusTrue,
 				},
 			},
+			NodeDeploymentMap: map[string]bool{},
 		},
 	}
 }
@@ -177,6 +178,23 @@ func newEngineImageDaemonSet() *appsv1.DaemonSet {
 			DesiredNumberScheduled: 1,
 			NumberAvailable:        1,
 		},
+	}
+}
+
+func newPod(status *corev1.PodStatus, name, namespace, nodeID string) *corev1.Pod {
+	if status == nil {
+		return nil
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: TestServiceAccount,
+			NodeName:           nodeID,
+		},
+		Status: *status,
 	}
 }
 

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -390,7 +390,7 @@ func (s *TestSuite) TestReconcileInstanceState(c *C) {
 
 		h := newTestInstanceHandler(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient)
 
-		ei, err := lhClient.LonghornV1beta1().EngineImages(TestNamespace).Create(newEngineImage(TestEngineImage, types.EngineImageStateReady))
+		ei, err := lhClient.LonghornV1beta1().EngineImages(TestNamespace).Create(newEngineImage(TestEngineImage, types.EngineImageStateDeployed))
 		c.Assert(err, IsNil)
 		err = eiIndexer.Add(ei)
 		c.Assert(err, IsNil)

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -55,23 +55,6 @@ func fakeInstanceManagerVersionUpdater(im *longhorn.InstanceManager) error {
 	return nil
 }
 
-func newPod(status *v1.PodStatus, name, namespace, nodeID string) *v1.Pod {
-	if status == nil {
-		return nil
-	}
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: v1.PodSpec{
-			ServiceAccountName: TestServiceAccount,
-			NodeName:           nodeID,
-		},
-		Status: *status,
-	}
-}
-
 func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory, lhClient *lhfake.Clientset, kubeClient *fake.Clientset,
 	controllerID string) *InstanceManagerController {

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -154,6 +154,16 @@ func (s *DataStore) GetEngineImageDaemonSet(name string) (*appsv1.DaemonSet, err
 	return resultRO.DeepCopy(), nil
 }
 
+func (s *DataStore) ListEngineImageDaemonSetPodsFromEngineImageName(EIName string) ([]*corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: types.GetEngineImageLabels(EIName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.ListPodsBySelector(selector)
+}
+
 // CreatePDB creates a PodDisruptionBudget resource for the given PDB object and namespace
 func (s *DataStore) CreatePDB(pdp *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 	return s.kubeClient.PolicyV1beta1().PodDisruptionBudgets(s.namespace).Create(pdp)

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -222,8 +222,11 @@ func (m *VolumeManager) GetEngineClient(volumeName string) (client engineapi.Eng
 	if e.Status.CurrentState != types.InstanceStateRunning {
 		return nil, fmt.Errorf("engine is not running")
 	}
-	if err := m.CheckEngineImageReadiness(e.Status.CurrentImage); err != nil {
-		return nil, errors.Wrapf(err, "cannot get engine client with image %v", e.Status.CurrentImage)
+	if isReady, err := m.CheckEngineImageReadiness(e.Status.CurrentImage, m.currentNodeID); !isReady {
+		if err != nil {
+			return nil, fmt.Errorf("cannot get engine client with image %v: %v", e.Status.CurrentImage, err)
+		}
+		return nil, fmt.Errorf("cannot get engine client with image %v because it isn't deployed on this node", e.Status.CurrentImage)
 	}
 
 	engineCollection := &engineapi.EngineCollection{}

--- a/manager/node.go
+++ b/manager/node.go
@@ -118,6 +118,10 @@ func (m *VolumeManager) ListNodes() (map[string]*longhorn.Node, error) {
 	return nodeList, nil
 }
 
+func (m *VolumeManager) ListReadyNodesWithEngineImage(image string) (map[string]*longhorn.Node, error) {
+	return m.ds.ListReadyNodesWithEngineImage(image)
+}
+
 func (m *VolumeManager) ListNodesSorted() ([]*longhorn.Node, error) {
 	nodeMap, err := m.ListNodes()
 	if err != nil {

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -386,6 +386,57 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 	tc.isNilReplica = true
 	testCases["there's no disk for replica"] = tc
 
+	// Test engine image is not deployed on any node
+	tc = generateSchedulerTestCase()
+	daemon1 = newDaemonPod(v1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1)
+	daemon2 = newDaemonPod(v1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2)
+	tc.daemons = []*v1.Pod{
+		daemon1,
+		daemon2,
+	}
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue)
+	disk = newDisk(TestDefaultDataPath, true, 0)
+	node1.Spec.Disks = map[string]types.DiskSpec{
+		getDiskID(TestNode1, "1"): disk,
+	}
+	node1.Status.DiskStatus = map[string]*types.DiskStatus{
+		getDiskID(TestNode1, "1"): {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+			StorageMaximum:   TestDiskSize,
+			Conditions: map[string]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
+			DiskUUID: getDiskID(TestNode1, "1"),
+		},
+	}
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue)
+	disk = newDisk(TestDefaultDataPath, true, 0)
+	node2.Spec.Disks = map[string]types.DiskSpec{
+		getDiskID(TestNode2, "1"): disk,
+	}
+	node2.Status.DiskStatus = map[string]*types.DiskStatus{
+		getDiskID(TestNode2, "1"): {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+			StorageMaximum:   TestDiskSize,
+			Conditions: map[string]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
+			DiskUUID: getDiskID(TestNode2, "1"),
+		},
+	}
+	nodes = map[string]*longhorn.Node{
+		TestNode1: node1,
+		TestNode2: node2,
+	}
+	tc.nodes = nodes
+	expectedNodes = map[string]*longhorn.Node{}
+	tc.expectedNodes = expectedNodes
+	tc.err = false
+	tc.isNilReplica = true
+	testCases["there's no engine image deployed on any node"] = tc
+
 	// Test anti affinity nodes, replica should schedule to both node1 and node2
 	tc = generateSchedulerTestCase()
 	daemon1 = newDaemonPod(v1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1)

--- a/types/resource.go
+++ b/types/resource.go
@@ -257,7 +257,7 @@ type EngineImageState string
 
 const (
 	EngineImageStateDeploying    = "deploying"
-	EngineImageStateReady        = "ready"
+	EngineImageStateDeployed     = "deployed"
 	EngineImageStateIncompatible = "incompatible"
 	EngineImageStateError        = "error"
 )
@@ -274,11 +274,12 @@ const (
 )
 
 type EngineImageStatus struct {
-	OwnerID    string               `json:"ownerID"`
-	State      EngineImageState     `json:"state"`
-	RefCount   int                  `json:"refCount"`
-	NoRefSince string               `json:"noRefSince"`
-	Conditions map[string]Condition `json:"conditions"`
+	OwnerID           string               `json:"ownerID"`
+	State             EngineImageState     `json:"state"`
+	RefCount          int                  `json:"refCount"`
+	NoRefSince        string               `json:"noRefSince"`
+	Conditions        map[string]Condition `json:"conditions"`
+	NodeDeploymentMap map[string]bool      `json:"nodeDeploymentMap"`
 
 	EngineVersionDetails
 }

--- a/types/setting.go
+++ b/types/setting.go
@@ -582,8 +582,8 @@ var (
 
 	SettingDefinitionConcurrentAutomaticEngineUpgradePerNodeLimit = SettingDefinition{
 		DisplayName: "Concurrent Automatic Engine Upgrade Per Node Limit",
-		Description: "This setting controls how Longhorn automatically upgrades volumes' engines after upgrading Longhorn manager." +
-			"The value of this setting specifies the maximum number of engines per node that are allowed to upgrade to the default engine image at the same time." +
+		Description: "This setting controls how Longhorn automatically upgrades volumes' engines after upgrading Longhorn manager. " +
+			"The value of this setting specifies the maximum number of engines per node that are allowed to upgrade to the default engine image at the same time. " +
 			"If the value is 0, Longhorn will not automatically upgrade volumes' engines to default version.",
 		Category: SettingCategoryGeneral,
 		Type:     SettingTypeInt,


### PR DESCRIPTION
If the engine image is failed to be deployed on some nodes, it shouldn't prevent Longhorn from operating volumes that don't have engine or replicas on those nodes. This PR changes from checking engine image's availability on all nodes to checking the engine image's availability on required nodes.

More details about the detail proposal is at https://github.com/longhorn/longhorn/issues/2081#issuecomment-780964823