### PR TITLE
kubelet csi corrupt mnt mitigations

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	timeoutAttachDetach     = 120 * time.Second
+	// we wait 1m30s for the volume state polling, this leaves 20s for the rest of the function call
+	timeoutAttachDetach     = 90 * time.Second
 	tickAttachDetach        = 2 * time.Second
 	timeoutBackupInitiation = 60 * time.Second
 	tickBackupInitiation    = 5 * time.Second

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -64,7 +64,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--timeout=2m5s", // we wait for 2 minutes for an attach/detach operation to complete
+			"--timeout=1m50s",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},
@@ -130,7 +130,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--timeout=2m5s", // we wait for 2 minutes, for the initial detach after creation to complete
+			"--timeout=1m50s",
 			"--enable-leader-election",
 			"--leader-election-type=leases",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
@@ -197,7 +197,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		[]string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
-			"--csiTimeout=2m5s", // TODO: change this to timeout once, we upgrade the external resizer version. we wait for 2 minutes for an expansion operation to complete
+			"--csiTimeout=1m50s", // TODO: change this to timeout once, we upgrade the external resizer version.
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -114,7 +114,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 							Name: "socket-dir",
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
-									Path: GetOnHostCSISocketDir(rootDir),
+									Path: GetCSISocketDir(rootDir),
 									Type: &HostPathDirectoryOrCreate,
 								},
 							},
@@ -396,36 +396,28 @@ func GetInContainerCSIRegistrationDir() string {
 	return DefaultInContainerCSIRegistrationDir
 }
 
-func GetInContainerPluginsDir() string {
-	return filepath.Join(DefaultInContainerKubeletRootDir, DefaultInContainerPluginsDirSuffix)
+func GetCSIPodsDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, "/pods")
 }
 
-func GetInContainerKubernetesCSIDir() string {
-	return filepath.Join(DefaultInContainerKubeletRootDir, DefaultInContainerPluginsDirSuffix, DefaultKubernetesCSIDirSuffix)
+func GetCSIKubernetesDir(kubeletRootDir string) string {
+	return filepath.Join(GetCSIPluginsDir(kubeletRootDir), DefaultKubernetesCSIDirSuffix)
 }
 
-func GetOnHostKubernetesCSIDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostPluginsDirSuffix, DefaultKubernetesCSIDirSuffix)
+func GetCSISocketDir(kubeletRootDir string) string {
+	return filepath.Join(GetCSIPluginsDir(kubeletRootDir), types.LonghornDriverName)
 }
 
-func GetOnHostCSISocketDir(kubeletRootDir string) string {
-	return filepath.Join(GetOnHostObseletedPluginsDir(kubeletRootDir), types.LonghornDriverName)
+func GetCSISocketFilePath(kubeletRootDir string) string {
+	return filepath.Join(GetCSISocketDir(kubeletRootDir), DefaultCSISocketFileName)
 }
 
-func GetOnHostCSISocketFilePath(kubeletRootDir string) string {
-	return filepath.Join(GetOnHostCSISocketDir(kubeletRootDir), DefaultCSISocketFileName)
+func GetCSIRegistrationDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, DefaultCSIRegistrationDirSuffix)
 }
 
-func GetOnHostCSIRegistrationDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostCSIRegistrationDirSuffix)
-}
-
-func GetOnHostPluginsDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostPluginsDirSuffix)
-}
-
-func GetOnHostObseletedPluginsDir(kubeletRootDir string) string {
-	return filepath.Join(kubeletRootDir, DefaultOnHostObseletedPluginsDirSuffix)
+func GetCSIPluginsDir(kubeletRootDir string) string {
+	return filepath.Join(kubeletRootDir, DefaultCSIPluginsDirSuffix)
 }
 
 func GetCSIEndpoint() string {

--- a/csi/nfs/nsenter_mount.go
+++ b/csi/nfs/nsenter_mount.go
@@ -131,6 +131,9 @@ func (n *Mounter) Unmount(target string) error {
 	if len(outputBytes) != 0 {
 		logrus.Debugf("Output of unmounting %s: %v", target, string(outputBytes))
 	}
+	if err != nil {
+		err = fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(outputBytes))
+	}
 
 	if err != nil && strings.Contains(err.Error(), "device busy") {
 		logrus.Infof("detected busy nfs mount point %v will do lazy unmount", target)
@@ -138,6 +141,9 @@ func (n *Mounter) Unmount(target string) error {
 		outputBytes, err = n.ne.Exec("umount", args).CombinedOutput()
 		if len(outputBytes) != 0 {
 			logrus.Debugf("Output of lazy unmounting %s: %v", target, string(outputBytes))
+		}
+		if err != nil {
+			err = fmt.Errorf("lazy unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(outputBytes))
 		}
 	}
 

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -86,7 +86,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// Check volume attachment status
 	if volume.State != string(types.VolumeStateAttached) || volume.Controllers[0].Endpoint == "" {
-		logrus.Infof("volume %v hasn't been attached yet, try unmounting potential mount point %v", volumeID, targetPath)
+		logrus.Debugf("volume %v hasn't been attached yet, try unmounting potential mount point %v", volumeID, targetPath)
 		if err := unmount(targetPath, mounter); err != nil {
 			logrus.Debugf("failed to unmount error: %v", err)
 		}

--- a/csi/util.go
+++ b/csi/util.go
@@ -178,7 +178,6 @@ func ensureMountPoint(targetPath string, mounter mount.Interface) (bool, error) 
 
 	IsCorruptedMnt := mount.IsCorruptedMnt(err)
 	if !IsCorruptedMnt {
-
 		logrus.Debugf("mount point %v try reading dir to make sure it's healthy", targetPath)
 		if _, err := ioutil.ReadDir(targetPath); err != nil {
 			logrus.Debugf("mount point %v was identified as corrupt by ReadDir", targetPath)


### PR DESCRIPTION
This is for v1.1.2 

- does not contain csi locking.
- contains the plugin path fixes, this might leave the obsolete plugin around, not sure in regard to updates.

I try unmounting a mount point when volume is not attached is encountered.
Since it means that any prior mount point would be useless at the moment.

Since we use soft mount, the nfs calls will return withhin 15s
I decreased the timeout of the external sidecars to 1m50s
and the final volume state polling of the csi driver to 90s, this gives the rest of the function 20s