### PR TITLE
Use Readonly returns for listers where we only read

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -475,13 +475,13 @@ func (nc *NodeController) enqueueNode(obj interface{}) {
 }
 
 func (nc *NodeController) enqueueSetting(obj interface{}) {
-	nodeList, err := nc.ds.ListNodes()
+	nodesRO, err := nc.ds.ListNodesRO()
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't list nodes: %v ", err))
 		return
 	}
 
-	for _, node := range nodeList {
+	for _, node := range nodesRO {
 		nc.enqueueNode(node)
 	}
 }
@@ -515,12 +515,12 @@ func (nc *NodeController) enqueueReplica(obj interface{}) {
 }
 
 func (nc *NodeController) enqueueManagerPod(obj interface{}) {
-	nodeList, err := nc.ds.ListNodes()
+	nodesRO, err := nc.ds.ListNodesRO()
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't list nodes: %v ", err))
 		return
 	}
-	for _, node := range nodeList {
+	for _, node := range nodesRO {
 		nc.enqueueNode(node)
 	}
 }
@@ -542,14 +542,14 @@ func (nc *NodeController) enqueueKubernetesNode(obj interface{}) {
 		}
 	}
 
-	node, err := nc.ds.GetNode(kubernetesNode.Name)
+	nodeRO, err := nc.ds.GetNodeRO(kubernetesNode.Name)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			utilruntime.HandleError(fmt.Errorf("couldn't get longhorn node %v: %v ", kubernetesNode.Name, err))
 		}
 		return
 	}
-	nc.enqueueNode(node)
+	nc.enqueueNode(nodeRO)
 }
 
 type diskInfo struct {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -587,17 +587,14 @@ func (rc *ReplicaController) enqueueInstanceManagerChange(obj interface{}) {
 	}
 
 	// replica's NodeID won't change, don't need to check instance manager
-	rs, err := rc.ds.ListReplicasByNode(im.Spec.NodeID)
+	replicasRO, err := rc.ds.ListReplicasByNodeRO(im.Spec.NodeID)
 	if err != nil {
-		log := getLoggerForInstanceManager(rc.logger, im)
-		log.Warn("Failed to list replicas on node")
+		getLoggerForInstanceManager(rc.logger, im).Warn("Failed to list replicas on node")
 		return
 	}
 
-	for _, rList := range rs {
-		for _, r := range rList {
-			rc.enqueueReplica(r)
-		}
+	for _, r := range replicasRO {
+		rc.enqueueReplica(r)
 	}
 	return
 }

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1242,20 +1242,23 @@ func (s *DataStore) GetBackingImageManager(name string) (*longhorn.BackingImageM
 	return resultRO.DeepCopy(), nil
 }
 
-// ListBackingImageManagers returns object includes all BackingImageManager in namespace
-func (s *DataStore) ListBackingImageManagers() (map[string]*longhorn.BackingImageManager, error) {
+func (s *DataStore) listBackingImageManagers(selector labels.Selector) (map[string]*longhorn.BackingImageManager, error) {
 	itemMap := map[string]*longhorn.BackingImageManager{}
 
-	list, err := s.bimLister.BackingImageManagers(s.namespace).List(labels.Everything())
+	list, err := s.bimLister.BackingImageManagers(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, itemRO := range list {
-		// Cannot use cached object from lister
 		itemMap[itemRO.Name] = itemRO.DeepCopy()
 	}
 	return itemMap, nil
+}
+
+// ListBackingImageManagers returns object includes all BackingImageManager in namespace
+func (s *DataStore) ListBackingImageManagers() (map[string]*longhorn.BackingImageManager, error) {
+	return s.listBackingImageManagers(labels.Everything())
 }
 
 // ListBackingImageManagersByNode gets a list of BackingImageManager
@@ -1265,18 +1268,7 @@ func (s *DataStore) ListBackingImageManagersByNode(nodeName string) (map[string]
 	if err != nil {
 		return nil, err
 	}
-
-	itemMap := map[string]*longhorn.BackingImageManager{}
-	list, err := s.bimLister.BackingImageManagers(s.namespace).List(nodeSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, itemRO := range list {
-		// Cannot use cached object from lister
-		itemMap[itemRO.Name] = itemRO.DeepCopy()
-	}
-	return itemMap, nil
+	return s.listBackingImageManagers(nodeSelector)
 }
 
 // ListBackingImageManagersByDiskUUID gets a list of BackingImageManager
@@ -1290,18 +1282,7 @@ func (s *DataStore) ListBackingImageManagersByDiskUUID(diskUUID string) (map[str
 	if err != nil {
 		return nil, err
 	}
-
-	itemMap := map[string]*longhorn.BackingImageManager{}
-	list, err := s.bimLister.BackingImageManagers(s.namespace).List(diskSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, itemRO := range list {
-		// Cannot use cached object from lister
-		itemMap[itemRO.Name] = itemRO.DeepCopy()
-	}
-	return itemMap, nil
+	return s.listBackingImageManagers(diskSelector)
 }
 
 // ListDefaultBackingImageManagers gets a list of BackingImageManager

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1691,7 +1691,7 @@ func (s *DataStore) ListReplicasByNode(name string) (map[string][]*longhorn.Repl
 }
 
 // ListReplicasByDiskUUID gets a list of Replicas on a specific disk the given namespace.
-func (s *DataStore) ListReplicasByDiskUUID(uuid string) ([]*longhorn.Replica, error) {
+func (s *DataStore) ListReplicasByDiskUUID(uuid string) (map[string]*longhorn.Replica, error) {
 	diskSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			types.LonghornDiskUUIDKey: uuid,
@@ -1700,7 +1700,7 @@ func (s *DataStore) ListReplicasByDiskUUID(uuid string) ([]*longhorn.Replica, er
 	if err != nil {
 		return nil, err
 	}
-	return s.rLister.Replicas(s.namespace).List(diskSelector)
+	return s.listReplicas(diskSelector)
 }
 
 func getBackingImageSelector(backingImageName string) (labels.Selector, error) {

--- a/manager/node.go
+++ b/manager/node.go
@@ -184,11 +184,11 @@ func (m *VolumeManager) DeleteNode(name string) error {
 		return err
 	}
 	// only remove node from longhorn without any volumes on it
-	replicas, err := m.ds.ListReplicasByNode(name)
+	replicas, err := m.ds.ListReplicasByNodeRO(name)
 	if err != nil {
 		return err
 	}
-	engines, err := m.ds.ListEnginesByNode(name)
+	engines, err := m.ds.ListEnginesByNodeRO(name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is probably a couple more places where we can use the ReadOnly elements from the cache directly, instead of having to go through the deepCopy if we are only using the items for evaluation.

There is also a fix for ListReplicasByDiskUUID returning the raw cached object which is then potentially modified by NodeController::syncDiskStatus




