### PR TITLE
Backport v1.1.3: Fix the rebuilding race condition

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -290,8 +290,10 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 	} else if len(engine.Spec.UpgradedReplicaAddressMap) == 0 {
 		syncReplicaAddressMap = true
 	}
-	if syncReplicaAddressMap {
+	if syncReplicaAddressMap && !reflect.DeepEqual(engine.Status.CurrentReplicaAddressMap, engine.Spec.ReplicaAddressMap) {
 		engine.Status.CurrentReplicaAddressMap = engine.Spec.ReplicaAddressMap
+		// Make sure the CurrentReplicaAddressMap persist in the etcd before continue
+		return nil
 	}
 
 	if err := ec.instanceHandler.ReconcileInstanceState(engine, &engine.Spec.InstanceSpec, &engine.Status.InstanceStatus); err != nil {


### PR DESCRIPTION
we use engine.Status.CurrentReplicaAddressMap to know which replica
needed to rebuild. Need to persist the engine.Status.CurrentReplicaAddressMap
to etcd before start rebuilding. Otherwise we might start rebuild and
later on engine.Status.CurrentReplicaAddressMap might be failed to persist
in etcd. In this case, we make the rebuilding replica as UNKNOWN and remove it
while it is in rebuilding

longhorn/longhorn#2849
