### PR TITLE
Validate backing image checksum during creation

### DIFF
--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -70,9 +70,18 @@ func (m *VolumeManager) CreateBackingImage(name, checksum, sourceType string, pa
 		return nil, fmt.Errorf("invalid name %v", name)
 	}
 
+	if len(checksum) != 0 {
+		checksum = strings.TrimSpace(checksum)
+
+		if !util.ValidateChecksumSHA512(checksum) {
+			return nil, fmt.Errorf("invalid checksum %v", checksum)
+		}
+	}
+
 	for k, v := range parameters {
 		parameters[k] = strings.TrimSpace(v)
 	}
+
 	switch types.BackingImageDataSourceType(sourceType) {
 	case types.BackingImageDataSourceTypeDownload:
 		if parameters[types.DataSourceTypeDownloadParameterURL] == "" {
@@ -124,7 +133,7 @@ func (m *VolumeManager) CreateBackingImage(name, checksum, sourceType string, pa
 		},
 		Spec: types.BackingImageSpec{
 			Disks:            map[string]struct{}{},
-			Checksum:         strings.TrimSpace(checksum),
+			Checksum:         checksum,
 			SourceType:       types.BackingImageDataSourceType(sourceType),
 			SourceParameters: parameters,
 		},

--- a/util/util.go
+++ b/util/util.go
@@ -282,6 +282,11 @@ func ValidateName(name string) bool {
 	return validName.MatchString(name)
 }
 
+func ValidateChecksumSHA512(checksum string) bool {
+	validChecksum := regexp.MustCompile(`^[a-f0-9]{128}$`)
+	return validChecksum.MatchString(checksum)
+}
+
 func GetBackupID(backupURL string) (string, error) {
 	u, err := url.Parse(backupURL)
 	if err != nil {


### PR DESCRIPTION
- Trim write-spaces for the backing image creation input
- Make sure the given backing image checksum is SHA512 value during creation. If the checksum is not given, skip the validation.

Ref: https://github.com/longhorn/longhorn/issues/3154