### PR TITLE
types: Improve the CPU reservation error log

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -534,7 +534,7 @@ func ValidateCPUReservationValues(engineManagerCPUStr, replicaManagerCPUStr stri
 		return fmt.Errorf("guaranteed/requested replica manager CPU value %v is not int: %v", replicaManagerCPUStr, err)
 	}
 	if engineManagerCPU+replicaManagerCPU < 0 || engineManagerCPU+replicaManagerCPU > 40 {
-		return fmt.Errorf("the sum of the engine manager CPU value %v and the replica manager CPU value %v should not be greater than 40%% or smaller than 0%%", engineManagerCPU, replicaManagerCPU)
+		return fmt.Errorf("the requested engine manager CPU and replica manager CPU are %v%% and %v%% of a node total CPU, respectively. The sum should not be smaller than 0%% or greater than 40%%", engineManagerCPU, replicaManagerCPU)
 	}
 	return nil
 }


### PR DESCRIPTION
If the user sets a wrong CPU value on a specific node, the error log will convert the concrete value to a percentage value without symbol `%`, which is confusing. e.g.

If I set the requested engine manager CPU to 20000m but the total CPU of this node is 2000m, the error message is:
```
the sum of the engine manager CPU value 1000 and the replica manager CPU value 13 should not be greater than 40% or smaller than 0%
```

Longhorn #2207

Signed-off-by: Shuo Wu <shuo@rancher.com>