### PR TITLE
Revert the Backup CR Ready state

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -331,7 +331,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	}
 
 	// Update Backup CR status
-	backup.Status.State = types.BackupStateReady
+	backup.Status.State = types.BackupStateCompleted
 	backup.Status.URL = backupInfo.URL
 	backup.Status.SnapshotName = backupInfo.SnapshotName
 	backup.Status.SnapshotCreatedAt = backupInfo.SnapshotCreated

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -284,7 +284,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	for _, b := range clusterBackups {
 		// Skip the Backup CR which is created from the local cluster and
 		// the snapshot backup hasn't be completed or pulled from the remote backup target yet
-		if b.Spec.SnapshotName != "" && b.Status.State != types.BackupStateCompleted && b.Status.State != types.BackupStateReady {
+		if b.Spec.SnapshotName != "" && b.Status.State != types.BackupStateCompleted {
 			continue
 		}
 		clustersSet.Insert(b.Name)

--- a/types/resource.go
+++ b/types/resource.go
@@ -741,7 +741,6 @@ type BackupState string
 const (
 	BackupStateInProgress = BackupState("InProgress")
 	BackupStateCompleted  = BackupState("Completed")
-	BackupStateReady      = BackupState("Ready")
 	BackupStateError      = BackupState("Error")
 	BackupStateUnknown    = BackupState("Unknown")
 )


### PR DESCRIPTION
Previously we introduced the Backup CR `Ready` state, we want to distinguish the difference between the backup creation is completed and the backup is pulled from the remote backup target. And the GUI could check the state is `Ready` or not, and decide the button `Restore` and `Get URL` are clickable/unclickable.

But this introduces a corner case that the backup state might be transit from `Ready` back to `Completed` because we have two actors updating the same `status.state`, one is backup creation routine and the other one is synced from the remote backup target routine. The user might be confused what's the difference between the two states.

After that, we decided to let GUI decide the button `Restore` and `Get URL` are clickable/unclickable by `status.URL` is empty _or_ not. So, we could revert the Backup CR `Ready` state. This makes the final state would be `Completed` if the backup creation succeeds _or_ pulled from the remote backup target.

https://github.com/longhorn/longhorn/issues/2949