### PR TITLE
Backup refactoring enhancement

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -237,11 +237,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		if backupTarget.DeletionTimestamp == nil && backupTarget.Spec.BackupTargetURL != "" &&
 			backupVolume != nil && backupVolume.DeletionTimestamp == nil {
 			// Initialize a backup target client
-			credential, err := bc.ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-			if err != nil {
-				return err
-			}
-			backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+			backupTargetClient, err := getBackupTargetClient(bc.ds, backupTarget)
 			if err != nil {
 				log.WithError(err).Error("Error init backup target client")
 				return nil // Ignore error to prevent enqueue
@@ -285,11 +281,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	// Perform backup snapshot to remote backup target
 	if backup.Spec.SnapshotName != "" && backup.Status.State == "" {
 		// Initialize a backup target client
-		credential, err := bc.ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-		if err != nil {
-			return err
-		}
-		backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+		backupTargetClient, err := getBackupTargetClient(bc.ds, backupTarget)
 		if err != nil {
 			log.WithError(err).Error("Error init backup target client")
 			return nil // Ignore error to prevent enqueue
@@ -319,11 +311,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	}
 
 	// Initialize a backup target client
-	credential, err := bc.ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-	if err != nil {
-		return err
-	}
-	backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+	backupTargetClient, err := getBackupTargetClient(bc.ds, backupTarget)
 	if err != nil {
 		log.WithError(err).Error("Error init a backup target client")
 		return nil // Ignore error to prevent enqueue

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -235,7 +235,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 			return err
 		}
 
-		if backupTarget.DeletionTimestamp == nil && backupTarget.Spec.BackupTargetURL != "" &&
+		if backupTarget.Spec.BackupTargetURL != "" &&
 			backupVolume != nil && backupVolume.DeletionTimestamp == nil {
 			// Initialize a backup target client
 			backupTargetClient, err := getBackupTargetClient(bc.ds, backupTarget)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -214,6 +214,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
+		log.Warnf("Cannot found the %s backup target", types.DefaultBackupTargetName)
 		return nil
 	}
 

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -331,7 +332,9 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	backupURL := backupstore.EncodeBackupURL(backup.Name, backupVolumeName, backupTargetClient.URL)
 	backupInfo, err := backupTargetClient.InspectBackupConfig(backupURL)
 	if err != nil {
-		log.WithError(err).Error("Error inspecting backup config")
+		if !strings.Contains(err.Error(), "in progress") {
+			log.WithError(err).Error("Error inspecting backup config")
+		}
 		return nil // Ignore error to prevent enqueue
 	}
 	if backupInfo == nil {

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -278,7 +278,7 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 	// Get a list of all the backup volumes that exist as custom resources in the cluster
 	clusterBackupVolumes, err := btc.ds.ListBackupVolumes()
 	if err != nil {
-		log.WithError(err).Error("Error listing backup volumes in the cluster, proceeding with pull into cluster")
+		log.WithError(err).Error("Error listing backup volumes in the cluster")
 		return err
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -293,7 +293,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	// Get a list of all the backups that exist as custom resources in the cluster
 	clusterBackups, err := bvc.ds.ListBackupsWithBackupVolumeName(backupVolumeName)
 	if err != nil {
-		log.WithError(err).Error("Error listing backups in the cluster, proceeding with pull into cluster")
+		log.WithError(err).Error("Error listing backups in the cluster")
 		return err
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -209,6 +209,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
+		log.Warnf("Cannot found the %s backup target", types.DefaultBackupTargetName)
 		return nil
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -290,6 +290,11 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 
 	clustersSet := sets.NewString()
 	for _, b := range clusterBackups {
+		// Skip the Backup CR which is created from local cluster and
+		// the snapshot backup haven't be finished yet
+		if b.Spec.SnapshotName != "" && b.Status.State != types.BackupStateCompleted {
+			continue
+		}
 		clustersSet.Insert(b.Name)
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -334,8 +334,10 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		return nil
 	}
 
-	// Check the backup volume config metadata got changed
-	if backupVolume.Status.LastModificationTime.Equal(configMetadata.ModificationTime) {
+	// If there is no backup CR creation/deletion and the backup volume config metadata not changed
+	// skip read the backup volume config
+	if len(backupsToPull) == 0 && len(backupsToDelete) == 0 &&
+		backupVolume.Status.LastModificationTime.Equal(configMetadata.ModificationTime) {
 		backupVolume.Status.LastSyncedAt = syncTime
 		return nil
 	}

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -221,7 +221,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		}
 
 		// Delete the backup volume from the remote backup target
-		if backupTarget.DeletionTimestamp == nil && backupTarget.Spec.BackupTargetURL != "" {
+		if backupTarget.Spec.BackupTargetURL != "" {
 			// Initialize a backup target client
 			backupTargetClient, err := getBackupTargetClient(bvc.ds, backupTarget)
 			if err != nil {

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/longhorn/backupstore"
 
 	"github.com/longhorn/longhorn-manager/datastore"
-	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
@@ -223,11 +222,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		// Delete the backup volume from the remote backup target
 		if backupTarget.DeletionTimestamp == nil && backupTarget.Spec.BackupTargetURL != "" {
 			// Initialize a backup target client
-			credential, err := bvc.ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-			if err != nil {
-				return err
-			}
-			backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+			backupTargetClient, err := getBackupTargetClient(bvc.ds, backupTarget)
 			if err != nil {
 				log.WithError(err).Error("Error init backup target client")
 				return nil // Ignore error to prevent enqueue
@@ -263,11 +258,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	}
 
 	// Initialize a backup target client
-	credential, err := bvc.ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-	if err != nil {
-		return err
-	}
-	backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+	backupTargetClient, err := getBackupTargetClient(bvc.ds, backupTarget)
 	if err != nil {
 		log.WithError(err).Error("Error init backup target client")
 		return nil // Ignore error to prevent enqueue

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1086,7 +1086,7 @@ func restoreBackup(log logrus.FieldLogger, engine *longhorn.Engine, rsMap map[st
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-		return nil
+		return fmt.Errorf("cannot found the %s backup target", types.DefaultBackupTargetName)
 	}
 
 	// Initialize a backup target client

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1090,15 +1090,7 @@ func restoreBackup(log logrus.FieldLogger, engine *longhorn.Engine, rsMap map[st
 	}
 
 	// Initialize a backup target client
-	credential, err := ds.GetCredentialFromSecret(backupTarget.Spec.CredentialSecret)
-	if err != nil {
-		return err
-	}
-	defaultEngineImage, err := ds.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
-	if err != nil {
-		return err
-	}
-	backupTargetClient, err := engineapi.NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential)
+	backupTargetClient, err := getBackupTargetClient(ds, backupTarget)
 	if err != nil {
 		return errors.Wrapf(err, "cannot init backup target client for backup restoration of engine %v", engine.Name)
 	}

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -210,7 +210,7 @@ func (sc *SettingController) syncSetting(key string) (err error) {
 		if err := sc.syncUpgradeChecker(); err != nil {
 			return err
 		}
-	case string(types.SettingNameBackupTargetCredentialSecret), string(types.SettingNameBackupTarget), string(types.SettingNameBackupstorePollInterval):
+	case string(types.SettingNameBackupTarget), string(types.SettingNameBackupTargetCredentialSecret), string(types.SettingNameBackupstorePollInterval):
 		if err := sc.syncBackupTarget(); err != nil {
 			return err
 		}
@@ -822,6 +822,7 @@ func (sc *SettingController) enqueueSettingForNode(obj interface{}) {
 
 	sc.queue.AddRateLimited(sc.namespace + "/" + string(types.SettingNameGuaranteedEngineManagerCPU))
 	sc.queue.AddRateLimited(sc.namespace + "/" + string(types.SettingNameGuaranteedReplicaManagerCPU))
+	sc.queue.AddRateLimited(sc.namespace + "/" + string(types.SettingNameBackupTarget))
 }
 
 func (sc *SettingController) enqueueSettingForBackupTarget(obj interface{}) {

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -307,7 +307,6 @@ func (sc *SettingController) syncBackupTarget() (err error) {
 				BackupTargetURL:  targetSetting.Value,
 				CredentialSecret: secretSetting.Value,
 				PollInterval:     metav1.Duration{Duration: pollInterval},
-				SyncRequestedAt:  &metav1.Time{Time: time.Now().Add(time.Second).UTC()},
 			},
 		})
 		if err != nil {
@@ -323,7 +322,7 @@ func (sc *SettingController) syncBackupTarget() (err error) {
 		backupTarget.Spec.PollInterval = metav1.Duration{Duration: pollInterval}
 		if !reflect.DeepEqual(existingBackupTarget.Spec, backupTarget.Spec) {
 			// Force sync backup target once the BackupTarget spec be updated
-			backupTarget.Spec.SyncRequestedAt = &metav1.Time{Time: time.Now().Add(time.Second).UTC()}
+			backupTarget.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
 			if _, err = sc.ds.UpdateBackupTarget(backupTarget); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 				sc.logger.WithError(err).Warn("Failed to update backup target")
 			}
@@ -675,7 +674,7 @@ func (bst *BackupStoreTimer) Start() {
 			return false, err
 		}
 
-		backupTarget.Spec.SyncRequestedAt = &metav1.Time{Time: time.Now().Add(time.Second).UTC()}
+		backupTarget.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
 		if _, err = bst.ds.UpdateBackupTarget(backupTarget); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 			log.WithError(err).Warn("Failed to updating backup target")
 		}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3029,6 +3029,11 @@ func (s *DataStore) DeleteBackup(backupName string) error {
 	return s.lhClient.LonghornV1beta1().Backups(s.namespace).Delete(context.TODO(), backupName, metav1.DeleteOptions{})
 }
 
+// DeleteAllBackupsForBackupVolume won't result in immediately deletion since finalizer was set by default
+func (s *DataStore) DeleteAllBackupsForBackupVolume(backupVolumeName string) error {
+	return s.lhClient.LonghornV1beta1().Backups(s.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", types.LonghornLabelBackupVolume, backupVolumeName)})
+}
+
 // RemoveFinalizerForBackup will result in deletion if DeletionTimestamp was set
 func (s *DataStore) RemoveFinalizerForBackup(backup *longhorn.Backup) error {
 	if !util.FinalizerExists(longhornFinalizerKey, backup) {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -254,9 +254,6 @@ func (s *DataStore) ListSettings() (map[types.SettingName]*longhorn.Setting, err
 func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]string, error) {
 	secret, err := s.GetSecretRO(s.namespace, secretName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	credentialSecret := make(map[string]string)

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -134,6 +134,9 @@ func parseBackupNamesList(output, volumeName string) ([]string, error) {
 	}
 
 	backupNames := []string{}
+	if volumeData.Messages[string(backupstore.MessageTypeError)] != "" {
+		return backupNames, errors.New(volumeData.Messages[string(backupstore.MessageTypeError)])
+	}
 	for backupName := range volumeData.Backups {
 		backupNames = append(backupNames, backupName)
 	}

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -273,7 +273,7 @@ func (e *Engine) SnapshotBackup(backupName, snapName, backupTarget, backingImage
 			args = append(args, "--backing-image-checksum", backingImageChecksum)
 		}
 	}
-	if backupName != "" {
+	if backupName != "" && version.ClientVersion.CLIAPIVersion > CLIVersionFour {
 		args = append(args, "--backup-name", backupName)
 	}
 	for k, v := range labels {

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -22,20 +22,12 @@ type BackupTargetClient struct {
 }
 
 // NewBackupTargetClient returns the backup target client
-func NewBackupTargetClient(defaultEngineImage, url string, credential map[string]string) (*BackupTargetClient, error) {
-	backupType, err := util.CheckBackupType(url)
-	if err != nil {
-		return nil, err
-	}
-	if backupType == types.BackupStoreTypeS3 && credential == nil {
-		return nil, fmt.Errorf("Could not backup for %s without credential secret", types.BackupStoreTypeS3)
-	}
-
+func NewBackupTargetClient(defaultEngineImage, url string, credential map[string]string) *BackupTargetClient {
 	return &BackupTargetClient{
 		Image:      defaultEngineImage,
 		URL:        url,
 		Credential: credential,
-	}, nil
+	}
 }
 
 func (btc *BackupTargetClient) LonghornEngineBinary() string {

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -166,9 +166,8 @@ func (m *VolumeManager) BackupSnapshot(backupName, volumeName, snapshotName stri
 			Name: backupName,
 		},
 		Spec: types.SnapshotBackupSpec{
-			SyncRequestedAt: &metav1.Time{Time: time.Now().UTC()},
-			SnapshotName:    snapshotName,
-			Labels:          labels,
+			SnapshotName: snapshotName,
+			Labels:       labels,
 		},
 	}
 	_, err := m.ds.CreateBackup(backupCR, volumeName)

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
 
@@ -261,20 +260,6 @@ func (m *VolumeManager) GetBackupVolume(volumeName string) (*longhorn.BackupVolu
 }
 
 func (m *VolumeManager) DeleteBackupVolume(volumeName string) error {
-	backupVolume, err := m.ds.GetBackupVolumeRO(volumeName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	// Request to delete remote config
-	backupVolume.Spec.FileCleanupRequired = true
-	backupVolume, err = m.ds.UpdateBackupVolume(backupVolume)
-	if err != nil && !datastore.ErrorIsConflict(err) {
-		return err
-	}
 	return m.ds.DeleteBackupVolume(volumeName)
 }
 
@@ -287,18 +272,5 @@ func (m *VolumeManager) GetBackup(backupName, volumeName string) (*longhorn.Back
 }
 
 func (m *VolumeManager) DeleteBackup(backupName, volumeName string) error {
-	backup, err := m.ds.GetBackupRO(backupName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	// Request to delete remote config
-	backup.Spec.FileCleanupRequired = true
-	if _, err = m.ds.UpdateBackup(backup); err != nil && !datastore.ErrorIsConflict(err) {
-		return err
-	}
 	return m.ds.DeleteBackup(backupName)
 }

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -278,10 +278,6 @@ func (from *BackingImageDataSourceStatus) DeepCopyInto(to *BackingImageDataSourc
 
 func (in *BackupTargetSpec) DeepCopyInto(out *BackupTargetSpec) {
 	*out = *in
-	out.PollInterval = in.PollInterval
-	if in.SyncRequestedAt != nil {
-		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
-	}
 	return
 }
 
@@ -293,26 +289,16 @@ func (in *BackupTargetStatus) DeepCopyInto(out *BackupTargetStatus) {
 			out.Conditions[key] = value
 		}
 	}
-	if in.LastSyncedAt != nil {
-		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
-	}
 	return
 }
 
 func (in *BackupVolumeSpec) DeepCopyInto(out *BackupVolumeSpec) {
 	*out = *in
-	if in.SyncRequestedAt != nil {
-		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
-	}
 	return
 }
 
 func (in *BackupVolumeStatus) DeepCopyInto(out *BackupVolumeStatus) {
 	*out = *in
-	if in.LastModificationTime != nil {
-		in, out := &in.LastModificationTime, &out.LastModificationTime
-		*out = (*in).DeepCopy()
-	}
 	if in.Labels != nil {
 		out.Labels = make(map[string]string)
 		for key, value := range in.Labels {
@@ -325,17 +311,11 @@ func (in *BackupVolumeStatus) DeepCopyInto(out *BackupVolumeStatus) {
 			out.Messages[key] = value
 		}
 	}
-	if in.LastSyncedAt != nil {
-		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
-	}
 	return
 }
 
 func (in *SnapshotBackupSpec) DeepCopyInto(out *SnapshotBackupSpec) {
 	*out = *in
-	if in.SyncRequestedAt != nil {
-		out.SyncRequestedAt = in.SyncRequestedAt.DeepCopy()
-	}
 	if in.Labels != nil {
 		out.Labels = make(map[string]string)
 		for key, value := range in.Labels {
@@ -358,9 +338,6 @@ func (in *SnapshotBackupStatus) DeepCopyInto(out *SnapshotBackupStatus) {
 		for key, value := range in.Messages {
 			out.Messages[key] = value
 		}
-	}
-	if in.LastSyncedAt != nil {
-		out.LastSyncedAt = in.LastSyncedAt.DeepCopy()
 	}
 	return
 }

--- a/types/resource.go
+++ b/types/resource.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -693,7 +695,7 @@ type BackupTargetSpec struct {
 	BackupTargetURL  string          `json:"backupTargetURL"`
 	CredentialSecret string          `json:"credentialSecret"`
 	PollInterval     metav1.Duration `json:"pollInterval"`
-	SyncRequestedAt  *metav1.Time    `json:"syncRequestedAt"`
+	SyncRequestedAt  metav1.Time     `json:"syncRequestedAt"`
 }
 
 const (
@@ -706,16 +708,16 @@ type BackupTargetStatus struct {
 	OwnerID      string               `json:"ownerID"`
 	Available    bool                 `json:"available"`
 	Conditions   map[string]Condition `json:"conditions"`
-	LastSyncedAt *metav1.Time         `json:"lastSyncedAt"`
+	LastSyncedAt metav1.Time          `json:"lastSyncedAt"`
 }
 
 type BackupVolumeSpec struct {
-	SyncRequestedAt *metav1.Time `json:"syncRequestedAt"`
+	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
 type BackupVolumeStatus struct {
 	OwnerID              string            `json:"ownerID"`
-	LastModificationTime *metav1.Time      `json:"lastModificationTime"`
+	LastModificationTime time.Time         `json:"lastModificationTime"`
 	Size                 string            `json:"size"`
 	Labels               map[string]string `json:"labels"`
 	CreatedAt            string            `json:"createdAt"`
@@ -725,11 +727,11 @@ type BackupVolumeStatus struct {
 	Messages             map[string]string `json:"messages"`
 	BackingImageName     string            `json:"backingImageName"`
 	BackingImageChecksum string            `json:"backingImageChecksum"`
-	LastSyncedAt         *metav1.Time      `json:"lastSyncedAt"`
+	LastSyncedAt         metav1.Time       `json:"lastSyncedAt"`
 }
 
 type SnapshotBackupSpec struct {
-	SyncRequestedAt *metav1.Time      `json:"syncRequestedAt"`
+	SyncRequestedAt metav1.Time       `json:"syncRequestedAt"`
 	SnapshotName    string            `json:"snapshotName"`
 	Labels          map[string]string `json:"labels"`
 }
@@ -758,7 +760,7 @@ type SnapshotBackupStatus struct {
 	VolumeSize             string            `json:"volumeSize"`
 	VolumeCreated          string            `json:"volumeCreated"`
 	VolumeBackingImageName string            `json:"volumeBackingImageName"`
-	LastSyncedAt           *metav1.Time      `json:"lastSyncedAt"`
+	LastSyncedAt           metav1.Time       `json:"lastSyncedAt"`
 }
 
 type RecurringJobSpec struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -710,8 +710,7 @@ type BackupTargetStatus struct {
 }
 
 type BackupVolumeSpec struct {
-	SyncRequestedAt     *metav1.Time `json:"syncRequestedAt"`
-	FileCleanupRequired bool         `json:"fileCleanupRequired"`
+	SyncRequestedAt *metav1.Time `json:"syncRequestedAt"`
 }
 
 type BackupVolumeStatus struct {
@@ -730,10 +729,9 @@ type BackupVolumeStatus struct {
 }
 
 type SnapshotBackupSpec struct {
-	SyncRequestedAt     *metav1.Time      `json:"syncRequestedAt"`
-	FileCleanupRequired bool              `json:"fileCleanupRequired"`
-	SnapshotName        string            `json:"snapshotName"`
-	Labels              map[string]string `json:"labels"`
+	SyncRequestedAt *metav1.Time      `json:"syncRequestedAt"`
+	SnapshotName    string            `json:"snapshotName"`
+	Labels          map[string]string `json:"labels"`
 }
 
 type BackupState string

--- a/types/resource.go
+++ b/types/resource.go
@@ -739,11 +739,10 @@ type SnapshotBackupSpec struct {
 type BackupState string
 
 const (
-	BackupStatePending    = BackupState("pending")
-	BackupStateInProgress = BackupState("inprogress")
-	BackupStateCompleted  = BackupState("completed")
-	BackupStateError      = BackupState("error")
-	BackupStateUnknown    = BackupState("unknown")
+	BackupStateInProgress = BackupState("InProgress")
+	BackupStateCompleted  = BackupState("Completed")
+	BackupStateError      = BackupState("Error")
+	BackupStateUnknown    = BackupState("Unknown")
 )
 
 type SnapshotBackupStatus struct {


### PR DESCRIPTION
https://github.com/longhorn/longhorn-manager/pull/952#discussion_r686744828: Updates backup creation state to ETCD
https://github.com/longhorn/longhorn-manager/pull/952#discussion_r686749679: Correct log message
https://github.com/longhorn/longhorn-manager/pull/952#discussion_r686754880: Skip the last modification check and directly inspect the backup volume if there is a backup CR creation/deletion.
https://github.com/longhorn/longhorn-manager/blob/master/upgrade/v111to120/upgrade.go#L34-L35: Address TODO, creates BackupTarget CR inside the setting_controller.
https://github.com/longhorn/longhorn/issues/2870: Remove `spec.FileCleanupRequired`, delete Backup CRs then delete BackupVolume CR
https://github.com/longhorn/longhorn/issues/2888: The volume event log is filtered by volume name at the frontend, so send the event with the *longhorn.Volume object
https://github.com/longhorn/longhorn/issues/2896: Add node_informer+backup_target_informer in setting_controller to enqueue BackupTarget event when node status change _or_ backup target CR be deleted status change
https://github.com/longhorn/longhorn/issues/2910: Unset backup target in setting CR, waits backup_target_controller/backup_volume_controller to removes the BackupVolume/Backup CRs
https://github.com/longhorn/longhorn/issues/2897: Add longhorn engine version > 4 when using flag `--backup-name`