### PR TITLE
Increase the hardcoded NFS client timeout

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -182,8 +182,8 @@ func (ns *NodeServer) nodePublishSharedVolume(volumeName, shareEndpoint, targetP
 		"soft", // for this release we use soft mode, so we can always cleanup mount points
 		"sync",
 		"intr",
-		"timeo=7",
-		"retrans=3",
+		"timeo=30",  // This is tenths of a second, so a 3 second timeout, each retrans the timeout will be linearly increased, 3s, 6s, 9s
+		"retrans=3", // We try the io operation for a total of 3 times, before failing, max runtime of 18s
 		// "clientaddr=" // TODO: try to set the client address of the mount to the ip of the pod that is consuming the volume
 	}
 


### PR DESCRIPTION
We use a 3s timeout, with 3 retransmission tries before failure.
After each timeout the timeout will be linearly increased (3s, 6s, 9s)
This means that an IO operation has a maximum runtime of 18s before failure.

For the HA solution we want to use hard mode, which will lead to an infinite
retry, since in that mode we want to be able to guarantee the survival of
the workload pods instead of having to terminate them.

longhorn/longhorn#2528

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
