### PR TITLE
CSI driver fixes (path, locks, etc)

### DIFF
--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -114,7 +114,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 							Name: "socket-dir",
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
-									Path: GetOnHostCSISocketDir(rootDir),
+									Path: GetCSISocketDir(rootDir),
 									Type: &HostPathDirectoryOrCreate,
 								},
 							},
@@ -396,36 +396,28 @@ func GetInContainerCSIRegistrationDir() string {
 	return DefaultInContainerCSIRegistrationDir
 }
 
-func GetInContainerPluginsDir() string {
-	return filepath.Join(DefaultInContainerKubeletRootDir, DefaultInContainerPluginsDirSuffix)
+func GetCSIPodsDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, "/pods")
 }
 
-func GetInContainerKubernetesCSIDir() string {
-	return filepath.Join(DefaultInContainerKubeletRootDir, DefaultInContainerPluginsDirSuffix, DefaultKubernetesCSIDirSuffix)
+func GetCSIKubernetesDir(kubeletRootDir string) string {
+	return filepath.Join(GetCSIPluginsDir(kubeletRootDir), DefaultKubernetesCSIDirSuffix)
 }
 
-func GetOnHostKubernetesCSIDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostPluginsDirSuffix, DefaultKubernetesCSIDirSuffix)
+func GetCSISocketDir(kubeletRootDir string) string {
+	return filepath.Join(GetCSIPluginsDir(kubeletRootDir), types.LonghornDriverName)
 }
 
-func GetOnHostCSISocketDir(kubeletRootDir string) string {
-	return filepath.Join(GetOnHostObseletedPluginsDir(kubeletRootDir), types.LonghornDriverName)
+func GetCSISocketFilePath(kubeletRootDir string) string {
+	return filepath.Join(GetCSISocketDir(kubeletRootDir), DefaultCSISocketFileName)
 }
 
-func GetOnHostCSISocketFilePath(kubeletRootDir string) string {
-	return filepath.Join(GetOnHostCSISocketDir(kubeletRootDir), DefaultCSISocketFileName)
+func GetCSIRegistrationDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, DefaultCSIRegistrationDirSuffix)
 }
 
-func GetOnHostCSIRegistrationDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostCSIRegistrationDirSuffix)
-}
-
-func GetOnHostPluginsDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostPluginsDirSuffix)
-}
-
-func GetOnHostObseletedPluginsDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostObseletedPluginsDirSuffix)
+func GetCSIPluginsDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, DefaultCSIPluginsDirSuffix)
 }
 
 func GetCSIEndpoint() string {

--- a/csi/lock.go
+++ b/csi/lock.go
@@ -1,0 +1,40 @@
+package csi
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sync"
+)
+
+const OperationTryLockFMT = "%s: try to lock resource %s"
+const OperationPendingFMT = "pending operation for resource %v"
+
+// OperationLocks stores a guarded set of all resources with an ongoing operation.
+// resources are identified by their id example resources: volumeID, snapshotID, etc.
+type OperationLocks struct {
+	ops sets.String
+	m   sync.Mutex
+}
+
+func NewOperationLocks() *OperationLocks {
+	return &OperationLocks{
+		ops: sets.NewString(),
+	}
+}
+
+// TryAcquire tries to acquire the lock for operating on a resource returns true on success
+// if another operation is already in progress for this resource returns false
+func (lock *OperationLocks) TryAcquire(resource string) bool {
+	lock.m.Lock()
+	defer lock.m.Unlock()
+	if lock.ops.Has(resource) {
+		return false
+	}
+	lock.ops.Insert(resource)
+	return true
+}
+
+func (lock *OperationLocks) Release(resource string) {
+	lock.m.Lock()
+	defer lock.m.Unlock()
+	lock.ops.Delete(resource)
+}

--- a/csi/server.go
+++ b/csi/server.go
@@ -123,16 +123,16 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 		logLevel = logrus.InfoLevel
 	}
 
-	log.Logf(logLevel, "GRPC call: %s request: %+v", info.FullMethod, protosanitizer.StripSecrets(req))
+	log.Logf(logLevel, "%s: req: %+v", info.FullMethod, protosanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)
 	if err != nil {
 		if logLevel == logrus.TraceLevel {
-			log.Errorf("GRPC call: %s request: %+v failed with error: %v", info.FullMethod, protosanitizer.StripSecrets(req), err)
+			log.Errorf("%s: req: %+v err: %v", info.FullMethod, protosanitizer.StripSecrets(req), err)
 		} else {
-			log.Errorf("GRPC error: %v", err)
+			log.Errorf("%s: err: %v", info.FullMethod, err)
 		}
 	} else {
-		log.Logf(logLevel, "GRPC response: %+v", protosanitizer.StripSecrets(resp))
+		log.Logf(logLevel, "%s: rsp: %+v", info.FullMethod, protosanitizer.StripSecrets(resp))
 	}
 	return resp, err
 }


### PR DESCRIPTION
The path cleanup might need to be modified to take care of the old invalid socket locations on existing systems.
But future systems should be working correctly now.

- Cleanup CSI Plugin paths
- Ensure only a single in flight CSI operation for a resource
- Validate csi requests on entry and improve logging