### PR TITLE
Remove VA cleanup feature

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -90,7 +90,6 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	daemonSetInformer := kubeInformerFactory.Apps().V1().DaemonSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
-	volumeAttachmentInformer := kubeInformerFactory.Storage().V1beta1().VolumeAttachments()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
 	csiDriverInformer := kubeInformerFactory.Storage().V1beta1().CSIDrivers()
 	storageclassInformer := kubeInformerFactory.Storage().V1().StorageClasses()
@@ -147,7 +146,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		kubeClient, namespace, controllerID, serviceAccount)
 	kpvc := NewKubernetesPVController(logger, ds, scheme,
 		volumeInformer, persistentVolumeInformer,
-		persistentVolumeClaimInformer, podInformer, volumeAttachmentInformer,
+		persistentVolumeClaimInformer, podInformer,
 		kubeClient, controllerID)
 	knc := NewKubernetesNodeController(logger, ds, scheme,
 		nodeInformer, settingInformer, kubeNodeInformer,


### PR DESCRIPTION
This removes the VA cleanup feature, since the use case is covered by the pod deletion feature.
It's better to only have a single way of accomplishing this.

I didn't touch the settings as part of this PR, since it's not important and they are just ignored.
So I can easily backport to 1.1.2

longhorn/longhorn#2060