### PR TITLE
[Backport][v1.1.3] Fix migration issue and enhance the failed replica reusage & cleanup

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1694,10 +1694,8 @@ func (vc *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, e *longho
 	dataPathToNewReplica := map[string]*longhorn.Replica{}
 	for _, r := range rs {
 		dataPath := types.GetReplicaDataPath(r.Spec.DiskPath, r.Spec.DataDirectoryName)
-		if r.Spec.EngineImage == v.Status.CurrentImage && r.Status.CurrentState == types.InstanceStateRunning {
-			if mode, exists := e.Status.ReplicaModeMap[r.Name]; exists && mode == types.ReplicaModeRW {
-				dataPathToOldRunningReplica[dataPath] = r
-			}
+		if r.Spec.EngineImage == v.Status.CurrentImage && r.Status.CurrentState == types.InstanceStateRunning && r.Spec.HealthyAt != "" {
+			dataPathToOldRunningReplica[dataPath] = r
 		} else if r.Spec.EngineImage == v.Spec.EngineImage {
 			dataPathToNewReplica[dataPath] = r
 		} else {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2374,21 +2374,14 @@ func (vc *VolumeController) getCurrentEngineAndCleanupOthers(v *longhorn.Volume,
 }
 
 func (vc *VolumeController) createAndStartMatchingReplicas(v *longhorn.Volume,
-	rs, pathToOldRunnngRs, pathToNewRs map[string]*longhorn.Replica,
+	rs, pathToOldRs, pathToNewRs map[string]*longhorn.Replica,
 	fixupFunc func(r *longhorn.Replica, obj string), obj string) error {
-	log := getLoggerForVolume(vc.logger, v)
 
-	if len(pathToNewRs) == v.Spec.NumberOfReplicas {
-		return nil
+	if len(pathToOldRs) == 0 {
+		return fmt.Errorf("no old replica for the volume")
 	}
 
-	if len(pathToOldRunnngRs) != v.Spec.NumberOfReplicas {
-		log.Debugf("Volume old healthy replica count %v doesn't match the desired replica count %v",
-			len(pathToOldRunnngRs), v.Spec.NumberOfReplicas)
-		return nil
-	}
-
-	for path, r := range pathToOldRunnngRs {
+	for path, r := range pathToOldRs {
 		if pathToNewRs[path] != nil {
 			continue
 		}
@@ -2402,6 +2395,14 @@ func (vc *VolumeController) createAndStartMatchingReplicas(v *longhorn.Volume,
 		}
 		pathToNewRs[path] = newReplica
 		rs[newReplica.Name] = newReplica
+	}
+	for path, r := range pathToNewRs {
+		if pathToOldRs[path] != nil {
+			continue
+		}
+		if err := vc.deleteReplica(r, rs); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 	return nil
 }
@@ -2508,16 +2509,27 @@ func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*
 		es[migrationEngine.Name] = migrationEngine
 	}
 
-	currentReplicas := map[string]*longhorn.Replica{}
+	currentAvailableReplicas := map[string]*longhorn.Replica{}
 	migrationReplicas := map[string]*longhorn.Replica{}
 	unknownReplicas := map[string]*longhorn.Replica{}
 	for _, r := range rs {
-		dataPath := types.GetReplicaDataPath(r.Spec.DiskPath, r.Spec.DataDirectoryName)
-		if r.Spec.FailedAt != "" {
+		isUnavailable, err := vc.IsReplicaUnavailable(r)
+		if err != nil {
+			return err
+		}
+		if isUnavailable {
 			continue
 		}
+		dataPath := types.GetReplicaDataPath(r.Spec.DiskPath, r.Spec.DataDirectoryName)
 		if r.Spec.EngineName == currentEngine.Name {
-			currentReplicas[dataPath] = r
+			if currentEngine.Status.ReplicaModeMap[r.Name] == types.ReplicaModeWO {
+				logrus.Debugf("Cannot start migration since the current replica %v is mode WriteOnly, which means the rebuilding is in progress", r.Name)
+				return nil
+			}
+			if currentEngine.Status.ReplicaModeMap[r.Name] != types.ReplicaModeRW {
+				return fmt.Errorf("unexpected mode %v for the current replica %v, cannot continue migration", currentEngine.Status.ReplicaModeMap[r.Name], r.Name)
+			}
+			currentAvailableReplicas[dataPath] = r
 		} else if r.Spec.EngineName == migrationEngine.Name {
 			migrationReplicas[dataPath] = r
 		} else {
@@ -2526,7 +2538,7 @@ func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*
 		}
 	}
 
-	if err := vc.createAndStartMatchingReplicas(v, rs, currentReplicas, migrationReplicas, func(r *longhorn.Replica, engineName string) {
+	if err := vc.createAndStartMatchingReplicas(v, rs, currentAvailableReplicas, migrationReplicas, func(r *longhorn.Replica, engineName string) {
 		r.Spec.EngineName = engineName
 	}, migrationEngine.Name); err != nil {
 		return err
@@ -2535,7 +2547,7 @@ func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*
 	if migrationEngine.Spec.DesireState != types.InstanceStateRunning {
 		replicaAddressMap := map[string]string{}
 		for _, r := range migrationReplicas {
-			// wait for all potentially healthy replicas become running
+			// wait for all potentially available replicas become running
 			if r.Status.CurrentState != types.InstanceStateRunning {
 				return nil
 			}
@@ -2565,6 +2577,42 @@ func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*
 
 	vc.logger.Infof("volume migration engine on node %v is ready", v.Spec.MigrationNodeID)
 	return nil
+}
+
+func (vc *VolumeController) IsReplicaUnavailable(r *longhorn.Replica) (bool, error) {
+	log := vc.logger.WithFields(logrus.Fields{
+		"replica":       r.Name,
+		"replicaNodeID": r.Spec.NodeID,
+	})
+
+	if r.Spec.FailedAt != "" || r.Spec.NodeID == "" || r.Spec.DiskID == "" {
+		return true, nil
+	}
+
+	isDownOrDeleted, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID)
+	if err != nil {
+		log.WithError(err).Errorf("Unable to check if node %v is still running for failed replica", r.Spec.NodeID)
+		return true, err
+	}
+	if isDownOrDeleted {
+		return true, nil
+	}
+
+	node, err := vc.ds.GetNode(r.Spec.NodeID)
+	if err != nil {
+		log.WithError(err).Errorf("Unable to get node %v for failed replica", r.Spec.NodeID)
+		return true, err
+	}
+	for _, diskStatus := range node.Status.DiskStatus {
+		if diskStatus.DiskUUID != r.Spec.DiskID {
+			continue
+		}
+		if types.GetCondition(diskStatus.Conditions, types.DiskConditionTypeReady).Status != types.ConditionStatusTrue {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // isResponsibleFor picks a running node that has the default engine image deployed.

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -818,22 +818,25 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	// volume attaching, start replicas, one node down
 	tc = generateVolumeTestCaseTemplate()
 	tc.volume.Spec.NodeID = TestNode1
-	tc.volume.Status.CurrentNodeID = TestNode1
+	tc.volume.Spec.StaleReplicaTimeout = 1<<24 - 1
 	tc.nodes[1] = newNode(TestNode2, TestNamespace, false, types.ConditionStatusFalse, string(types.NodeConditionReasonKubernetesNodeGone))
 	for _, r := range tc.replicas {
+		// Assume the volume is previously attached then detached.
+		r.Spec.HealthyAt = getTestNow()
 		r.Status.CurrentState = types.InstanceStateStopped
 	}
 	tc.copyCurrentToExpect()
+	tc.expectVolume.Status.CurrentNodeID = TestNode1
 	tc.expectVolume.Status.State = types.VolumeStateAttaching
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.EngineImage
-	expectRs := map[string]*longhorn.Replica{}
 	for _, r := range tc.expectReplicas {
-		if r.Spec.NodeID != TestNode2 {
+		if r.Spec.NodeID == TestNode2 {
+			r.Spec.DesireState = types.InstanceStateStopped
+			r.Spec.FailedAt = getTestNow()
+		} else {
 			r.Spec.DesireState = types.InstanceStateRunning
-			expectRs[r.Name] = r
 		}
 	}
-	tc.expectReplicas = expectRs
 	testCases["volume attaching - start replicas - node failed"] = tc
 
 	// Disable revision counter
@@ -859,7 +862,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		expectEs[e.Name] = e
 	}
 	tc.expectEngines = expectEs
-	expectRs = map[string]*longhorn.Replica{}
+	expectRs := map[string]*longhorn.Replica{}
 	for _, r := range tc.expectReplicas {
 		r.Spec.DesireState = types.InstanceStateRunning
 		r.Spec.RevisionCounterDisabled = true

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -377,8 +377,8 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		if v.Status.State != types.VolumeStateAttached {
 			return nil, fmt.Errorf("invalid volume state to start migration %v", v.Status.State)
 		}
-		if v.Status.Robustness != types.VolumeRobustnessHealthy {
-			return nil, fmt.Errorf("volume must be healthy to start migration")
+		if v.Status.Robustness != types.VolumeRobustnessHealthy && v.Status.Robustness != types.VolumeRobustnessDegraded {
+			return nil, fmt.Errorf("volume must be healthy or degraded to start migration")
 		}
 		if v.Spec.EngineImage != v.Status.CurrentImage {
 			return nil, fmt.Errorf("upgrading in process for volume, cannot start migration")


### PR DESCRIPTION
longhorn/longhorn#2805

This backport PR includes some commits related to [the PR](https://github.com/longhorn/longhorn-manager/pull/1039) of  longhorn/longhorn#2460. But the concurrent rebuilding limit feature won't be in. These commits are more about the enhancement of failed replica reusage & cleanup: If a newly created replica fails at the 1st rebuilding, which won't contain any data hence there is no need to reuse this kind of replicas.