### PR TITLE
[CSI Sanity] Auto-attach volume for K8s CSI snapshot

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1136,6 +1136,9 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["updateDataLocality"] = struct{}{}
 			actions["updateAccessMode"] = struct{}{}
 			actions["updateReplicaAutoBalance"] = struct{}{}
+			actions["snapshotList"] = struct{}{}
+			actions["snapshotCreate"] = struct{}{}
+			actions["snapshotBackup"] = struct{}{}
 			actions["recurringJobAdd"] = struct{}{}
 			actions["recurringJobDelete"] = struct{}{}
 			actions["recurringJobList"] = struct{}{}

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -421,6 +421,14 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 							},
 							Env: []v1.EnvVar{
 								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
 									Name: "NODE_ID",
 									ValueFrom: &v1.EnvVarSource{
 										FieldRef: &v1.ObjectFieldSelector{


### PR DESCRIPTION
Some csi-sanity test fails because Longhorn doesn't support snapshot/backup when the volume is detached.

For Kubernetes CSI snapshot the volume should be fine with auto-attachment since the VolumeSnapshot spec uses PVC as the source. 

https://github.com/longhorn/longhorn/issues/2271