### PR TITLE
Add a new backup state ready

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -331,7 +331,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	}
 
 	// Update Backup CR status
-	backup.Status.State = types.BackupStateCompleted
+	backup.Status.State = types.BackupStateReady
 	backup.Status.URL = backupInfo.URL
 	backup.Status.SnapshotName = backupInfo.SnapshotName
 	backup.Status.SnapshotCreatedAt = backupInfo.SnapshotCreated

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -282,9 +282,9 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 
 	clustersSet := sets.NewString()
 	for _, b := range clusterBackups {
-		// Skip the Backup CR which is created from local cluster and
-		// the snapshot backup haven't be finished yet
-		if b.Spec.SnapshotName != "" && b.Status.State != types.BackupStateCompleted {
+		// Skip the Backup CR which is created from the local cluster and
+		// the snapshot backup hasn't be pulled from the remote backup target yet
+		if b.Spec.SnapshotName != "" && b.Status.State != types.BackupStateReady {
 			continue
 		}
 		clustersSet.Insert(b.Name)

--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -667,6 +667,10 @@ spec:
           type: string
           description: The snapshot creation time
           jsonPath: .status.snapshotCreatedAt
+        - name: State
+          type: string
+          description: The backup state
+          jsonPath: .status.state
         - name: LastSyncedAt
           type: string
           description: The backup last synced time

--- a/types/resource.go
+++ b/types/resource.go
@@ -741,6 +741,7 @@ type BackupState string
 const (
 	BackupStateInProgress = BackupState("InProgress")
 	BackupStateCompleted  = BackupState("Completed")
+	BackupStateReady      = BackupState("Ready")
 	BackupStateError      = BackupState("Error")
 	BackupStateUnknown    = BackupState("Unknown")
 )


### PR DESCRIPTION
To differentiate the backup that is ready to be used, add a new state `Ready`.
- `Completed` state means the backup creation is finished but hasn't be synced from the remote backup target.
- `Ready` state means the backup is sync from the remote backup target and ready to be used.

https://github.com/longhorn/longhorn/issues/2912

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>