### PR TITLE
Only watch and update toleration/priority class for managed components

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -323,12 +323,12 @@ func (sc *SettingController) updateTaintToleration() error {
 	}
 	newTolerationsMap := util.TolerationListToMap(newTolerationsList)
 
-	daemonsetList, err := sc.ds.ListDaemonSet()
+	daemonsetList, err := sc.ds.ListDaemonSetWithLabels(types.GetBaseLabelsForSystemManagedComponent())
 	if err != nil {
 		return errors.Wrapf(err, "failed to list Longhorn daemonsets for toleration update")
 	}
 
-	deploymentList, err := sc.ds.ListDeployment()
+	deploymentList, err := sc.ds.ListDeploymentWithLabels(types.GetBaseLabelsForSystemManagedComponent())
 	if err != nil {
 		return errors.Wrapf(err, "failed to list Longhorn deployments for toleration update")
 	}
@@ -448,12 +448,12 @@ func (sc *SettingController) updatePriorityClass() error {
 	}
 	newPriorityClass := setting.Value
 
-	daemonsetList, err := sc.ds.ListDaemonSet()
+	daemonsetList, err := sc.ds.ListDaemonSetWithLabels(types.GetBaseLabelsForSystemManagedComponent())
 	if err != nil {
 		return errors.Wrapf(err, "failed to list Longhorn daemonsets for priority class update")
 	}
 
-	deploymentList, err := sc.ds.ListDeployment()
+	deploymentList, err := sc.ds.ListDeploymentWithLabels(types.GetBaseLabelsForSystemManagedComponent())
 	if err != nil {
 		return errors.Wrapf(err, "failed to list Longhorn deployments for priority class update")
 	}

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -507,8 +507,7 @@ func (c *ShareManagerController) syncShareManagerVolume(sm *longhorn.ShareManage
 
 func (c *ShareManagerController) cleanupShareManagerPod(sm *longhorn.ShareManager) error {
 	log := getLoggerForShareManager(c.logger, sm)
-
-	podName := getPodNameForShareManager(sm)
+	podName := types.GetShareManagerPodNameFromShareManagerName(sm.Name)
 	pod, err := c.ds.GetPod(podName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.WithError(err).WithField("pod", podName).Error("failed to retrieve pod for share manager from datastore")
@@ -554,7 +553,7 @@ func (c *ShareManagerController) syncShareManagerPod(sm *longhorn.ShareManager) 
 	}
 
 	log := getLoggerForShareManager(c.logger, sm)
-	pod, err := c.ds.GetPod(getPodNameForShareManager(sm))
+	pod, err := c.ds.GetPod(types.GetShareManagerPodNameFromShareManagerName(sm.Name))
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.WithError(err).Error("failed to retrieve pod for share manager from datastore")
 		return err
@@ -694,16 +693,12 @@ func (c *ShareManagerController) createServiceManifest(sm *longhorn.ShareManager
 	return service
 }
 
-func getPodNameForShareManager(sm *longhorn.ShareManager) string {
-	return types.LonghornLabelShareManager + "-" + sm.Name
-}
-
 func (c *ShareManagerController) createPodManifest(sm *longhorn.ShareManager, annotations map[string]string, tolerations []v1.Toleration,
 	pullPolicy v1.PullPolicy, resourceReq *v1.ResourceRequirements, registrySecret string, priorityClass string) *v1.Pod {
 	privileged := true
 	podSpec := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            getPodNameForShareManager(sm),
+			Name:            types.GetShareManagerPodNameFromShareManagerName(sm.Name),
 			Namespace:       sm.Namespace,
 			Labels:          types.GetShareManagerLabels(sm.Name, sm.Spec.Image),
 			Annotations:     annotations,

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -320,6 +320,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 			Name:        types.CSIPluginName,
 			Namespace:   namespace,
 			Annotations: map[string]string{types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix): tolerationsString},
+			Labels:      types.GetBaseLabelsForSystemManagedComponent(),
 		},
 
 		Spec: appsv1.DaemonSetSpec{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -32,13 +32,13 @@ const (
 )
 
 func getCommonService(commonName, namespace string) *v1.Service {
+	serviceLabels := types.GetBaseLabelsForSystemManagedComponent()
+	serviceLabels["app"] = commonName
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      commonName,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"app": commonName,
-			},
+			Labels:    serviceLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{
@@ -57,24 +57,24 @@ func getCommonService(commonName, namespace string) *v1.Service {
 func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir string, args []string, replicaCount int32,
 	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *appsv1.Deployment {
 
-	labels := map[string]string{
-		"app": commonName,
-	}
+	deploymentLabels := types.GetBaseLabelsForSystemManagedComponent()
+	deploymentLabels["app"] = commonName
 
 	commonDeploymentSpec := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        commonName,
 			Namespace:   namespace,
 			Annotations: map[string]string{types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix): tolerationsString},
+			Labels:      deploymentLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: map[string]string{"app": commonName},
 			},
 			Replicas: &replicaCount,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: map[string]string{"app": commonName},
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: serviceAccount,

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -35,6 +35,12 @@ const (
 	PodLivenessProbeFailureThreshold = 3
 )
 
+func labelMapToLabelSelector(labels map[string]string) (labels.Selector, error) {
+	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: labels,
+	})
+}
+
 func (s *DataStore) getManagerLabel() map[string]string {
 	return map[string]string{
 		//TODO standardize key
@@ -251,6 +257,14 @@ func (s *DataStore) ListDaemonSet() ([]*appsv1.DaemonSet, error) {
 	return s.dsLister.DaemonSets(s.namespace).List(labels.Everything())
 }
 
+func (s *DataStore) ListDaemonSetWithLabels(labels map[string]string) ([]*appsv1.DaemonSet, error) {
+	selector, err := labelMapToLabelSelector(labels)
+	if err != nil {
+		return nil, err
+	}
+	return s.dsLister.DaemonSets(s.namespace).List(selector)
+}
+
 // UpdateDaemonSet updates the DaemonSet for the given DaemonSet object and namespace
 func (s *DataStore) UpdateDaemonSet(obj *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	return s.kubeClient.AppsV1().DaemonSets(s.namespace).Update(obj)
@@ -271,6 +285,14 @@ func (s *DataStore) GetDeployment(name string) (*appsv1.Deployment, error) {
 // ListDeployment gets a list of all Deployment for the given namespace
 func (s *DataStore) ListDeployment() ([]*appsv1.Deployment, error) {
 	return s.dpLister.Deployments(s.namespace).List(labels.Everything())
+}
+
+func (s *DataStore) ListDeploymentWithLabels(labels map[string]string) ([]*appsv1.Deployment, error) {
+	selector, err := labelMapToLabelSelector(labels)
+	if err != nil {
+		return nil, err
+	}
+	return s.dpLister.Deployments(s.namespace).List(selector)
 }
 
 // UpdateDeployment updates Deployment for the given Deployment object and namespace

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -81,6 +81,12 @@ spec:
           name: longhorn-default-setting
 #      imagePullSecrets:
 #      - name: ""
+#      priorityClassName:
+#      tolerations:
+#      - key: "key"
+#        operator: "Equal"
+#        value: "value"
+#        effect: "NoSchedule"
       serviceAccountName: longhorn-service-account
   updateStrategy:
     rollingUpdate:

--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -28,7 +28,13 @@ spec:
           - name: LONGHORN_MANAGER_IP
             value: "http://longhorn-backend:9500"
 #      imagePullSecrets:
-#      - name:
+#        - name: ""
+#      priorityClassName:
+#      tolerations:
+#      - key: "key"
+#        operator: "Equal"
+#        value: "value"
+#        effect: "NoSchedule"
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/install/02-components/04-driver.yaml
+++ b/deploy/install/02-components/04-driver.yaml
@@ -67,8 +67,14 @@ spec:
           #  value: "3"
           #- name: CSI_SNAPSHOTTER_REPLICA_COUNT
           #  value: "3"
-      #imagePullSecrets:
-      #- name:
+#      imagePullSecrets:
+#        - name: ""
+#      priorityClassName:
+#      tolerations:
+#      - key: "key"
+#        operator: "Equal"
+#        value: "value"
+#        effect: "NoSchedule"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/manager/engineimage.go
+++ b/manager/engineimage.go
@@ -61,7 +61,8 @@ func (m *VolumeManager) CreateEngineImage(image string) (*longhorn.EngineImage, 
 	name := types.GetEngineImageChecksumName(image)
 	ei := &longhorn.EngineImage{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: types.GetEngineImageLabels(name),
 		},
 		Spec: types.EngineImageSpec{
 			Image: image,

--- a/types/setting.go
+++ b/types/setting.go
@@ -377,7 +377,10 @@ var (
 
 	SettingDefinitionTaintToleration = SettingDefinition{
 		DisplayName: "Kubernetes Taint Toleration",
-		Description: "To dedicate nodes to store Longhorn replicas and reject other general workloads, set tolerations for Longhorn and add taints for the storage nodes. " +
+		Description: "If you want to dedicate nodes to store Longhorn replicas and reject other general workloads, you can set toleration for *all* Longhorn components and add taints for the storage nodes. " +
+			"Longhorn system contains user deployed components (e.g, Longhorn manager, Longhorn driver, Longhorn UI) and system managed components (e.g, instance manager, engine image, CSI driver, etc.) " +
+			"This setting only sets taint toleration for system managed components. " +
+			"Depend on how you deployed Longhorn, you need to set taint toleration for user deployed components in Helm chart or deployment YAML file. " +
 			"All Longhorn volumes should be detached before modifying toleration settings. " +
 			"We recommend setting tolerations during Longhorn deployment because the Longhorn system cannot be operated during the update. " +
 			"Multiple tolerations can be set here, and these tolerations are separated by semicolon. For example: \n\n" +
@@ -385,7 +388,7 @@ var (
 			"* `:` this toleration tolerates everything because an empty key with operator `Exists` matches all keys, values and effects \n\n" +
 			"* `key1=value1:`  this toleration has empty effect. It matches all effects with key `key1` \n\n" +
 			"Because `kubernetes.io` is used as the key of all Kubernetes default tolerations, it should not be used in the toleration settings.\n\n " +
-			"WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES!",
+			"WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES! ",
 		Category: SettingCategoryDangerZone,
 		Type:     SettingTypeString,
 		Required: false,

--- a/types/setting.go
+++ b/types/setting.go
@@ -377,10 +377,10 @@ var (
 
 	SettingDefinitionTaintToleration = SettingDefinition{
 		DisplayName: "Kubernetes Taint Toleration",
-		Description: "If you want to dedicate nodes to store Longhorn replicas and reject other general workloads, you can set toleration for *all* Longhorn components and add taints for the storage nodes. " +
+		Description: "If you want to dedicate nodes to just store Longhorn replicas and reject other general workloads, you can set tolerations for **all** Longhorn components and add taints to the nodes dedicated for storage. " +
 			"Longhorn system contains user deployed components (e.g, Longhorn manager, Longhorn driver, Longhorn UI) and system managed components (e.g, instance manager, engine image, CSI driver, etc.) " +
-			"This setting only sets taint toleration for system managed components. " +
-			"Depend on how you deployed Longhorn, you need to set taint toleration for user deployed components in Helm chart or deployment YAML file. " +
+			"This setting only sets taint tolerations for system managed components. " +
+			"Depending on how you deployed Longhorn, you need to set taint tolerations for user deployed components in Helm chart or deployment YAML file. " +
 			"All Longhorn volumes should be detached before modifying toleration settings. " +
 			"We recommend setting tolerations during Longhorn deployment because the Longhorn system cannot be operated during the update. " +
 			"Multiple tolerations can be set here, and these tolerations are separated by semicolon. For example: \n\n" +
@@ -512,10 +512,14 @@ var (
 	}
 	SettingDefinitionPriorityClass = SettingDefinition{
 		DisplayName: "Priority Class",
-		Description: "The name of the Priority Class to set on the Longhorn workloads. This can help prevent Longhorn workloads from being evicted under Node Pressure.\nWARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES.",
-		Category:    SettingCategoryDangerZone,
-		Required:    false,
-		ReadOnly:    false,
+		Description: "The name of the Priority Class to set on the Longhorn components. This can help prevent Longhorn components from being evicted under Node Pressure. \n" +
+			"Longhorn system contains user deployed components (e.g, Longhorn manager, Longhorn driver, Longhorn UI) and system managed components (e.g, instance manager, engine image, CSI driver, etc.) " +
+			"Note that this setting only sets Priority Class for system managed components. " +
+			"Depending on how you deployed Longhorn, you need to set Priority Class for user deployed components in Helm chart or deployment YAML file. \n" +
+			"WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES.",
+		Category: SettingCategoryDangerZone,
+		Required: false,
+		ReadOnly: false,
 	}
 	SettingDefinitionDisableRevisionCounter = SettingDefinition{
 		DisplayName: "Disable Revision Counter",

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -109,7 +109,7 @@ func upgrade(currentNodeID, namespace string, config *restclient.Config, lhClien
 				if err = doAPIVersionUpgrade(namespace, config, lhClient); err != nil {
 					return
 				}
-				if err = doCRDUpgrade(namespace, lhClient); err != nil {
+				if err = doCRUpgrade(namespace, lhClient); err != nil {
 					return
 				}
 				if err = doPodsUpgrade(namespace, lhClient, kubeClient); err != nil {
@@ -211,27 +211,30 @@ func doAPIVersionUpgrade(namespace string, config *restclient.Config, lhClient *
 	return nil
 }
 
-func doCRDUpgrade(namespace string, lhClient *lhclientset.Clientset) (err error) {
-	defer func() {
-		err = errors.Wrap(err, "upgrade CRD failed")
-	}()
-	if err := v070to080.UpgradeCRDs(namespace, lhClient); err != nil {
-		return err
-	}
-	if err := v100to101.UpgradeCRDs(namespace, lhClient); err != nil {
-		return err
-	}
-	if err := v110to111.UpgradeCRs(namespace, lhClient); err != nil {
-		return err
-	}
-	return nil
-}
-
 func upgradeLocalNode() (err error) {
 	defer func() {
 		err = errors.Wrap(err, "upgrade local node failed")
 	}()
 	if err := v070to080.UpgradeLocalNode(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func doCRUpgrade(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrap(err, "upgrade CRD failed")
+	}()
+	if err := v070to080.UpgradeCRs(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := v100to101.UpgradeCRs(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := v102to110.UpgradeCRs(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := v110to111.UpgradeCRs(namespace, lhClient); err != nil {
 		return err
 	}
 	return nil
@@ -244,13 +247,7 @@ func doPodsUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeClient
 	if err = v100to101.UpgradeInstanceManagerPods(namespace, lhClient, kubeClient); err != nil {
 		return err
 	}
-	if err = v102to110.UpgradeInstanceManagerPods(namespace, lhClient, kubeClient); err != nil {
-		return err
-	}
-	if err = v102to110.UpgradeVolumes(namespace, lhClient); err != nil {
-		return err
-	}
-	if err = v102to110.UpgradeReplicas(namespace, lhClient); err != nil {
+	if err = v102to110.UpgradePods(namespace, kubeClient); err != nil {
 		return err
 	}
 	if err = v110to111.UpgradePods(namespace, lhClient, kubeClient); err != nil {

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/longhorn/longhorn-manager/types"
+)
+
+func ListShareManagerPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, error) {
+	smPodsList, err := kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(types.GetShareManagerComponentLabel()).String(),
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return []v1.Pod{}, nil
+		}
+		return nil, err
+	}
+	return smPodsList.Items, nil
+}
+
+func ListIMPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, error) {
+	imPodsList, err := kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", types.GetLonghornLabelComponentKey(), types.LonghornLabelInstanceManager),
+	})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if imPodsList != nil {
+		return imPodsList.Items, nil
+	}
+	return []v1.Pod{}, nil
+}
+
+func MergeStringMaps(baseMap, overwriteMap map[string]string) map[string]string {
+	result := map[string]string{}
+	for k, v := range baseMap {
+		result[k] = v
+	}
+	for k, v := range overwriteMap {
+		result[k] = v
+	}
+	return result
+}

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
@@ -17,9 +16,6 @@ func ListShareManagerPods(namespace string, kubeClient *clientset.Clientset) ([]
 		LabelSelector: labels.Set(types.GetShareManagerComponentLabel()).String(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return []v1.Pod{}, nil
-		}
 		return nil, err
 	}
 	return smPodsList.Items, nil
@@ -29,14 +25,10 @@ func ListIMPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, er
 	imPodsList, err := kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", types.GetLonghornLabelComponentKey(), types.LonghornLabelInstanceManager),
 	})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
 		return nil, err
 	}
-
-	if imPodsList != nil {
-		return imPodsList.Items, nil
-	}
-	return []v1.Pod{}, nil
+	return imPodsList.Items, nil
 }
 
 func MergeStringMaps(baseMap, overwriteMap map[string]string) map[string]string {

--- a/upgrade/v070to080/upgrade.go
+++ b/upgrade/v070to080/upgrade.go
@@ -36,7 +36,7 @@ func UpgradeLocalNode() error {
 	return nil
 }
 
-func UpgradeCRDs(namespace string, lhClient *lhclientset.Clientset) error {
+func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
 	if err := doInstanceManagerUpgrade(namespace, lhClient); err != nil {
 		return err
 	}

--- a/upgrade/v100to101/upgrade.go
+++ b/upgrade/v100to101/upgrade.go
@@ -76,7 +76,7 @@ func upgradeInstanceMangerPodLabel(pod *v1.Pod, im *longhorn.InstanceManager, ku
 	return nil
 }
 
-func UpgradeCRDs(namespace string, lhClient *lhclientset.Clientset) error {
+func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
 	if err := doInstanceManagerUpgrade(namespace, lhClient); err != nil {
 		return err
 	}

--- a/upgrade/v102to110/upgrade.go
+++ b/upgrade/v102to110/upgrade.go
@@ -1,8 +1,6 @@
 package v102to110
 
 import (
-	"encoding/json"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -13,12 +11,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 
-	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	"github.com/longhorn/longhorn-manager/types"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
 	"github.com/longhorn/longhorn-manager/util"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 )
 
 // This upgrade is needed because we add one more field `controller: true`
@@ -36,7 +35,7 @@ func UpgradeInstanceManagerPods(namespace string, lhClient *lhclientset.Clientse
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager pods failed")
 	}()
 
-	imPods, err := listIMPods(namespace, kubeClient)
+	imPods, err := upgradeutil.ListIMPods(namespace, kubeClient)
 	if err != nil {
 		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing instance manager pods before updating Pod's owner reference")
 	}
@@ -45,32 +44,7 @@ func UpgradeInstanceManagerPods(namespace string, lhClient *lhclientset.Clientse
 			return err
 		}
 	}
-
-	imPods, err = listIMPods(namespace, kubeClient)
-	if err != nil {
-		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing instance manager pods before updating Pod's toleration annotation")
-	}
-	for _, pod := range imPods {
-		if err := updateIMPodLastAppliedTolerationsAnnotation(&pod, kubeClient, namespace); err != nil {
-			return err
-		}
-	}
-
 	return nil
-}
-
-func listIMPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, error) {
-	imPodsList, err := kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", types.GetLonghornLabelComponentKey(), types.LonghornLabelInstanceManager),
-	})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	if imPodsList != nil {
-		return imPodsList.Items, nil
-	}
-	return []v1.Pod{}, nil
 }
 
 func upgradeInstanceMangerPodOwnerRef(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
@@ -194,134 +168,4 @@ func UpgradeReplicas(namespace string, lhClient *lhclientset.Clientset) (err err
 		}
 	}
 	return nil
-}
-
-func UpdateDeploymentAndDaemonset(namespace string, kubeClient *clientset.Clientset) (err error) {
-	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"UpdateLastAppliedTolerationsAnnotation failed")
-	}()
-
-	if err := updateDeploymentLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
-		return err
-	}
-	if err := updateDaemonsetLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
-		return err
-	}
-	return nil
-}
-
-func updateDaemonsetLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
-	daemonsetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "failed to list Longhorn daemonsets for toleration annotation update")
-	}
-	for _, ds := range daemonsetList.Items {
-		dsp := &ds
-		needToUpdate, err := needToUpdateTolerationAnnotation(dsp)
-		if err != nil {
-			return err
-		}
-		if !needToUpdate {
-			continue
-		}
-		appliedTolerations := getNonDefaultTolerationList(dsp.Spec.Template.Spec.Tolerations)
-		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
-		if err != nil {
-			return err
-		}
-		if err := util.SetAnnotation(dsp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
-			return err
-		}
-		if _, err := kubeClient.AppsV1().DaemonSets(namespace).Update(dsp); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func updateDeploymentLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
-	deploymentList, err := kubeClient.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "failed to list Longhorn deployments for toleration annotation update")
-	}
-
-	for _, dp := range deploymentList.Items {
-		dpp := &dp
-		needToUpdate, err := needToUpdateTolerationAnnotation(dpp)
-		if err != nil {
-			return err
-		}
-		if !needToUpdate {
-			continue
-		}
-		appliedTolerations := getNonDefaultTolerationList(dpp.Spec.Template.Spec.Tolerations)
-		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
-		if err != nil {
-			return err
-		}
-		if err := util.SetAnnotation(dpp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
-			return err
-		}
-		if _, err := kubeClient.AppsV1().Deployments(namespace).Update(dpp); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func updateIMPodLastAppliedTolerationsAnnotation(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
-	needToUpdate, err := needToUpdateTolerationAnnotation(pod)
-	if err != nil {
-		return err
-	}
-	if !needToUpdate {
-		return nil
-	}
-	appliedTolerations := getNonDefaultTolerationList(pod.Spec.Tolerations)
-	appliedTolerationsByte, err := json.Marshal(appliedTolerations)
-	if err != nil {
-		return err
-	}
-	if err := util.SetAnnotation(pod, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
-		return err
-	}
-	if _, err = kubeClient.CoreV1().Pods(namespace).Update(pod); err != nil {
-		return errors.Wrapf(err, "failed to update toleration annotation for instance manager pod %v", pod.GetName())
-	}
-	return nil
-}
-
-func getNonDefaultTolerationList(tolerations []v1.Toleration) []v1.Toleration {
-	result := []v1.Toleration{}
-	for _, t := range tolerations {
-		if !util.IsKubernetesDefaultToleration(t) {
-			result = append(result, t)
-		}
-	}
-	return result
-}
-
-func needToUpdateTolerationAnnotation(obj runtime.Object) (bool, error) {
-	objMeta, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-
-	annos := objMeta.GetAnnotations()
-	if annos == nil {
-		return true, nil
-	}
-
-	_, ok := annos[types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix)]
-	if ok {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/upgrade/v102to110/upgrade.go
+++ b/upgrade/v102to110/upgrade.go
@@ -30,7 +30,24 @@ const (
 	upgradeLogPrefix = "upgrade from v1.0.2 to v1.1.0: "
 )
 
-func UpgradeInstanceManagerPods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
+func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := upgradeVolumes(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeReplicas(namespace, lhClient); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradePods(namespace string, kubeClient *clientset.Clientset) (err error) {
+	if err := upgradeInstanceManagerPods(namespace, kubeClient); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeInstanceManagerPods(namespace string, kubeClient *clientset.Clientset) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager pods failed")
 	}()
@@ -78,7 +95,7 @@ func upgradeInstanceMangerPodOwnerRef(pod *v1.Pod, kubeClient *clientset.Clients
 	return nil
 }
 
-func UpgradeVolumes(namespace string, lhClient *lhclientset.Clientset) (err error) {
+func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade volume failed")
 	}()
@@ -114,7 +131,7 @@ func UpgradeVolumes(namespace string, lhClient *lhclientset.Clientset) (err erro
 	return nil
 }
 
-func UpgradeReplicas(namespace string, lhClient *lhclientset.Clientset) (err error) {
+func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade replica failed")
 	}()

--- a/upgrade/v110to111/upgrade.go
+++ b/upgrade/v110to111/upgrade.go
@@ -33,7 +33,10 @@ const (
 // deprecating the old setting automatically:
 // https://github.com/longhorn/longhorn/issues/2207
 
-func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
+func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"UpgradeCRs failed")
+	}()
 	if err := upgradeLonghornNodes(namespace, lhClient); err != nil {
 		return err
 	}
@@ -51,6 +54,9 @@ func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
 }
 
 func UpgradePods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"UpgradePods failed")
+	}()
 	if err := upgradeInstanceManagerPods(namespace, kubeClient); err != nil {
 		return err
 	}
@@ -95,7 +101,7 @@ func UpgradeDeploymentAndDaemonSet(namespace string, kubeClient *clientset.Clien
 
 func upgradeLonghornNodes(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade longhorn node failed")
+		err = errors.Wrapf(err, "upgrade longhorn node failed")
 	}()
 
 	deprecatedCPUSetting, err := lhClient.LonghornV1beta1().Settings(namespace).Get(string(types.SettingNameGuaranteedEngineCPU), metav1.GetOptions{})
@@ -151,7 +157,7 @@ func upgradeLonghornNodes(namespace string, lhClient *lhclientset.Clientset) (er
 
 func upgradeInstanceManagers(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager failed")
+		err = errors.Wrapf(err, "upgrade instance manager failed")
 	}()
 
 	imList, err := lhClient.LonghornV1beta1().InstanceManagers(namespace).List(metav1.ListOptions{})
@@ -167,6 +173,9 @@ func upgradeInstanceManagers(namespace string, lhClient *lhclientset.Clientset) 
 	return nil
 }
 func upgradeLabelsForInstanceManager(im *longhorn.InstanceManager, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeLabelsForInstanceManager failed")
+	}()
 	metadata, err := meta.Accessor(im)
 	if err != nil {
 		return err
@@ -186,7 +195,7 @@ func upgradeLabelsForInstanceManager(im *longhorn.InstanceManager, lhClient *lhc
 
 func upgradeShareManagers(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade share manager failed")
+		err = errors.Wrapf(err, "upgrade share manager failed")
 	}()
 	smList, err := lhClient.LonghornV1beta1().ShareManagers(namespace).List(metav1.ListOptions{})
 	if err != nil {
@@ -201,6 +210,9 @@ func upgradeShareManagers(namespace string, lhClient *lhclientset.Clientset) (er
 }
 
 func upgradeLabelsForShareManager(sm *longhorn.ShareManager, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeLabelsForShareManager failed")
+	}()
 	metadata, err := meta.Accessor(sm)
 	if err != nil {
 		return err
@@ -219,7 +231,7 @@ func upgradeLabelsForShareManager(sm *longhorn.ShareManager, lhClient *lhclients
 
 func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade engine image failed")
+		err = errors.Wrapf(err, "upgrade engine image failed")
 	}()
 
 	eiList, err := lhClient.LonghornV1beta1().EngineImages(namespace).List(metav1.ListOptions{})
@@ -235,6 +247,9 @@ func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset) (err
 }
 
 func upgradeLabelsForEngineImage(ei *longhorn.EngineImage, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeLabelsForEngineImage failed")
+	}()
 	metadata, err := meta.Accessor(ei)
 	if err != nil {
 		return err
@@ -253,7 +268,7 @@ func upgradeLabelsForEngineImage(ei *longhorn.EngineImage, lhClient *lhclientset
 
 func upgradeShareManagerPods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade share manager pods failed")
+		err = errors.Wrapf(err, "upgrade share manager pods failed")
 	}()
 	smPods, err := upgradeutil.ListShareManagerPods(namespace, kubeClient)
 	if err != nil {
@@ -275,6 +290,9 @@ func upgradeShareManagerPods(namespace string, lhClient *lhclientset.Clientset, 
 }
 
 func upgradeShareManagerPodsLabels(pod *v1.Pod, sm *longhorn.ShareManager, kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeShareManagerPodsLabels failed")
+	}()
 	metadata, err := meta.Accessor(pod)
 	if err != nil {
 		return err
@@ -293,7 +311,7 @@ func upgradeShareManagerPodsLabels(pod *v1.Pod, sm *longhorn.ShareManager, kubeC
 
 func upgradeInstanceManagerPods(namespace string, kubeClient *clientset.Clientset) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager pods failed")
+		err = errors.Wrapf(err, "upgrade instance manager pods failed")
 	}()
 	imPods, err := upgradeutil.ListIMPods(namespace, kubeClient)
 	if err != nil {
@@ -309,6 +327,9 @@ func upgradeInstanceManagerPods(namespace string, kubeClient *clientset.Clientse
 }
 
 func updateIMPodLastAppliedTolerationsAnnotation(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "updateIMPodLastAppliedTolerationsAnnotation failed")
+	}()
 	needToUpdate, err := needToUpdateTolerationAnnotation(pod)
 	if err != nil {
 		return err
@@ -331,6 +352,9 @@ func updateIMPodLastAppliedTolerationsAnnotation(pod *v1.Pod, kubeClient *client
 }
 
 func upgradeCSIDeploymentsLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeCSIDeploymentsLabels failed")
+	}()
 	for _, dpName := range []string{types.CSIAttacherName, types.CSIProvisionerName, types.CSIResizerName, types.CSISnapshotterName} {
 		dp, err := kubeClient.AppsV1().Deployments(namespace).Get(dpName, metav1.GetOptions{})
 		if err != nil {
@@ -347,6 +371,9 @@ func upgradeCSIDeploymentsLabels(kubeClient *clientset.Clientset, namespace stri
 }
 
 func upgradeLabelsForDeployment(dp *appsv1.Deployment, kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeLabelsForDeployment failed")
+	}()
 	metadata, err := meta.Accessor(dp)
 	if err != nil {
 		return err
@@ -364,6 +391,9 @@ func upgradeLabelsForDeployment(dp *appsv1.Deployment, kubeClient *clientset.Cli
 }
 
 func upgradeCSIDaemonSetsLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeCSIDaemonSetsLabels failed")
+	}()
 	dsList := []*appsv1.DaemonSet{}
 
 	eiDaemonSetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{
@@ -380,7 +410,7 @@ func upgradeCSIDaemonSetsLabels(kubeClient *clientset.Clientset, namespace strin
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if csiPluginDaemonSet != nil {
+	if err == nil {
 		dsList = append(dsList, csiPluginDaemonSet)
 	}
 
@@ -393,6 +423,9 @@ func upgradeCSIDaemonSetsLabels(kubeClient *clientset.Clientset, namespace strin
 }
 
 func upgradeLabelsForDaemonSet(ds *appsv1.DaemonSet, kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeLabelsForDaemonSet failed")
+	}()
 	metadata, err := meta.Accessor(ds)
 	if err != nil {
 		return err
@@ -410,6 +443,9 @@ func upgradeLabelsForDaemonSet(ds *appsv1.DaemonSet, kubeClient *clientset.Clien
 }
 
 func upgradeCSIServicesLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeCSIServicesLabels failed")
+	}()
 	for _, svName := range []string{types.CSIAttacherName, types.CSIProvisionerName, types.CSIResizerName, types.CSISnapshotterName} {
 		sv, err := kubeClient.CoreV1().Services(namespace).Get(svName, metav1.GetOptions{})
 		if err != nil {
@@ -426,6 +462,9 @@ func upgradeCSIServicesLabels(kubeClient *clientset.Clientset, namespace string)
 }
 
 func upgradeShareManagerServicesLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "upgradeShareManagerServicesLabels failed")
+	}()
 	svList, err := kubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{
 		LabelSelector: types.GetLonghornLabelKey(types.LonghornLabelShareManager),
 	})
@@ -458,6 +497,9 @@ func upgradeLabelsForService(sv *v1.Service, kubeClient *clientset.Clientset, na
 }
 
 func updateCSIDaemonSetsLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "updateCSIDaemonSetsLastAppliedTolerationsAnnotation failed")
+	}()
 	daemonsetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.Set(types.GetBaseLabelsForSystemManagedComponent()).String(),
 	})
@@ -492,6 +534,9 @@ func updateCSIDaemonSetsLastAppliedTolerationsAnnotation(kubeClient *clientset.C
 }
 
 func updateCSIDeploymentsLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "updateCSIDeploymentsLastAppliedTolerationsAnnotation failed")
+	}()
 	deploymentList, err := kubeClient.AppsV1().Deployments(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.Set(types.GetBaseLabelsForSystemManagedComponent()).String(),
 	})

--- a/upgrade/v110to111/upgrade.go
+++ b/upgrade/v110to111/upgrade.go
@@ -1,15 +1,28 @@
 package v110to111
 
 import (
+	"encoding/json"
 	"math"
+	"reflect"
 	"strconv"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+
 	"github.com/longhorn/longhorn-manager/types"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 )
 
 const (
@@ -21,13 +34,66 @@ const (
 // https://github.com/longhorn/longhorn/issues/2207
 
 func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) error {
-	if err := doLonghornNodeUpgrade(namespace, lhClient); err != nil {
+	if err := upgradeLonghornNodes(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeInstanceManagers(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeShareManagers(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeEngineImages(namespace, lhClient); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func UpgradePods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
+	if err := upgradeInstanceManagerPods(namespace, kubeClient); err != nil {
+		return err
+	}
+	if err := upgradeShareManagerPods(namespace, lhClient, kubeClient); err != nil {
 		return err
 	}
 	return nil
 }
 
-func doLonghornNodeUpgrade(namespace string, lhClient *lhclientset.Clientset) (err error) {
+func UpgradeServices(namespace string, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"UpgradeServices failed")
+	}()
+	if err := upgradeCSIServicesLabels(kubeClient, namespace); err != nil {
+		return err
+	}
+	if err := upgradeShareManagerServicesLabels(kubeClient, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeDeploymentAndDaemonSet(namespace string, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"UpgradeDeploymentAndDaemonset failed")
+	}()
+
+	if err := upgradeCSIDeploymentsLabels(kubeClient, namespace); err != nil {
+		return err
+	}
+	if err := upgradeCSIDaemonSetsLabels(kubeClient, namespace); err != nil {
+		return err
+	}
+	if err := updateCSIDeploymentsLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
+		return err
+	}
+	if err := updateCSIDaemonSetsLastAppliedTolerationsAnnotation(kubeClient, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeLonghornNodes(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade longhorn node failed")
 	}()
@@ -81,4 +147,410 @@ func doLonghornNodeUpgrade(namespace string, lhClient *lhclientset.Clientset) (e
 	}
 
 	return nil
+}
+
+func upgradeInstanceManagers(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager failed")
+	}()
+
+	imList, err := lhClient.LonghornV1beta1().InstanceManagers(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, im := range imList.Items {
+		if err := upgradeLabelsForInstanceManager(&im, lhClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func upgradeLabelsForInstanceManager(im *longhorn.InstanceManager, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(im)
+	if err != nil {
+		return err
+	}
+	instanceManagerLabels := metadata.GetLabels()
+	newInstanceManagerLabels := upgradeutil.MergeStringMaps(instanceManagerLabels, types.GetInstanceManagerLabels(im.Spec.NodeID, im.Spec.Image, im.Spec.Type))
+	if reflect.DeepEqual(instanceManagerLabels, newInstanceManagerLabels) {
+		return nil
+	}
+
+	metadata.SetLabels(newInstanceManagerLabels)
+	if _, err := lhClient.LonghornV1beta1().InstanceManagers(namespace).Update(im); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to update the spec for instance manager %v during the instance managers upgrade", im.Name)
+	}
+	return nil
+}
+
+func upgradeShareManagers(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade share manager failed")
+	}()
+	smList, err := lhClient.LonghornV1beta1().ShareManagers(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, sm := range smList.Items {
+		if err := upgradeLabelsForShareManager(&sm, lhClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeLabelsForShareManager(sm *longhorn.ShareManager, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(sm)
+	if err != nil {
+		return err
+	}
+	shareManagerLabels := metadata.GetLabels()
+	newShareManagerLabels := upgradeutil.MergeStringMaps(shareManagerLabels, types.GetShareManagerLabels(sm.Name, sm.Spec.Image))
+	if reflect.DeepEqual(shareManagerLabels, newShareManagerLabels) {
+		return nil
+	}
+	metadata.SetLabels(newShareManagerLabels)
+	if _, err := lhClient.LonghornV1beta1().ShareManagers(namespace).Update(sm); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade engine image failed")
+	}()
+
+	eiList, err := lhClient.LonghornV1beta1().EngineImages(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, ei := range eiList.Items {
+		if err := upgradeLabelsForEngineImage(&ei, lhClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeLabelsForEngineImage(ei *longhorn.EngineImage, lhClient *lhclientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(ei)
+	if err != nil {
+		return err
+	}
+	engineImageLabels := metadata.GetLabels()
+	newEngineImageLabels := upgradeutil.MergeStringMaps(engineImageLabels, types.GetEngineImageLabels(ei.Name))
+	if reflect.DeepEqual(engineImageLabels, newEngineImageLabels) {
+		return nil
+	}
+	metadata.SetLabels(newEngineImageLabels)
+	if _, err := lhClient.LonghornV1beta1().EngineImages(namespace).Update(ei); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeShareManagerPods(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade share manager pods failed")
+	}()
+	smPods, err := upgradeutil.ListShareManagerPods(namespace, kubeClient)
+	if err != nil {
+		return err
+	}
+	for _, pod := range smPods {
+		sm, err := lhClient.LonghornV1beta1().ShareManagers(namespace).Get(types.GetShareManagerNameFromShareManagerPodName(pod.Name), metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if err := upgradeShareManagerPodsLabels(&pod, sm, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeShareManagerPodsLabels(pod *v1.Pod, sm *longhorn.ShareManager, kubeClient *clientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(pod)
+	if err != nil {
+		return err
+	}
+	podLabels := metadata.GetLabels()
+	newPodLabels := upgradeutil.MergeStringMaps(podLabels, types.GetShareManagerLabels(sm.Name, sm.Spec.Image))
+	if reflect.DeepEqual(podLabels, newPodLabels) {
+		return nil
+	}
+	metadata.SetLabels(newPodLabels)
+	if _, err := kubeClient.CoreV1().Pods(namespace).Update(pod); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeInstanceManagerPods(namespace string, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade instance manager pods failed")
+	}()
+	imPods, err := upgradeutil.ListIMPods(namespace, kubeClient)
+	if err != nil {
+		return err
+	}
+	for _, pod := range imPods {
+		if err := updateIMPodLastAppliedTolerationsAnnotation(&pod, kubeClient, namespace); err != nil {
+			return err
+		}
+		// Note that we already upgrade instance manager pods' labels in v100to101, so no need to upgrade it here
+	}
+	return nil
+}
+
+func updateIMPodLastAppliedTolerationsAnnotation(pod *v1.Pod, kubeClient *clientset.Clientset, namespace string) (err error) {
+	needToUpdate, err := needToUpdateTolerationAnnotation(pod)
+	if err != nil {
+		return err
+	}
+	if !needToUpdate {
+		return nil
+	}
+	appliedTolerations := getNonDefaultTolerationList(pod.Spec.Tolerations)
+	appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+	if err != nil {
+		return err
+	}
+	if err := util.SetAnnotation(pod, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+		return err
+	}
+	if _, err = kubeClient.CoreV1().Pods(namespace).Update(pod); err != nil {
+		return errors.Wrapf(err, "failed to update toleration annotation for instance manager pod %v", pod.GetName())
+	}
+	return nil
+}
+
+func upgradeCSIDeploymentsLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	for _, dpName := range []string{types.CSIAttacherName, types.CSIProvisionerName, types.CSIResizerName, types.CSISnapshotterName} {
+		dp, err := kubeClient.AppsV1().Deployments(namespace).Get(dpName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if err := upgradeLabelsForDeployment(dp, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeLabelsForDeployment(dp *appsv1.Deployment, kubeClient *clientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(dp)
+	if err != nil {
+		return err
+	}
+	dpLabels := metadata.GetLabels()
+	newDPLabels := upgradeutil.MergeStringMaps(dpLabels, types.GetBaseLabelsForSystemManagedComponent())
+	if reflect.DeepEqual(dpLabels, newDPLabels) {
+		return nil
+	}
+	metadata.SetLabels(newDPLabels)
+	if _, err := kubeClient.AppsV1().Deployments(namespace).Update(dp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeCSIDaemonSetsLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	dsList := []*appsv1.DaemonSet{}
+
+	eiDaemonSetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(types.GetEngineImageComponentLabel()).String(),
+	})
+	if err != nil {
+		return err
+	}
+	for _, ds := range eiDaemonSetList.Items {
+		dsList = append(dsList, &ds)
+	}
+
+	csiPluginDaemonSet, err := kubeClient.AppsV1().DaemonSets(namespace).Get(types.CSIPluginName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if csiPluginDaemonSet != nil {
+		dsList = append(dsList, csiPluginDaemonSet)
+	}
+
+	for _, ds := range dsList {
+		if err := upgradeLabelsForDaemonSet(ds, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeLabelsForDaemonSet(ds *appsv1.DaemonSet, kubeClient *clientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(ds)
+	if err != nil {
+		return err
+	}
+	dsLabels := metadata.GetLabels()
+	newDSLabels := upgradeutil.MergeStringMaps(dsLabels, types.GetBaseLabelsForSystemManagedComponent())
+	if reflect.DeepEqual(dsLabels, newDSLabels) {
+		return nil
+	}
+	metadata.SetLabels(newDSLabels)
+	if _, err := kubeClient.AppsV1().DaemonSets(namespace).Update(ds); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeCSIServicesLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	for _, svName := range []string{types.CSIAttacherName, types.CSIProvisionerName, types.CSIResizerName, types.CSISnapshotterName} {
+		sv, err := kubeClient.CoreV1().Services(namespace).Get(svName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if err := upgradeLabelsForService(sv, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeShareManagerServicesLabels(kubeClient *clientset.Clientset, namespace string) (err error) {
+	svList, err := kubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{
+		LabelSelector: types.GetLonghornLabelKey(types.LonghornLabelShareManager),
+	})
+	if err != nil {
+		return err
+	}
+	for _, sv := range svList.Items {
+		if err := upgradeLabelsForService(&sv, kubeClient, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeLabelsForService(sv *v1.Service, kubeClient *clientset.Clientset, namespace string) (err error) {
+	metadata, err := meta.Accessor(sv)
+	if err != nil {
+		return err
+	}
+	svLabels := metadata.GetLabels()
+	newSVLabels := upgradeutil.MergeStringMaps(svLabels, types.GetBaseLabelsForSystemManagedComponent())
+	if reflect.DeepEqual(svLabels, newSVLabels) {
+		return nil
+	}
+	metadata.SetLabels(newSVLabels)
+	if _, err := kubeClient.CoreV1().Services(namespace).Update(sv); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateCSIDaemonSetsLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	daemonsetList, err := kubeClient.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(types.GetBaseLabelsForSystemManagedComponent()).String(),
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list Longhorn daemonsets for toleration annotation update")
+	}
+	for _, ds := range daemonsetList.Items {
+		dsp := &ds
+		needToUpdate, err := needToUpdateTolerationAnnotation(dsp)
+		if err != nil {
+			return err
+		}
+		if !needToUpdate {
+			continue
+		}
+		appliedTolerations := getNonDefaultTolerationList(dsp.Spec.Template.Spec.Tolerations)
+		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+		if err != nil {
+			return err
+		}
+		if err := util.SetAnnotation(dsp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+			return err
+		}
+		if _, err := kubeClient.AppsV1().DaemonSets(namespace).Update(dsp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateCSIDeploymentsLastAppliedTolerationsAnnotation(kubeClient *clientset.Clientset, namespace string) (err error) {
+	deploymentList, err := kubeClient.AppsV1().Deployments(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(types.GetBaseLabelsForSystemManagedComponent()).String(),
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list Longhorn deployments for toleration annotation update")
+	}
+
+	for _, dp := range deploymentList.Items {
+		dpp := &dp
+		needToUpdate, err := needToUpdateTolerationAnnotation(dpp)
+		if err != nil {
+			return err
+		}
+		if !needToUpdate {
+			continue
+		}
+		appliedTolerations := getNonDefaultTolerationList(dpp.Spec.Template.Spec.Tolerations)
+		appliedTolerationsByte, err := json.Marshal(appliedTolerations)
+		if err != nil {
+			return err
+		}
+		if err := util.SetAnnotation(dpp, types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix), string(appliedTolerationsByte)); err != nil {
+			return err
+		}
+		if _, err := kubeClient.AppsV1().Deployments(namespace).Update(dpp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getNonDefaultTolerationList(tolerations []v1.Toleration) []v1.Toleration {
+	result := []v1.Toleration{}
+	for _, t := range tolerations {
+		if !util.IsKubernetesDefaultToleration(t) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func needToUpdateTolerationAnnotation(obj runtime.Object) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	annos := objMeta.GetAnnotations()
+	if annos == nil {
+		return true, nil
+	}
+
+	_, ok := annos[types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix)]
+	if ok {
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
Longhorn shouldn't modify user deployed components (e.g., manager, driver,
UI) because doing so would have problems for users who deploy Longhorn using
GitOps tools.

* This PR adds a new labels `longhornio/managed-by: longhorn manager` to all
managed components. Then Longhorn only watchs and updates toleration/priority class for those
managed components

* This PR also makes sure that the labels is added after upgrade Longhorn from
an older version.

Now that we only watch/update managed components, we should allow user to specify Helm values for user deployed components (manager, driver, UI). This is tracked at https://github.com/longhorn/longhorn/pull/2348

longhorn/longhorn#2120