### PR TITLE
app: Increase the timeout for the http client

### DIFF
--- a/app/volume.go
+++ b/app/volume.go
@@ -31,6 +31,8 @@ const (
 	FlagRetain       = "retain"
 	FlagBackup       = "backup"
 
+	HTTPClientTimout = 1 * time.Minute
+
 	SnapshotPurgeStatusInterval = 5 * time.Second
 
 	WaitInterval              = 5 * time.Second
@@ -141,7 +143,10 @@ func NewJob(managerURL, volumeName, snapshotName string, labels map[string]strin
 		return nil, errors.Wrap(err, "unable to get clientset")
 	}
 
-	clientOpts := &longhornclient.ClientOpts{Url: managerURL}
+	clientOpts := &longhornclient.ClientOpts{
+		Url:     managerURL,
+		Timeout: HTTPClientTimout,
+	}
 	apiClient, err := longhornclient.NewRancherClient(clientOpts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not create longhorn-manager api client")


### PR DESCRIPTION
The default request timeout for recurring jobs is 10s, which is
definitely not enough. If multiple recurring jobs for a volume
start simultaneously (due to the mutex lock), or some steps take
several seconds, the timeout will fail the recurring jobs.

Increasing the timeout is not able to completely avoid duplicate 
snapshots/backups if there are intensive snapshot-related
operations. But this should reduce the probability.

longhorn/longhorn#2278

Signed-off-by: Shuo Wu <shuo.wu@suse.com>