### PR TITLE
Cherry-pick: Add more labels to cronjob and cronjob pod

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2156,6 +2156,7 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            types.GetCronJobNameForVolumeAndJob(v.Name, job.Name),
 			Namespace:       vc.namespace,
+			Labels:          types.GetCronJobLabels(v.Name, job),
 			OwnerReferences: datastore.GetOwnerReferencesForVolume(v),
 		},
 		Spec: batchv1beta1.CronJobSpec{
@@ -2167,7 +2168,8 @@ func (vc *VolumeController) createCronJob(v *longhorn.Volume, job *types.Recurri
 					BackoffLimit: &backoffLimit,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: types.GetCronJobNameForVolumeAndJob(v.Name, job.Name),
+							Name:   types.GetCronJobNameForVolumeAndJob(v.Name, job.Name),
+							Labels: types.GetCronJobPodLabels(v.Name, job),
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -100,21 +100,13 @@ func (s *DataStore) ListVolumeCronJobROs(volumeName string) (map[string]*batchv1
 	return itemMap, nil
 }
 
-// CreateVolumeCronJob sets CronJob labels in volume meta and
-// creates a CronJob resource for the given namespace
+// CreateVolumeCronJob creates a CronJob resource for the given namespace
 func (s *DataStore) CreateVolumeCronJob(volumeName string, cronJob *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
-	if err := tagVolumeLabel(volumeName, cronJob); err != nil {
-		return nil, err
-	}
 	return s.kubeClient.BatchV1beta1().CronJobs(s.namespace).Create(cronJob)
 }
 
-// UpdateVolumeCronJob sets CronJob labels in volume meta and
-// updates CronJobs for the given namespace
+// UpdateVolumeCronJob updates CronJobs for the given namespace
 func (s *DataStore) UpdateVolumeCronJob(volumeName string, cronJob *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
-	if err := tagVolumeLabel(volumeName, cronJob); err != nil {
-		return nil, err
-	}
 	return s.kubeClient.BatchV1beta1().CronJobs(s.namespace).Update(cronJob)
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -69,8 +69,8 @@ const (
 	LonghornLabelShareManagerImage    = "share-manager-image"
 	LonghornLabelBackingImage         = "backing-image"
 	LonghornLabelBackingImageManager  = "backing-image-manager"
-
-	LonghornLabelManagedBy = "managed-by"
+	LonghornLabelManagedBy            = "managed-by"
+	LonghornLabelCronJobTask          = "job-task"
 
 	KubernetesFailureDomainRegionLabelKey = "failure-domain.beta.kubernetes.io/region"
 	KubernetesFailureDomainZoneLabelKey   = "failure-domain.beta.kubernetes.io/zone"
@@ -313,6 +313,20 @@ func GetShareManagerLabels(name, image string) map[string]string {
 		labels[GetLonghornLabelKey(LonghornLabelShareManagerImage)] = GetShareManagerImageChecksumName(GetImageCanonicalName(image))
 	}
 
+	return labels
+}
+
+func GetCronJobLabels(volumeName string, job *RecurringJob) map[string]string {
+	labels := GetBaseLabelsForSystemManagedComponent()
+	labels[LonghornLabelVolume] = volumeName
+	labels[GetLonghornLabelKey(LonghornLabelCronJobTask)] = string(job.Task)
+	return labels
+}
+
+func GetCronJobPodLabels(volumeName string, job *RecurringJob) map[string]string {
+	labels := make(map[string]string)
+	labels[LonghornLabelVolume] = volumeName
+	labels[GetLonghornLabelKey(LonghornLabelCronJobTask)] = string(job.Task)
 	return labels
 }
 


### PR DESCRIPTION
Labels added to cronjob: job type, managed by longhorn manager, longhorn volume name
Labels added to crobjob pods: job type, longhorn volume name

Note that Kubernetes automatically add job-name label to cronjob pod

longhorn/longhorn#2701