### PR TITLE
Keep uninstall job in default namespace

### DIFF
--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -1,8 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-uninstall-service-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-uninstall-role
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumes", "persistentvolumeclaims", "nodes", "configmaps", "secrets", "services", "endpoints"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "statefulsets", "deployments"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["*"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["*"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers", "storageclasses"]
+    verbs: ["*"]
+  - apiGroups: ["longhorn.io"]
+    resources: ["volumes", "engines", "replicas", "settings", "engineimages", "nodes", "instancemanagers", "sharemanagers", "backingimages"]
+    verbs: ["*"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-uninstall-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-uninstall-role
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-uninstall-service-account
+    namespace: default
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: longhorn-uninstall
-  namespace: longhorn-system
+  namespace: default
 spec:
   activeDeadlineSeconds: 900
   backoffLimit: 1
@@ -22,8 +77,6 @@ spec:
         - --force
         env:
         - name: LONGHORN_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: longhorn-system
       restartPolicy: OnFailure
-      serviceAccountName: longhorn-service-account
+      serviceAccountName: longhorn-uninstall-service-account

--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -1,3 +1,33 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: longhorn-uninstall-psp
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+  - NET_RAW
+  allowedCapabilities:
+  - SYS_ADMIN
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - secret
+  - projected
+  - hostPath
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,6 +69,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["*"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["longhorn-uninstall-psp"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### Why

According to https://github.com/longhorn/longhorn-manager/pull/849#issuecomment-804234586
> When the user deletes the longhorn-system namespace by mistake and gets stuck, the Pod cannot be created in that namespace. That's why we're running the uninstaller job in the default namespace.

#### How
- Rvert the change of removing ServiceAccount, ClusterRole, and ClusterRoleBinding
- Keep the job running in `default` namespace
- Add PSP `longhorn-uninstall-psp` for ServiceAccount `longhorn-uninstall-service-account`

#### Issues
https://github.com/longhorn/longhorn/issues/2292