### PR TITLE
Volume creation with an invalid FromBackup should fail

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2316,6 +2316,9 @@ func (vc *VolumeController) checkAndInitVolumeRestore(v *longhorn.Volume) error 
 	if err != nil {
 		return fmt.Errorf("cannot get backup %v: %v", v.Spec.FromBackup, err)
 	}
+	if backup == nil {
+		return fmt.Errorf("cannot find backup %v of volume %v", v.Spec.FromBackup, v.Name)
+	}
 
 	size, err := util.ConvertSize(backup.Size)
 	if err != nil {

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -195,6 +195,10 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 		if err != nil {
 			return nil, fmt.Errorf("cannot get backup %v: %v", spec.FromBackup, err)
 		}
+		if backup == nil {
+			return nil, fmt.Errorf("cannot find backup %v of volume %v", v.Spec.FromBackup, v.Name)
+		}
+
 		logrus.Infof("Override size of volume %v to %v because it's from backup", name, backup.VolumeSize)
 		// formalize the final size to the unit in bytes
 		size, err = util.ConvertSize(backup.VolumeSize)


### PR DESCRIPTION
Currently if the FromBackup specified backup cannot be found in the backup store, the volume create call will succeed which signals that the volume can be created. This will then lead to a npe in the controller.

https://github.com/longhorn/longhorn/issues/2686