### PR TITLE
Add pprof and disable-profiler cmd flag

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1172,13 +1172,17 @@ type Server struct {
 	m   *manager.VolumeManager
 	wsc *controller.WebsocketController
 	fwd *Fwd
+
+	profilerEnabled bool
 }
 
-func NewServer(m *manager.VolumeManager, wsc *controller.WebsocketController) *Server {
+func NewServer(m *manager.VolumeManager, wsc *controller.WebsocketController, profilerEnabled bool) *Server {
 	s := &Server{
 		m:   m,
 		wsc: wsc,
 		fwd: NewFwd(m),
+
+		profilerEnabled: profilerEnabled,
 	}
 	return s
 }

--- a/api/router.go
+++ b/api/router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -174,5 +175,24 @@ func NewRouter(s *Server) *mux.Router {
 	r.Path("/v1/ws/events").Handler(f(schemas, eventListStream))
 	r.Path("/v1/ws/{period}/events").Handler(f(schemas, eventListStream))
 
+	if s.profilerEnabled {
+		attachProfiler(r)
+	}
+
 	return r
+}
+
+func attachProfiler(r *mux.Router) {
+	r.HandleFunc("/debug/pprof/", pprof.Index)
+	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	r.Handle("/debug/pprof/block", pprof.Handler("block"))
+	r.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	r.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	r.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	r.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	r.Handle("/debug/vars", http.DefaultServeMux)
 }

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -32,6 +32,7 @@ const (
 	FlagManagerImage             = "manager-image"
 	FlagServiceAccount           = "service-account"
 	FlagKubeConfig               = "kube-config"
+	FlagDisableProfiler          = "disable-profiler"
 )
 
 func DaemonCmd() cli.Command {
@@ -65,6 +66,10 @@ func DaemonCmd() cli.Command {
 			cli.StringFlag{
 				Name:  FlagKubeConfig,
 				Usage: "Specify path to kube config (optional)",
+			},
+			cli.BoolFlag{
+				Name:  FlagDisableProfiler,
+				Usage: "Disable profiler (optional)",
 			},
 		},
 		Action: func(c *cli.Context) {
@@ -108,6 +113,11 @@ func startManager(c *cli.Context) error {
 	kubeconfigPath := c.String(FlagKubeConfig)
 
 	defaultSettingPath := os.Getenv(types.EnvDefaultSettingPath)
+
+	var profilerEnabled bool = true
+	if c.Bool(FlagDisableProfiler) {
+		profilerEnabled = false
+	}
 
 	if err := environmentCheck(); err != nil {
 		logrus.Errorf("Failed environment check, please make sure you " +
@@ -183,7 +193,7 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
-	server := api.NewServer(m, wsc)
+	server := api.NewServer(m, wsc, profilerEnabled)
 	router := http.Handler(api.NewRouter(server))
 
 	router = util.FilteredLoggingHandler(map[string]struct{}{

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -36,6 +36,8 @@ spec:
         - longhornio/longhorn-manager:master-head
         - --service-account
         - longhorn-service-account
+#       By default, Longhorn manager profiler is enabled to help with troubleshooting. Uncomment below to disable profiler.
+#       - --disable-profiler
         ports:
         - containerPort: 9500
           name: manager


### PR DESCRIPTION
Add pprof and enabled by default for Longhorn manager. Users can set cmd option flag `--disable-profiler` at deployment.

https://github.com/longhorn/longhorn/issues/2696