### PR TITLE
Fix flexvolume url for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-ad
 ```
 
 ### Flexvolume Plugin Directory
-By default we're using the [default Flexvolume Plugin directory](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md#prerequisites), which is `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`.
+By default we're using the [default Flexvolume Plugin directory](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md#prerequisitess), which is `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`.
 
 For GKE 1.8+, it should be at: `/home/kubernetes/flexvolume`.
 


### PR DESCRIPTION
Fix flexvolume url for readme to resolve issue '[BUG] README.md flexvolume url is 404'

Longhorn: #
Signed-off-by: Clark Hsu <clark.hsu@suse.com>