### PR TITLE
Add volume encryption support

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -58,6 +58,8 @@ type Volume struct {
 
 	Migratable bool `json:"migratable"`
 
+	Secure bool `json:"secure"`
+
 	Replicas      []Replica       `json:"replicas"`
 	Controllers   []Controller    `json:"controllers"`
 	BackupStatus  []BackupStatus  `json:"backupStatus"`
@@ -964,6 +966,8 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		ShareState:    v.Status.ShareState,
 
 		Migratable: v.Spec.Migratable,
+
+		Secure: v.Spec.Secure,
 
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,

--- a/api/volume.go
+++ b/api/volume.go
@@ -153,6 +153,7 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		Size:                    size,
 		AccessMode:              volume.AccessMode,
 		Migratable:              volume.Migratable,
+		Secure:                  volume.Secure,
 		Frontend:                volume.Frontend,
 		FromBackup:              volume.FromBackup,
 		NumberOfReplicas:        volume.NumberOfReplicas,

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -69,6 +69,8 @@ type Volume struct {
 
 	Robustness string `json:"robustness,omitempty" yaml:"robustness,omitempty"`
 
+	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
+
 	ShareEndpoint string `json:"shareEndpoint,omitempty" yaml:"share_endpoint,omitempty"`
 
 	ShareState string `json:"shareState,omitempty" yaml:"share_state,omitempty"`

--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -1,0 +1,90 @@
+package crypto
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	mapperFilePathPrefix = "/dev/mapper"
+)
+
+// VolumeMapper returns the path for mapped encrypted device.
+func VolumeMapper(volume string) string {
+	return path.Join(mapperFilePathPrefix, volume)
+}
+
+// EncryptVolume encrypts provided device with LUKS.
+func EncryptVolume(devicePath, passphrase string) error {
+	logrus.Debugf("Encrypting device %s with LUKS", devicePath)
+	if _, _, err := luksFormat(devicePath, passphrase); err != nil {
+		return fmt.Errorf("failed to encrypt device %s with LUKS: %w", devicePath, err)
+	}
+	return nil
+}
+
+// OpenVolume opens volume so that it can be used by the client.
+func OpenVolume(volume, devicePath, passphrase string) error {
+	if isOpen, _ := IsDeviceOpen(VolumeMapper(volume)); isOpen {
+		logrus.Debugf("device %s is already opened at %s", devicePath, VolumeMapper(volume))
+		return nil
+	}
+
+	logrus.Debugf("Opening device %s with LUKS on %s", devicePath, volume)
+	_, stderr, err := luksOpen(volume, devicePath, passphrase)
+	if err != nil {
+		logrus.Warnf("failed to open LUKS device %s: %s", devicePath, stderr)
+	}
+	return err
+}
+
+// CloseVolume closes encrypted volume so it can be detached.
+func CloseVolume(volume string) error {
+	logrus.Debugf("Closing LUKS device %s", volume)
+	_, _, err := luksClose(volume)
+	return err
+}
+
+// IsDeviceOpen determines if encrypted device is already open.
+func IsDeviceOpen(device string) (bool, error) {
+	_, mappedFile, err := DeviceEncryptionStatus(device)
+	return mappedFile != "", err
+}
+
+// DeviceEncryptionStatus looks to identify if the passed device is a LUKS mapping
+// and if so what the device is and the mapper name as used by LUKS.
+// If not, just returns the original device and an empty string.
+func DeviceEncryptionStatus(devicePath string) (mappedDevice, mapper string, err error) {
+	if !strings.HasPrefix(devicePath, mapperFilePathPrefix) {
+		return devicePath, "", nil
+	}
+	volume := strings.TrimPrefix(devicePath, mapperFilePathPrefix+"/")
+	stdout, _, err := luksStatus(volume)
+	if err != nil {
+		logrus.Debugf("device %s is not an active LUKS device: %v", devicePath, err)
+		return devicePath, "", nil
+	}
+	lines := strings.Split(string(stdout), "\n")
+	if len(lines) < 1 {
+		return "", "", fmt.Errorf("device encryption status returned no stdout for %s", devicePath)
+	}
+	if !strings.HasSuffix(lines[0], " is active.") {
+		// Implies this is not a LUKS device
+		return devicePath, "", nil
+	}
+	for i := 1; i < len(lines); i++ {
+		kv := strings.SplitN(strings.TrimSpace(lines[i]), ":", 2)
+		if len(kv) < 1 {
+			return "", "", fmt.Errorf("device encryption status output for %s is badly formatted: %s",
+				devicePath, lines[i])
+		}
+		if strings.Compare(kv[0], "device") == 0 {
+			return strings.TrimSpace(kv[1]), volume, nil
+		}
+	}
+	// Identified as LUKS, but failed to identify a mapped device
+	return "", "", fmt.Errorf("mapped device not found in path %s", devicePath)
+}

--- a/csi/crypto/luks.go
+++ b/csi/crypto/luks.go
@@ -1,0 +1,56 @@
+package crypto
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func luksOpen(volume, devicePath, passphrase string) (stdout, stderr []byte, err error) {
+	return cryptSetupWithPassphrase(&passphrase,
+		"luksOpen", devicePath, volume, "-d", "/dev/stdin")
+}
+
+func luksClose(volume string) (stdout, stderr []byte, err error) {
+	return cryptSetup("luksClose", volume)
+}
+
+func luksFormat(devicePath, passphrase string) (stdout, stderr []byte, err error) {
+	return cryptSetupWithPassphrase(&passphrase,
+		"-q", "luksFormat", "--type", "luks2", "--hash", "sha256",
+		devicePath, "-d", "/dev/stdin")
+}
+
+func luksStatus(volume string) (stdout, stderr []byte, err error) {
+	return cryptSetup("status", volume)
+}
+
+func cryptSetup(args ...string) (stdout, stderr []byte, err error) {
+	return cryptSetupWithPassphrase(nil, args...)
+}
+
+// cryptSetupWithPassphrase runs cryptsetup via nsenter inside of the host namespaces
+// cryptsetup returns 0 on success and a non-zero value on error.
+// 1 wrong parameters, 2 no permission (bad passphrase),
+// 3 out of memory, 4 wrong device specified,
+// 5 device already exists or device is busy.
+func cryptSetupWithPassphrase(passphrase *string, args ...string) (stdout, stderr []byte, err error) {
+	nsenterArgs := []string{"-t 1", "--all", "cryptsetup"}
+	nsenterArgs = append(nsenterArgs, args...)
+	cmd := exec.Command("nsenter", nsenterArgs...)
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	if passphrase != nil {
+		cmd.Stdin = strings.NewReader(*passphrase)
+	}
+
+	if err := cmd.Run(); err != nil {
+		return stdoutBuf.Bytes(), stderrBuf.Bytes(), fmt.Errorf("failed to run cryptsetup args: %v error: %v", args, err)
+	}
+
+	return stdoutBuf.Bytes(), nil, nil
+}

--- a/csi/util.go
+++ b/csi/util.go
@@ -101,6 +101,14 @@ func getVolumeOptions(volOptions map[string]string) (*longhornclient.Volume, err
 		vol.Migratable = isMigratable
 	}
 
+	if secure, ok := volOptions["secure"]; ok {
+		isSecure, err := strconv.ParseBool(secure)
+		if err != nil {
+			return nil, errors.Wrap(err, "Invalid parameter secure")
+		}
+		vol.Secure = isSecure
+	}
+
 	if numberOfReplicas, ok := volOptions["numberOfReplicas"]; ok {
 		nor, err := strconv.Atoi(numberOfReplicas)
 		if err != nil || nor < 0 {

--- a/examples/secure/secret-secure-global.yaml
+++ b/examples/secure/secret-secure-global.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: longhorn-system
+stringData:
+  CRYPTO_KEY_VALUE: "Simple secure passphrase"
+  CRYPTO_KEY_PROVIDER: "secret" # this is optional we currently only support direct keys via secrets

--- a/examples/secure/storageclass-secure-global.yaml
+++ b/examples/secure/storageclass-secure-global.yaml
@@ -1,0 +1,26 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-secure-global
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
+  fromBackup: ""
+  secure: "true"
+  # we currently don't need secrets for volume creation
+  # but it allows for failing the CreateVolume call early
+  # if the required secret has not been setup yet.
+  csi.storage.k8s.io/provisioner-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-publish-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-stage-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+  # we only need secure keys for node operations, I left these as examples
+  # in case we implement external key vaults in the future
+  # csi.storage.k8s.io/controller-publish-secret-name: "longhorn-secure"
+  # csi.storage.k8s.io/controller-publish-secret-namespace: "longhorn-system"
+  # csi.storage.k8s.io/controller-expand-secret-name: "longhorn-secure"
+  # csi.storage.k8s.io/controller-expand-secret-namespace: "longhorn-system"

--- a/examples/secure/storageclass-secure-per-volume-dedicated-namespace.yaml
+++ b/examples/secure/storageclass-secure-per-volume-dedicated-namespace.yaml
@@ -1,0 +1,26 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-secure-per-volume-ns-longhorn-system
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
+  fromBackup: ""
+  secure: "true"
+  # we currently don't need secrets for volume creation
+  # but it allows for failing the CreateVolume call early
+  # if the required secret has not been setup yet.
+  csi.storage.k8s.io/provisioner-secret-name: ${pvc.name}
+  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-publish-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+  # we only need secure keys for node operations, I left these as examples
+  # in case we implement external key vaults in the future
+  # csi.storage.k8s.io/controller-publish-secret-name: ${pvc.name}
+  # csi.storage.k8s.io/controller-publish-secret-namespace: "longhorn-system"
+  # csi.storage.k8s.io/controller-expand-secret-name: ${pvc.name}
+  # csi.storage.k8s.io/controller-expand-secret-namespace: "longhorn-system"

--- a/examples/secure/storageclass-secure-per-volume.yaml
+++ b/examples/secure/storageclass-secure-per-volume.yaml
@@ -1,0 +1,26 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-secure-per-volume
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880" # 48 hours in minutes
+  fromBackup: ""
+  secure: "true"
+  # we currently don't need secrets for volume creation
+  # but it allows for failing the CreateVolume call early
+  # if the required secret has not been setup yet.
+  csi.storage.k8s.io/provisioner-secret-name: ${pvc.name}
+  csi.storage.k8s.io/provisioner-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/node-publish-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+  # we only need secure keys for node operations, I left these as examples
+  # in case we implement external key vaults in the future
+  # csi.storage.k8s.io/controller-publish-secret-name: ${pvc.name}
+  # csi.storage.k8s.io/controller-publish-secret-namespace: ${pvc.namespace}
+  # csi.storage.k8s.io/controller-expand-secret-name: ${pvc.name}
+  # csi.storage.k8s.io/controller-expand-secret-namespace: ${pvc.namespace}

--- a/types/resource.go
+++ b/types/resource.go
@@ -102,6 +102,8 @@ type VolumeSpec struct {
 	AccessMode              AccessMode     `json:"accessMode"`
 	Migratable              bool           `json:"migratable"`
 
+	Secure bool `json:"secure"`
+
 	NumberOfReplicas   int                `json:"numberOfReplicas"`
 	ReplicaAutoBalance ReplicaAutoBalance `json:"replicaAutoBalance"`
 


### PR DESCRIPTION
Add support for volume encryption,  the general  flow works like this:

Host Requirements:
- dm_crypt module loaded
- cryptsetup installed

NodeStageVolume -> NodePublishVolume  changes:
before we used NodePublish for all calls, this implements NodeStageVolume support.
So NodePublishVolume just becomes a bind mount of the per node mounted device (RWO Device, CryptoDevice)
Kubernetes is responsible for the reference counting

Volume Creation:
- encryption parameters are specified via the storageclass
- requires a secret according to the storage class parameters, templates are resolved
- the secret refs are added to the kubernetes PV via the side cars
- if secret is not present, PVC will be remain in pending state

Volume usage:
NodeStageVolume:
- formats the device via cryptsetup as luks
- opens the device, which creates a mapped crypto device /dev/mapper/<volume-name>
- replaces the devicePath with the cryptoDevice
- traditional volume flow takes over.

Volume teardown:
NodeUnstageVolume:
-  unmount
- closes crypto device

Additional Information:
- I also added ReadOnly filesystem support longhorn/longhorn#2575
- If you want to try this out: `joshimoo/longhorn-manager:1859-pv-encryption` then use the examples/secure/global class and global secret. The rest is magic :)
- TODO: add additional information

longhorn/longhorn#1859