### PR TITLE
Bump longhorn/backupstore version to add KubernetesStatus metadata to volume.cfg

### DIFF
--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -25,6 +25,7 @@ type BackupTarget struct {
 type backupVolume struct {
 	Name             string
 	Size             string
+	Labels           map[string]string
 	Created          string
 	LastBackupName   string
 	LastBackupAt     string
@@ -138,6 +139,7 @@ func parseBackupVolumesList(output string) (map[string]*BackupVolume, error) {
 		volumes[name] = &BackupVolume{
 			Name:             name,
 			Size:             v.Size,
+			Labels:           v.Labels,
 			Created:          v.Created,
 			LastBackupName:   v.LastBackupName,
 			LastBackupAt:     v.LastBackupAt,

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -22,20 +22,6 @@ type BackupTarget struct {
 	Credential map[string]string
 }
 
-type backupVolume struct {
-	Name             string
-	Size             string
-	Labels           map[string]string
-	Created          string
-	LastBackupName   string
-	LastBackupAt     string
-	BackingImageName string
-	BackingImageURL  string
-	DataStored       string
-	Messages         map[backupstore.MessageType]string
-	Backups          map[string]interface{}
-}
-
 func NewBackupTarget(backupTarget, engineImage string, credential map[string]string) *BackupTarget {
 	return &BackupTarget{
 		URL:        backupTarget,
@@ -97,7 +83,7 @@ func parseBackup(v interface{}) (*Backup, error) {
 }
 
 func parseBackupsList(output, volumeName string) ([]*Backup, error) {
-	data := map[string]*backupVolume{}
+	data := map[string]*BackupVolume{}
 	if err := json.Unmarshal([]byte(output), &data); err != nil {
 		return nil, errors.Wrapf(err, "error parsing BackupsList: \n%s", output)
 	}
@@ -118,7 +104,7 @@ func parseBackupsList(output, volumeName string) ([]*Backup, error) {
 }
 
 func parseBackupVolumesList(output string) (map[string]*BackupVolume, error) {
-	data := map[string]*backupVolume{}
+	data := map[string]*BackupVolume{}
 	if err := json.Unmarshal([]byte(output), &data); err != nil {
 		return nil, errors.Wrapf(err, "error parsing BackupVolumesList: \n%s", output)
 	}

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -55,6 +55,23 @@ const backupsListText = `
 }
 `
 
+const backupVolumesListText = `
+{
+	"pvc-1": {
+		"Name": "pvc-1",
+		"Size": "1073741824",
+		"Labels":{
+			"KubernetesStatus": "{\"pvName\":\"pvc-1\",\"namespace\":\"default\",\"pvcName\":\"longhorn-1-volv-pvc\",\"workloadsStatus\":[{\"podName\":\"volume-test-2\",\"workloadType\":\"\"}]}",
+			"foo": "bar"
+		},
+		"Created": "2017-03-25T02:26:59Z",
+		"LastBackupName": "backup-1",
+		"LastBackupAt": "2017-03-25T02:27:00Z",
+		"DataStored": "1163919360"
+	}
+}
+`
+
 func TestParseOneBackup(t *testing.T) {
 	assert := require.New(t)
 
@@ -88,4 +105,25 @@ func TestParseBackupsList(t *testing.T) {
 	}
 	assert.NotNil(snapshots["volume-snap-snap1.img"])
 	assert.NotNil(snapshots["volume-snap-snap4.img"])
+}
+
+func TestParseBackupVolumesList(t *testing.T) {
+	assert := require.New(t)
+
+	bvl, err := parseBackupVolumesList(backupVolumesListText)
+	assert.Nil(err)
+	assert.Equal(map[string]*BackupVolume{
+		"pvc-1": {
+			Name: "pvc-1",
+			Size: "1073741824",
+			Labels: map[string]string{
+				"KubernetesStatus": "{\"pvName\":\"pvc-1\",\"namespace\":\"default\",\"pvcName\":\"longhorn-1-volv-pvc\",\"workloadsStatus\":[{\"podName\":\"volume-test-2\",\"workloadType\":\"\"}]}",
+				"foo":              "bar",
+			},
+			Created:        "2017-03-25T02:26:59Z",
+			LastBackupName: "backup-1",
+			LastBackupAt:   "2017-03-25T02:27:00Z",
+			DataStored:     "1163919360",
+		},
+	}, bvl)
 }

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -98,18 +98,17 @@ type Volume struct {
 }
 
 type BackupVolume struct {
-	Name           string                             `json:"name"`
-	Size           string                             `json:"size"`
-	Labels         map[string]string                  `json:"labels"`
-	Created        string                             `json:"created"`
-	LastBackupName string                             `json:"lastBackupName"`
-	LastBackupAt   string                             `json:"lastBackupAt"`
-	DataStored     string                             `json:"dataStored"`
-	Messages       map[backupstore.MessageType]string `json:"messages"`
-	Backups        map[string]*Backup                 `json:"backups"`
-
-	BackingImageName string `json:"backingImageName"`
-	BackingImageURL  string `json:"backingImageURL"`
+	Name             string                             `json:"name"`
+	Size             string                             `json:"size"`
+	Labels           map[string]string                  `json:"labels"`
+	Created          string                             `json:"created"`
+	LastBackupName   string                             `json:"lastBackupName"`
+	LastBackupAt     string                             `json:"lastBackupAt"`
+	DataStored       string                             `json:"dataStored"`
+	Messages         map[backupstore.MessageType]string `json:"messages"`
+	Backups          map[string]*Backup                 `json:"backups"`
+	BackingImageName string                             `json:"backingImageName"`
+	BackingImageURL  string                             `json:"backingImageURL"`
 
 	// Deprecated
 	BaseImage string `json:"baseImage"`

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -100,6 +100,7 @@ type Volume struct {
 type BackupVolume struct {
 	Name           string                             `json:"name"`
 	Size           string                             `json:"size"`
+	Labels         map[string]string                  `json:"labels"`
 	Created        string                             `json:"created"`
 	LastBackupName string                             `json:"lastBackupName"`
 	LastBackupAt   string                             `json:"lastBackupAt"`

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
-	github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae
+	github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c
 	github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536
 	github.com/longhorn/longhorn-instance-manager v0.0.0-20201016215346-d8437b4e156e
 	github.com/miekg/dns v1.1.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae h1:UL9KjJB5GqC4b83rbPZukW+vP+2b/NNF7pLU+L4J2jI=
-github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
+github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c h1:rWPYE7lzP0n1fj9/vuQxnz9t6hrki+Tc7VCMelugCOI=
+github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536 h1:+Z/mGnoCdY+YCX+y4X19E2YT4FsVA3aVm7uLj1tg/wM=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/longhorn-instance-manager v0.0.0-20201016215346-d8437b4e156e h1:4cCwm8nlmqaS0aaJWb13gUa2xOxGSI3xrNcQq/dHEZo=

--- a/vendor/github.com/longhorn/backupstore/backupstore.go
+++ b/vendor/github.com/longhorn/backupstore/backupstore.go
@@ -10,6 +10,7 @@ import (
 type Volume struct {
 	Name             string
 	Size             int64 `json:",string"`
+	Labels           map[string]string
 	CreatedTime      string
 	LastBackupName   string
 	LastBackupAt     string

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -325,6 +325,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 	volume.BlockCount = volume.BlockCount + newBlocks
 	// The volume may be expanded
 	volume.Size = config.Volume.Size
+	volume.Labels = config.Labels
 	volume.BackingImageName = config.Volume.BackingImageName
 	volume.BackingImageURL = config.Volume.BackingImageURL
 

--- a/vendor/github.com/longhorn/backupstore/list.go
+++ b/vendor/github.com/longhorn/backupstore/list.go
@@ -2,6 +2,7 @@ package backupstore
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
@@ -11,6 +12,7 @@ import (
 type VolumeInfo struct {
 	Name           string
 	Size           int64 `json:",string"`
+	Labels         map[string]string
 	Created        string
 	LastBackupName string
 	LastBackupAt   string
@@ -121,6 +123,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 	return &VolumeInfo{
 		Name:             volume.Name,
 		Size:             volume.Size,
+		Labels:           volume.Labels,
 		Created:          volume.CreatedTime,
 		LastBackupName:   volume.LastBackupName,
 		LastBackupAt:     volume.LastBackupAt,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/kr/pretty
 github.com/kr/text
 # github.com/kubernetes-csi/csi-lib-utils v0.6.1
 github.com/kubernetes-csi/csi-lib-utils/protosanitizer
-# github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae
+# github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/logging
 github.com/longhorn/backupstore/util


### PR DESCRIPTION
#### Proposed Changes
- Pass labels to backup volume structure
- Add unit-test to test parseBackupVolumesList
- Consolidate two backupVolume/BackupVolume structure into one
- Bump longhorn/backupstore version to add KubernetesStatus metadata to volume.cfg

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1539