### PR TITLE
Fixing IM pods get deleted during new Longhorn installation

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -751,13 +751,11 @@ func (imc *InstanceManagerController) enqueueKubernetesNode(obj interface{}) {
 func (imc *InstanceManagerController) cleanupInstanceManager(im *longhorn.InstanceManager) error {
 	log := getLoggerForInstanceManager(imc.logger, im)
 	im.Status.IP = ""
+	if len(im.Status.Instances) > 0 {
+		im.Status.Instances = map[string]types.InstanceProcess{}
+	}
 	if imc.isMonitoring(im.Name) {
 		imc.stopMonitoring(im)
-	}
-
-	// Need to update the instances before deleting pod.
-	if err := imc.updateInstanceMapForCleanup(im.Name); err != nil {
-		logrus.Errorf("failed to mark existing instances to error when stopping instance manager monitor: %v", err)
 	}
 
 	pod, err := imc.ds.GetPod(im.Name)
@@ -768,7 +766,7 @@ func (imc *InstanceManagerController) cleanupInstanceManager(im *longhorn.Instan
 		if err := imc.ds.DeletePod(pod.Name); err != nil {
 			return err
 		}
-		log.Warnf("Deleted instance manager pod %v for instance manager %v", im.Name, im.Status.CurrentState)
+		log.Warnf("Deleted instance manager pod %v because the instance manager has CurrentState %v", pod.Name, im.Status.CurrentState)
 	}
 
 	return nil
@@ -1079,20 +1077,6 @@ func (imc *InstanceManagerController) isMonitoring(imName string) bool {
 
 	_, ok := imc.instanceManagerMonitorMap[imName]
 	return ok
-}
-
-func (imc *InstanceManagerController) updateInstanceMapForCleanup(imName string) error {
-	im, err := imc.ds.GetInstanceManager(imName)
-	if err != nil {
-		return fmt.Errorf("failed to get instance manager %v to cleanup instance map: %v", imName, err)
-	}
-	im.Status.Instances = map[string]types.InstanceProcess{}
-
-	if _, err := imc.ds.UpdateInstanceManagerStatus(im); err != nil {
-		return fmt.Errorf("failed to update instance map for instance manager %v: %v", imName, err)
-	}
-
-	return nil
 }
 
 func (m *InstanceManagerMonitor) Run() {


### PR DESCRIPTION
**Problem:**
When we [clean up the instance manager CR](https://github.com/longhorn/longhorn-manager/blob/51c3b60138b0ca85c8bbfdffa4cc6998844246a8/controller/instance_manager_controller.go#L420), we update the IM CR at the middle of the syncInstanceManager loop [here](https://github.com/longhorn/longhorn-manager/blob/51c3b60138b0ca85c8bbfdffa4cc6998844246a8/controller/instance_manager_controller.go#L759). This update alter the IM CR and create [the conflict](https://github.com/longhorn/longhorn-manager/blob/51c3b60138b0ca85c8bbfdffa4cc6998844246a8/controller/instance_manager_controller.go#L310) at the end of the loop. Because of the conflict, we successfully create the pod but fail to set [im.Status.CurrentState = types.InstanceManagerStateStarting](https://github.com/longhorn/longhorn-manager/blob/51c3b60138b0ca85c8bbfdffa4cc6998844246a8/controller/instance_manager_controller.go#L433). And in the next reconciliation loop, we [mark the IM CR error](https://github.com/longhorn/longhorn-manager/blob/51c3b60138b0ca85c8bbfdffa4cc6998844246a8/controller/instance_manager_controller.go#L356) and clean up the newly created IM pod.

**Fix:**
Avoid updating the instance manager CR in the middle of the syncInstanceManager loop because doing so would create conflicts when we update the IM CR at the end of the loop.
One may ask what happen if the IM pod is deleted but the IM CR fails to be cleaned up. In this case, Longhorn will retry to clean up the IM CR and retry to delete the already deleted IM pod. So, eventually, the world's state will become the desired state. 
 
longhorn/longhorn#2446
