### PR TITLE
use pvc to expand volume (#2422)

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -326,7 +326,7 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 		kubeStatus := volume.Status.KubernetesStatus
 
 		if kubeStatus.PVName != "" {
-			if err := vc.ds.DeletePersisentVolume(kubeStatus.PVName); err != nil {
+			if err := vc.ds.DeletePersistentVolume(kubeStatus.PVName); err != nil {
 				if !datastore.ErrorIsNotFound(err) {
 					return err
 				}
@@ -334,7 +334,7 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 		}
 
 		if kubeStatus.PVCName != "" && kubeStatus.LastPVCRefAt == "" {
-			if err := vc.ds.DeletePersisentVolumeClaim(kubeStatus.Namespace, kubeStatus.PVCName); err != nil {
+			if err := vc.ds.DeletePersistentVolumeClaim(kubeStatus.Namespace, kubeStatus.PVCName); err != nil {
 				if !datastore.ErrorIsNotFound(err) {
 					return err
 				}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -669,16 +669,11 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	// we can only call the longhorn expansion api if the requested size is larger than the volume size
-	// since longhorn treats the size differently than kubernetes, in kubernetes capacity is a request
-	// to ensure that the volume has at least that amount of capacity.
 	requestedSize := req.CapacityRange.GetRequiredBytes()
-	if requestedSize > existingSize {
-		if existVol, err = cs.apiClient.Volume.ActionExpand(existVol, &longhornclient.ExpandInput{
-			Size: strconv.FormatInt(requestedSize, 10),
-		}); err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
-		}
+	if existVol, err = cs.apiClient.Volume.ActionExpand(existVol, &longhornclient.ExpandInput{
+		Size: strconv.FormatInt(requestedSize, 10),
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	// kubernetes doesn't support volume shrinking and the csi spec specifies to return true

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -389,45 +389,51 @@ func (s *DataStore) GetKubernetesNode(name string) (*corev1.Node, error) {
 	return s.knLister.Get(name)
 }
 
-// CreatePersisentVolume creates a PersistentVolume resource for the given
+// CreatePersistentVolume creates a PersistentVolume resource for the given
 // PersistentVolume object
-func (s *DataStore) CreatePersisentVolume(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+func (s *DataStore) CreatePersistentVolume(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
 	return s.kubeClient.CoreV1().PersistentVolumes().Create(pv)
 }
 
-// DeletePersisentVolume deletes the PersistentVolume for the given
+// DeletePersistentVolume deletes the PersistentVolume for the given
 // PersistentVolume name
-func (s *DataStore) DeletePersisentVolume(pvName string) error {
+func (s *DataStore) DeletePersistentVolume(pvName string) error {
 	return s.kubeClient.CoreV1().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
 }
 
-// UpdatePersisentVolume updates the PersistentVolume for the given
+// UpdatePersistentVolume updates the PersistentVolume for the given
 // PersistentVolume object
-func (s *DataStore) UpdatePersisentVolume(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+func (s *DataStore) UpdatePersistentVolume(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
 	return s.kubeClient.CoreV1().PersistentVolumes().Update(pv)
 }
 
-// GetPersisentVolume gets the PersistentVolume from the index for the
+// GetPersistentVolume gets the PersistentVolume from the index for the
 // given name
-func (s *DataStore) GetPersisentVolume(pvName string) (*corev1.PersistentVolume, error) {
+func (s *DataStore) GetPersistentVolume(pvName string) (*corev1.PersistentVolume, error) {
 	return s.pvLister.Get(pvName)
 }
 
-// CreatePersisentVolumeClaim creates a PersistentVolumeClaim resource
+// CreatePersistentVolumeClaim creates a PersistentVolumeClaim resource
 // for the given PersistentVolumeclaim object and namespace
-func (s *DataStore) CreatePersisentVolumeClaim(ns string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+func (s *DataStore) CreatePersistentVolumeClaim(ns string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
 	return s.kubeClient.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
 }
 
-// DeletePersisentVolumeClaim deletes the PersistentVolumeClaim for the
+// DeletePersistentVolumeClaim deletes the PersistentVolumeClaim for the
 // given name and namespace
-func (s *DataStore) DeletePersisentVolumeClaim(ns, pvcName string) error {
+func (s *DataStore) DeletePersistentVolumeClaim(ns, pvcName string) error {
 	return s.kubeClient.CoreV1().PersistentVolumeClaims(ns).Delete(pvcName, &metav1.DeleteOptions{})
 }
 
-// GetPersisentVolumeClaim gets the PersistentVolumeClaim from the
+// UpdatePersistentVolumeClaim expand the PersistentVolumeClaim from the
 // index for the given name and namespace
-func (s *DataStore) GetPersisentVolumeClaim(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
+func (s *DataStore) UpdatePersistentVolumeClaim(namespace string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	return s.kubeClient.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
+}
+
+// GetPersistentVolumeClaim gets the PersistentVolumeClaim from the
+// index for the given name and namespace
+func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
 	return s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
 }
 

--- a/manager/kubernetes.go
+++ b/manager/kubernetes.go
@@ -44,7 +44,7 @@ func (m *VolumeManager) PVCreate(name, pvName, fsType string) (v *longhorn.Volum
 	}
 
 	pv := datastore.NewPVManifestForVolume(v, pvName, storageClassName, fsType)
-	pv, err = m.ds.CreatePersisentVolume(pv)
+	pv, err = m.ds.CreatePersistentVolume(pv)
 	if err != nil {
 		return nil, err
 	}
@@ -89,21 +89,21 @@ func (m *VolumeManager) PVCCreate(name, namespace, pvcName string) (v *longhorn.
 		return nil, fmt.Errorf("cannot found PV %v or the PV status %v is invalid for PVC creation", ks.PVName, ks.PVStatus)
 	}
 
-	pv, err := m.ds.GetPersisentVolume(ks.PVName)
+	pv, err := m.ds.GetPersistentVolume(ks.PVName)
 	if err != nil {
 		return nil, err
 	}
 	// cleanup ClaimRef of PV. Otherwise the existing PV cannot be reused.
 	if pv.Spec.ClaimRef != nil {
 		pv.Spec.ClaimRef = nil
-		pv, err = m.ds.UpdatePersisentVolume(pv)
+		pv, err = m.ds.UpdatePersistentVolume(pv)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	pvc := datastore.NewPVCManifestForVolume(v, ks.PVName, namespace, pvcName, pv.Spec.StorageClassName)
-	pvc, err = m.ds.CreatePersisentVolumeClaim(namespace, pvc)
+	pvc, err = m.ds.CreatePersistentVolumeClaim(namespace, pvc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Proposed Changes ####

use pvc to expand volume to resolve ticket 'Application couldn't mount the volume after expanded the volume' (#2422)

- Modify 'Expand' API to provide PVC/PV expand

#### Types of Changes ####
 
Bug fix

#### Verification ####

```
GIVEN:
- Kubernetes cluster deployed
- Longhorn deployed
- a statefulset/deployment with mounted volume deployed
WHEN:
- scale down replicas for statefulset/deployment to zero
- POST `Expand` to `longhorn_backend` 
THEN:
- wait for pvc/pv successful expand
- statefulset/deployment scale replica to 1 and disk attached successfully
```

Curl API

```
ACTION=expand
curl -sSX POST -H 'Content-Type: application/json' "http://${BACKEND_URL}:${BACKEND_PORT}/v1/volumes/${PV_NAME}?action=${ACTION}" -d '{"size":"4Gi"}' 
```

if volume is not detached will receive error like this

```
{
  "actions": {},
  "code": "Server Error",
  "detail": "",
  "links": {
    "self": "http://longhorn-backend.longhorn-system.svc.cluster.local:9500/v1/volumes/pvc-5d3833f1-5530-426f-bb8e-cb7b6aef467a"
  },
  "message": "invalid volume state to expand: pvc-5d3833f1-5530-426f-bb8e-cb7b6aef467a",
  "status": 500,
  "type": "error"
}
```

#### Linked Issues ####

Refs: https://github.com/longhorn/longhorn/issues/2422

#### Further Comments ####

Signed-off-by: Clark Hsu <clark.hsu@suse.com>