### PR TITLE
Correct pointer init and copy for backup related CRs

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -226,6 +226,13 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		return err
 	}
 
+	if backup.Status.LastSyncedAt == nil {
+		backup.Status.LastSyncedAt = &metav1.Time{Time: time.Time{}}
+		if backup, err = bc.ds.UpdateBackupStatus(backup); err != nil {
+			return err
+		}
+	}
+
 	// Examine DeletionTimestamp to determine if object is under deletion
 	if !backup.DeletionTimestamp.IsZero() {
 		// No need to delete the backup from the remote backup target

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -208,6 +208,13 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 
 	log := getLoggerForBackupTarget(btc.logger, backupTarget)
 
+	if backupTarget.Status.LastSyncedAt == nil {
+		backupTarget.Status.LastSyncedAt = &metav1.Time{Time: time.Time{}}
+		if backupTarget, err = btc.ds.UpdateBackupTargetStatus(backupTarget); err != nil {
+			return err
+		}
+	}
+
 	// Check the controller should run synchronization
 	if !backupTarget.Status.LastSyncedAt.IsZero() &&
 		backupTarget.Status.LastSyncedAt.Time.After(backupTarget.Spec.SyncRequestedAt.Time) {

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -214,6 +214,13 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		return nil
 	}
 
+	if backupVolume.Status.LastSyncedAt == nil {
+		backupVolume.Status.LastSyncedAt = &metav1.Time{Time: time.Time{}}
+		if backupVolume, err = bvc.ds.UpdateBackupVolumeStatus(backupVolume); err != nil {
+			return err
+		}
+	}
+
 	// Examine DeletionTimestamp to determine if object is under deletion
 	if !backupVolume.DeletionTimestamp.IsZero() {
 		// Delete related Backup CRs with the given backup volume name

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -280,8 +280,7 @@ func (in *BackupTargetSpec) DeepCopyInto(out *BackupTargetSpec) {
 	*out = *in
 	out.PollInterval = in.PollInterval
 	if in.SyncRequestedAt != nil {
-		in, out := &in.SyncRequestedAt, &out.SyncRequestedAt
-		*out = (*in).DeepCopy()
+		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
 	}
 	return
 }
@@ -289,8 +288,7 @@ func (in *BackupTargetSpec) DeepCopyInto(out *BackupTargetSpec) {
 func (in *BackupTargetStatus) DeepCopyInto(out *BackupTargetStatus) {
 	*out = *in
 	if in.LastSyncedAt != nil {
-		in, out := &in.LastSyncedAt, &out.LastSyncedAt
-		*out = (*in).DeepCopy()
+		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
 	}
 	return
 }
@@ -298,8 +296,7 @@ func (in *BackupTargetStatus) DeepCopyInto(out *BackupTargetStatus) {
 func (in *BackupVolumeSpec) DeepCopyInto(out *BackupVolumeSpec) {
 	*out = *in
 	if in.SyncRequestedAt != nil {
-		in, out := &in.SyncRequestedAt, &out.SyncRequestedAt
-		*out = (*in).DeepCopy()
+		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
 	}
 	return
 }
@@ -311,22 +308,19 @@ func (in *BackupVolumeStatus) DeepCopyInto(out *BackupVolumeStatus) {
 		*out = (*in).DeepCopy()
 	}
 	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		out.Labels = make(map[string]string)
+		for key, value := range in.Labels {
+			out.Labels[key] = value
 		}
 	}
 	if in.Messages != nil {
-		in, out := &in.Messages, &out.Messages
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		out.Messages = make(map[string]string)
+		for key, value := range in.Messages {
+			out.Messages[key] = value
 		}
 	}
 	if in.LastSyncedAt != nil {
-		in, out := &in.LastSyncedAt, &out.LastSyncedAt
-		*out = (*in).DeepCopy()
+		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
 	}
 	return
 }
@@ -334,14 +328,12 @@ func (in *BackupVolumeStatus) DeepCopyInto(out *BackupVolumeStatus) {
 func (in *SnapshotBackupSpec) DeepCopyInto(out *SnapshotBackupSpec) {
 	*out = *in
 	if in.SyncRequestedAt != nil {
-		in, out := &in.SyncRequestedAt, &out.SyncRequestedAt
-		*out = (*in).DeepCopy()
+		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
 	}
 	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		out.Labels = make(map[string]string)
+		for key, value := range in.Labels {
+			out.Labels[key] = value
 		}
 	}
 	return
@@ -350,22 +342,19 @@ func (in *SnapshotBackupSpec) DeepCopyInto(out *SnapshotBackupSpec) {
 func (in *SnapshotBackupStatus) DeepCopyInto(out *SnapshotBackupStatus) {
 	*out = *in
 	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		out.Labels = make(map[string]string)
+		for key, value := range in.Labels {
+			out.Labels[key] = value
 		}
 	}
 	if in.Messages != nil {
-		in, out := &in.Messages, &out.Messages
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		out.Messages = make(map[string]string)
+		for key, value := range in.Messages {
+			out.Messages[key] = value
 		}
 	}
 	if in.LastSyncedAt != nil {
-		in, out := &in.LastSyncedAt, &out.LastSyncedAt
-		*out = (*in).DeepCopy()
+		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
 	}
 	return
 }

--- a/upgrade/v111to120/upgrade.go
+++ b/upgrade/v111to120/upgrade.go
@@ -31,6 +31,7 @@ func UpgradeCRs(namespace string, lhClient *lhclientset.Clientset) (err error) {
 	if err := upgradeBackingImages(namespace, lhClient); err != nil {
 		return err
 	}
+	// TODO: Need to re-consider if this is required.
 	if err := upgradeBackupTargets(namespace, lhClient); err != nil {
 		return nil
 	}
@@ -232,6 +233,7 @@ func upgradeBackupTargets(namespace string, lhClient *lhclientset.Clientset) (er
 			BackupTargetURL:  targetSetting.Value,
 			CredentialSecret: secretSetting.Value,
 			PollInterval:     metav1.Duration{Duration: pollInterval},
+			SyncRequestedAt:  &metav1.Time{Time: time.Now().Add(time.Second).UTC()},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
1. The controllers need to guarantee there is no nil pointer before reconciling a resource.
2. The deep copy functions look weird. I have no time to verify if it's actually correct. I directly use the simplest way to rewrite them.