### PR TITLE
Fix sanity test - source volume not found

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -108,6 +108,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 				if err != nil {
 					return nil, status.Errorf(codes.NotFound, "cannot clone volume: source volume %s is unavailable", srcVolume.VolumeId)
 				}
+				if longhornSrcVol == nil {
+					return nil, status.Errorf(codes.NotFound, "cannot clone volume: source volume %s is not found", srcVolume.VolumeId)
+				}
 
 				// check size of source and requested
 				srcVolSizeBytes, err := strconv.ParseInt(longhornSrcVol.Size, 10, 64)


### PR DESCRIPTION
Running csi-sanity `CreateVolume [It] should fail when the volume source volume is not found` fails at:
```
    unexpected error: transport is closing
    Expected
        <codes.Code>: 14
    to equal
        <codes.Code>: 5
```
This also crashes all CSI workloads with stacktrace in log.
![Screenshot-2021-09-08-17:19:22](https://user-images.githubusercontent.com/22583541/132494156-c9ca134f-b1b0-4af4-a1d5-92d0ed7c6d3d.png)

Result after fix:
```
Ran 1 of 78 Specs in 0.113 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 77 Skipped
```

https://github.com/longhorn/longhorn/issues/2271