### PR TITLE
Fix backing image backup creation failed

### DIFF
--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -181,7 +181,7 @@ func (s *Server) SnapshotBackup(w http.ResponseWriter, req *http.Request) (err e
 		labels[types.KubernetesStatusLabel] = string(kubeStatus)
 	}
 
-	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), volName, input.Name, vol.Spec.BackingImage, labels); err != nil {
+	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), volName, input.Name, labels); err != nil {
 		return err
 	}
 

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -245,7 +245,7 @@ func (btc *BackupTargetClient) DeleteBackup(backupURL string) error {
 	return nil
 }
 
-func (e *Engine) SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels map[string]string, credential map[string]string) (string, error) {
+func (e *Engine) SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels, credential map[string]string) (string, error) {
 	if snapName == VolumeHeadName {
 		return "", fmt.Errorf("invalid operation: cannot backup %v", VolumeHeadName)
 	}

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -175,7 +175,7 @@ func (e *EngineSimulator) SnapshotPurgeStatus() (map[string]*types.PurgeStatus, 
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (e *EngineSimulator) SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels map[string]string, credential map[string]string) (string, error) {
+func (e *EngineSimulator) SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels, credential map[string]string) (string, error) {
 	return "", fmt.Errorf("Not implemented")
 }
 

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -76,7 +76,7 @@ type EngineClient interface {
 	SnapshotRevert(name string) error
 	SnapshotPurge() error
 	SnapshotPurgeStatus() (map[string]*types.PurgeStatus, error)
-	SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels map[string]string, credential map[string]string) (string, error)
+	SnapshotBackup(backupName, snapName, backupTarget, backingImageName, backingImageChecksum string, labels, credential map[string]string) (string, error)
 	SnapshotBackupStatus() (map[string]*types.BackupStatus, error)
 
 	BackupRestore(backupTarget, backupName, backupVolume, lastRestored string, credential map[string]string) error

--- a/types/resource.go
+++ b/types/resource.go
@@ -655,12 +655,10 @@ type BackupVolumeStatus struct {
 }
 
 type SnapshotBackupSpec struct {
-	SyncRequestedAt      *metav1.Time      `json:"syncRequestedAt"`
-	FileCleanupRequired  bool              `json:"fileCleanupRequired"`
-	SnapshotName         string            `json:"snapshotName"`
-	Labels               map[string]string `json:"labels"`
-	BackingImage         string            `json:"backingImage"`
-	BackingImageChecksum string            `json:"backingImageChecksum"`
+	SyncRequestedAt     *metav1.Time      `json:"syncRequestedAt"`
+	FileCleanupRequired bool              `json:"fileCleanupRequired"`
+	SnapshotName        string            `json:"snapshotName"`
+	Labels              map[string]string `json:"labels"`
 }
 
 type BackupState string


### PR DESCRIPTION
#### Proposal Changes

- Remove backing image name and checksum from Backup CR
- Do backing image checksum validation in backup_controller:
  1. Get volume CR, if any error, return to enqueue (not found error or other error)
  2. Get BackingImage CR according to the `volume.Spec.BackingImage`
  3. Get BackupVolume CR (backup volume name is the same as volume name).
      1. If found, check the BackupVolume.status.BackingImageChecksum and BackingImage.status.BackingImageChecksum matched
      2. If not found, it's the first backup of this volume, no BackingImageChecksum need to be verified
      3. If other error, return to enqueue
  4. Call engine API `snapshotBackup`

#### Issues
https://github.com/longhorn/longhorn/issues/2871
https://github.com/longhorn/longhorn/issues/2876

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>