### PR TITLE
[BACKPORT] Check the Backup CR state instead of engine's backup state

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -587,13 +587,13 @@ func (job *Job) doRecurringBackup() (err error) {
 		switch info.State {
 		case string(longhorn.BackupStateCompleted):
 			complete = true
-			job.logger.Debugf("Complete creating backup %v", info.BackupURL)
+			job.logger.Debugf("Complete creating backup %v", info.Id)
 		case string(longhorn.BackupStateNew), string(longhorn.BackupStateInProgress):
-			job.logger.Debugf("Creating backup %v, current progress %v", info.BackupURL, info.Progress)
+			job.logger.Debugf("Creating backup %v, current progress %v", info.Id, info.Progress)
 		case string(longhorn.BackupStateError), string(longhorn.BackupStateUnknown):
-			return fmt.Errorf("failed to create backup %v: %v", info.BackupURL, info.Error)
+			return fmt.Errorf("failed to create backup %v: %v", info.Id, info.Error)
 		default:
-			return fmt.Errorf("invalid state %v for backup %v", info.State, info.BackupURL)
+			return fmt.Errorf("invalid state %v for backup %v", info.State, info.Id)
 		}
 
 		if complete {

--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -585,12 +585,12 @@ func (job *Job) doRecurringBackup() (err error) {
 		complete := false
 
 		switch info.State {
-		case engineapi.BackupStateComplete:
+		case string(longhorn.BackupStateCompleted):
 			complete = true
 			job.logger.Debugf("Complete creating backup %v", info.BackupURL)
-		case engineapi.BackupStateInProgress:
+		case string(longhorn.BackupStateNew), string(longhorn.BackupStateInProgress):
 			job.logger.Debugf("Creating backup %v, current progress %v", info.BackupURL, info.Progress)
-		case engineapi.BackupStateError:
+		case string(longhorn.BackupStateError), string(longhorn.BackupStateUnknown):
 			return fmt.Errorf("failed to create backup %v: %v", info.BackupURL, info.Error)
 		default:
 			return fmt.Errorf("invalid state %v for backup %v", info.State, info.BackupURL)

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -16,6 +16,12 @@ import (
 	"github.com/longhorn/longhorn-manager/util"
 )
 
+const (
+	backupStateInProgress = "in_progress"
+	backupStateComplete   = "complete"
+	backupStateError      = "error"
+)
+
 type BackupTargetClient struct {
 	Image      string
 	URL        string
@@ -314,11 +320,11 @@ func (e *Engine) SnapshotBackupStatus(backupName, replicaAddress string) (*longh
 func ConvertEngineBackupState(state string) longhorn.BackupState {
 	// https://github.com/longhorn/longhorn-engine/blob/9da3616/pkg/replica/backup.go#L20-L22
 	switch state {
-	case BackupStateInProgress:
+	case backupStateInProgress:
 		return longhorn.BackupStateInProgress
-	case BackupStateComplete:
+	case backupStateComplete:
 		return longhorn.BackupStateCompleted
-	case BackupStateError:
+	case backupStateError:
 		return longhorn.BackupStateError
 	default:
 		return longhorn.BackupStateUnknown

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -225,15 +225,15 @@ func TestConvertEngineBackupState(t *testing.T) {
 		expectState longhorn.BackupState
 	}{
 		{
-			inputState:  BackupStateInProgress,
+			inputState:  backupStateInProgress,
 			expectState: longhorn.BackupStateInProgress,
 		},
 		{
-			inputState:  BackupStateComplete,
+			inputState:  backupStateComplete,
 			expectState: longhorn.BackupStateCompleted,
 		},
 		{
-			inputState:  BackupStateError,
+			inputState:  backupStateError,
 			expectState: longhorn.BackupStateError,
 		},
 		{

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -28,10 +28,6 @@ const (
 
 	commonTimeout = 1 * time.Minute
 
-	BackupStateComplete   = "complete"
-	BackupStateError      = "error"
-	BackupStateInProgress = "in_progress"
-
 	// MaxPollCount, MinPollCount, PollInterval determines how often
 	// we sync with others
 


### PR DESCRIPTION
### Proposal Changes

- Update the recurring job to check the Backup CR state (`InProgress`/`Completed`/`Error`) instead of checking the engine's backup state (`in_progress`/`complete`/`error`)
- Change the engine CR state to private variable to avoid misuse.

#### Issue

https://github.com/longhorn/longhorn/issues/3312