### PR TITLE
Enable uninstall job security context privileged

### DIFF
--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -1,63 +1,8 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: longhorn-uninstall-service-account
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: longhorn-uninstall-role
-rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - "*"
-  - apiGroups: [""]
-    resources: ["pods", "persistentvolumes", "persistentvolumeclaims", "nodes", "configmaps", "secrets", "services", "endpoints"]
-    verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["daemonsets", "statefulsets", "deployments"]
-    verbs: ["*"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
-    verbs: ["*"]
-  - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
-    verbs: ["*"]
-  - apiGroups: ["scheduling.k8s.io"]
-    resources: ["priorityclasses"]
-    verbs: ["watch", "list"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers", "storageclasses"]
-    verbs: ["*"]
-  - apiGroups: ["longhorn.io"]
-    resources: ["volumes", "engines", "replicas", "settings", "engineimages", "nodes", "instancemanagers", "sharemanagers", "backingimages"]
-    verbs: ["*"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: longhorn-uninstall-bind
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: longhorn-uninstall-role
-subjects:
-  - kind: ServiceAccount
-    name: longhorn-uninstall-service-account
-    namespace: default
----
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: longhorn-uninstall
-  namespace: default
+  namespace: longhorn-system
 spec:
   activeDeadlineSeconds: 900
   backoffLimit: 1
@@ -77,6 +22,8 @@ spec:
         - --force
         env:
         - name: LONGHORN_NAMESPACE
-          value: longhorn-system
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       restartPolicy: OnFailure
-      serviceAccountName: longhorn-uninstall-service-account
+      serviceAccountName: longhorn-service-account

--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -69,6 +69,8 @@ spec:
       - name: longhorn-uninstall
         image: longhornio/longhorn-manager:master
         imagePullPolicy: Always
+        securityContext:
+          privileged: true
         command:
         - longhorn-manager
         - uninstall


### PR DESCRIPTION
#### Symptom

```shell
kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn.yaml
kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/uninstall/uninstall.yaml
kubectl get job/longhorn-uninstall -n default -w
```
The job pod in the stuck state.

#### Root Cause
According to PSP Policy Order:

> 1. PodSecurityPolicies which allow the pod as-is, without changing defaults or mutating the pod, are preferred. The order of these non-mutating PodSecurityPolicies doesn't matter.
> 2. If the pod must be defaulted or mutated, the first PodSecurityPolicy (ordered by name) to allow the pod is selected.

since the uninstall Job did not set any `securityContext`, it causes it would fall into `global-restricted-psp` first since the pod must be defaulted or mutated, the first PodSecurityPolicy (ordered by name) to allow the pod is selected.

#### Solution

- Configure the `privileged: true` to uninstall Job, to match against 
https://github.com/longhorn/longhorn-manager/blob/v1.1.0/deploy/install/02-components/01-manager.yaml#L21-L22
- Remove the new service account and uses the existing service-account create when install https://github.com/longhorn/longhorn-manager/blob/v1.1.0/deploy/install/01-prerequisite/02-serviceaccount.yaml (this matches the helm chart)

#### Issues
https://github.com/longhorn/longhorn/issues/2292