### PR TITLE
Backport to v1.2.1: Explicitly set default fsType to EXT4

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -133,6 +133,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 			"--timeout=1m50s",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
+			"--default-fstype=ext4",
 		},
 		int32(replicaCount),
 		tolerations,

--- a/deploy/install/01-prerequisite/06-storageclass.yaml
+++ b/deploy/install/01-prerequisite/06-storageclass.yaml
@@ -14,6 +14,7 @@ data:
     reclaimPolicy: Delete
     volumeBindingMode: Immediate
     parameters:
+      fsType: "ext4"
       numberOfReplicas: "3"
       staleReplicaTimeout: "2880"
       fromBackup: ""


### PR DESCRIPTION
This allow Kubernetes to properly changes the volume ownership
and permissions when user specify fsGroup in workload pod

longhorn/longhorn#2964