### PR TITLE
Fix bug: Longhorn always restart the managed components when the node selector is empty

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -579,6 +579,11 @@ func (sc *SettingController) updateNodeSelector() error {
 		return errors.Wrapf(err, "failed to list backing image manager pods for node selector update")
 	}
 	for _, dp := range deploymentList {
+		if dp.Spec.Template.Spec.NodeSelector == nil {
+			if len(newNodeSelector) == 0 {
+				continue
+			}
+		}
 		if reflect.DeepEqual(dp.Spec.Template.Spec.NodeSelector, newNodeSelector) {
 			continue
 		}
@@ -588,6 +593,11 @@ func (sc *SettingController) updateNodeSelector() error {
 		}
 	}
 	for _, ds := range daemonsetList {
+		if ds.Spec.Template.Spec.NodeSelector == nil {
+			if len(newNodeSelector) == 0 {
+				continue
+			}
+		}
 		if reflect.DeepEqual(ds.Spec.Template.Spec.NodeSelector, newNodeSelector) {
 			continue
 		}
@@ -599,6 +609,11 @@ func (sc *SettingController) updateNodeSelector() error {
 	pods := append(imPodList, smPodList...)
 	pods = append(pods, bimPodList...)
 	for _, pod := range pods {
+		if pod.Spec.NodeSelector == nil {
+			if len(newNodeSelector) == 0 {
+				continue
+			}
+		}
 		if reflect.DeepEqual(pod.Spec.NodeSelector, newNodeSelector) {
 			continue
 		}


### PR DESCRIPTION
When node selector is empty,  the object return by client-go has a `nil` map for nodeSelector. This makes the deep equal comparison always fail since the nodeSelector is an empty map. As the result, Longhorn manage restarts the managed components

longhorn/longhorn#2199