### PR TITLE
Update share-manager images to v1_20210914

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20210731
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20210820
+        - longhornio/longhorn-share-manager:v1_20210914
         - --backing-image-manager-image
         - longhornio/backing-image-manager:v2_20210820
         - --manager-image

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210820
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master-head
-longhornio/longhorn-share-manager:v1_20210820
+longhornio/longhorn-share-manager:v1_20210914
 longhornio/longhorn-ui:master-head


### PR DESCRIPTION
fixes previously created EXT4 RWX volumes that are now trying to be used as XFS

longhorn/longhorn#2991