### PR TITLE
Support AWS IAM Role

### DIFF
--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -95,6 +95,7 @@ func uninstall(c *cli.Context) error {
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
@@ -109,7 +110,7 @@ func uninstall(c *cli.Context) error {
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -85,6 +85,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	daemonSetInformer := kubeInformerFactory.Apps().V1().DaemonSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
@@ -102,7 +103,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,
@@ -151,6 +152,9 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	kcfmc := NewKubernetesConfigMapController(logger, ds, scheme,
 		configMapInformer,
 		kubeClient, controllerID, namespace)
+	ksc := NewKubernetesSecretController(logger, ds, scheme,
+		secretInformer,
+		kubeClient, controllerID, namespace)
 
 	go kubeInformerFactory.Start(stopCh)
 	go lhInformerFactory.Start(stopCh)
@@ -172,6 +176,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	go knc.Run(Workers, stopCh)
 	go kpc.Run(Workers, stopCh)
 	go kcfmc.Run(Workers, stopCh)
+	go ksc.Run(Workers, stopCh)
 
 	return ds, ws, nil
 }

--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -63,6 +63,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	daemonSetInformer := kubeInformerFactory.Apps().V1().DaemonSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
@@ -83,7 +84,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -457,6 +457,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
@@ -471,7 +472,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -76,6 +76,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
@@ -90,7 +91,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -232,6 +232,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	daemonSetInformer := kubeInformerFactory.Apps().V1().DaemonSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
@@ -250,7 +251,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/kubernetes_secret_controller.go
+++ b/controller/kubernetes_secret_controller.go
@@ -1,0 +1,201 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/controller"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+)
+
+type KubernetesSecretController struct {
+	*baseController
+
+	// use as the OwnerID of the controller
+	namespace    string
+	controllerID string
+
+	kubeClient    clientset.Interface
+	eventRecorder record.EventRecorder
+
+	ds *datastore.DataStore
+
+	secretSynced cache.InformerSynced
+}
+
+func NewKubernetesSecretController(
+	logger logrus.FieldLogger,
+	ds *datastore.DataStore,
+	scheme *runtime.Scheme,
+	secretInformer coreinformers.SecretInformer,
+	kubeClient clientset.Interface,
+	controllerID string,
+	namespace string) *KubernetesSecretController {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(logrus.Infof)
+	// TODO: remove the wrapper when every clients have moved to use the clientset.
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{
+		Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events(""),
+	})
+
+	ks := &KubernetesSecretController{
+		baseController: newBaseController("longhorn-kubernetes-secret-controller", logger),
+
+		namespace:    namespace,
+		controllerID: controllerID,
+
+		ds: ds,
+
+		kubeClient:    kubeClient,
+		eventRecorder: eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "longhorn-kubernetes-secret-controller"}),
+
+		secretSynced: secretInformer.Informer().HasSynced,
+	}
+
+	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ks.enqueueSecretChange,
+		UpdateFunc: func(old, cur interface{}) { ks.enqueueSecretChange(cur) },
+		DeleteFunc: ks.enqueueSecretChange,
+	})
+
+	return ks
+}
+
+func (ks *KubernetesSecretController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer ks.queue.ShutDown()
+
+	ks.logger.Infof("Start")
+	defer ks.logger.Infof("Shutting down")
+
+	if !cache.WaitForNamedCacheSync(ks.name, stopCh, ks.secretSynced) {
+		return
+	}
+	for i := 0; i < workers; i++ {
+		go wait.Until(ks.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+func (ks *KubernetesSecretController) worker() {
+	for ks.processNextWorkItem() {
+	}
+}
+
+func (ks *KubernetesSecretController) processNextWorkItem() bool {
+	key, quit := ks.queue.Get()
+	if quit {
+		return false
+	}
+	defer ks.queue.Done(key)
+	err := ks.syncHandler(key.(string))
+	ks.handleErr(err, key)
+	return true
+}
+
+func (ks *KubernetesSecretController) handleErr(err error, key interface{}) {
+	if err == nil {
+		ks.queue.Forget(key)
+		return
+	}
+
+	if ks.queue.NumRequeues(key) < maxRetries {
+		ks.logger.WithError(err).Warnf("Error syncing Secret %v", key)
+		ks.queue.AddRateLimited(key)
+		return
+	}
+
+	ks.logger.WithError(err).Warnf("Dropping Secret %v out of the queue", key)
+	ks.queue.Forget(key)
+	utilruntime.HandleError(err)
+}
+
+func (ks *KubernetesSecretController) syncHandler(key string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "%v: fail to sync %v", ks.name, key)
+	}()
+
+	namespace, secretName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	if err := ks.reconcileSecret(namespace, secretName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ks *KubernetesSecretController) reconcileSecret(namespace, secretName string) error {
+	if namespace != ks.namespace {
+		// Not ours, skip it
+		return nil
+	}
+
+	backupTarget, err := ks.ds.GetSettingValueExisted(types.SettingNameBackupTarget)
+	if err != nil {
+		// The backup target does not exist, skip it
+		return nil
+	}
+	backupType, err := util.CheckBackupType(backupTarget)
+	if err != nil {
+		// Invalid backup target, skip it
+		return nil
+	}
+	if backupType != types.BackupStoreTypeS3 {
+		// We only focus on backup target S3, skip it
+		return nil
+	}
+
+	sn, err := ks.ds.GetSettingValueExisted(types.SettingNameBackupTargetCredentialSecret)
+	if err != nil {
+		// The backup target credential secret does not exist, skip it
+		return nil
+	}
+	if sn != secretName {
+		// Not ours, skip it
+		return nil
+	}
+
+	secret, err := ks.ds.GetSecretRO(namespace, secretName)
+	if err != nil {
+		return err
+	}
+
+	// Annotates AWS IAM role arn to the manager as well as the replica instance managers
+	awsIAMRoleArn := string(secret.Data[types.AWSIAMRoleArn])
+	update, err := ks.ds.AnnotateAWSIAMRoleArn(ks.controllerID, awsIAMRoleArn)
+	if err != nil {
+		return err
+	}
+
+	if update {
+		ks.logger.Infof("Annotates the AWS IAM role succeeded")
+	}
+	return nil
+}
+
+func (ks *KubernetesSecretController) enqueueSecretChange(obj interface{}) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+
+	ks.queue.AddRateLimited(key)
+}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -67,6 +67,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 	storageclassInformer := kubeInformerFactory.Storage().V1().StorageClasses()
@@ -80,7 +81,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -82,6 +82,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
@@ -96,7 +97,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -68,6 +68,8 @@ type DataStore struct {
 	pvcStoreSynced     cache.InformerSynced
 	cfmLister          corelisters.ConfigMapLister
 	cfmStoreSynced     cache.InformerSynced
+	secretLister       corelisters.SecretLister
+	secretStoreSynced  cache.InformerSynced
 	knLister           corelisters.NodeLister
 	knStoreSynced      cache.InformerSynced
 	pcLister           schedulinglisters.PriorityClassLister
@@ -102,6 +104,7 @@ func NewDataStore(
 	persistentVolumeInformer coreinformers.PersistentVolumeInformer,
 	persistentVolumeClaimInformer coreinformers.PersistentVolumeClaimInformer,
 	configMapInformer coreinformers.ConfigMapInformer,
+	secretInformer coreinformers.SecretInformer,
 	kubeNodeInformer coreinformers.NodeInformer,
 	priorityClassInformer schedulinginformers.PriorityClassInformer,
 	csiDriverInformer storageinformers.CSIDriverInformer,
@@ -150,6 +153,8 @@ func NewDataStore(
 		pvcStoreSynced:     persistentVolumeClaimInformer.Informer().HasSynced,
 		cfmLister:          configMapInformer.Lister(),
 		cfmStoreSynced:     configMapInformer.Informer().HasSynced,
+		secretLister:       secretInformer.Lister(),
+		secretStoreSynced:  secretInformer.Informer().HasSynced,
 		knLister:           kubeNodeInformer.Lister(),
 		knStoreSynced:      kubeNodeInformer.Informer().HasSynced,
 		pcLister:           priorityClassInformer.Lister(),

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -441,6 +441,23 @@ func (s *DataStore) GetConfigMap(namespace, name string) (*corev1.ConfigMap, err
 	return resultRO.DeepCopy(), nil
 }
 
+// GetSecretRO gets Secret with the given namespace and name
+// This function returns direct reference to the internal cache object and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) GetSecretRO(namespace, name string) (*corev1.Secret, error) {
+	return s.secretLister.Secrets(namespace).Get(name)
+}
+
+// GetSecret return a new Secret object with the given namespace and name
+func (s *DataStore) GetSecret(namespace, name string) (*corev1.Secret, error) {
+	resultRO, err := s.secretLister.Secrets(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	// Cannot use cached object from lister
+	return resultRO.DeepCopy(), nil
+}
+
 // GetPriorityClass gets the PriorityClass from the index for the
 // given name
 func (s *DataStore) GetPriorityClass(pcName string) (*schedulingv1.PriorityClass, error) {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -287,11 +287,11 @@ func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]strin
 	}
 	credentialSecret := make(map[string]string)
 	if secret.Data != nil {
-		if err := s.annotateAWSIAMRole(string(secret.Data[types.AWSIAMRole])); err != nil {
+		if err := s.annotateAWSIAMRole(string(secret.Data[types.AWSIAMRoleArn])); err != nil {
 			return nil, err
 		}
 
-		credentialSecret[types.AWSIAMRole] = string(secret.Data[types.AWSIAMRole])
+		credentialSecret[types.AWSIAMRoleArn] = string(secret.Data[types.AWSIAMRoleArn])
 		credentialSecret[types.AWSAccessKey] = string(secret.Data[types.AWSAccessKey])
 		credentialSecret[types.AWSSecretKey] = string(secret.Data[types.AWSSecretKey])
 		credentialSecret[types.AWSEndPoint] = string(secret.Data[types.AWSEndPoint])

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -236,7 +236,6 @@ func (s *DataStore) ListSettings() (map[types.SettingName]*longhorn.Setting, err
 // have the correct AWS IAM role arn assigned to them based on the passed `awsIAMRoleArn`
 func (s *DataStore) AnnotateAWSIAMRoleArn(controllerID, awsIAMRoleArn string) (bool, error) {
 	update := false
-
 	selector, err := s.getManagerSelector()
 	if err != nil {
 		return update, err
@@ -277,10 +276,10 @@ func (s *DataStore) AnnotateAWSIAMRoleArn(controllerID, awsIAMRoleArn string) (b
 			continue
 		}
 
-		update = update || true
 		if _, err = s.kubeClient.CoreV1().Pods(s.namespace).Update(pod); err != nil {
 			return update, err
 		}
+		update = true
 	}
 	return update, nil
 }

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -263,16 +263,16 @@ func (s *DataStore) AnnotateAWSIAMRoleArn(controllerID, awsIAMRoleArn string) (b
 			continue
 		}
 
-		val, exist := pod.Annotations[types.AWSIAMRroleAnnotation]
+		val, exist := pod.Annotations[types.AWSIAMRoleAnnotation]
 		updateAnnotation := awsIAMRoleArn != "" && awsIAMRoleArn != val
 		deleteAnnotation := awsIAMRoleArn == "" && exist
 		if updateAnnotation {
 			if pod.Annotations == nil {
 				pod.Annotations = make(map[string]string)
 			}
-			pod.Annotations[types.AWSIAMRroleAnnotation] = awsIAMRoleArn
+			pod.Annotations[types.AWSIAMRoleAnnotation] = awsIAMRoleArn
 		} else if deleteAnnotation {
-			delete(pod.Annotations, types.AWSIAMRroleAnnotation)
+			delete(pod.Annotations, types.AWSIAMRoleAnnotation)
 		} else {
 			continue
 		}

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -53,7 +53,7 @@ func getBackupCredentialEnv(backupTarget string, credential map[string]string) (
 		missingKeys = append(missingKeys, types.AWSSecretKey)
 	}
 	// If AWS IAM Role not present, then the AWS credentials must be exists
-	if credential[types.AWSIAMRole] == "" && len(missingKeys) > 0 {
+	if credential[types.AWSIAMRoleArn] == "" && len(missingKeys) > 0 {
 		return nil, fmt.Errorf("Could not backup to %s, missing %v in the secret", backupType, missingKeys)
 	}
 	if len(missingKeys) == 0 {

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -119,7 +119,7 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 			name:         "provides AWS IAM role",
 			backupTarget: "s3://backupbucket@us-east-1/",
 			credential: map[string]string{
-				"AWS_IAM_ROLE": "AWS_IAM_ARN: arn:aws:iam::013456789:role/longhorn",
+				"AWS_IAM_ROLE_ARN": "AWS_IAM_ARN: arn:aws:iam::013456789:role/longhorn",
 			},
 		},
 		{
@@ -128,7 +128,7 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 			credential: map[string]string{
 				"AWS_ACCESS_KEY_ID":     "my-aws-access-key-id",
 				"AWS_SECRET_ACCESS_KEY": "my-aws-secret-access-key",
-				"AWS_IAM_ROLE":          "AWS_IAM_ARN: arn:aws:iam::013456789:role/longhorn",
+				"AWS_IAM_ROLE_ARN":      "AWS_IAM_ARN: arn:aws:iam::013456789:role/longhorn",
 			},
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
-	github.com/longhorn/backupstore v0.0.0-20210302061525-eb790e398638
+	github.com/longhorn/backupstore v0.0.0-20210315131747-51dcc71901ed
 	github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536
 	github.com/longhorn/longhorn-instance-manager v0.0.0-20201016215346-d8437b4e156e
 	github.com/miekg/dns v1.1.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/longhorn/backupstore v0.0.0-20210302061525-eb790e398638 h1:YgqENwHGHkAnuYZbUaCzjhwyymTvRYESYaHSHe/Ej7c=
-github.com/longhorn/backupstore v0.0.0-20210302061525-eb790e398638/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
+github.com/longhorn/backupstore v0.0.0-20210315131747-51dcc71901ed h1:Ax+IeL8r4ynqCXIs2kj68sEMZWB/H+mhFG/U2/hHqDY=
+github.com/longhorn/backupstore v0.0.0-20210315131747-51dcc71901ed/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536 h1:+Z/mGnoCdY+YCX+y4X19E2YT4FsVA3aVm7uLj1tg/wM=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/longhorn-instance-manager v0.0.0-20201016215346-d8437b4e156e h1:4cCwm8nlmqaS0aaJWb13gUa2xOxGSI3xrNcQq/dHEZo=

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -73,6 +73,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
@@ -87,7 +88,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
 		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
-		configMapInformer, kubeNodeInformer, priorityClassInformer,
+		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,
 		serviceInformer,

--- a/types/types.go
+++ b/types/types.go
@@ -107,12 +107,12 @@ const (
 
 	BackupStoreTypeS3 = "s3"
 
-	AWSIAMRroleAnnotation = "iam.amazonaws.com/role"
-	AWSIAMRoleArn         = "AWS_IAM_ROLE_ARN"
-	AWSAccessKey          = "AWS_ACCESS_KEY_ID"
-	AWSSecretKey          = "AWS_SECRET_ACCESS_KEY"
-	AWSEndPoint           = "AWS_ENDPOINTS"
-	AWSCert               = "AWS_CERT"
+	AWSIAMRoleAnnotation = "iam.amazonaws.com/role"
+	AWSIAMRoleArn        = "AWS_IAM_ROLE_ARN"
+	AWSAccessKey         = "AWS_ACCESS_KEY_ID"
+	AWSSecretKey         = "AWS_SECRET_ACCESS_KEY"
+	AWSEndPoint          = "AWS_ENDPOINTS"
+	AWSCert              = "AWS_CERT"
 
 	HTTPSProxy = "HTTPS_PROXY"
 	HTTPProxy  = "HTTP_PROXY"

--- a/types/types.go
+++ b/types/types.go
@@ -107,6 +107,7 @@ const (
 
 	BackupStoreTypeS3 = "s3"
 
+	AWSIAMRole   = "AWS_IAM_ROLE"
 	AWSAccessKey = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
 	AWSEndPoint  = "AWS_ENDPOINTS"

--- a/types/types.go
+++ b/types/types.go
@@ -107,11 +107,12 @@ const (
 
 	BackupStoreTypeS3 = "s3"
 
-	AWSIAMRole   = "AWS_IAM_ROLE"
-	AWSAccessKey = "AWS_ACCESS_KEY_ID"
-	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
-	AWSEndPoint  = "AWS_ENDPOINTS"
-	AWSCert      = "AWS_CERT"
+	AWSIAMRroleAnnotation = "iam.amazonaws.com/role"
+	AWSIAMRole            = "AWS_IAM_ROLE"
+	AWSAccessKey          = "AWS_ACCESS_KEY_ID"
+	AWSSecretKey          = "AWS_SECRET_ACCESS_KEY"
+	AWSEndPoint           = "AWS_ENDPOINTS"
+	AWSCert               = "AWS_CERT"
 
 	HTTPSProxy = "HTTPS_PROXY"
 	HTTPProxy  = "HTTP_PROXY"

--- a/types/types.go
+++ b/types/types.go
@@ -108,7 +108,7 @@ const (
 	BackupStoreTypeS3 = "s3"
 
 	AWSIAMRroleAnnotation = "iam.amazonaws.com/role"
-	AWSIAMRole            = "AWS_IAM_ROLE"
+	AWSIAMRoleArn         = "AWS_IAM_ROLE_ARN"
 	AWSAccessKey          = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey          = "AWS_SECRET_ACCESS_KEY"
 	AWSEndPoint           = "AWS_ENDPOINTS"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/kr/pretty
 github.com/kr/text
 # github.com/kubernetes-csi/csi-lib-utils v0.6.1
 github.com/kubernetes-csi/csi-lib-utils/protosanitizer
-# github.com/longhorn/backupstore v0.0.0-20210302061525-eb790e398638
+# github.com/longhorn/backupstore v0.0.0-20210315131747-51dcc71901ed
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/logging
 github.com/longhorn/backupstore/util


### PR DESCRIPTION
#### Proposed Changes
- Create a new secret controller, the purpose is to update the annotation of the `iam.amazonaws.com/role` to longhorn manager and replica instance manager Pod.
- If the user performs S3 list/backup/restore/delete, the longhorn-manager checks:
  - AWS_IAM_ROLE_ARN :heavy_check_mark: & AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY :heavy_check_mark: -> :ok:
  - AWS_IAM_ROLE_ARN :heavy_check_mark: & AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY :x: -> :ok:
  - AWS_IAM_ROLE_ARN :x: & AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY :heavy_check_mark: -> :ok:
  - AWS_IAM_ROLE_ARN :x: & AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY :x: -> :x:
- Bump longhorn/backupstore version

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1526