### PR TITLE
[Back-port v1.2.1] Enforce overprovisioning limit when expanding volume size and fix the rounding issue with Storage Over Provisioning Percentage

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2487,6 +2487,10 @@ func (vc *VolumeController) reconcileVolumeSize(v *longhorn.Volume, e *longhorn.
 		vc.eventRecorder.Eventf(v, v1.EventTypeNormal, EventReasonCanceledExpansion,
 			"Canceled expanding the volume %v, will automatically detach it", v.Name)
 	} else {
+		if err := vc.scheduler.CheckReplicasSizeExpansion(v, e.Spec.VolumeSize, v.Spec.Size); err != nil {
+			log.Debugf("cannot start volume expansion: %v", err)
+			return nil
+		}
 		log.Infof("Start volume expand from size %v to size %v", e.Spec.VolumeSize, v.Spec.Size)
 		v.Status.ExpansionRequired = true
 	}


### PR DESCRIPTION

longhorn/longhorn#2962
longhorn/longhorn#2952

