### PR TITLE
Remove unnecessary comparisons

### DIFF
--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -263,14 +263,14 @@ func (rc *ReplicaController) UpdateReplicaEvictionStatus(replica *longhorn.Repli
 
 	// Check if eviction has been requested on this replica
 	if rc.isEvictionRequested(replica) &&
-		(!replica.Status.EvictionRequested) {
+		!replica.Status.EvictionRequested {
 		replica.Status.EvictionRequested = true
 		log.Debug("Replica has requested eviction")
 	}
 
 	// Check if eviction has been cancelled on this replica
 	if !rc.isEvictionRequested(replica) &&
-		(replica.Status.EvictionRequested) {
+		replica.Status.EvictionRequested {
 		replica.Status.EvictionRequested = false
 		log.Debug("Replica has cancelled eviction")
 	}


### PR DESCRIPTION
Fixes `staticcheck S1002` caught by [Sonatype Lift](https://lift.sonatype.com/result/longhorn/longhorn-manager/01FHW2JKTWJ3Z4RA5MMT2A53WS?t=CustomTool%20%22Staticcheck%22%7CS1002).