### PR TITLE
Fix UI can't set empty backup target credential secret

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -115,7 +115,10 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 	case types.SettingNameBackupTargetCredentialSecret:
 		secret, err := s.GetSecretRO(s.namespace, value)
 		if err != nil {
-			return errors.Wrapf(err, "failed to list the secret %v before modifying backup target credential secret setting", value)
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "failed to get the secret before modifying backup target credential secret setting")
+			}
+			return nil
 		}
 		checkKeyList := []string{
 			types.AWSAccessKey,


### PR DESCRIPTION
#### Proposal change

If the secret is not found, do not proceed with it.
Also, remove duplicate retry on conflict since it's being handled at
- https://github.com/longhorn/longhorn-manager/blob/dbdea97/api/router.go#L61
- https://github.com/longhorn/longhorn-manager/blob/dbdea97/api/router.go#L47
- https://github.com/longhorn/longhorn-manager/blob/dbdea97/api/router.go#L25-L35

#### Issue
https://github.com/longhorn/longhorn/issues/3261