### PR TITLE
[Backport-v1.2.x] Change to millisecond-level precision

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -253,7 +252,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 
 		// Request backup_volume_controller to reconcile BackupVolume immediately if it's the last backup
 		if backupVolume != nil && backupVolume.Status.LastBackupName == backup.Name {
-			backupVolume.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
+			backupVolume.Spec.SyncRequestedAt = time.Now().UTC()
 			if _, err = bc.ds.UpdateBackupVolume(backupVolume); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 				log.WithError(err).Errorf("Error updating backup volume %s spec", backupVolumeName)
 				// Do not return err to enqueue since backup_controller is responsible to
@@ -264,7 +263,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		return bc.ds.RemoveFinalizerForBackup(backup)
 	}
 
-	syncTime := metav1.Time{Time: time.Now().UTC()}
+	syncTime := time.Now().UTC()
 	existingBackup := backup.DeepCopy()
 	defer func() {
 		if err != nil {
@@ -307,7 +306,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 
 	// The backup config had synced
 	if !backup.Status.LastSyncedAt.IsZero() &&
-		!backup.Spec.SyncRequestedAt.After(backup.Status.LastSyncedAt.Time) {
+		!backup.Spec.SyncRequestedAt.After(backup.Status.LastSyncedAt) {
 		return nil
 	}
 
@@ -506,7 +505,7 @@ func (bc *BackupController) backupCreation(log logrus.FieldLogger, engineClient 
 			state = types.BackupStateCompleted
 			event(nil, state, backup, volume)
 
-			syncTime := metav1.Time{Time: time.Now().UTC()}
+			syncTime := time.Now().UTC()
 			backupVolume, err := bc.ds.GetBackupVolume(volumeName)
 			if err == nil {
 				// Request backup_volume_controller to reconcile BackupVolume immediately.

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -234,13 +234,13 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 
 	// Check the controller should run synchronization
 	if !backupTarget.Status.LastSyncedAt.IsZero() &&
-		!backupTarget.Spec.SyncRequestedAt.After(backupTarget.Status.LastSyncedAt.Time) {
+		!backupTarget.Spec.SyncRequestedAt.After(backupTarget.Status.LastSyncedAt) {
 		return nil
 	}
 
 	var backupTargetClient *engineapi.BackupTargetClient
 	existingBackupTarget := backupTarget.DeepCopy()
-	syncTime := metav1.Time{Time: time.Now().UTC()}
+	syncTime := time.Now().UTC()
 	defer func() {
 		if err != nil {
 			return

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -237,7 +237,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		return bvc.ds.RemoveFinalizerForBackupVolume(backupVolume)
 	}
 
-	syncTime := metav1.Time{Time: time.Now().UTC()}
+	syncTime := time.Now().UTC()
 	existingBackupVolume := backupVolume.DeepCopy()
 	defer func() {
 		if err != nil {
@@ -254,7 +254,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 
 	// Check the controller should run synchronization
 	if !backupVolume.Status.LastSyncedAt.IsZero() &&
-		!backupVolume.Spec.SyncRequestedAt.After(backupVolume.Status.LastSyncedAt.Time) {
+		!backupVolume.Spec.SyncRequestedAt.After(backupVolume.Status.LastSyncedAt) {
 		return nil
 	}
 

--- a/controller/kubernetes_secret_controller.go
+++ b/controller/kubernetes_secret_controller.go
@@ -255,7 +255,7 @@ func (ks *KubernetesSecretController) triggerSyncBackupTarget(backupTarget *long
 		return nil
 	}
 
-	backupTarget.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
+	backupTarget.Spec.SyncRequestedAt = time.Now().UTC()
 	if _, err := ks.ds.UpdateBackupTarget(backupTarget); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 		ks.logger.WithError(err).Warn("Failed to updating backup target")
 	}

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -327,7 +327,7 @@ func (sc *SettingController) syncBackupTarget() (err error) {
 		backupTarget.Spec.PollInterval = metav1.Duration{Duration: pollInterval}
 		if !reflect.DeepEqual(existingBackupTarget.Spec, backupTarget.Spec) {
 			// Force sync backup target once the BackupTarget spec be updated
-			backupTarget.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
+			backupTarget.Spec.SyncRequestedAt = time.Now().UTC()
 			if _, err = sc.ds.UpdateBackupTarget(backupTarget); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 				sc.logger.WithError(err).Warn("Failed to update backup target")
 			}
@@ -679,7 +679,7 @@ func (bst *BackupStoreTimer) Start() {
 			return false, err
 		}
 
-		backupTarget.Spec.SyncRequestedAt = metav1.Time{Time: time.Now().UTC()}
+		backupTarget.Spec.SyncRequestedAt = time.Now().UTC()
 		if _, err = bst.ds.UpdateBackupTarget(backupTarget); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 			log.WithError(err).Warn("Failed to updating backup target")
 		}

--- a/types/resource.go
+++ b/types/resource.go
@@ -697,7 +697,7 @@ type BackupTargetSpec struct {
 	BackupTargetURL  string          `json:"backupTargetURL"`
 	CredentialSecret string          `json:"credentialSecret"`
 	PollInterval     metav1.Duration `json:"pollInterval"`
-	SyncRequestedAt  metav1.Time     `json:"syncRequestedAt"`
+	SyncRequestedAt  time.Time       `json:"syncRequestedAt"`
 }
 
 const (
@@ -710,11 +710,11 @@ type BackupTargetStatus struct {
 	OwnerID      string               `json:"ownerID"`
 	Available    bool                 `json:"available"`
 	Conditions   map[string]Condition `json:"conditions"`
-	LastSyncedAt metav1.Time          `json:"lastSyncedAt"`
+	LastSyncedAt time.Time            `json:"lastSyncedAt"`
 }
 
 type BackupVolumeSpec struct {
-	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
+	SyncRequestedAt time.Time `json:"syncRequestedAt"`
 }
 
 type BackupVolumeStatus struct {
@@ -729,11 +729,11 @@ type BackupVolumeStatus struct {
 	Messages             map[string]string `json:"messages"`
 	BackingImageName     string            `json:"backingImageName"`
 	BackingImageChecksum string            `json:"backingImageChecksum"`
-	LastSyncedAt         metav1.Time       `json:"lastSyncedAt"`
+	LastSyncedAt         time.Time         `json:"lastSyncedAt"`
 }
 
 type SnapshotBackupSpec struct {
-	SyncRequestedAt metav1.Time       `json:"syncRequestedAt"`
+	SyncRequestedAt time.Time         `json:"syncRequestedAt"`
 	SnapshotName    string            `json:"snapshotName"`
 	Labels          map[string]string `json:"labels"`
 }
@@ -761,7 +761,7 @@ type SnapshotBackupStatus struct {
 	VolumeSize             string            `json:"volumeSize"`
 	VolumeCreated          string            `json:"volumeCreated"`
 	VolumeBackingImageName string            `json:"volumeBackingImageName"`
-	LastSyncedAt           metav1.Time       `json:"lastSyncedAt"`
+	LastSyncedAt           time.Time         `json:"lastSyncedAt"`
 }
 
 type RecurringJobSpec struct {


### PR DESCRIPTION
Address PR comment https://github.com/longhorn/longhorn-manager/pull/1009#issuecomment-906903691

Change the BackupTarget/BackupVolume/Backup CR from second-level precision to millisecond-level precision.
It fixes if more than two controllers set the `spec.syncRequestedAt` within a short time (within 1 second), the second one would not be handled.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>