### PR TITLE
Add restore support (PV creation) support for encrypted volumes

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -201,6 +201,9 @@ type UpdateAccessModeInput struct {
 type PVCreateInput struct {
 	PVName string `json:"pvName"`
 	FSType string `json:"fsType"`
+
+	SecretName      string `json:"secretName"`
+	SecretNamespace string `json:"secretNamespace"`
 }
 
 type PVCCreateInput struct {

--- a/api/model.go
+++ b/api/model.go
@@ -58,7 +58,7 @@ type Volume struct {
 
 	Migratable bool `json:"migratable"`
 
-	Secure bool `json:"secure"`
+	Encrypted bool `json:"encrypted"`
 
 	Replicas      []Replica       `json:"replicas"`
 	Controllers   []Controller    `json:"controllers"`
@@ -967,7 +967,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 
 		Migratable: v.Spec.Migratable,
 
-		Secure: v.Spec.Secure,
+		Encrypted: v.Spec.Encrypted,
 
 		Conditions:       v.Status.Conditions,
 		KubernetesStatus: v.Status.KubernetesStatus,

--- a/api/volume.go
+++ b/api/volume.go
@@ -465,7 +465,7 @@ func (s *Server) PVCreate(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	_, err = util.RetryOnConflictCause(func() (interface{}, error) {
-		return s.m.PVCreate(id, input.PVName, input.FSType)
+		return s.m.PVCreate(id, input.PVName, input.FSType, input.SecretNamespace, input.SecretName)
 	})
 	if err != nil {
 		return err

--- a/api/volume.go
+++ b/api/volume.go
@@ -153,7 +153,7 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		Size:                    size,
 		AccessMode:              volume.AccessMode,
 		Migratable:              volume.Migratable,
-		Secure:                  volume.Secure,
+		Encrypted:               volume.Encrypted,
 		Frontend:                volume.Frontend,
 		FromBackup:              volume.FromBackup,
 		NumberOfReplicas:        volume.NumberOfReplicas,

--- a/client/generated_pvcreate_input.go
+++ b/client/generated_pvcreate_input.go
@@ -10,6 +10,10 @@ type PVCreateInput struct {
 	FsType string `json:"fsType,omitempty" yaml:"fs_type,omitempty"`
 
 	PvName string `json:"pvName,omitempty" yaml:"pv_name,omitempty"`
+
+	SecretName string `json:"secretName,omitempty" yaml:"secret_name,omitempty"`
+
+	SecretNamespace string `json:"secretNamespace,omitempty" yaml:"secret_namespace,omitempty"`
 }
 
 type PVCreateInputCollection struct {

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -27,6 +27,8 @@ type Volume struct {
 
 	DiskSelector []string `json:"diskSelector,omitempty" yaml:"disk_selector,omitempty"`
 
+	Encrypted bool `json:"encrypted,omitempty" yaml:"encrypted,omitempty"`
+
 	EngineImage string `json:"engineImage,omitempty" yaml:"engine_image,omitempty"`
 
 	FromBackup string `json:"fromBackup,omitempty" yaml:"from_backup,omitempty"`
@@ -68,8 +70,6 @@ type Volume struct {
 	RevisionCounterDisabled bool `json:"revisionCounterDisabled,omitempty" yaml:"revision_counter_disabled,omitempty"`
 
 	Robustness string `json:"robustness,omitempty" yaml:"robustness,omitempty"`
-
-	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
 
 	ShareEndpoint string `json:"shareEndpoint,omitempty" yaml:"share_endpoint,omitempty"`
 

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -337,16 +337,16 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	logrus.Debugf("volume %v device %v contains filesystem of format %v", volumeID, devicePath, diskFormat)
 
-	if volume.Secure {
+	if volume.Encrypted {
 		secrets := req.GetSecrets()
 		keyProvider := secrets[CryptoKeyProvider]
 		passphrase := secrets[CryptoKeyValue]
 		if keyProvider != "" && keyProvider != "secret" {
-			return nil, status.Errorf(codes.InvalidArgument, "unsupported key provider %v for secure volume %v", keyProvider, volumeID)
+			return nil, status.Errorf(codes.InvalidArgument, "unsupported key provider %v for encrypted volume %v", keyProvider, volumeID)
 		}
 
 		if len(passphrase) == 0 {
-			return nil, status.Errorf(codes.InvalidArgument, "missing passphrase for secure volume %v", volumeID)
+			return nil, status.Errorf(codes.InvalidArgument, "missing passphrase for encrypted volume %v", volumeID)
 		}
 
 		if diskFormat != "" && diskFormat != "crypto_LUKS" {

--- a/csi/util.go
+++ b/csi/util.go
@@ -101,12 +101,12 @@ func getVolumeOptions(volOptions map[string]string) (*longhornclient.Volume, err
 		vol.Migratable = isMigratable
 	}
 
-	if secure, ok := volOptions["secure"]; ok {
-		isSecure, err := strconv.ParseBool(secure)
+	if encrypted, ok := volOptions["encrypted"]; ok {
+		isEncrypted, err := strconv.ParseBool(encrypted)
 		if err != nil {
-			return nil, errors.Wrap(err, "Invalid parameter secure")
+			return nil, errors.Wrap(err, "Invalid parameter encrypted")
 		}
-		vol.Secure = isSecure
+		vol.Encrypted = isEncrypted
 	}
 
 	if numberOfReplicas, ok := volOptions["numberOfReplicas"]; ok {

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -536,9 +536,14 @@ func NewPVManifestForVolume(v *longhorn.Volume, pvName, storageClassName, fsType
 		"staleReplicaTimeout": strconv.Itoa(v.Spec.StaleReplicaTimeout),
 	}
 
+	if v.Spec.Encrypted {
+		volAttributes["encrypted"] = strconv.FormatBool(v.Spec.Encrypted)
+	}
+
 	accessMode := corev1.ReadWriteOnce
 	if v.Spec.AccessMode == types.AccessModeReadWriteMany {
 		accessMode = corev1.ReadWriteMany
+		volAttributes["migratable"] = strconv.FormatBool(v.Spec.Migratable)
 	}
 
 	return NewPVManifest(v.Spec.Size, pvName, v.Name, storageClassName, fsType, volAttributes, accessMode)

--- a/examples/crypto/secret-crypto-global.yaml
+++ b/examples/crypto/secret-crypto-global.yaml
@@ -5,5 +5,5 @@ metadata:
   name: longhorn-crypto
   namespace: longhorn-system
 stringData:
-  CRYPTO_KEY_VALUE: "Simple secure passphrase"
+  CRYPTO_KEY_VALUE: "Simple passphrase"
   CRYPTO_KEY_PROVIDER: "secret" # this is optional we currently only support direct keys via secrets

--- a/examples/crypto/storageclass-crypto-global.yaml
+++ b/examples/crypto/storageclass-crypto-global.yaml
@@ -1,26 +1,26 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: longhorn-secure-global
+  name: longhorn-crypto-global
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 parameters:
   numberOfReplicas: "3"
   staleReplicaTimeout: "2880" # 48 hours in minutes
   fromBackup: ""
-  secure: "true"
+  encrypted: "true"
   # we currently don't need secrets for volume creation
   # but it allows for failing the CreateVolume call early
   # if the required secret has not been setup yet.
-  csi.storage.k8s.io/provisioner-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/provisioner-secret-name: "longhorn-crypto"
   csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
-  csi.storage.k8s.io/node-publish-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/node-publish-secret-name: "longhorn-crypto"
   csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
-  csi.storage.k8s.io/node-stage-secret-name: "longhorn-secure"
+  csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
   csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
-  # we only need secure keys for node operations, I left these as examples
+  # we only need crypto keys for node operations, I left these as examples
   # in case we implement external key vaults in the future
-  # csi.storage.k8s.io/controller-publish-secret-name: "longhorn-secure"
+  # csi.storage.k8s.io/controller-publish-secret-name: "longhorn-crypto"
   # csi.storage.k8s.io/controller-publish-secret-namespace: "longhorn-system"
-  # csi.storage.k8s.io/controller-expand-secret-name: "longhorn-secure"
+  # csi.storage.k8s.io/controller-expand-secret-name: "longhorn-crypto"
   # csi.storage.k8s.io/controller-expand-secret-namespace: "longhorn-system"

--- a/examples/crypto/storageclass-crypto-per-volume-dedicated-namespace.yaml
+++ b/examples/crypto/storageclass-crypto-per-volume-dedicated-namespace.yaml
@@ -1,26 +1,26 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: longhorn-secure-per-volume
+  name: longhorn-secure-per-volume-ns-longhorn-system
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 parameters:
   numberOfReplicas: "3"
   staleReplicaTimeout: "2880" # 48 hours in minutes
   fromBackup: ""
-  secure: "true"
+  encrypted: "true"
   # we currently don't need secrets for volume creation
   # but it allows for failing the CreateVolume call early
   # if the required secret has not been setup yet.
   csi.storage.k8s.io/provisioner-secret-name: ${pvc.name}
-  csi.storage.k8s.io/provisioner-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
   csi.storage.k8s.io/node-publish-secret-name: ${pvc.name}
-  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
   csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
-  csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
-  # we only need secure keys for node operations, I left these as examples
+  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+  # we only need crypto keys for node operations, I left these as examples
   # in case we implement external key vaults in the future
   # csi.storage.k8s.io/controller-publish-secret-name: ${pvc.name}
-  # csi.storage.k8s.io/controller-publish-secret-namespace: ${pvc.namespace}
+  # csi.storage.k8s.io/controller-publish-secret-namespace: "longhorn-system"
   # csi.storage.k8s.io/controller-expand-secret-name: ${pvc.name}
-  # csi.storage.k8s.io/controller-expand-secret-namespace: ${pvc.namespace}
+  # csi.storage.k8s.io/controller-expand-secret-namespace: "longhorn-system"

--- a/examples/crypto/storageclass-crypto-per-volume.yaml
+++ b/examples/crypto/storageclass-crypto-per-volume.yaml
@@ -1,26 +1,26 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: longhorn-secure-per-volume-ns-longhorn-system
+  name: longhorn-crypto-per-volume
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 parameters:
   numberOfReplicas: "3"
   staleReplicaTimeout: "2880" # 48 hours in minutes
   fromBackup: ""
-  secure: "true"
+  encrypted: "true"
   # we currently don't need secrets for volume creation
   # but it allows for failing the CreateVolume call early
   # if the required secret has not been setup yet.
   csi.storage.k8s.io/provisioner-secret-name: ${pvc.name}
-  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/provisioner-secret-namespace: ${pvc.namespace}
   csi.storage.k8s.io/node-publish-secret-name: ${pvc.name}
-  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
   csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
-  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
-  # we only need secure keys for node operations, I left these as examples
+  csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+  # we only need crypto keys for node operations, I left these as examples
   # in case we implement external key vaults in the future
   # csi.storage.k8s.io/controller-publish-secret-name: ${pvc.name}
-  # csi.storage.k8s.io/controller-publish-secret-namespace: "longhorn-system"
+  # csi.storage.k8s.io/controller-publish-secret-namespace: ${pvc.namespace}
   # csi.storage.k8s.io/controller-expand-secret-name: ${pvc.name}
-  # csi.storage.k8s.io/controller-expand-secret-namespace: "longhorn-system"
+  # csi.storage.k8s.io/controller-expand-secret-namespace: ${pvc.namespace}

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -282,6 +282,7 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 			Size:                    size,
 			AccessMode:              spec.AccessMode,
 			Migratable:              spec.Migratable,
+			Encrypted:               spec.Encrypted,
 			Frontend:                spec.Frontend,
 			EngineImage:             defaultEngineImage,
 			FromBackup:              spec.FromBackup,

--- a/types/resource.go
+++ b/types/resource.go
@@ -102,7 +102,7 @@ type VolumeSpec struct {
 	AccessMode              AccessMode     `json:"accessMode"`
 	Migratable              bool           `json:"migratable"`
 
-	Secure bool `json:"secure"`
+	Encrypted bool `json:"encrypted"`
 
 	NumberOfReplicas   int                `json:"numberOfReplicas"`
 	ReplicaAutoBalance ReplicaAutoBalance `json:"replicaAutoBalance"`


### PR DESCRIPTION
By passing `secretNamespace, secretName` as part of the PVCreate input.
We can add the necessary secret reference to the PV that longhorn creates for restore/manual created volumes.
These fields are only evaluated if the volume has been marked as `Encrypted` (i.e. v.Spec.Encrypted == true)

NOTE: we renamed the Secure field to Encrypted

longhorn/longhorn#1859