### PR TITLE
Fixed bug: restoring backup always point to the latest backup

### DIFF
--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -301,6 +301,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		types.VolumeConditionTypeRestore, types.ConditionStatusFalse, "", "")
 	for _, e := range tc.engines {
 		e.Spec.BackupVolume = TestBackupVolumeName
+		e.Spec.RequestedBackupRestore = TestBackupName
 		e.Status.ReplicaModeMap = map[string]types.ReplicaMode{}
 	}
 	for _, r := range tc.replicas {


### PR DESCRIPTION
Set the `e.Spec.RequestedBackupRestore` to the correct backup in `v.Spec.FromBackup` for non-DR restoring volume

This fix should fix:
* First time restore from a correct backup
* Retry to restore from a correct backup

longhorn/longhorn#3111