### PR TITLE
Fix auto salvage logic and log stream socket connection leaking

### DIFF
--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -335,7 +335,7 @@ func (h *InstanceHandler) printInstanceLogs(instanceName string, obj runtime.Obj
 	if err != nil {
 		return err
 	}
-
+	defer stream.Close()
 	for {
 		line, err := stream.Recv()
 		if err == io.EOF {

--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -220,13 +220,11 @@ func (h *InstanceHandler) ReconcileInstanceState(obj interface{}, spec *types.In
 
 	if spec.LogRequested {
 		if !status.LogFetched {
+			logrus.Warnf("Try to get requested log for %v in instance manager %v", instanceName, status.InstanceManagerName)
 			if im == nil {
 				logrus.Warnf("Cannot get the log for %v due to Instance Manager is already gone", status.InstanceManagerName)
-			} else {
-				logrus.Warnf("Try to get requested log for %v on node %v", instanceName, im.Spec.NodeID)
-				if err := h.printInstanceLogs(instanceName, runtimeObj); err != nil {
-					logrus.Warnf("cannot get requested log for instance %v on node %v, error %v", instanceName, im.Spec.NodeID, err)
-				}
+			} else if err := h.printInstanceLogs(instanceName, runtimeObj); err != nil {
+				logrus.Warnf("cannot get requested log for instance %v on node %v, error %v", instanceName, im.Spec.NodeID, err)
 			}
 			status.LogFetched = true
 		}


### PR DESCRIPTION
### Fix autosalvage logic doesn't work when there is a replica with both failedAt and healthyAt empty

When the volume has no healthy replica, there could be 2 cases:
* All replicas have never ever become healthy (both failedAt and healthyAt are empty),
  e.g. newly created volume
* There are some replicas which were once healthy but now failed

We should do auto salvage in the second case

### Fix log stream socket connection leaking
Close the stream when done

longhorn/longhorn#2778