### PR TITLE
Increase ReadinessProbe TimeoutSeconds to 5 secs

### DIFF
--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -791,6 +791,7 @@ func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(b
 							},
 						},
 						InitialDelaySeconds: datastore.PodProbeInitialDelay,
+						TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
 						PeriodSeconds:       datastore.PodProbePeriodSeconds,
 					},
 					VolumeMounts: []v1.VolumeMount{

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -762,8 +762,8 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 									},
 								},
 								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       5,
+								TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
+								PeriodSeconds:       datastore.PodProbePeriodSeconds,
 							},
 							SecurityContext: &v1.SecurityContext{
 								Privileged: &privileged,

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -762,6 +762,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 									},
 								},
 								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
 								PeriodSeconds:       5,
 							},
 							SecurityContext: &v1.SecurityContext{

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -834,8 +834,8 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 					ImagePullPolicy: imagePullPolicy,
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
-								Command: []string{"/usr/local/bin/grpc_health_probe", "-addr=:8500"},
+							TCPSocket: &v1.TCPSocketAction{
+								Port: intstr.FromInt(engineapi.InstanceManagerDefaultPort),
 							},
 						},
 						InitialDelaySeconds: datastore.PodProbeInitialDelay,

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -839,6 +839,7 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 							},
 						},
 						InitialDelaySeconds: datastore.PodProbeInitialDelay,
+						TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
 						PeriodSeconds:       datastore.PodProbePeriodSeconds,
 						FailureThreshold:    datastore.PodLivenessProbeFailureThreshold,
 					},

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -734,6 +734,7 @@ func (c *ShareManagerController) createPodManifest(sm *longhorn.ShareManager, an
 							},
 						},
 						InitialDelaySeconds: datastore.PodProbeInitialDelay,
+						TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
 						PeriodSeconds:       datastore.PodProbePeriodSeconds,
 						FailureThreshold:    datastore.PodLivenessProbeFailureThreshold,
 					},

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -31,7 +31,7 @@ const (
 	KubeStatusPollInterval = 1 * time.Second
 
 	PodProbeInitialDelay             = 3
-	PodProbeTimeoutSeconds           = 5
+	PodProbeTimeoutSeconds           = PodProbePeriodSeconds - 1
 	PodProbePeriodSeconds            = 5
 	PodLivenessProbeFailureThreshold = 3
 )

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -31,6 +31,7 @@ const (
 	KubeStatusPollInterval = 1 * time.Second
 
 	PodProbeInitialDelay             = 3
+	PodProbeTimeoutSeconds           = 5
 	PodProbePeriodSeconds            = 5
 	PodLivenessProbeFailureThreshold = 3
 )


### PR DESCRIPTION
#### Proposal Change

- Increase the Pods' ReadinessProbe.TimeoutSeconds from 1 sec to `PodProbePeriodSeconds-1` secs (4 secs).
  - Backing image manager Pods
  - Engine image Pods
  - Share manager Pods

- Change instance manager Pod LivenessProbe to TCP probe to decrease the overhead than gRPC probe.

#### Related Issue

https://github.com/longhorn/longhorn/issues/2590#issuecomment-856389880

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>