### PR TITLE
Ownership transferring refactoring

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -190,10 +190,10 @@ func (bic *BackingImageController) syncBackingImage(key string) (err error) {
 
 	log := getLoggerForBackingImage(bic.logger, backingImage)
 
+	if !bic.isResponsibleFor(backingImage) {
+		return nil
+	}
 	if backingImage.Status.OwnerID != bic.controllerID {
-		if !bic.isResponsibleFor(backingImage) {
-			return nil
-		}
 		backingImage.Status.OwnerID = bic.controllerID
 		backingImage, err = bic.ds.UpdateBackingImageStatus(backingImage)
 		if err != nil {

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -250,11 +250,11 @@ func isControllerResponsibleFor(controllerID string, ds *datastore.DataStore, na
 	// we use this approach so that if there is an issue with the data store
 	// we don't accidentally transfer ownership
 	isOwnerUnavailable := func(node string) bool {
-		nodeDown, err := ds.IsNodeDownOrDeleted(node)
+		isUnavailable, err := ds.IsNodeDownOrDeletedOrMissingManager(node)
 		if node != "" && err != nil {
-			logrus.Errorf("Error while checking if object %v node %v is down or deleted: %v", name, node, err)
+			logrus.Errorf("Error while checking IsNodeDownOrDeletedOrMissingManager for object %v, node %v: %v", name, node, err)
 		}
-		return node == "" || nodeDown
+		return node == "" || isUnavailable
 	}
 
 	isPreferredOwner := controllerID == preferredOwnerID

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -473,8 +473,8 @@ func (ic *EngineImageController) getVolumesForEngineImageUpgrading(volumes map[s
 			continue
 		}
 		canBeUpgraded := ic.canDoOfflineEngineImageUpgrade(v, newEngineImageResource) || ic.canDoLiveEngineImageUpgrade(v, newEngineImageResource)
-		isCurrentEIAvailable, _ := ic.ds.CheckEngineImageReadinessForVolume(v.Status.CurrentImage, v.Name, v.Status.CurrentNodeID)
-		isNewEIAvailable, _ := ic.ds.CheckEngineImageReadinessForVolume(newEngineImageResource.Spec.Image, v.Name, v.Status.CurrentNodeID)
+		isCurrentEIAvailable, _ := ic.ds.CheckEngineImageReadyOnAllVolumeReplicas(v.Status.CurrentImage, v.Name, v.Status.CurrentNodeID)
+		isNewEIAvailable, _ := ic.ds.CheckEngineImageReadyOnAllVolumeReplicas(newEngineImageResource.Spec.Image, v.Name, v.Status.CurrentNodeID)
 		validCandidate := v.Spec.EngineImage != newEngineImageResource.Spec.Image && canBeUpgraded && isCurrentEIAvailable && isNewEIAvailable
 		if validCandidate {
 			candidates[v.Status.OwnerID] = append(candidates[v.Status.OwnerID], v)

--- a/controller/kubernetes_configmap_controller.go
+++ b/controller/kubernetes_configmap_controller.go
@@ -32,7 +32,6 @@ const (
 type KubernetesConfigMapController struct {
 	*baseController
 
-	// use as the OwnerID of the controller
 	namespace    string
 	controllerID string
 

--- a/controller/kubernetes_node_controller.go
+++ b/controller/kubernetes_node_controller.go
@@ -204,7 +204,6 @@ func (knc *KubernetesNodeController) syncKubernetesNode(key string) (err error) 
 	}()
 
 	if knc.controllerID != kubeNode.Name {
-		// not our's
 		return nil
 	}
 

--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -223,7 +223,6 @@ func (kc *KubernetesPVController) syncKubernetesStatus(key string) (err error) {
 	}
 
 	if volume.Status.OwnerID != kc.controllerID {
-		// Not ours
 		return nil
 	}
 

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -253,7 +253,7 @@ func (m *VolumeManager) GetEngineClient(volumeName string) (client engineapi.Eng
 	if e.Status.CurrentState != types.InstanceStateRunning {
 		return nil, fmt.Errorf("engine is not running")
 	}
-	if isReady, err := m.CheckEngineImageReadiness(e.Status.CurrentImage, m.currentNodeID); !isReady {
+	if isReady, err := m.ds.CheckEngineImageReadiness(e.Status.CurrentImage, m.currentNodeID); !isReady {
 		if err != nil {
 			return nil, fmt.Errorf("cannot get engine client with image %v: %v", e.Status.CurrentImage, err)
 		}

--- a/manager/engineimage.go
+++ b/manager/engineimage.go
@@ -112,11 +112,3 @@ func (m *VolumeManager) DeployEngineImage(image string) error {
 	}
 	return nil
 }
-
-func (m *VolumeManager) CheckEngineImageReadiness(image string, nodes ...string) (isReady bool, err error) {
-	return m.ds.CheckEngineImageReadiness(image, nodes...)
-}
-
-func (m *VolumeManager) CheckEngineImageReadinessForVolume(image, volumeName, nodeID string) (isReady bool, err error) {
-	return m.ds.CheckEngineImageReadinessForVolume(image, volumeName, nodeID)
-}

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -315,11 +315,11 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		return nil, err
 	}
 
-	if isReady, err := m.CheckEngineImageReadinessForVolume(v.Spec.EngineImage, v.Name, nodeID); !isReady {
+	if isReady, err := m.ds.CheckEngineImageReadyOnAtLeastOneVolumeReplica(v.Spec.EngineImage, v.Name, nodeID); !isReady {
 		if err != nil {
 			return nil, fmt.Errorf("cannot attach volume %v with image %v: %v", v.Name, v.Spec.EngineImage, err)
 		}
-		return nil, fmt.Errorf("cannot attach volume %v with image %v because the engine image %v is not deployed on the replicas' nodes or the node that the volume is going to attach to", v.Name, v.Spec.EngineImage, v.Spec.EngineImage)
+		return nil, fmt.Errorf("cannot attach volume %v because the engine image %v is not deployed on at least one of the the replicas' nodes or the node that the volume is going to attach to", v.Name, v.Spec.EngineImage)
 	}
 
 	scheduleCondition := types.GetCondition(v.Status.Conditions, types.VolumeConditionTypeScheduled)
@@ -824,7 +824,7 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 		return nil, err
 	}
 
-	if isReady, err := m.CheckEngineImageReadinessForVolume(image, v.Name, v.Status.CurrentNodeID); !isReady {
+	if isReady, err := m.ds.CheckEngineImageReadyOnAllVolumeReplicas(image, v.Name, v.Status.CurrentNodeID); !isReady {
 		if err != nil {
 			return nil, fmt.Errorf("cannot upgrade engine image for volume %v from image %v to image %v: %v", v.Name, v.Spec.EngineImage, image, err)
 		}


### PR DESCRIPTION
1. When the manager pod on the owner node of the CR is missing, we switch
the ownerID of the CR to a different node
2. Don’t cleaning up CRs base on the current ownerID. The convention is 
that ownerID only indicates which node should watch the CR. We shouldn’t 
make any other logic depend on the ownerID. This way we can freely transfer
ownership
3. Make sure that when the engine/instance manager CR is transfered to 
new ownerID, the old owner must stop monitoring them. Also, remove 
engine/instance manager monitoring from the monitoring map of engine/instance 
manager controller when stop monitoring the engine. This allow the old
owner to restart the monitoring when the CRs’ owner is transfered back to it
4. Don’t clear the engine status when switching ownership. The new owner 
will take care of continuing to update the engine. This create a smooth
owner transferring.
5. Modify the isResponsibleFor() in engine, volume, engine image controller 
so that the current owner can continue to be the owner if the preferred 
owner doesn’t have engine image deployed.
6. Make sure the replica/engine instance is able to stop when the IM is 
in error state
7. The controller should at least look at each resource to determine
whether it's responsible for it or not, it's no the enqueue functions's
responsibility to make that determination
8. Allow attaching volume if there is engine image ready on at least one of 
the replicas' nodes of the volume.  This allow volumes to be attached/auto 
reattached when there are replicas on failed/non-exist nodes while still make
sure not to fail all of the replicas


longhorn/longhorn#2377
longhorn/longhorn#2329