### PR TITLE
Add functions to get pv pvc from kubernetes client for volume expansion

### DIFF
--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -408,10 +408,22 @@ func (s *DataStore) UpdatePersistentVolume(pv *corev1.PersistentVolume) (*corev1
 	return s.kubeClient.CoreV1().PersistentVolumes().Update(pv)
 }
 
-// GetPersistentVolume gets the PersistentVolume from the index for the
+// GetPersistentVolumeRO gets the PersistentVolume from the index for the
 // given name
-func (s *DataStore) GetPersistentVolume(pvName string) (*corev1.PersistentVolume, error) {
+// This function returns direct reference to the internal cache object and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) GetPersistentVolumeRO(pvName string) (*corev1.PersistentVolume, error) {
 	return s.pvLister.Get(pvName)
+}
+
+// GetPersistentVolume gets a mutable PersistentVolume for the given name
+func (s *DataStore) GetPersistentVolume(pvName string) (*corev1.PersistentVolume, error) {
+	resultRO, err := s.pvLister.Get(pvName)
+	if err != nil {
+		return nil, err
+	}
+	// Cannot use cached object from lister
+	return resultRO.DeepCopy(), nil
 }
 
 // CreatePersistentVolumeClaim creates a PersistentVolumeClaim resource
@@ -432,10 +444,22 @@ func (s *DataStore) UpdatePersistentVolumeClaim(namespace string, pvc *corev1.Pe
 	return s.kubeClient.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
 }
 
-// GetPersistentVolumeClaim gets the PersistentVolumeClaim from the
+// GetPersistentVolumeClaimRO gets the PersistentVolumeClaim from the
 // index for the given name and namespace
-func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
+// This function returns direct reference to the internal cache object and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) GetPersistentVolumeClaimRO(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
 	return s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+}
+
+// GetPersistentVolumeClaim gets a mutable PersistentVolumeClaim for the given name and namespace
+func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
+	resultRO, err := s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+	if err != nil {
+		return nil, err
+	}
+	// Cannot use cached object from lister
+	return resultRO.DeepCopy(), nil
 }
 
 // GetConfigMapRO gets ConfigMap with the given name in s.namespace


### PR DESCRIPTION
#### Proposed Changes ####

Add functions to get pv pvc from kubernetes client for volume expansion to resolve issue '[BUG] Application couldn't mount the volume after expanded the volume'

- Once the pvc's status become bound, tried the expansions. Only the alternate operation of expansion works on the detached volume. The sequence is 1st - fail, 2nd- pass, 3rd - fail, 4th- pass etc.

#### Types of Changes ####

Bug Fix

#### Verification ####

Use `longhorn-static` should always return error message 

```
unable to expand volume test: persistentvolumeclaims "test" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize
```

#### Linked Issues ####

Refs: https://github.com/longhorn/longhorn/issues/2422

#### Further Comments ####

None

Signed-off-by: Clark Hsu <clark.hsu@suse.com>