### PR TITLE
Remove duplicate engine::info call to extract volume endpoint

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -762,16 +762,17 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		return err
 	}
 	if cliAPIVersion >= engineapi.MinCLIVersion {
-		endpoint, err := client.Endpoint()
+		volumeInfo, err := client.Info()
+		if err != nil {
+			return err
+		}
+
+		endpoint, err := engineapi.GetEngineEndpoint(volumeInfo, engine.Status.IP)
 		if err != nil {
 			return err
 		}
 		engine.Status.Endpoint = endpoint
 
-		volumeInfo, err := client.Info()
-		if err != nil {
-			return err
-		}
 		if volumeInfo.LastExpansionError != "" && volumeInfo.LastExpansionFailedAt != "" &&
 			(engine.Status.LastExpansionError != volumeInfo.LastExpansionError ||
 				engine.Status.LastExpansionFailedAt != volumeInfo.LastExpansionFailedAt) {

--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	devtypes "github.com/longhorn/go-iscsi-helper/types"
 	imutil "github.com/longhorn/longhorn-instance-manager/pkg/util"
 
 	"github.com/longhorn/longhorn-manager/types"
@@ -140,25 +139,6 @@ func (e *Engine) Info() (*Volume, error) {
 		return nil, errors.Wrapf(err, "cannot decode volume info: %v", output)
 	}
 	return info, nil
-}
-
-func (e *Engine) Endpoint() (string, error) {
-	info, err := e.Info()
-	if err != nil {
-		return "", err
-	}
-
-	switch info.Frontend {
-	case devtypes.FrontendTGTBlockDev:
-		return info.Endpoint, nil
-	case devtypes.FrontendTGTISCSI:
-		// it will looks like this in the end
-		// iscsi://10.42.0.12:3260/iqn.2014-09.com.rancher:vol-name/1
-		return "iscsi://" + e.ip + ":" + DefaultISCSIPort + "/" + info.Endpoint + "/" + DefaultISCSILUN, nil
-	case "":
-		return "", nil
-	}
-	return "", fmt.Errorf("Unknown frontend %v", info.Endpoint)
 }
 
 func (e *Engine) Version(clientOnly bool) (*EngineVersion, error) {

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -191,10 +191,6 @@ func (e *EngineSimulator) Info() (*Volume, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 
-func (e *EngineSimulator) Endpoint() (string, error) {
-	return "", fmt.Errorf("Not implemented")
-}
-
 func (e *EngineSimulator) Expand(size int64) error {
 	return fmt.Errorf("Not implemented")
 }


### PR DESCRIPTION
Remove duplicate engine::info call to extract volume endpoint

Since we already require the volume info any way this is an unnecessary
process/engine client socket creation in the monitoring loop. 

In summary one engine monitor loop after these fixes will open 
`f() = 8e + 6*r`  connections the expected connection count for
a volume with 3 replicas is around 312 time-wait connection in a 
minute window.

additional explanation on why this cannot be further improved at
https://github.com/longhorn/longhorn-engine/pull/646

longhorn/longhorn#2818