### PR TITLE
[Back-port v1.1.3] Enforce overprovisioning limit when expanding volume size and fix the rounding issue with Storage Over Provisioning Percentage

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1855,6 +1855,10 @@ func (vc *VolumeController) reconcileVolumeSize(v *longhorn.Volume, e *longhorn.
 		vc.eventRecorder.Eventf(v, v1.EventTypeNormal, EventReasonCanceledExpansion,
 			"Canceled expanding the volume %v, will automatically detach it", v.Name)
 	} else {
+		if err := vc.scheduler.CheckReplicasSizeExpansion(v, e.Spec.VolumeSize, v.Spec.Size); err != nil {
+			log.Debugf("cannot start volume expansion: %v", err)
+			return nil
+		}
 		log.Infof("Start volume expand from size %v to size %v", e.Spec.VolumeSize, v.Spec.Size)
 		v.Status.ExpansionRequired = true
 	}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -647,6 +648,11 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	if existVol, err = cs.apiClient.Volume.ActionExpand(existVol, &longhornclient.ExpandInput{
 		Size: strconv.FormatInt(requestedSize, 10),
 	}); err != nil {
+		// TODO: This manual error code parsing should be refactored once Longhorn API implements error code response
+		// https://github.com/longhorn/longhorn/issues/1875
+		if matched, _ := regexp.MatchString("cannot schedule .* more bytes to disk", err.Error()); matched {
+			return nil, status.Errorf(codes.OutOfRange, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
+	"github.com/longhorn/longhorn-manager/scheduler"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
@@ -26,7 +27,8 @@ import (
 )
 
 type VolumeManager struct {
-	ds *datastore.DataStore
+	ds        *datastore.DataStore
+	scheduler *scheduler.ReplicaScheduler
 
 	currentNodeID string
 	sb            *SupportBundle
@@ -38,7 +40,8 @@ const (
 
 func NewVolumeManager(currentNodeID string, ds *datastore.DataStore) *VolumeManager {
 	return &VolumeManager{
-		ds: ds,
+		ds:        ds,
+		scheduler: scheduler.NewReplicaScheduler(ds),
 
 		currentNodeID: currentNodeID,
 	}
@@ -641,6 +644,10 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 	if v.Spec.Size >= size {
 		logrus.Infof("Volume %v expansion is not necessary since current size %v >= %v", v.Name, v.Spec.Size, size)
 		return v, nil
+	}
+
+	if err := m.scheduler.CheckReplicasSizeExpansion(v, v.Spec.Size, size); err != nil {
+		return nil, err
 	}
 
 	logrus.Infof("Volume %v expansion from %v to %v requested", v.Name, v.Spec.Size, size)


### PR DESCRIPTION

longhorn/longhorn#2962
longhorn/longhorn#2952
