### PR TITLE
Apply podAntiAffinity rules to csi sidecar containers

### DIFF
--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -82,6 +82,30 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 					Tolerations:        tolerations,
 					NodeSelector:       nodeSelector,
 					PriorityClassName:  priorityClass,
+					Affinity: &v1.Affinity{
+						PodAntiAffinity: &v1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+								{
+									Weight: 1,
+									PodAffinityTerm: v1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values: []string{
+														commonName,
+													},
+												},
+											},
+										},
+
+										TopologyKey: v1.LabelHostname,
+									},
+								},
+							},
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name:            commonName,


### PR DESCRIPTION
To prevent the csi sidecar containers from running on one host,
apply podAntiAffinity rules to spread the workloads to different
workers.

Longhorn#2894

Signed-off-by: Derek Su <derek.su@suse.com>