### PR TITLE
2631 deep copy fix

### DIFF
--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -98,9 +98,24 @@ func (e *EngineStatus) DeepCopyInto(to *EngineStatus) {
 	}
 	if e.Snapshots != nil {
 		to.Snapshots = make(map[string]*Snapshot)
-		for key, value := range e.Snapshots {
+		for key, source := range e.Snapshots {
 			to.Snapshots[key] = &Snapshot{}
-			*to.Snapshots[key] = *value
+			*to.Snapshots[key] = *source
+			out := to.Snapshots[key]
+
+			if source.Children != nil {
+				out.Children = make(map[string]bool)
+				for key, value := range source.Children {
+					out.Children[key] = value
+				}
+			}
+
+			if source.Labels != nil {
+				out.Labels = make(map[string]string)
+				for key, value := range source.Labels {
+					out.Labels[key] = value
+				}
+			}
 		}
 	}
 }

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -37,6 +37,11 @@ func (v *VolumeStatus) DeepCopyInto(to *VolumeStatus) {
 			to.Conditions[key] = value
 		}
 	}
+
+	if v.KubernetesStatus.WorkloadsStatus != nil {
+		to.KubernetesStatus.WorkloadsStatus = make([]WorkloadStatus, len(v.KubernetesStatus.WorkloadsStatus))
+		copy(to.KubernetesStatus.WorkloadsStatus, v.KubernetesStatus.WorkloadsStatus)
+	}
 }
 
 func (e *EngineSpec) DeepCopyInto(to *EngineSpec) {


### PR DESCRIPTION
Fixes missed deepcopy sub element cases for 
- EngineStatus->Snapshots->Snapshot 
- VolumeStatus.KubernetesStatus.WorkloadStatus

longhorn/longhorn#2631