### PR TITLE
Fixes the RWX attach call

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -69,7 +69,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--timeout=2m5s",
+			"--timeout=2m5s", // we wait for 2 minutes for an attach/detach operation to complete
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},
@@ -134,7 +134,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--timeout=2m5s",
+			"--timeout=2m5s", // we wait for 2 minutes, for the initial detach after creation to complete
 			"--enable-leader-election",
 			"--leader-election-type=leases",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
@@ -200,6 +200,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
+			"--timeout=2m5s", // we wait for 2 minutes for an expansion operation to complete
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -617,9 +617,16 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 		return nil, fmt.Errorf("cannot expand volume before replica scheduling success")
 	}
 
-	if v.Spec.Size >= size {
-		return nil, fmt.Errorf("cannot expand volume %v with current size %v to a smaller or the same size %v", v.Name, v.Spec.Size, size)
+	if v.Spec.Size > size {
+		return nil, fmt.Errorf("cannot expand volume %v with current size %v to a smaller size %v", v.Name, v.Spec.Size, size)
 	}
+
+	if v.Spec.Size == size {
+		logrus.Infof("Volume %v expansion is not necessary since current size %v == %v", v.Name, v.Spec.Size, size)
+		return v, nil
+	}
+
+	logrus.Infof("Volume %v expandsion from %v to %v requested", v.Name, v.Spec.Size, size)
 	v.Spec.Size = size
 
 	// Support off-line expansion only.
@@ -630,7 +637,6 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 		return nil, err
 	}
 
-	logrus.Debugf("Expanding volume %v to size %v", v.Name, size)
 	return v, nil
 }
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -314,9 +314,6 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 	if err != nil {
 		return nil, err
 	}
-	if !v.Spec.Migratable && v.Status.State != types.VolumeStateDetached {
-		return nil, fmt.Errorf("invalid state to attach %v: %v", name, v.Status.State)
-	}
 
 	if isReady, err := m.CheckEngineImageReadinessForVolume(v.Spec.EngineImage, v.Name, nodeID); !isReady {
 		if err != nil {
@@ -348,8 +345,8 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		return v, nil
 	}
 
-	if v.Status.State != types.VolumeStateDetached && !v.Spec.Migratable {
-		return nil, fmt.Errorf("invalid state %v to attach volume %v is migratable %v", name, v.Status.State, v.Spec.Migratable)
+	if v.Spec.AccessMode != types.AccessModeReadWriteMany && v.Status.State != types.VolumeStateDetached {
+		return nil, fmt.Errorf("invalid state %v to attach RWO volume %v", v.Status.State, name)
 	}
 
 	isVolumeShared := v.Spec.AccessMode == types.AccessModeReadWriteMany && !v.Spec.Migratable


### PR DESCRIPTION
Also added a fix in a separate commit for an issue on the CSI drivers, volume expansion idempotency. Since I was testing the RWX expansion at the same time.

https://github.com/longhorn/longhorn/issues/2316
https://github.com/longhorn/longhorn/issues/2181

@shuo-wu closed the other pr in favor of this one, kept the old error behavior except in the case where the requested size == the actual size, since that makes the call idempotent. We still error out in the longhorn api where size < actual size.
For the csi part it's expected behavior to return success in case where size < actual size and include the actual size. 