### PR TITLE
api: Fix forwarder for https requests

### DIFF
--- a/api/forwarder.go
+++ b/api/forwarder.go
@@ -114,6 +114,14 @@ func (f *Fwd) HandleProxyRequestByNodeID(targetAddress string, req *http.Request
 	req.Host = targetAddress
 	req.URL.Host = targetAddress
 	req.URL.Scheme = "http"
+	h := req.Header
+	if h.Get("X-Forwarded-Proto") == "https" {
+		h.Set("X-Forwarded-Proto", "http")
+	}
+	if h.Get("X-Forwarded-Host") != "" {
+		h.Del("X-Forwarded-Host")
+	}
+	req.Header = h
 	logrus.Debugf("Forwarding request to %v", targetAddress)
 
 	return true, nil


### PR DESCRIPTION
The forwarder simply modifying the schema of a HTTPS request to
HTTP makes the URL become invalid. Since it contradicts the
entries "X-Forwarded-Proto" and "X-Forwarded-Host" in the Header.
By removing or modifying these 2 entries, the issue gets resolved.

longhorn/longhorn#2869