### PR TITLE
Fix replica auto-balance rebuild loop in zones

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1933,6 +1933,9 @@ func (vc *VolumeController) getReplicaCountForAutoBalanceNode(v *longhorn.Volume
 	} else {
 		adjustCount = unevenCount
 	}
+	if adjustCount < 0 {
+		adjustCount = 0
+	}
 	log.Debugf("Found %v node available for auto-balance duplicates in %v", adjustCount, nodeExtraRs)
 
 	return adjustCount, nodeExtraRs, err
@@ -1968,8 +1971,10 @@ func (vc *VolumeController) getReplenishReplicasCount(v *longhorn.Volume, rs map
 		var nCandidates []string
 		adjustCount, _, nCandidates := vc.getReplicaCountForAutoBalanceBestEffort(v, e, rs, vc.getReplicaCountForAutoBalanceNode)
 		if adjustCount == 0 {
-			_, _, zCandidates := vc.getReplicaCountForAutoBalanceBestEffort(v, e, rs, vc.getReplicaCountForAutoBalanceZone)
-			nCandidates = vc.getNodeCandidatesForAutoBalanceZone(v, e, rs, zCandidates)
+			adjustCount, _, zCandidates := vc.getReplicaCountForAutoBalanceBestEffort(v, e, rs, vc.getReplicaCountForAutoBalanceZone)
+			if adjustCount != 0 {
+				nCandidates = vc.getNodeCandidatesForAutoBalanceZone(v, e, rs, zCandidates)
+			}
 		}
 		// TODO: remove checking and let schedular handle this part after
 		// https://github.com/longhorn/longhorn/issues/2667


### PR DESCRIPTION
This issue was raised by @kaxing at manual regressions for https://github.com/longhorn/longhorn/issues/587.
- [When there are two equal zones(with the same node numbers), replica-auto-balance will rebuild replica in between zones.](https://github.com/longhorn/longhorn/issues/587#issuecomment-881419481)
- And [one of the replica will rebuilding in between zones.](https://github.com/longhorn/longhorn/issues/587#issuecomment-882194830)

I can reproduce it manually on a cluster with 7 nodes, 3 zones, and 5 replicas. This is caused by the unnecessary hardNodeAffinity by the multiple candidates. This skips the node candidate when the replica adjust count is zero.