### PR TITLE
WS data cleanup

### DIFF
--- a/api/backingimage.go
+++ b/api/backingimage.go
@@ -21,7 +21,7 @@ func (s *Server) BackingImageList(rw http.ResponseWriter, req *http.Request) (er
 }
 
 func (s *Server) backingImageList(apiContext *api.ApiContext) (*client.GenericCollection, error) {
-	list, err := s.m.ListBackingImages()
+	list, err := s.m.ListBackingImagesSorted()
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing backing image")
 	}

--- a/api/model.go
+++ b/api/model.go
@@ -1146,7 +1146,7 @@ func toBackingImageResource(bi *longhorn.BackingImage, apiContext *api.ApiContex
 	return res
 }
 
-func toBackingImageCollection(bis map[string]*longhorn.BackingImage, apiContext *api.ApiContext) *client.GenericCollection {
+func toBackingImageCollection(bis []*longhorn.BackingImage, apiContext *api.ApiContext) *client.GenericCollection {
 	data := []interface{}{}
 	for _, bi := range bis {
 		data = append(data, toBackingImageResource(bi, apiContext))

--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -20,6 +20,23 @@ func (m *VolumeManager) ListBackingImages() (map[string]*longhorn.BackingImage, 
 	return m.ds.ListBackingImages()
 }
 
+func (m *VolumeManager) ListBackingImagesSorted() ([]*longhorn.BackingImage, error) {
+	backingImageMap, err := m.ds.ListBackingImages()
+	if err != nil {
+		return []*longhorn.BackingImage{}, err
+	}
+
+	backingImages := make([]*longhorn.BackingImage, len(backingImageMap))
+	backingImageNames, err := sortKeys(backingImageMap)
+	if err != nil {
+		return []*longhorn.BackingImage{}, err
+	}
+	for i, backingImageName := range backingImageNames {
+		backingImages[i] = backingImageMap[backingImageName]
+	}
+	return backingImages, nil
+}
+
 func (m *VolumeManager) GetBackingImage(name string) (*longhorn.BackingImage, error) {
 	return m.ds.GetBackingImage(name)
 }


### PR DESCRIPTION
- Fix backing image data send over WS when no update. 
  https://github.com/longhorn/longhorn/issues/2672
- Do not send WS an empty data list when no update.

https://github.com/longhorn/longhorn/issues/2372