### PR TITLE
Allow users to set startingDeadlineSeconds for CronJobs

### DIFF
--- a/client/generated_recurring_job.go
+++ b/client/generated_recurring_job.go
@@ -15,6 +15,8 @@ type RecurringJob struct {
 
 	Retain int64 `json:"retain,omitempty" yaml:"retain,omitempty"`
 
+	StartingDeadlineSeconds int64 `json:"startingDeadlineSeconds,omitempty" yaml:"starting_deadline_seconds,omitempty"`
+
 	Task string `json:"task,omitempty" yaml:"task,omitempty"`
 }
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2147,6 +2147,13 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 	if err != nil {
 		return nil, err
 	}
+	startingDeadlineSeconds, err := vc.ds.GetSettingAsInt(types.SettingNameDefaultCronJobStartingDeadlineSeconds)
+	if err != nil {
+		return nil, err
+	}
+	if job.StartingDeadlineSeconds > 0 {
+		startingDeadlineSeconds = job.StartingDeadlineSeconds
+	}
 	// for mounting inside container
 	privilege := true
 	cronJob := &batchv1beta1.CronJob{
@@ -2160,6 +2167,7 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 			ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 			Suspend:                    &suspend,
 			SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
+			StartingDeadlineSeconds:    &startingDeadlineSeconds,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					BackoffLimit: &backoffLimit,

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -8,6 +8,7 @@ data:
     backup-target:
     backup-target-credential-secret:
     allow-recurring-job-while-volume-detached:
+    default-cronjob-starting-deadline-seconds:
     create-default-disk-labeled-nodes:
     default-data-path:
     replica-soft-anti-affinity:

--- a/types/resource.go
+++ b/types/resource.go
@@ -150,11 +150,12 @@ const (
 )
 
 type RecurringJob struct {
-	Name   string            `json:"name"`
-	Task   RecurringJobType  `json:"task"`
-	Cron   string            `json:"cron"`
-	Retain int               `json:"retain"`
-	Labels map[string]string `json:"labels"`
+	Name                    string            `json:"name"`
+	Task                    RecurringJobType  `json:"task"`
+	Cron                    string            `json:"cron"`
+	Retain                  int               `json:"retain"`
+	StartingDeadlineSeconds int64             `json:"startingDeadlineSeconds"`
+	Labels                  map[string]string `json:"labels"`
 }
 
 type InstanceState string


### PR DESCRIPTION
The startingDeadlineSeconds value helps to prevent Kubernetes
from permanently stopping the CronJob if it hasn't been running
for a long time

The startingDeadlineSeconds setting contains 2 levels:

1. The default value for all cronjobs that user can change in
setting page in Longhorn UI
2. The setting value per cronjob. This is similar to the retain
count. If the user specifies this setting, it will overwrite
the default setting.

longhorn/longhorn#2513