### PR TITLE
Lower csi sidecar log level

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -62,7 +62,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 		attacherImage,
 		rootDir,
 		[]string{
-			"--v=5",
+			"--v=2",
 			"--csi-address=$(ADDRESS)",
 			"--timeout=1m50s",
 			"--leader-election",
@@ -128,7 +128,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 		provisionerImage,
 		rootDir,
 		[]string{
-			"--v=5",
+			"--v=2",
 			"--csi-address=$(ADDRESS)",
 			"--timeout=1m50s",
 			"--leader-election",
@@ -194,7 +194,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 		resizerImage,
 		rootDir,
 		[]string{
-			"--v=5",
+			"--v=2",
 			"--csi-address=$(ADDRESS)",
 			"--timeout=1m50s",
 			"--leader-election",
@@ -259,7 +259,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 		snapshotterImage,
 		rootDir,
 		[]string{
-			"--v=5",
+			"--v=2",
 			"--csi-address=$(ADDRESS)",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
@@ -358,7 +358,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 								Privileged: pointer.BoolPtr(true),
 							},
 							Args: []string{
-								"--v=5",
+								"--v=2",
 								"--csi-address=$(ADDRESS)",
 								"--kubelet-registration-path=" + GetCSISocketFilePath(rootDir),
 							},


### PR DESCRIPTION
Reduce the csi side car log level to V(2)

Which is recommended for most systems, since we don't heavily rely on the
logs from the csi sidecars, this should be fine. More information on the
available log levels below.

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

longhorn/longhorn#1202