### PR TITLE
Track terminating pods

### DIFF
--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -276,12 +276,7 @@ func (kc *KubernetesPVController) syncKubernetesStatus(key string) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// for the workloads we only track non terminating pods
-	activePods := filterPods(pods, func(p *v1.Pod) bool {
-		return p.DeletionTimestamp == nil
-	})
-	kc.setWorkloads(ks, activePods)
+	kc.setWorkloads(ks, pods)
 
 	return nil
 }

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -376,7 +376,7 @@ func (s *TestSuite) TestSyncKubernetesStatus(c *C) {
 	tc.expectVolume.Status.KubernetesStatus.WorkloadsStatus = workloads
 	testCases["pod phase updated to 'failed'"] = tc
 
-	// pod deleted
+	// pod deletion requested (retain workload status)
 	tc = generateKubernetesTestCaseTemplate()
 	tc.pv.Status.Phase = apiv1.VolumeBound
 	workloads = []types.WorkloadStatus{}
@@ -398,8 +398,34 @@ func (s *TestSuite) TestSyncKubernetesStatus(c *C) {
 		WorkloadsStatus: workloads,
 	}
 	tc.copyCurrentToExpect()
+	tc.expectVolume.Status.KubernetesStatus.LastPodRefAt = ""
+	testCases["pod deletion requested"] = tc
+
+	// pod deleted (set podLastRefAt)
+	tc = generateKubernetesTestCaseTemplate()
+	tc.pv.Status.Phase = apiv1.VolumeBound
+	workloads = []types.WorkloadStatus{}
+	for _, p := range tc.pods {
+		p.DeletionTimestamp = &deleteTime
+		ws := types.WorkloadStatus{
+			PodName:      p.Name,
+			PodStatus:    string(p.Status.Phase),
+			WorkloadName: TestWorkloadName,
+			WorkloadType: TestWorkloadKind,
+		}
+		workloads = append(workloads, ws)
+	}
+	tc.volume.Status.KubernetesStatus = types.KubernetesStatus{
+		PVName:          TestPVName,
+		PVStatus:        string(apiv1.VolumeBound),
+		Namespace:       TestNamespace,
+		PVCName:         TestPVCName,
+		WorkloadsStatus: workloads,
+	}
+	tc.copyCurrentToExpect()
+	tc.pods = nil // pod has been deleted
 	tc.expectVolume.Status.KubernetesStatus.LastPodRefAt = getTestNow()
-	testCases["pod deleted"] = tc
+	testCases["pod deletion done"] = tc
 
 	// pv phase updated: bound -> failed
 	tc = generateKubernetesTestCaseTemplate()

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -351,8 +351,13 @@ func (c *ShareManagerController) syncShareManagerEndpoint(sm *longhorn.ShareMana
 	}
 
 	service, err := c.ds.GetService(sm.Namespace, sm.Name)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+
+	if service == nil {
+		c.logger.Warn("missing service for share-manager, unsetting endpoint")
+		sm.Status.Endpoint = ""
 	}
 
 	sm.Status.Endpoint = fmt.Sprintf("nfs://%v/%v", service.Spec.ClusterIP, sm.Name)

--- a/types/resource.go
+++ b/types/resource.go
@@ -545,6 +545,7 @@ const (
 	ShareManagerStateUnknown  = ShareManagerState("unknown")
 	ShareManagerStateStarting = ShareManagerState("starting")
 	ShareManagerStateRunning  = ShareManagerState("running")
+	ShareManagerStateStopping = ShareManagerState("stopping")
 	ShareManagerStateStopped  = ShareManagerState("stopped")
 	ShareManagerStateError    = ShareManagerState("error")
 )


### PR DESCRIPTION
We changed the behavior so that we only set lastPodRefAt once there are
no more pods present, previously this was already set when the last pod
went into terminating state.

I added a unit test for both cases, to verify the behavior of tracking in
terminating state and lastPodRefAt setting once there are no more pods
present for that volume.

longhorn/longhorn#2874

Signed-off-by: Joshua Moody <joshua.moody@suse.com>