### PR TITLE
[Backport-v1.2.x] Fix backup target status.available always false

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -355,14 +355,13 @@ func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineIm
 
 	isResponsible := isControllerResponsibleFor(bc.controllerID, bc.ds, b.Name, "", b.Status.OwnerID)
 
-	readyNodesWithEI, err := bc.ds.ListReadyNodesWithEngineImage(defaultEngineImage)
+	readyNodesWithReadyEI, err := bc.ds.ListReadyNodesWithReadyEngineImage(defaultEngineImage)
 	if err != nil {
 		return false, err
 	}
-	// No node in the system has the default engine image,
-	// Fall back to the default logic where we pick a running node to be the owner
-	if len(readyNodesWithEI) == 0 {
-		return isResponsible, nil
+	// No node in the system has the default engine image in ready state
+	if len(readyNodesWithReadyEI) == 0 {
+		return false, nil
 	}
 
 	currentOwnerEngineAvailable, err := bc.ds.CheckEngineImageReadiness(defaultEngineImage, b.Status.OwnerID)

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -383,14 +383,13 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 
 	isResponsible := isControllerResponsibleFor(bvc.controllerID, bvc.ds, bv.Name, "", bv.Status.OwnerID)
 
-	readyNodesWithEI, err := bvc.ds.ListReadyNodesWithEngineImage(defaultEngineImage)
+	readyNodesWithReadyEI, err := bvc.ds.ListReadyNodesWithReadyEngineImage(defaultEngineImage)
 	if err != nil {
 		return false, err
 	}
-	// No node in the system has the default engine image,
-	// Fall back to the default logic where we pick a running node to be the owner
-	if len(readyNodesWithEI) == 0 {
-		return isResponsible, nil
+	// No node in the system has the default engine image in ready state
+	if len(readyNodesWithReadyEI) == 0 {
+		return false, nil
 	}
 
 	currentOwnerEngineAvailable, err := bvc.ds.CheckEngineImageReadiness(defaultEngineImage, bv.Status.OwnerID)

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -142,7 +142,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		settingInformer, nodeInformer, backupTargetInformer,
 		kubeClient, namespace, controllerID, version)
 	btc := NewBackupTargetController(logger, ds, scheme,
-		backupTargetInformer,
+		backupTargetInformer, engineImageInformer,
 		kubeClient, controllerID, namespace)
 	bvc := NewBackupVolumeController(logger, ds, scheme,
 		backupVolumeInformer,


### PR DESCRIPTION
#### Proposal Change

If the user configures a valid backup target and the poll interval to 0 during the default engine image is not ready, the backup target `status.available=false` even the default engine image is ready.

Check the backup target available or not shouldn't depend on the poll interval setting (i.e., the `spec.syncRequestedAt` and `status.lastSyncedAt`).
Therefore, change the check of `spec.syncRequestedAt > status.lastSyncedAt` before listing remote backup volumes. (To list remote backup volumes or not depends on the poll interval setting)

#### Issues

https://github.com/longhorn/longhorn/issues/2960