### PR TITLE
Remove the schedule condition check from the Volume attach call

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -322,10 +322,6 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		return nil, fmt.Errorf("cannot attach volume %v because the engine image %v is not deployed on at least one of the the replicas' nodes or the node that the volume is going to attach to", v.Name, v.Spec.EngineImage)
 	}
 
-	scheduleCondition := types.GetCondition(v.Status.Conditions, types.VolumeConditionTypeScheduled)
-	if scheduleCondition.Status != types.ConditionStatusTrue {
-		return nil, fmt.Errorf("volume %v cannot be scheduled due to lack of nodes or disks satisfied the space requirement", name)
-	}
 	restoreCondition := types.GetCondition(v.Status.Conditions, types.VolumeConditionTypeRestore)
 	if restoreCondition.Status == types.ConditionStatusTrue {
 		return nil, fmt.Errorf("volume %v is restoring data", name)


### PR DESCRIPTION
This condition is already covered by the readiness check in the detached
state. I identified some issues with the way the scheduling conditions are
handled in the volume controller, but they are outside of the scope for
v1.1.1 This is a surgical fix, to allow for rwx volumes to be used even if
one replica cannot be scheduled.

The share manager currently does not check for this condition, and will
always allow for volume usage even if not all replicas could be scheduled.
After creation, this is part of the problem, since the intent of the
scheduling failure is to keep the volume in the creation state, right now
the volume controller does not do this instead, it has some hacks for the
detached state.

I plan on looking into this, when working on the volume controller refactor.

longhorn/longhorn#2463

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
