### PR TITLE
Create the BackupVolume CR if it's the 1st volume backup

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -237,7 +237,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 			return err
 		}
 
-		if backupTarget.Spec.BackupTargetURL != "" &&
+		if backupTarget.Status.Available &&
 			backupVolume != nil && backupVolume.DeletionTimestamp == nil {
 			// Initialize a backup target client
 			backupTargetClient, err := getBackupTargetClient(bc.ds, backupTarget)
@@ -280,6 +280,11 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 			bc.enqueueBackup(backup)
 		}
 	}()
+
+	// Check the controller should run synchronization
+	if !backupTarget.Status.Available {
+		return nil
+	}
 
 	// Perform backup snapshot to the remote backup target
 	// If the Backup CR is created by the user/API layer (spec.snapshotName != "") and has not been synced (status.lastSyncedAt == ""),

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -333,8 +333,12 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 	}
 
 	clusterBackupVolumesSet := sets.NewString()
-	for _, b := range clusterBackupVolumes {
-		clusterBackupVolumesSet.Insert(b.Name)
+	for _, bv := range clusterBackupVolumes {
+		// Skip the BackupVolume CR which hasn't be pulled from the remote backup target yet
+		if bv.Status.LastSyncedAt.IsZero() {
+			continue
+		}
+		clusterBackupVolumesSet.Insert(bv.Name)
 	}
 
 	// TODO: add a unit test, separate to a function

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -218,7 +218,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		}
 
 		// Delete the backup volume from the remote backup target
-		if backupTarget.Spec.BackupTargetURL != "" {
+		if backupTarget.Status.Available {
 			// Initialize a backup target client
 			backupTargetClient, err := getBackupTargetClient(bvc.ds, backupTarget)
 			if err != nil {
@@ -250,8 +250,9 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	}()
 
 	// Check the controller should run synchronization
-	if !backupVolume.Status.LastSyncedAt.IsZero() &&
-		!backupVolume.Spec.SyncRequestedAt.After(backupVolume.Status.LastSyncedAt.Time) {
+	if !backupTarget.Status.Available ||
+		(!backupVolume.Status.LastSyncedAt.IsZero() &&
+			!backupVolume.Spec.SyncRequestedAt.After(backupVolume.Status.LastSyncedAt.Time)) {
 		return nil
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -280,8 +280,10 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	clustersSet := sets.NewString()
 	for _, b := range clusterBackups {
 		// Skip the Backup CR which is created from the local cluster and
-		// the snapshot backup hasn't be completed or pulled from the remote backup target yet
-		if b.Spec.SnapshotName != "" && b.Status.State != longhorn.BackupStateCompleted {
+		// the snapshot backup hasn't be completed and sync with the remote backup target yet
+		// note that the error/unknown Backup CRs would be included in the clustersSet
+		if b.Status.LastSyncedAt.IsZero() && b.Spec.SnapshotName != "" &&
+			(b.Status.State == longhorn.BackupStateNew || b.Status.State == longhorn.BackupStateInProgress || b.Status.State == longhorn.BackupStateCompleted) {
 			continue
 		}
 		clustersSet.Insert(b.Name)

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -160,6 +160,21 @@ func (m *VolumeManager) BackupSnapshot(backupName, volumeName, snapshotName stri
 		return err
 	}
 
+	_, err := m.ds.GetBackupVolumeRO(volumeName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		backupVolumeCR := &longhorn.BackupVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+			},
+		}
+		if _, err := m.ds.CreateBackupVolume(backupVolumeCR); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
 	backupCR := &longhorn.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: backupName,
@@ -169,7 +184,7 @@ func (m *VolumeManager) BackupSnapshot(backupName, volumeName, snapshotName stri
 			Labels:       labels,
 		},
 	}
-	_, err := m.ds.CreateBackup(backupCR, volumeName)
+	_, err = m.ds.CreateBackup(backupCR, volumeName)
 	return err
 }
 


### PR DESCRIPTION
#### Proposal Changes
- Create BackupVolume CR for the volume 1st backup.
- Inside backup_controller:
  - Do not run pull remote backup _or_ create a backup if the backup target is unavailable.
  - Only inspect the remote backup if it's a New/InProgress/Completed Backup CR.
- Inside backup_volume_controller:
  - Do not run pull remote backup volume if the backup target URL is unavailable.
  - Skip removes the Backup CR which is still in backup creation state (New/InProgress/Completed) and hasn't be synced from the remote backup target yet.
- Inside backup_target_controller: Skip removes the BackupVolume CR which hasn't be synced from the remote backup target yet.

#### Issues
- https://github.com/longhorn/longhorn/issues/3082
- https://github.com/longhorn/longhorn/issues/3141