### PR TITLE
HOTFIX replicaset issues when IM crashes

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -118,6 +118,38 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
+	// we validate the staging path to make sure the global mount is still valid
+	if isMnt, err := ensureMountPoint(stagingPath, mounter); err != nil || !isMnt {
+		msg := fmt.Sprintf("NodePublishVolume: staging path is no longer valid for volume %v", volumeID)
+		logrus.Error(msg)
+
+		// HACK: normally when we return FailedPrecondition below kubelet should call NodeStageVolume again
+		//	but currently it does not, so we manually call NodeStageVolume to remount the block device globally
+		//	we currently don't reuse the previously mapped block device (major:minor) so the initial mount even after
+		//	reattachment of the longhorn block dev is no longer valid
+		logrus.Warnf("NodePublishVolume: calling NodeUnstageVolume for volume %v", volumeID)
+		_, _ = ns.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{
+			VolumeId:          volumeID,
+			StagingTargetPath: stagingPath,
+		})
+
+		logrus.Warnf("NodePublishVolume: calling NodeStageVolume for volume %v", volumeID)
+		_, err := ns.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
+			VolumeId:          volumeID,
+			PublishContext:    req.PublishContext,
+			StagingTargetPath: stagingPath,
+			VolumeCapability:  volumeCapability,
+			Secrets:           req.Secrets,
+			VolumeContext:     req.VolumeContext,
+		})
+		if err != nil {
+			logrus.Errorf("NodePublishVolume: failed NodeStageVolume staging path is still in a bad state for volume %v", volumeID)
+			return nil, status.Error(codes.FailedPrecondition, msg)
+		}
+
+		logrus.Infof("NodePublishVolume: NodeStageVolume call succeeded for volume %v continuing with regular NodePublishVolume flow", volumeID)
+	}
+
 	isMnt, err := ensureMountPoint(targetPath, mounter)
 	if err != nil {
 		msg := fmt.Sprintf("NodePublishVolume: failed to prepare mount point for volume %v error %v", volumeID, err)


### PR DESCRIPTION
After evaluating different options for addressing this issue.
I decided to do a check on the staging path and on failure to do a manual NodeUnstageVolume and NodeStageVolume call as part of the NodePublishVolume call.

The issue is only present for replicasets since they bypass the NodeStage phase depending on UpdateStrategy.
I tested this patch set for:

- RWO/RWX volumes with replica sets / stateful sets
- I tested IM crashes/deletions
- I tested kubelet restarts

This fix does not work for RWO encrypyted volumes, I worked on fixes for the encrypted RWO case.
But it introduces to much risk and issues around the case where a replicaset has multiple pods on the same node so I left them out of this patch set.

longhorn/longhorn#3070