### PR TITLE
Backing Image Upload

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -482,6 +482,7 @@ func backingImageSchema(backingImage *client.Schema) {
 			Input:  "backingImageCleanupInput",
 			Output: "backingImage",
 		},
+		BackingImageUpload: {},
 	}
 
 	name := backingImage.ResourceFields["name"]
@@ -1182,6 +1183,7 @@ func toBackingImageResource(bi *longhorn.BackingImage, apiContext *api.ApiContex
 	}
 	res.Actions = map[string]string{
 		"backingImageCleanup": apiContext.UrlBuilder.ActionLink(res.Resource, "backingImageCleanup"),
+		BackingImageUpload:    apiContext.UrlBuilder.ActionLink(res.Resource, BackingImageUpload),
 	}
 	return res
 }

--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"reflect"
 
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -47,6 +48,17 @@ func (m *VolumeManager) ListBackingImageDataSources() (map[string]*longhorn.Back
 
 func (m *VolumeManager) GetBackingImageDataSource(name string) (*longhorn.BackingImageDataSource, error) {
 	return m.ds.GetBackingImageDataSource(name)
+}
+
+func (m *VolumeManager) GetBackingImageDataSourcePod(name string) (*v1.Pod, error) {
+	pod, err := m.ds.GetPod(types.GetBackingImageDataSourcePodName(name))
+	if err != nil {
+		return nil, err
+	}
+	if pod == nil || pod.Labels[types.GetLonghornLabelKey(types.LonghornLabelBackingImageDataSource)] != name {
+		return nil, fmt.Errorf("cannot find pod for backing image data source %v", name)
+	}
+	return pod, nil
 }
 
 func (m *VolumeManager) CreateBackingImage(name, checksum, sourceType string, parameters map[string]string) (bi *longhorn.BackingImage, err error) {


### PR DESCRIPTION
longhorn/longhorn#2404

Workflow:
1. Users create a backing image by uploading a local file via UI.
2. UI calls the backing image creation API then waits for backing image field `uploadAddress` to become non-empty.
3. Longhorn manager pods will ask the backing image manager pods to launch an HTTP upload server for the backing image after receiving the backing image creation call. When the upload server is launched, backing image field `uploadAddress` will be set.
4. UI starts to call the upload-related APIs for the backing image. Longhorn manager pod will forward the requests to the upload server in the backing image manager pods:
    1. Action `uploadServerStart` will ask the upload server to create a tmp file and set the total size for the backing image. This means upload start.
    2. Action `chunkPrepare` is used to check if each chunk is already uploaded or not. If the chunk is not correct, it will do clean up first. Then a chunk file will be created. This API will be called before uploading each chunk.
    3. Action `chunkUpload` is for chunk upload. This will write the actual chunk data to the chunk file.
    4. After uploading all chunks, action `chunkCoalesce` will be invoked. This will copy all chunk data into the tmp file created by `uploadServerStart` then clean up all chunk files.
    5. Finally, action `uploadServerClose` is to indicate upload complete.
5.  If the upload is interrupted. UI can retry upload for the users. With action `chunkPrepare`, Longhorn can skip re-uploading existing chunks.

Besides, for uploaded backing images. Longhorn cannot clean up all downloaded files even if the backing image timeout is reached. And for the backing image cleanup API, Longhorn needs to avoid users force deleting all downloaded files. If they want to clean up all files, they can directly delete the backing image.