### PR TITLE
Remove volume attachment recovery policy from settings

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -63,7 +63,6 @@ const (
 	SettingNameRegistrySecret                               = SettingName("registry-secret")
 	SettingNameDisableSchedulingOnCordonedNode              = SettingName("disable-scheduling-on-cordoned-node")
 	SettingNameReplicaZoneSoftAntiAffinity                  = SettingName("replica-zone-soft-anti-affinity")
-	SettingNameVolumeAttachmentRecoveryPolicy               = SettingName("volume-attachment-recovery-policy")
 	SettingNameNodeDownPodDeletionPolicy                    = SettingName("node-down-pod-deletion-policy")
 	SettingNameAllowNodeDrainWithLastHealthyReplica         = SettingName("allow-node-drain-with-last-healthy-replica")
 	SettingNameMkfsExt4Parameters                           = SettingName("mkfs-ext4-parameters")
@@ -113,7 +112,6 @@ var (
 		SettingNameRegistrySecret,
 		SettingNameDisableSchedulingOnCordonedNode,
 		SettingNameReplicaZoneSoftAntiAffinity,
-		SettingNameVolumeAttachmentRecoveryPolicy,
 		SettingNameNodeDownPodDeletionPolicy,
 		SettingNameAllowNodeDrainWithLastHealthyReplica,
 		SettingNameMkfsExt4Parameters,
@@ -184,7 +182,6 @@ var (
 		SettingNameRegistrySecret:                               SettingDefinitionRegistrySecret,
 		SettingNameDisableSchedulingOnCordonedNode:              SettingDefinitionDisableSchedulingOnCordonedNode,
 		SettingNameReplicaZoneSoftAntiAffinity:                  SettingDefinitionReplicaZoneSoftAntiAffinity,
-		SettingNameVolumeAttachmentRecoveryPolicy:               SettingDefinitionVolumeAttachmentRecoveryPolicy,
 		SettingNameNodeDownPodDeletionPolicy:                    SettingDefinitionNodeDownPodDeletionPolicy,
 		SettingNameAllowNodeDrainWithLastHealthyReplica:         SettingDefinitionAllowNodeDrainWithLastHealthyReplica,
 		SettingNameMkfsExt4Parameters:                           SettingDefinitionMkfsExt4Parameters,
@@ -531,23 +528,6 @@ var (
 		ReadOnly:    false,
 		Default:     "true",
 	}
-	SettingDefinitionVolumeAttachmentRecoveryPolicy = SettingDefinition{
-		DisplayName: "Volume Attachment Recovery Policy",
-		Description: "Defines the Longhorn action when a Volume is stuck with a Deployment Pod on a failed node.\n" +
-			"- **wait** leads to the deletion of the volume attachment as soon as the pods deletion time has passed.\n" +
-			"- **never** is the default Kubernetes behavior of never deleting volume attachments on terminating pods.\n" +
-			"- **immediate** leads to the deletion of the volume attachment as soon as all workload pods are pending.\n",
-		Category: SettingCategoryGeneral,
-		Type:     SettingTypeDeprecated,
-		Required: true,
-		ReadOnly: false,
-		Default:  string(VolumeAttachmentRecoveryPolicyWait),
-		Choices: []string{
-			string(VolumeAttachmentRecoveryPolicyNever),
-			string(VolumeAttachmentRecoveryPolicyWait),
-			string(VolumeAttachmentRecoveryPolicyImmediate),
-		},
-	}
 	SettingDefinitionNodeDownPodDeletionPolicy = SettingDefinition{
 		DisplayName: "Pod Deletion Policy When Node is Down",
 		Description: "Defines the Longhorn action when a Volume is stuck with a StatefulSet/Deployment Pod on a node that is down.\n" +
@@ -755,14 +735,6 @@ var (
 	}
 )
 
-type VolumeAttachmentRecoveryPolicy string
-
-const (
-	VolumeAttachmentRecoveryPolicyNever     = VolumeAttachmentRecoveryPolicy("never") // Kubernetes default behavior
-	VolumeAttachmentRecoveryPolicyWait      = VolumeAttachmentRecoveryPolicy("wait")  // Longhorn default behavior
-	VolumeAttachmentRecoveryPolicyImmediate = VolumeAttachmentRecoveryPolicy("immediate")
-)
-
 type NodeDownPodDeletionPolicy string
 
 const (
@@ -890,8 +862,6 @@ func ValidateInitSetting(name, value string) (err error) {
 		}
 
 	// multi-choices
-	case SettingNameVolumeAttachmentRecoveryPolicy:
-		fallthrough
 	case SettingNameNodeDownPodDeletionPolicy:
 		fallthrough
 	case SettingNameDefaultDataLocality:


### PR DESCRIPTION
The volume attachment recovery policy is deprecated/removed from LH v1.1.2.
We'll release v1.3.0 in the next coming release, we could consider fully removing the code from the setting.