### PR TITLE
Update sm image to v1_20211020 (fs expansion support)

### DIFF
--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --instance-manager-image
         - longhornio/longhorn-instance-manager:v1_20210731
         - --share-manager-image
-        - longhornio/longhorn-share-manager:v1_20210914
+        - longhornio/longhorn-share-manager:v1_20211020
         - --backing-image-manager-image
         - longhornio/backing-image-manager:v2_20210820
         - --manager-image

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -7,5 +7,5 @@ longhornio/backing-image-manager:v2_20210820
 longhornio/longhorn-engine:master-head
 longhornio/longhorn-instance-manager:v1_20210731
 longhornio/longhorn-manager:master-head
-longhornio/longhorn-share-manager:v1_20210914
+longhornio/longhorn-share-manager:v1_20211020
 longhornio/longhorn-ui:master-head


### PR DESCRIPTION
Add filesystem expansion support into the share-manager, this is required
to support expansion for encrypted volumes. The expansion happens during
the mount phase of the volume.

longhorn/longhorn#2868