### PR TITLE
Change default storage class to longhorn

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -415,7 +415,7 @@ var (
 		Type:        SettingTypeString,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "longhorn-static",
+		Default:     "longhorn",
 	}
 
 	SettingDefinitionTaintToleration = SettingDefinition{


### PR DESCRIPTION
Change default storage class to longhorn to resolve issue 'Application couldn't mount the volume after expanded the volume'

Longhorn: #2692
Signed-off-by: Clark Hsu <clark.hsu@suse.com>