### PR TITLE
Revert leader election vendor update

### DIFF
--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -300,6 +300,7 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
+		LeaseDurationSeconds: le.observedRecord.LeaseDurationSeconds,
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -90,25 +90,24 @@ func (ll *LeaseLock) Identity() string {
 }
 
 func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
-	holderIdentity := ""
+	var r LeaderElectionRecord
 	if spec.HolderIdentity != nil {
-		holderIdentity = *spec.HolderIdentity
+		r.HolderIdentity = *spec.HolderIdentity
 	}
-	leaseDurationSeconds := 0
 	if spec.LeaseDurationSeconds != nil {
-		leaseDurationSeconds = int(*spec.LeaseDurationSeconds)
+		r.LeaseDurationSeconds = int(*spec.LeaseDurationSeconds)
 	}
-	leaseTransitions := 0
 	if spec.LeaseTransitions != nil {
-		leaseTransitions = int(*spec.LeaseTransitions)
+		r.LeaderTransitions = int(*spec.LeaseTransitions)
 	}
-	return &LeaderElectionRecord{
-		HolderIdentity:       holderIdentity,
-		LeaseDurationSeconds: leaseDurationSeconds,
-		AcquireTime:          metav1.Time{spec.AcquireTime.Time},
-		RenewTime:            metav1.Time{spec.RenewTime.Time},
-		LeaderTransitions:    leaseTransitions,
+	if spec.AcquireTime != nil {
+		r.AcquireTime = metav1.Time{spec.AcquireTime.Time}
 	}
+	if spec.RenewTime != nil {
+		r.RenewTime = metav1.Time{spec.RenewTime.Time}
+	}
+	return &r
+
 }
 
 func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.LeaseSpec {


### PR DESCRIPTION
Revert the change from master temporarily to make the longhorn-manager master branch able to use it.

related to https://github.com/longhorn/longhorn/issues/2828
