### PR TITLE
Increase rancher HTTP client default timeout to 1 min

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -229,7 +229,7 @@ func (rancherClient *RancherBaseClientImpl) setupRequest(req *http.Request) {
 
 func (rancherClient *RancherBaseClientImpl) newHttpClient() *http.Client {
 	if rancherClient.Opts.Timeout == 0 {
-		rancherClient.Opts.Timeout = time.Second * 10
+		rancherClient.Opts.Timeout = time.Minute
 	}
 	return &http.Client{Timeout: rancherClient.Opts.Timeout}
 }


### PR DESCRIPTION
My cluster `longhorn-csi-plugin` hits Longhorn client timeout easily.
```log
level=fatal msg="Error starting CSI manager: Failed to initialize Longhorn API client: Get \"http://longhorn-backend:9500/v1\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Follow #887, increase the Longhorn client timeout to 1 min.