### PR TITLE
Ensure cleanup of corrupted mount points

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -202,6 +203,10 @@ func (ns *NodeServer) nodePublishMountVolume(volumeName, devicePath, targetPath,
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !notMnt {
+		if _, err := ioutil.ReadDir(targetPath); err != nil {
+			logrus.Errorf("NodePublishVolume: the volume mount %s exists but is not healthy", volumeName)
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 		logrus.Debugf("NodePublishVolume: the volume %s has been mounted", volumeName)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}

--- a/csi/util.go
+++ b/csi/util.go
@@ -178,31 +178,6 @@ func isLikelyNotMountPointAttach(targetpath string) (bool, error) {
 	return notMnt, err
 }
 
-func isLikelyNotMountPointDetach(targetpath string) (bool, error) {
-	notMnt, err := mount.New("").IsLikelyNotMountPoint(targetpath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return notMnt, fmt.Errorf("targetpath not found")
-		}
-	}
-	return notMnt, err
-}
-
-// Should be similar to the detect function in `util` package
-// For csi plugins, util.DetectFileSystem is not available since we cannot use NSExecutor in the workloads
-func detectFileSystem(devicePath string) (string, error) {
-	mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: mount.NewOSExec()}
-	output, err := mounter.Run("blkid", devicePath)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get the file system info from device %v, maybe there is no Linux file system on the volume", devicePath)
-	}
-	items := strings.Split(string(output), " ")
-	if len(items) < 3 {
-		return "", fmt.Errorf("failed to detect the file system from device %v, invalid output of command blkid", devicePath)
-	}
-	return strings.Trim(strings.TrimPrefix(strings.TrimSpace(items[2]), "TYPE="), "\""), nil
-}
-
 // isBlockDevice return true if volumePath file is a block device, false otherwise.
 func isBlockDevice(volumePath string) (bool, error) {
 	var stat unix.Stat_t


### PR DESCRIPTION
Ensure that corrupt mount points are cleaned up during NodePublishVolume calls, this currently returns an error afterwards to make sure that kubelet can cleanup on it's side. In the future we might want to consider utilizing the NodeStateVolume calls to actually deal with the block device then only do bind mounts during NodePublishVolume calls.

We should also update the node plugin (lock per volume) to keek track of currently running operations for a single volume. To prevent multiple operations from running concurrently, the correct error to return then is aborted. Since that will signal that a previous operation is in progress.


longhorn/longhorn#2629
supersedes longhorn/longhorn-manager#908