### PR TITLE
Fix csi resizer timeout param usage

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -200,7 +200,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--timeout=2m5s", // we wait for 2 minutes for an expansion operation to complete
+			"--csiTimeout=2m5s", // TODO: change this to timeout once, we upgrade the external resizer version. we wait for 2 minutes for an expansion operation to complete
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},


### PR DESCRIPTION
We are using a really old csi resizer image, that doesn't yet support the
new `timeout` param, instead it relies on an old `csiTimeout` param.
Decided against updating the csi images and instead will do a full update
of all the csi images for 1.2.

See https://github.com/kubernetes-csi/external-resizer/pull/82

longhorn/longhorn#2347

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
