### PR TITLE
update unsintall controller to cleanup share manager crds (#2384)

### DIFF
--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -132,6 +132,7 @@ func uninstall(c *cli.Context) error {
 		engineImageInformer,
 		nodeInformer,
 		imInformer,
+		smInformer,
 		backingImageInformer,
 		daemonSetInformer,
 		deploymentInformer,


### PR DESCRIPTION
#### Proposed Changes ####

update unsinstall controller to cleanup share manager crds to resolve ticket '[BUG] uninstall-controller does not cleanup share-manager crds' (#2384)

- add clean up for share-manager and settings

#### Types of Changes ####

Bug

#### Verification ####

- deploy longhorn
- deploy a rxw volume/pod
- uninstall using uninstaller from "https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/uninstall/uninstall.yaml"
- check log for uninstaller

```
ttime="2021-04-01T06:49:07Z" level=info msg="Found 1 share managers remaining" controller=longhorn-uninstall
time="2021-04-01T06:49:07Z" level=info msg="Marked for deletion" controller=longhorn-uninstall owner=centos-worker-0 shareManager=pvc-d6e490b0-0437-481c-ba0f-c6d8944757f4 state=running volume=pvc-d6e490b0-0437-481c-ba0f-c6d8944757f4
time="2021-04-01T06:49:07Z" level=info msg="Found 1 share managers remaining" controller=longhorn-uninstall
time="2021-04-01T06:49:07Z" level=info msg="Marked for deletion" controller=longhorn-uninstall owner= shareManager=pvc-d6e490b0-0437-481c-ba0f-c6d8944757f4 state= volume=pvc-d6e490b0-0437-481c-ba0f-c6d8944757f4
time="2021-04-01T06:49:07Z" level=info msg="Found 1 share managers remaining" controller=longhorn-uninstall
time="2021-04-01T06:49:07Z" level=info msg="Found 1 share managers remaining" controller=longhorn-uninstall
```

#### Linked Issues ####

Refs: # https://github.com/longhorn/longhorn/issues/2384

#### Further Comments ####

None

Signed-off-by: Clark Hsu <clark.hsu@suse.com>