### PR TITLE
Fix recurringJob CRs not created during upgrade

### DIFF
--- a/types/resource.go
+++ b/types/resource.go
@@ -187,7 +187,7 @@ const (
 //       spec.
 type RecurringJob struct {
 	Name        string            `json:"name"`
-	Groups      []string          `json:"groups"`
+	Groups      []string          `json:"groups,omitempty"`
 	Task        RecurringJobType  `json:"task"`
 	Cron        string            `json:"cron"`
 	Retain      int               `json:"retain"`
@@ -765,7 +765,7 @@ type SnapshotBackupStatus struct {
 
 type RecurringJobSpec struct {
 	Name        string            `json:"name"`
-	Groups      []string          `json:"groups"`
+	Groups      []string          `json:"groups,omitempty"`
 	Task        RecurringJobType  `json:"task"`
 	Cron        string            `json:"cron"`
 	Retain      int               `json:"retain"`


### PR DESCRIPTION
@kaxing has managed to reproduce this on his local machine. The issue could be seen during manager re-try at failed run that is causing the volume spec to get removed before CR creation.

This PR refactors the recurringJob upgrade flow to ensure the recurringJob CRs are created before updating the storageClass and volume CRs.

This also fixed the environment-based inconsistent behavior when creating recurring job CR with null spec.groups.

https://github.com/longhorn/longhorn/issues/2961#issuecomment-909810861