### PR TITLE
2867-rwx-encryption-support

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -788,21 +788,56 @@ func (c *ShareManagerController) createPodManifest(sm *longhorn.ShareManager, an
 		}
 	}
 
-	// host mount the devices, so we can mount the shared longhorn-volume into the export folder
-	hostToContainer := v1.MountPropagationHostToContainer
 	podSpec.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
 		{
-			MountPath:        "/host/dev",
-			Name:             "dev",
-			MountPropagation: &hostToContainer,
+			Name:      "host-dev",
+			MountPath: "/dev",
+		},
+		{
+			Name:      "host-sys",
+			MountPath: "/sys",
+		},
+		{
+			Name:      "host-proc",
+			MountPath: "/host/proc", // we use this to enter the host namespace
+		},
+		{
+			Name:      "lib-modules",
+			MountPath: "/lib/modules",
+			ReadOnly:  true,
 		},
 	}
+
 	podSpec.Spec.Volumes = []v1.Volume{
 		{
-			Name: "dev",
+			Name: "host-dev",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
 					Path: "/dev",
+				},
+			},
+		},
+		{
+			Name: "host-sys",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/sys",
+				},
+			},
+		},
+		{
+			Name: "host-proc",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/proc",
+				},
+			},
+		},
+		{
+			Name: "lib-modules",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/lib/modules",
 				},
 			},
 		},

--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -20,7 +20,7 @@ func VolumeMapper(volume string) string {
 // EncryptVolume encrypts provided device with LUKS.
 func EncryptVolume(devicePath, passphrase string) error {
 	logrus.Debugf("Encrypting device %s with LUKS", devicePath)
-	if _, _, err := luksFormat(devicePath, passphrase); err != nil {
+	if _, err := luksFormat(devicePath, passphrase); err != nil {
 		return fmt.Errorf("failed to encrypt device %s with LUKS: %w", devicePath, err)
 	}
 	return nil
@@ -34,9 +34,9 @@ func OpenVolume(volume, devicePath, passphrase string) error {
 	}
 
 	logrus.Debugf("Opening device %s with LUKS on %s", devicePath, volume)
-	_, stderr, err := luksOpen(volume, devicePath, passphrase)
+	_, err := luksOpen(volume, devicePath, passphrase)
 	if err != nil {
-		logrus.Warnf("failed to open LUKS device %s: %s", devicePath, stderr)
+		logrus.Warnf("failed to open LUKS device %s: %s", devicePath, err)
 	}
 	return err
 }
@@ -44,7 +44,7 @@ func OpenVolume(volume, devicePath, passphrase string) error {
 // CloseVolume closes encrypted volume so it can be detached.
 func CloseVolume(volume string) error {
 	logrus.Debugf("Closing LUKS device %s", volume)
-	_, _, err := luksClose(volume)
+	_, err := luksClose(volume)
 	return err
 }
 
@@ -62,7 +62,7 @@ func DeviceEncryptionStatus(devicePath string) (mappedDevice, mapper string, err
 		return devicePath, "", nil
 	}
 	volume := strings.TrimPrefix(devicePath, mapperFilePathPrefix+"/")
-	stdout, _, err := luksStatus(volume)
+	stdout, err := luksStatus(volume)
 	if err != nil {
 		logrus.Debugf("device %s is not an active LUKS device: %v", devicePath, err)
 		return devicePath, "", nil

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -176,7 +176,7 @@ func (ns *NodeServer) nodeStageSharedVolume(volumeID, shareEndpoint, targetPath 
 			"vers=4.1",
 			"noresvport",
 			"soft", // for this release we use soft mode, so we can always cleanup mount points
-			"sync", // sync mode is prohibitively expensive on the client
+			// "sync", // sync mode is prohibitively expensive on the client, so we allow for host defaults
 			"intr",
 			"timeo=30",  // This is tenths of a second, so a 3 second timeout, each retrans the timeout will be linearly increased, 3s, 6s, 9s
 			"retrans=3", // We try the io operation for a total of 3 times, before failing, max runtime of 18s

--- a/csi/server.go
+++ b/csi/server.go
@@ -19,6 +19,7 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -28,7 +29,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20210731
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v_20210820
+        - longhornio/longhorn-share-manager:v1_20210820
         - --backing-image-manager-image
         - longhornio/backing-image-manager:v2_20210809
         - --manager-image

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20210731
         - --share-manager-image
-        - joshimoo/longhorn-share-manager:v_20210819
+        - longhornio/longhorn-share-manager:v_20210820
         - --backing-image-manager-image
         - longhornio/backing-image-manager:v2_20210809
         - --manager-image

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20210731
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20210416
+        - joshimoo/longhorn-share-manager:v_20210819
         - --backing-image-manager-image
         - longhornio/backing-image-manager:v2_20210809
         - --manager-image

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-longhornio/longhorn-share-manager:v1_20210416
+joshimoo/longhorn-share-manager:v_20210819
 longhornio/longhorn-ui:master

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-longhornio/longhorn-share-manager:v_20210820
+longhornio/longhorn-share-manager:v1_20210820
 longhornio/longhorn-ui:master

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-joshimoo/longhorn-share-manager:v_20210819
+longhornio/longhorn-share-manager:v_20210820
 longhornio/longhorn-ui:master

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-longhornio/longhorn-share-manager:v1_20210416
+joshimoo/longhorn-share-manager:v_20210819
 longhornio/longhorn-ui:master

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-longhornio/longhorn-share-manager:v_20210820
+longhornio/longhorn-share-manager:v1_20210820
 longhornio/longhorn-ui:master

--- a/deploy/release-images.txt
+++ b/deploy/release-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210809
 longhornio/longhorn-engine:master
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master
-joshimoo/longhorn-share-manager:v_20210819
+longhornio/longhorn-share-manager:v_20210820
 longhornio/longhorn-ui:master


### PR DESCRIPTION
Add support for encrypted volumes, this works by retrieving the secret for the PV as part of the share-manager controller, the passphrase is then passed to the share-manager pod as an environment variable. From a security standpoint this isn't great but we currently have no way of securly transmitting that phasphrase, this would require a secure communication channel (grpc) to transmit the information at runtime.
REF: longhorn/longhorn#2867 longhorn/longhorn#1859

This also added new optional params "fs", "mount" to allow specifying a custom filesystem for the share-manager RWO volume. This has been requested in longhorn/longhorn#2814 These are optional and when not specified we use the same behavior as before. The fs/mount options are the ones specified as part of the storage class, since that information is persisted in the PV context. (So we treat this RWX volume the same way as an RWO volume) since it effectivly is still an RWO volume.

After discussing with @yasker I removed the forced `sync` mount option for the nfs client mount, instead it will rely on the host defaults which for most oses is async, since sync is prohibitly expensive. This addresses the performance difference between external provisioner based approach and the native longhorn RWX approach. REF longhorn/longhorn#2584 longhorn/longhorn#2549

I also added a hidden/undocumented nfsOptions parameter to the storage classes, that can be used to configure the nfs mount options, this is mostly for testing different settings withhout requiring a rebuild. This also allows us to update the share-manager independently of the csi-plugin in case we want to add support for UDP, etc. REF longhorn/longhorn#2630
