### PR TITLE
Fix bug Longhorn upgrades more than concurrentAutomaticEngineUpgradePerNodeLimit engines per nodes

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -843,3 +843,10 @@ func GenerateDiskConfig(path string) (*DiskConfig, error) {
 
 	return cfg, nil
 }
+
+func MinInt(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
`limitAutomaticEngineUpgradePerNode()` may be called multiple times with the same inputs. Therefore, we need to sort the `upgradingCandidates` slice so that the function has deterministic finalCandidates output. This prevents selecting more than `concurrentAutomaticEngineUpgradePerNodeLimitcandidates` to upgrade at the same time.

I am not sure why the `limitAutomaticEngineUpgradePerNode()` sometime is called multiple times with the same inputs. @joshimoo , @yasker Do you have any idea? I actually don't like the current fix (sorting the list of volumes) because it may hurt Longhorn in the long run when Longhorn is used to manage million of volumes. So, if we can prevent the `limitAutomaticEngineUpgradePerNode()` from being called multiple times with the same inputs, it would be a better solution, I think.

longhorn/longhorn#2328
