### PR TITLE
Fixed engine image never becomes deployed after upgrading

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -156,12 +156,12 @@ func newEngineImageDaemonSet() *appsv1.DaemonSet {
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: types.GetEngineImageLabels(getTestEngineImageName()),
+				MatchLabels: types.GetEIDaemonSetLabelSelector(getTestEngineImageName()),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   getTestEngineImageDaemonSetName(),
-					Labels: types.GetEngineImageLabels(getTestEngineImageName()),
+					Labels: types.GetEIDaemonSetLabelSelector(getTestEngineImageName()),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: TestServiceAccount,

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -722,7 +722,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: types.GetEngineImageLabels(ei.Name),
+				MatchLabels: types.GetEIDaemonSetLabelSelector(ei.Name),
 			},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,
@@ -733,7 +733,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            dsName,
-					Labels:          types.GetEngineImageLabels(ei.Name),
+					Labels:          types.GetEIDaemonSetLabelSelector(ei.Name),
 					OwnerReferences: datastore.GetOwnerReferencesForEngineImage(ei),
 				},
 				Spec: v1.PodSpec{

--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -147,7 +147,7 @@ func createEngineImageDaemonSetPod(name string, containerReadyStatus bool, nodeI
 		TestNamespace,
 		nodeID,
 	)
-	pod.Labels = types.GetEngineImageLabels(getTestEngineImageName())
+	pod.Labels = types.GetEIDaemonSetLabelSelector(getTestEngineImageName())
 	return pod
 }
 

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -162,7 +162,7 @@ func (s *DataStore) GetEngineImageDaemonSet(name string) (*appsv1.DaemonSet, err
 
 func (s *DataStore) ListEngineImageDaemonSetPodsFromEngineImageName(EIName string) ([]*corev1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: types.GetEngineImageLabels(EIName),
+		MatchLabels: types.GetEIDaemonSetLabelSelector(EIName),
 	})
 	if err != nil {
 		return nil, err

--- a/types/types.go
+++ b/types/types.go
@@ -238,6 +238,14 @@ func GetEngineImageLabels(engineImageName string) map[string]string {
 	return labels
 }
 
+// GetEIDaemonSetLabelSelector returns labels for engine image daemonset's Spec.Selector.MatchLabels
+func GetEIDaemonSetLabelSelector(engineImageName string) map[string]string {
+	labels := make(map[string]string)
+	labels[GetLonghornLabelComponentKey()] = LonghornLabelEngineImage
+	labels[GetLonghornLabelKey(LonghornLabelEngineImage)] = engineImageName
+	return labels
+}
+
 func GetEngineImageComponentLabel() map[string]string {
 	return map[string]string{
 		GetLonghornLabelComponentKey(): LonghornLabelEngineImage,


### PR DESCRIPTION
We recently changed the labels for engine image CR in the PR https://github.com/longhorn/longhorn-manager/pull/842. We added the label `longhorn.io/managed-by: longhorn-manager` to `engine image`, `engine image daemonset`, and `engine image daemonset pod` by updating the fucntion [GetEngineImageLabels()](https://github.com/longhorn/longhorn-manager/blob/f6ff18666ea238c4eec4bfdce9612796da1a0701/types/types.go#L234)

On the other hand, during Longhorn upgrading, we only update the label for `engine image`, `engine image daemonset` but not the `engine image daemonset pod`  of the existing engine image.

This creates a problem when we [syncNodeDeploymentMap()](https://github.com/longhorn/longhorn-manager/blob/f6ff18666ea238c4eec4bfdce9612796da1a0701/controller/engine_image_controller.go#L363), Longhorn couldn't find the pod of the old engine image using the label selector returned by [GetEngineImageLabels()](https://github.com/longhorn/longhorn-manager/blob/f6ff18666ea238c4eec4bfdce9612796da1a0701/types/types.go#L234)  and think that the old engine image is not deployed.

The propose solution in this PR is that we don't need to add the label `longhorn.io/managed-by: longhorn-manager`  to engine image daemonset pods at all (for both old and new engine image) because the engine image ds pods are not managed by Longhorn manager. It is managed by the daemonset controller. Then, we use the correct label selector to list the engine image pods (i.e., don't use function [GetEngineImageLabels()](https://github.com/longhorn/longhorn-manager/blob/f6ff18666ea238c4eec4bfdce9612796da1a0701/types/types.go#L234) but create a new function that returns the selector that doesn't include the label `longhorn.io/managed-by: longhorn-manager`)



longhorn/longhorn#2399