### PR TITLE
manager: Auto correct backing image name during creation

### DIFF
--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -9,6 +9,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
@@ -29,6 +30,7 @@ func (m *VolumeManager) CreateBackingImage(name, url string) (*longhorn.BackingI
 		return nil, fmt.Errorf("cannot create backing image with empty image URL")
 	}
 
+	name = util.AutoCorrectName(name, datastore.NameMaximumLength)
 	if !util.ValidateName(name) {
 		return nil, fmt.Errorf("invalid name %v", name)
 	}


### PR DESCRIPTION
If the backing image name is longer than 63 char, Longhorn cannot put it in the replica label. And Longhorn cannot list the replicas using the backing image name with the name.

longhorn/longhorn#2522