### PR TITLE
Allow users to sepecify node selector for Longhorn components

### DIFF
--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -790,7 +790,7 @@ func (c *BackingImageManagerController) isEligibleForPulling(currentBIM *longhor
 
 func (c *BackingImageManagerController) createBackingImageManagerPod(bim *longhorn.BackingImageManager) (err error) {
 	defer func() {
-		err = errors.Wrapf(err, "failed to create backing image manager pod")
+		err = errors.Wrap(err, "failed to create backing image manager pod")
 	}()
 
 	log := getLoggerForBackingImageManager(c.logger, bim)
@@ -801,13 +801,17 @@ func (c *BackingImageManagerController) createBackingImageManagerPod(bim *longho
 	if err != nil {
 		return err
 	}
+	nodeSelector, err := c.ds.GetSettingSystemManagedComponentsNodeSelector()
+	if err != nil {
+		return err
+	}
 	registrySecretSetting, err := c.ds.GetSetting(types.SettingNameRegistrySecret)
 	if err != nil {
 		return err
 	}
 	registrySecret := registrySecretSetting.Value
 
-	podManifest, err := c.generateBackingImageManagerPodManifest(bim, tolerations, registrySecret)
+	podManifest, err := c.generateBackingImageManagerPodManifest(bim, tolerations, registrySecret, nodeSelector)
 	if err != nil {
 		return err
 	}
@@ -820,7 +824,7 @@ func (c *BackingImageManagerController) createBackingImageManagerPod(bim *longho
 	return nil
 }
 
-func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(bim *longhorn.BackingImageManager, tolerations []v1.Toleration, registrySecret string) (*v1.Pod, error) {
+func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(bim *longhorn.BackingImageManager, tolerations []v1.Toleration, registrySecret string, nodeSelector map[string]string) (*v1.Pod, error) {
 	tolerationsByte, err := json.Marshal(tolerations)
 	if err != nil {
 		return nil, err
@@ -847,6 +851,7 @@ func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(b
 		Spec: v1.PodSpec{
 			ServiceAccountName: c.serviceAccount,
 			Tolerations:        util.GetDistinctTolerations(tolerations),
+			NodeSelector:       nodeSelector,
 			PriorityClassName:  priorityClass.Value,
 			Containers: []v1.Container{
 				{

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2122,6 +2122,10 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 	if err != nil {
 		return nil, err
 	}
+	nodeSelector, err := vc.ds.GetSettingSystemManagedComponentsNodeSelector()
+	if err != nil {
+		return nil, err
+	}
 	// for mounting inside container
 	privilege := true
 	cronJob := &batchv1beta1.CronJob{
@@ -2182,6 +2186,7 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 							ServiceAccountName: vc.ServiceAccount,
 							RestartPolicy:      v1.RestartPolicyOnFailure,
 							Tolerations:        util.GetDistinctTolerations(tolerations),
+							NodeSelector:       nodeSelector,
 						},
 					},
 				},

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -56,7 +56,7 @@ type AttacherDeployment struct {
 }
 
 func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *AttacherDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *AttacherDeployment {
 
 	service := getCommonService(types.CSIAttacherName, namespace)
 
@@ -79,6 +79,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
+		nodeSelector,
 	)
 
 	return &AttacherDeployment{
@@ -121,7 +122,7 @@ type ProvisionerDeployment struct {
 }
 
 func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ProvisionerDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *ProvisionerDeployment {
 
 	service := getCommonService(types.CSIProvisionerName, namespace)
 
@@ -145,6 +146,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
+		nodeSelector,
 	)
 
 	return &ProvisionerDeployment{
@@ -187,7 +189,7 @@ type ResizerDeployment struct {
 }
 
 func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *ResizerDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *ResizerDeployment {
 
 	service := getCommonService(types.CSIResizerName, namespace)
 
@@ -210,6 +212,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
+		nodeSelector,
 	)
 
 	return &ResizerDeployment{
@@ -252,7 +255,7 @@ type SnapshotterDeployment struct {
 }
 
 func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootDir string, replicaCount int, tolerations []v1.Toleration,
-	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *SnapshotterDeployment {
+	tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *SnapshotterDeployment {
 	service := getCommonService(types.CSISnapshotterName, namespace)
 
 	deployment := getCommonDeployment(
@@ -273,6 +276,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 		priorityClass,
 		registrySecret,
 		imagePullPolicy,
+		nodeSelector,
 	)
 
 	return &SnapshotterDeployment{
@@ -314,7 +318,7 @@ type PluginDeployment struct {
 }
 
 func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, managerImage, managerURL, rootDir string,
-	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *PluginDeployment {
+	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *PluginDeployment {
 
 	daemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -339,6 +343,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 				Spec: v1.PodSpec{
 					ServiceAccountName: serviceAccount,
 					Tolerations:        tolerations,
+					NodeSelector:       nodeSelector,
 					PriorityClassName:  priorityClass,
 					HostPID:            true,
 					Containers: []v1.Container{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -55,7 +55,7 @@ func getCommonService(commonName, namespace string) *v1.Service {
 }
 
 func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir string, args []string, replicaCount int32,
-	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy) *appsv1.Deployment {
+	tolerations []v1.Toleration, tolerationsString, priorityClass, registrySecret string, imagePullPolicy v1.PullPolicy, nodeSelector map[string]string) *appsv1.Deployment {
 
 	deploymentLabels := types.GetBaseLabelsForSystemManagedComponent()
 	deploymentLabels["app"] = commonName
@@ -79,6 +79,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 				Spec: v1.PodSpec{
 					ServiceAccountName: serviceAccount,
 					Tolerations:        tolerations,
+					NodeSelector:       nodeSelector,
 					PriorityClassName:  priorityClass,
 					Containers: []v1.Container{
 						{

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -117,6 +117,16 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 				return fmt.Errorf("cannot modify toleration setting before all volumes are detached")
 			}
 		}
+	case types.SettingNameSystemManagedComponentsNodeSelector:
+		list, err := s.ListVolumesRO()
+		if err != nil {
+			return errors.Wrapf(err, "failed to list volumes before modifying node selector for managed components setting")
+		}
+		for _, v := range list {
+			if v.Status.State != types.VolumeStateDetached {
+				return fmt.Errorf("cannot modify node selector for managed components setting before all volumes are detached")
+			}
+		}
 	case types.SettingNamePriorityClass:
 		if value != "" {
 			if _, err := s.GetPriorityClass(value); err != nil {
@@ -1952,6 +1962,18 @@ func (s *DataStore) GetSettingTaintToleration() ([]corev1.Toleration, error) {
 		return nil, err
 	}
 	return tolerationList, nil
+}
+
+func (s *DataStore) GetSettingSystemManagedComponentsNodeSelector() (map[string]string, error) {
+	setting, err := s.GetSetting(types.SettingNameSystemManagedComponentsNodeSelector)
+	if err != nil {
+		return nil, err
+	}
+	nodeSelector, err := types.UnmarshalNodeSelector(setting.Value)
+	if err != nil {
+		return nil, err
+	}
+	return nodeSelector, nil
 }
 
 // ResetMonitoringEngineStatus clean and update Engine status

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -20,6 +20,7 @@ data:
     default-longhorn-static-storage-class:
     backupstore-poll-interval:
     taint-toleration:
+    system-managed-components-node-selector:
     priority-class:
     auto-salvage:
     auto-delete-pod-when-volume-detached-unexpectedly:

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -89,6 +89,9 @@ spec:
 #        operator: "Equal"
 #        value: "value"
 #        effect: "NoSchedule"
+#      nodeSelector:
+#        label-key1: "label-value1"
+#        label-key2: "label-value2"
       serviceAccountName: longhorn-service-account
   updateStrategy:
     rollingUpdate:

--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -35,6 +35,9 @@ spec:
 #        operator: "Equal"
 #        value: "value"
 #        effect: "NoSchedule"
+#      nodeSelector:
+#        label-key1: "label-value1"
+#        label-key2: "label-value2"
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/install/02-components/04-driver.yaml
+++ b/deploy/install/02-components/04-driver.yaml
@@ -75,6 +75,9 @@ spec:
 #        operator: "Equal"
 #        value: "value"
 #        effect: "NoSchedule"
+#      nodeSelector:
+#        label-key1: "label-value1"
+#        label-key2: "label-value2"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0

--- a/deploy/uninstall/uninstall.yaml
+++ b/deploy/uninstall/uninstall.yaml
@@ -114,3 +114,14 @@ spec:
           value: longhorn-system
       restartPolicy: OnFailure
       serviceAccountName: longhorn-uninstall-service-account
+#      imagePullSecrets:
+#      - name: ""
+#      priorityClassName:
+#      tolerations:
+#        - key: "key"
+#          operator: "Equal"
+#          value: "value"
+#          effect: "NoSchedule"
+#      nodeSelector:
+#        label-key1: "label-value1"
+#        label-key2: "label-value2"


### PR DESCRIPTION
This feature allows user to limit Longhorn on a specific set of nodes in the cluster. 

User stories:
* Deploy Longhorn in a cluster with both Linux nodes and Windows nodes
* [Longhorn in GKE](https://forums.rancher.com/t/longhorn-in-gke-node-affinity/19814)

User experience:
1. Set the node selector for user-deployed components (Longhorn manager, UI, driver deployer) in Helm or YAML file
2. Then set the node selector for managed components (everything else) in `system-managed-components-node-selector` setting

Note: Workloads that use Longhorn volume can only run on the selected nodes in the cluster.

longhorn/longhorn#2199