### PR TITLE
controller: Skip waiting for replicas on down nodes before restore/DR…

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1953,6 +1953,11 @@ func (vc *VolumeController) checkForAutoDetachment(v *longhorn.Volume, e *longho
 		if r.Spec.NodeID == "" {
 			continue
 		}
+		if isDownOrDeleted, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID); err != nil {
+			return err
+		} else if isDownOrDeleted {
+			continue
+		}
 		if mode := e.Status.ReplicaModeMap[r.Name]; mode != types.ReplicaModeRW {
 			allScheduledReplicasIncluded = false
 			break


### PR DESCRIPTION
controller: Skip waiting for replicas on down nodes before restore/DR volume auto detachment

Longhorn 2929

Signed-off-by: Shuo Wu <shuo.wu@suse.com>
Signed-off-by: David Ko <dko@suse.com>