### PR TITLE
Adding fossa analyze/test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,27 @@ steps:
   - name: socket
     path: /var/run/docker.sock
 
+- name: fossa
+  image: registry.suse.com/suse/sle15:15.3.17.8.1
+  failure: ignore
+  environment:
+    FOSSA_API_KEY:
+      from_secret: FOSSA_API_KEY
+  commands:
+    - zypper -n install curl unzip
+    - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh"
+    - fossa analyze
+    - fossa test
+  when:
+    instance:
+      - drone-publish.longhorn.io
+    ref:
+      include:
+        - "refs/heads/master"
+    event:
+      - push
+      - tag
+
 - name: publish-image
   image: plugins/docker
   settings:


### PR DESCRIPTION
adds fossa analyze and test, the job has a `failure: ignore` as `fossa test` will return a non-zero exit which means we will get data and have to approve/fix everything in the fossa backend and then we can remove that after we get passing fossa tests.
