### PR TITLE
upgrade: Avoid CR update if there is nothing change

### DIFF
--- a/upgrade/v102to110/upgrade.go
+++ b/upgrade/v102to110/upgrade.go
@@ -122,7 +122,7 @@ func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset) (err erro
 			v = *updatedVolume
 		}
 
-		if v.Status.Robustness == types.VolumeRobustnessDegraded {
+		if v.Status.Robustness == types.VolumeRobustnessDegraded && v.Status.LastDegradedAt == "" {
 			v.Status.LastDegradedAt = util.Now()
 			if _, err := lhClient.LonghornV1beta1().Volumes(namespace).UpdateStatus(context.TODO(), &v, metav1.UpdateOptions{}); err != nil {
 				return err


### PR DESCRIPTION
This is a surgery fix for the original issue, which can not avoid
the old upgrade path intervening longhorn manager pod start.

To resolve this issue, Longhorn needs to somehow understand the
old version and the current version during system upgrade.

Longhorn/longhorn#2582