### PR TITLE
feat: add WebSocket for Backup page

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -185,6 +185,22 @@ func NewRouter(s *Server) *mux.Router {
 	r.Path("/v1/ws/backingimages").Handler(f(schemas, backingImageStream))
 	r.Path("/v1/ws/{period}/backingimages").Handler(f(schemas, backingImageStream))
 
+	backupVolumeStream := NewStreamHandlerFunc("backupvolumes", s.wsc.NewWatcher("backupVolume"), s.backupVolumeList)
+	r.Path("/v1/ws/backupvolumes").Handler(f(schemas, backupVolumeStream))
+	r.Path("/v1/ws/{period}/backupvolumes").Handler(f(schemas, backupVolumeStream))
+
+	// TODO:
+	// We haven't found a way to allow passing the volume name as a parameter to filter
+	// per-backup volume's backups change thru. WebSocket endpoint. Either by:
+	// - `/v1/ws/backups/{volName}`
+	// - `/v1/ws/backups?volName=<volName>`
+	// - `/v1/ws/backupvolumes/{backupName}`
+	// Once we enhance this part, the WebSocket endpoint could only send the updates of specific
+	// backup volume changes and decrease the traffic data it sends out.
+	backupStream := NewStreamHandlerFunc("backups", s.wsc.NewWatcher("backup"), s.backupListAll)
+	r.Path("/v1/ws/backups").Handler(f(schemas, backupStream))
+	r.Path("/v1/ws/{period}/backups").Handler(f(schemas, backupStream))
+
 	eventListStream := NewStreamHandlerFunc("events", s.wsc.NewWatcher("event"), s.eventList)
 	r.Path("/v1/ws/events").Handler(f(schemas, eventListStream))
 	r.Path("/v1/ws/{period}/events").Handler(f(schemas, eventListStream))

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -243,6 +243,22 @@ func (m *VolumeManager) ListBackupVolumes() (map[string]*longhorn.BackupVolume, 
 	return m.ds.ListBackupVolumes()
 }
 
+func (m *VolumeManager) ListBackupVolumesSorted() ([]*longhorn.BackupVolume, error) {
+	backupVolumeMap, err := m.ds.ListBackupVolumes()
+	if err != nil {
+		return []*longhorn.BackupVolume{}, err
+	}
+	backupVolumeNames, err := sortKeys(backupVolumeMap)
+	if err != nil {
+		return []*longhorn.BackupVolume{}, err
+	}
+	backupVolumes := make([]*longhorn.BackupVolume, len(backupVolumeMap))
+	for i, backupVolumeName := range backupVolumeNames {
+		backupVolumes[i] = backupVolumeMap[backupVolumeName]
+	}
+	return backupVolumes, nil
+}
+
 func (m *VolumeManager) GetBackupVolume(volumeName string) (*longhorn.BackupVolume, error) {
 	backupVolume, err := m.ds.GetBackupVolumeRO(volumeName)
 	if err != nil {
@@ -262,8 +278,40 @@ func (m *VolumeManager) DeleteBackupVolume(volumeName string) error {
 	return m.ds.DeleteBackupVolume(volumeName)
 }
 
+func (m *VolumeManager) ListAllBackupsSorted() ([]*longhorn.Backup, error) {
+	backupMap, err := m.ds.ListBackups()
+	if err != nil {
+		return []*longhorn.Backup{}, err
+	}
+	backupNames, err := sortKeys(backupMap)
+	if err != nil {
+		return []*longhorn.Backup{}, err
+	}
+	backups := make([]*longhorn.Backup, len(backupMap))
+	for i, backupName := range backupNames {
+		backups[i] = backupMap[backupName]
+	}
+	return backups, nil
+}
+
 func (m *VolumeManager) ListBackupsForVolume(volumeName string) (map[string]*longhorn.Backup, error) {
 	return m.ds.ListBackupsWithBackupVolumeName(volumeName)
+}
+
+func (m *VolumeManager) ListBackupsForVolumeSorted(volumeName string) ([]*longhorn.Backup, error) {
+	backupMap, err := m.ListBackupsForVolume(volumeName)
+	if err != nil {
+		return []*longhorn.Backup{}, err
+	}
+	backupNames, err := sortKeys(backupMap)
+	if err != nil {
+		return []*longhorn.Backup{}, err
+	}
+	backups := make([]*longhorn.Backup, len(backupMap))
+	for i, backupName := range backupNames {
+		backups[i] = backupMap[backupName]
+	}
+	return backups, nil
 }
 
 func (m *VolumeManager) GetBackup(backupName, volumeName string) (*longhorn.Backup, error) {


### PR DESCRIPTION
#### Proposal Change

Add WebSocket endpoint `/v1/ws/backupvolumes` and `/v1/ws/backups`.

Haven't found a way to allow passing the volume name as a parameter to filter per-backup volume's backups change. Either by:
- `/v1/ws/backups/{volName}`
- `/v1/ws/backups?volName=<volName>`
- `/v1/ws/backupvolumes/{backupName}`
    
So, the current behavior for the `backups` WebSocket endpoint is that sending all the Backup CRs to the frontend, and frontend will do filtering according to the field `backups.volumeName` when entering the page `Backup -> a Backup Volume`

This follows the same behavior as the `volume` WebSocket endpoint that also sending all the volume/engine/replica changes to the frontend. We need to improve the WebSocket data traffic sending in the future.

#### Issues

https://github.com/longhorn/longhorn/issues/2740