### PR TITLE
Update default share-manager image to v1_20210302

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20201216
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20210106
+        - longhornio/longhorn-share-manager:v1_20210302
         - --manager-image
         - longhornio/longhorn-manager:master
         - --service-account

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20210106
+longhornio/longhorn-share-manager:v1_20210302
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
 longhornio/csi-attacher:v2.2.1-lh1

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -1,6 +1,6 @@
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20201216
-longhornio/longhorn-share-manager:v1_20210106
+longhornio/longhorn-share-manager:v1_20210302
 longhornio/longhorn-manager:master
 longhornio/longhorn-ui:master
 longhornio/csi-attacher:v2.2.1-lh1


### PR DESCRIPTION
Include
- patched nfs-ganesha v3.3 to fallback to ipv4 when ipv6 is not available
  https://github.com/longhorn/longhorn/issues/2197

- Fix for pod hanging at ganasha server error due to missing /etc/mtab file.
  https://github.com/longhorn/longhorn/issues/2111

Test: https://github.com/longhorn/longhorn/issues/2197#issuecomment-788595045