### PR TITLE
Fix RWX attachment getting stuck on old node (timing issue)

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -162,6 +162,10 @@ func (kc *KubernetesPodController) syncHandler(key string) (err error) {
 		return errors.Wrapf(err, "Error getting Pod: %s", name)
 	}
 	nodeID := pod.Spec.NodeName
+	if nodeID == "" {
+		kc.logger.WithField("pod", pod.Name).Trace("skipping pod check since pod is not scheduled yet")
+		return nil
+	}
 	if err := kc.handlePodDeletionIfNodeDown(pod, nodeID, namespace); err != nil {
 		return err
 	}

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -482,7 +482,7 @@ func (c *ShareManagerController) syncShareManagerVolume(sm *longhorn.ShareManage
 		sm.Status.State = types.ShareManagerStateStarting
 	}
 
-	// HACK: at the moment the consumer needs to control the state transitions of the volume
+	// TODO: #2527 at the moment the consumer needs to control the state transitions of the volume
 	//  since it's not possible to just specify the desired state, we should fix that down the line.
 	//  for the actual state transition we need to request detachment then wait for detachment
 	//  afterwards we can request attachment to the new node.
@@ -490,16 +490,22 @@ func (c *ShareManagerController) syncShareManagerVolume(sm *longhorn.ShareManage
 	if volume.Spec.NodeID != "" && err != nil {
 		log.WithError(err).Warnf("cannot check IsNodeDownOrDeleted(%v) when syncShareManagerVolume", volume.Spec.NodeID)
 	}
-	shouldDetach := isDown && (volume.Status.State == types.VolumeStateAttached || volume.Status.State == types.VolumeStateAttaching)
+
+	nodeSwitch := volume.Spec.NodeID != "" && volume.Spec.NodeID != sm.Status.OwnerID
+	buggedVolume := volume.Spec.NodeID != "" && volume.Spec.NodeID == sm.Status.OwnerID && volume.Status.CurrentNodeID != "" && volume.Status.CurrentNodeID != volume.Spec.NodeID
+	shouldDetach := isDown || buggedVolume || nodeSwitch
 	if shouldDetach {
-		log.WithField("volume", volume.Name).Infof("Requesting Volume detach from previous node %v", volume.Status.CurrentNodeID)
-		volume.Spec.NodeID = ""
-		if volume, err = c.ds.UpdateVolume(volume); err != nil {
+		log.Infof("Requesting Volume detach from node %v attached node %v", volume.Spec.NodeID, volume.Status.CurrentNodeID)
+		if err = c.detachShareManagerVolume(sm); err != nil {
 			return err
 		}
 	}
 
-	if volume.Status.State == types.VolumeStateDetached && volume.Spec.NodeID == "" {
+	// TODO: #2527 this detach/attach is so brittle, we really need to fix the volume controller
+	// 	we need to wait till the volume is completely detached even though the state might be detached
+	// 	it might still have a current node id set, which will then block reattachment forever
+	shouldAttach := volume.Status.State == types.VolumeStateDetached && volume.Spec.NodeID == "" && volume.Status.CurrentNodeID == ""
+	if shouldAttach {
 		log.WithField("volume", volume.Name).Info("Requesting Volume attach to share manager node")
 		volume.Spec.NodeID = sm.Status.OwnerID
 		if volume, err = c.ds.UpdateVolume(volume); err != nil {


### PR DESCRIPTION
This detach/attach is so brittle, we really need to fix the volume controller
we need to wait till the volume is completely detached even though the state
might be detached it might still have a current node id set, which will then
block reattachment forever. Since the volume controller will error out,
when Status.CurrentNodeID != Spec.NodeID.

longhorn/longhorn#2933 longhorn/longhorn#2527