### PR TITLE
Handle the CRD validation error

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -91,6 +91,7 @@ spec:
               runningParameters:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               size:
                 format: int64
@@ -174,6 +175,7 @@ spec:
               runningParameters:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               size:
                 format: int64
@@ -303,6 +305,7 @@ spec:
                     uuid:
                       type: string
                   type: object
+                nullable: true
                 type: object
               currentState:
                 type: string
@@ -408,6 +411,7 @@ spec:
                     uuid:
                       type: string
                   type: object
+                nullable: true
                 type: object
               currentState:
                 type: string
@@ -501,12 +505,14 @@ spec:
                 additionalProperties:
                   type: integer
                 description: 'Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.'
+                nullable: true
                 type: object
               diskDownloadStateMap:
                 additionalProperties:
                   description: BackingImageDownloadState is replaced by BackingImageState.
                   type: string
                 description: 'Deprecated: Replaced by field `State` in `DiskFileStatusMap`.'
+                nullable: true
                 type: object
               diskFileStatusMap:
                 additionalProperties:
@@ -520,10 +526,12 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               diskLastRefAtMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               ownerID:
                 type: string
@@ -591,12 +599,14 @@ spec:
                 additionalProperties:
                   type: integer
                 description: 'Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.'
+                nullable: true
                 type: object
               diskDownloadStateMap:
                 additionalProperties:
                   description: BackingImageDownloadState is replaced by BackingImageState.
                   type: string
                 description: 'Deprecated: Replaced by field `State` in `DiskFileStatusMap`.'
+                nullable: true
                 type: object
               diskFileStatusMap:
                 additionalProperties:
@@ -610,10 +620,12 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               diskLastRefAtMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               ownerID:
                 type: string
@@ -703,6 +715,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -718,15 +731,18 @@ spec:
                 additionalProperties:
                   type: string
                 description: The labels of snapshot backup.
+                nullable: true
                 type: object
               lastSyncedAt:
                 description: The last time that the backup was synced with the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
                 description: The error messages when calling longhorn engine on listing or inspecting backups.
+                nullable: true
                 type: object
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup CR.
@@ -818,6 +834,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -833,15 +850,18 @@ spec:
                 additionalProperties:
                   type: string
                 description: The labels of snapshot backup.
+                nullable: true
                 type: object
               lastSyncedAt:
                 description: The last time that the backup was synced with the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
                 description: The error messages when calling longhorn engine on listing or inspecting backups.
+                nullable: true
                 type: object
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup CR.
@@ -961,6 +981,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -992,10 +1013,12 @@ spec:
                       type: string
                   type: object
                 description: Records the reason on why the backup target is unavailable.
+                nullable: true
                 type: object
               lastSyncedAt:
                 description: The last time that the controller synced with the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup target CR.
@@ -1055,6 +1078,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -1086,10 +1110,12 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: array
               lastSyncedAt:
                 description: The last time that the controller synced with the remote backup target.
                 format: date-time
+                nullable: true
                 type: string
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup target CR.
@@ -1163,6 +1189,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup volume.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -1184,6 +1211,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: The backup volume labels.
+                nullable: true
                 type: object
               lastBackupAt:
                 description: The latest volume backup time.
@@ -1194,15 +1222,18 @@ spec:
               lastModificationTime:
                 description: The backup volume config last modification time.
                 format: date-time
+                nullable: true
                 type: string
               lastSyncedAt:
                 description: The last time that the backup volume was synced into the cluster.
                 format: date-time
+                nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
                 description: The error messages when call longhorn engine on list or inspect backup volumes.
+                nullable: true
                 type: object
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup volume CR.
@@ -1252,6 +1283,7 @@ spec:
               syncRequestedAt:
                 description: The time to request run sync the remote backup volume.
                 format: date-time
+                nullable: true
                 type: string
             type: object
           status:
@@ -1273,6 +1305,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: The backup volume labels.
+                nullable: true
                 type: object
               lastBackupAt:
                 description: The latest volume backup time.
@@ -1283,15 +1316,18 @@ spec:
               lastModificationTime:
                 description: The backup volume config last modification time.
                 format: date-time
+                nullable: true
                 type: string
               lastSyncedAt:
                 description: The last time that the backup volume was synced into the cluster.
                 format: date-time
+                nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
                 description: The error messages when call longhorn engine on list or inspect backup volumes.
+                nullable: true
                 type: object
               ownerID:
                 description: The node ID on which the controller is responsible to reconcile this backup volume CR.
@@ -1402,6 +1438,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: object
               controllerAPIMinVersion:
                 type: integer
@@ -1418,6 +1455,7 @@ spec:
               nodeDeploymentMap:
                 additionalProperties:
                   type: boolean
+                nullable: true
                 type: object
               ownerID:
                 type: string
@@ -1503,6 +1541,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: array
               controllerAPIMinVersion:
                 type: integer
@@ -1519,6 +1558,7 @@ spec:
               nodeDeploymentMap:
                 additionalProperties:
                   type: boolean
+                nullable: true
                 type: object
               ownerID:
                 type: string
@@ -1663,6 +1703,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               cloneStatus:
                 additionalProperties:
@@ -1680,12 +1721,14 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               currentImage:
                 type: string
               currentReplicaAddressMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               currentSize:
                 format: int64
@@ -1724,6 +1767,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               rebuildStatus:
                 additionalProperties:
@@ -1739,10 +1783,12 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               replicaModeMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               restoreStatus:
                 additionalProperties:
@@ -1764,6 +1810,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               salvageExecuted:
                 type: boolean
@@ -1791,6 +1838,7 @@ spec:
                     usercreated:
                       type: boolean
                   type: object
+                nullable: true
                 type: object
               snapshotsError:
                 type: string
@@ -1904,6 +1952,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               cloneStatus:
                 additionalProperties:
@@ -1921,12 +1970,14 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               currentImage:
                 type: string
               currentReplicaAddressMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               currentSize:
                 format: int64
@@ -1965,6 +2016,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               rebuildStatus:
                 additionalProperties:
@@ -1980,10 +2032,12 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               replicaModeMap:
                 additionalProperties:
                   type: string
+                nullable: true
                 type: object
               restoreStatus:
                 additionalProperties:
@@ -2005,6 +2059,7 @@ spec:
                     state:
                       type: string
                   type: object
+                nullable: true
                 type: object
               salvageExecuted:
                 type: boolean
@@ -2032,6 +2087,7 @@ spec:
                     usercreated:
                       type: boolean
                   type: object
+                nullable: true
                 type: object
               snapshotsError:
                 type: string
@@ -2155,6 +2211,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: object
               ip:
                 type: string
@@ -2251,6 +2308,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: object
               ip:
                 type: string
@@ -2381,6 +2439,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: object
               diskStatus:
                 additionalProperties:
@@ -2407,6 +2466,7 @@ spec:
                             description: Type is the type of the condition.
                             type: string
                         type: object
+                      nullable: true
                       type: object
                     diskUUID:
                       type: string
@@ -2414,6 +2474,7 @@ spec:
                       additionalProperties:
                         format: int64
                         type: integer
+                      nullable: true
                       type: object
                     storageAvailable:
                       format: int64
@@ -2425,6 +2486,7 @@ spec:
                       format: int64
                       type: integer
                   type: object
+                nullable: true
                 type: object
               region:
                 type: string
@@ -2528,6 +2590,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: array
               diskStatus:
                 additionalProperties:
@@ -2554,6 +2617,7 @@ spec:
                             description: Type is the type of the condition.
                             type: string
                         type: object
+                      nullable: true
                       type: array
                     diskUUID:
                       type: string
@@ -2561,6 +2625,7 @@ spec:
                       additionalProperties:
                         format: int64
                         type: integer
+                      nullable: true
                       type: object
                     storageAvailable:
                       format: int64
@@ -2572,6 +2637,7 @@ spec:
                       format: int64
                       type: integer
                   type: object
+                nullable: true
                 type: object
               region:
                 type: string
@@ -3447,6 +3513,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: object
               currentImage:
                 type: string
@@ -3486,6 +3553,7 @@ spec:
                         workloadType:
                           type: string
                       type: object
+                    nullable: true
                     type: array
                 type: object
               lastBackup:
@@ -3695,6 +3763,7 @@ spec:
                       description: Type is the type of the condition.
                       type: string
                   type: object
+                nullable: true
                 type: array
               currentImage:
                 type: string
@@ -3734,6 +3803,7 @@ spec:
                         workloadType:
                           type: string
                       type: object
+                    nullable: true
                     type: array
                 type: object
               lastBackup:

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -54,14 +54,18 @@ type BackingImageStatus struct {
 	// +optional
 	Checksum string `json:"checksum"`
 	// +optional
+	// +nullable
 	DiskFileStatusMap map[string]*BackingImageDiskFileStatus `json:"diskFileStatusMap"`
 	// +optional
+	// +nullable
 	DiskLastRefAtMap map[string]string `json:"diskLastRefAtMap"`
 	// Deprecated: Replaced by field `State` in `DiskFileStatusMap`.
 	// +optional
+	// +nullable
 	DiskDownloadStateMap map[string]BackingImageDownloadState `json:"diskDownloadStateMap"`
 	// Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.
 	// +optional
+	// +nullable
 	DiskDownloadProgressMap map[string]int `json:"diskDownloadProgressMap"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
@@ -38,6 +38,7 @@ type BackingImageDataSourceStatus struct {
 	// +optional
 	OwnerID string `json:"ownerID"`
 	// +optional
+	// +nullable
 	RunningParameters map[string]string `json:"runningParameters"`
 	// +optional
 	CurrentState BackingImageState `json:"currentState"`

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
@@ -63,6 +63,7 @@ type BackingImageManagerStatus struct {
 	// +optional
 	CurrentState BackingImageManagerState `json:"currentState"`
 	// +optional
+	// +nullable
 	BackingImageFileMap map[string]BackingImageFileInfo `json:"backingImageFileMap"`
 	// +optional
 	IP string `json:"ip"`

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -16,6 +16,7 @@ const (
 type BackupSpec struct {
 	// The time to request run sync the remote backup.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 	// The snapshot name.
 	// +optional
@@ -60,9 +61,11 @@ type BackupStatus struct {
 	Size string `json:"size"`
 	// The labels of snapshot backup.
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The error messages when calling longhorn engine on listing or inspecting backups.
 	// +optional
+	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The volume name.
 	// +optional
@@ -78,6 +81,7 @@ type BackupStatus struct {
 	VolumeBackingImageName string `json:"volumeBackingImageName"`
 	// The last time that the backup was synced with the remote backup target.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
@@ -21,6 +21,7 @@ type BackupTargetSpec struct {
 	PollInterval metav1.Duration `json:"pollInterval"`
 	// The time to request run sync the remote backup target.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
@@ -34,9 +35,11 @@ type BackupTargetStatus struct {
 	Available bool `json:"available"`
 	// Records the reason on why the backup target is unavailable.
 	// +optional
+	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// The last time that the controller synced with the remote backup target.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
@@ -6,6 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type BackupVolumeSpec struct {
 	// The time to request run sync the remote backup volume.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
@@ -16,12 +17,14 @@ type BackupVolumeStatus struct {
 	OwnerID string `json:"ownerID"`
 	// The backup volume config last modification time.
 	// +optional
+	// +nullable
 	LastModificationTime metav1.Time `json:"lastModificationTime"`
 	// The backup volume size.
 	// +optional
 	Size string `json:"size"`
 	// The backup volume labels.
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The backup volume creation time.
 	// +optional
@@ -37,6 +40,7 @@ type BackupVolumeStatus struct {
 	DataStored string `json:"dataStored"`
 	// The error messages when call longhorn engine on list or inspect backup volumes.
 	// +optional
+	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The backing image name.
 	// +optional
@@ -46,6 +50,7 @@ type BackupVolumeStatus struct {
 	BackingImageChecksum string `json:"backingImageChecksum"`
 	// The last time that the backup volume was synced into the cluster.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engine.go
@@ -132,24 +132,32 @@ type EngineStatus struct {
 	// +optional
 	CurrentSize int64 `json:"currentSize,string"`
 	// +optional
+	// +nullable
 	CurrentReplicaAddressMap map[string]string `json:"currentReplicaAddressMap"`
 	// +optional
+	// +nullable
 	ReplicaModeMap map[string]ReplicaMode `json:"replicaModeMap"`
 	// +optional
 	Endpoint string `json:"endpoint"`
 	// +optional
 	LastRestoredBackup string `json:"lastRestoredBackup"`
 	// +optional
+	// +nullable
 	BackupStatus map[string]*EngineBackupStatus `json:"backupStatus"`
 	// +optional
+	// +nullable
 	RestoreStatus map[string]*RestoreStatus `json:"restoreStatus"`
 	// +optional
+	// +nullable
 	PurgeStatus map[string]*PurgeStatus `json:"purgeStatus"`
 	// +optional
+	// +nullable
 	RebuildStatus map[string]*RebuildStatus `json:"rebuildStatus"`
 	// +optional
+	// +nullable
 	CloneStatus map[string]*SnapshotCloneStatus `json:"cloneStatus"`
 	// +optional
+	// +nullable
 	Snapshots map[string]*Snapshot `json:"snapshots"`
 	// +optional
 	SnapshotsError string `json:"snapshotsError"`

--- a/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
@@ -56,8 +56,10 @@ type EngineImageStatus struct {
 	// +optional
 	NoRefSince string `json:"noRefSince"`
 	// +optional
+	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// +optional
+	// +nullable
 	NodeDeploymentMap    map[string]bool `json:"nodeDeploymentMap"`
 	EngineVersionDetails `json:""`
 }

--- a/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
@@ -128,6 +128,7 @@ type InstanceManagerStatus struct {
 	// +optional
 	CurrentState InstanceManagerState `json:"currentState"`
 	// +optional
+	// +nullable
 	Instances map[string]InstanceProcess `json:"instances"`
 	// +optional
 	IP string `json:"ip"`

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -46,6 +46,7 @@ type DiskSpec struct {
 
 type DiskStatus struct {
 	// +optional
+	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// +optional
 	StorageAvailable int64 `json:"storageAvailable"`
@@ -54,6 +55,7 @@ type DiskStatus struct {
 	// +optional
 	StorageMaximum int64 `json:"storageMaximum"`
 	// +optional
+	// +nullable
 	ScheduledReplica map[string]int64 `json:"scheduledReplica"`
 	// +optional
 	DiskUUID string `json:"diskUUID"`
@@ -82,8 +84,10 @@ type NodeSpec struct {
 // NodeStatus defines the observed state of the Longhorn node
 type NodeStatus struct {
 	// +optional
+	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// +optional
+	// +nullable
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
 	// +optional
 	Region string `json:"region"`

--- a/k8s/pkg/apis/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/volume.go
@@ -133,6 +133,7 @@ type KubernetesStatus struct {
 	LastPVCRefAt string `json:"lastPVCRefAt"`
 	// determine if Pod/Workload is history or not
 	// +optional
+	// +nullable
 	WorkloadsStatus []WorkloadStatus `json:"workloadsStatus"`
 	// +optional
 	LastPodRefAt string `json:"lastPodRefAt"`
@@ -218,6 +219,7 @@ type VolumeStatus struct {
 	// +optional
 	KubernetesStatus KubernetesStatus `json:"kubernetesStatus"`
 	// +optional
+	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// +optional
 	LastBackup string `json:"lastBackup"`

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
@@ -54,14 +54,18 @@ type BackingImageStatus struct {
 	// +optional
 	Checksum string `json:"checksum"`
 	// +optional
+	// +nullable
 	DiskFileStatusMap map[string]*BackingImageDiskFileStatus `json:"diskFileStatusMap"`
 	// +optional
+	// +nullable
 	DiskLastRefAtMap map[string]string `json:"diskLastRefAtMap"`
 	// Deprecated: Replaced by field `State` in `DiskFileStatusMap`.
 	// +optional
+	// +nullable
 	DiskDownloadStateMap map[string]BackingImageDownloadState `json:"diskDownloadStateMap"`
 	// Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.
 	// +optional
+	// +nullable
 	DiskDownloadProgressMap map[string]int `json:"diskDownloadProgressMap"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
@@ -38,6 +38,7 @@ type BackingImageDataSourceStatus struct {
 	// +optional
 	OwnerID string `json:"ownerID"`
 	// +optional
+	// +nullable
 	RunningParameters map[string]string `json:"runningParameters"`
 	// +optional
 	CurrentState BackingImageState `json:"currentState"`

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimagemanager.go
@@ -63,6 +63,7 @@ type BackingImageManagerStatus struct {
 	// +optional
 	CurrentState BackingImageManagerState `json:"currentState"`
 	// +optional
+	// +nullable
 	BackingImageFileMap map[string]BackingImageFileInfo `json:"backingImageFileMap"`
 	// +optional
 	IP string `json:"ip"`

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -16,6 +16,7 @@ const (
 type BackupSpec struct {
 	// The time to request run sync the remote backup.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 	// The snapshot name.
 	// +optional
@@ -60,9 +61,11 @@ type BackupStatus struct {
 	Size string `json:"size"`
 	// The labels of snapshot backup.
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The error messages when calling longhorn engine on listing or inspecting backups.
 	// +optional
+	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The volume name.
 	// +optional
@@ -78,6 +81,7 @@ type BackupStatus struct {
 	VolumeBackingImageName string `json:"volumeBackingImageName"`
 	// The last time that the backup was synced with the remote backup target.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta2/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backuptarget.go
@@ -21,6 +21,7 @@ type BackupTargetSpec struct {
 	PollInterval metav1.Duration `json:"pollInterval"`
 	// The time to request run sync the remote backup target.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
@@ -34,9 +35,11 @@ type BackupTargetStatus struct {
 	Available bool `json:"available"`
 	// Records the reason on why the backup target is unavailable.
 	// +optional
+	// +nullable
 	Conditions []Condition `json:"conditions"`
 	// The last time that the controller synced with the remote backup target.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
@@ -6,6 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type BackupVolumeSpec struct {
 	// The time to request run sync the remote backup volume.
 	// +optional
+	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
@@ -16,12 +17,14 @@ type BackupVolumeStatus struct {
 	OwnerID string `json:"ownerID"`
 	// The backup volume config last modification time.
 	// +optional
+	// +nullable
 	LastModificationTime metav1.Time `json:"lastModificationTime"`
 	// The backup volume size.
 	// +optional
 	Size string `json:"size"`
 	// The backup volume labels.
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The backup volume creation time.
 	// +optional
@@ -37,6 +40,7 @@ type BackupVolumeStatus struct {
 	DataStored string `json:"dataStored"`
 	// The error messages when call longhorn engine on list or inspect backup volumes.
 	// +optional
+	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The backing image name.
 	// +optional
@@ -46,6 +50,7 @@ type BackupVolumeStatus struct {
 	BackingImageChecksum string `json:"backingImageChecksum"`
 	// The last time that the backup volume was synced into the cluster.
 	// +optional
+	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engine.go
@@ -132,24 +132,32 @@ type EngineStatus struct {
 	// +optional
 	CurrentSize int64 `json:"currentSize,string"`
 	// +optional
+	// +nullable
 	CurrentReplicaAddressMap map[string]string `json:"currentReplicaAddressMap"`
 	// +optional
+	// +nullable
 	ReplicaModeMap map[string]ReplicaMode `json:"replicaModeMap"`
 	// +optional
 	Endpoint string `json:"endpoint"`
 	// +optional
 	LastRestoredBackup string `json:"lastRestoredBackup"`
 	// +optional
+	// +nullable
 	BackupStatus map[string]*EngineBackupStatus `json:"backupStatus"`
 	// +optional
+	// +nullable
 	RestoreStatus map[string]*RestoreStatus `json:"restoreStatus"`
 	// +optional
+	// +nullable
 	PurgeStatus map[string]*PurgeStatus `json:"purgeStatus"`
 	// +optional
+	// +nullable
 	RebuildStatus map[string]*RebuildStatus `json:"rebuildStatus"`
 	// +optional
+	// +nullable
 	CloneStatus map[string]*SnapshotCloneStatus `json:"cloneStatus"`
 	// +optional
+	// +nullable
 	Snapshots map[string]*Snapshot `json:"snapshots"`
 	// +optional
 	SnapshotsError string `json:"snapshotsError"`

--- a/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
@@ -56,8 +56,10 @@ type EngineImageStatus struct {
 	// +optional
 	NoRefSince string `json:"noRefSince"`
 	// +optional
+	// +nullable
 	Conditions []Condition `json:"conditions"`
 	// +optional
+	// +nullable
 	NodeDeploymentMap    map[string]bool `json:"nodeDeploymentMap"`
 	EngineVersionDetails `json:""`
 }

--- a/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
@@ -128,6 +128,7 @@ type InstanceManagerStatus struct {
 	// +optional
 	CurrentState InstanceManagerState `json:"currentState"`
 	// +optional
+	// +nullable
 	Instances map[string]InstanceProcess `json:"instances"`
 	// +optional
 	IP string `json:"ip"`

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -46,6 +46,7 @@ type DiskSpec struct {
 
 type DiskStatus struct {
 	// +optional
+	// +nullable
 	Conditions []Condition `json:"conditions"`
 	// +optional
 	StorageAvailable int64 `json:"storageAvailable"`
@@ -54,6 +55,7 @@ type DiskStatus struct {
 	// +optional
 	StorageMaximum int64 `json:"storageMaximum"`
 	// +optional
+	// +nullable
 	ScheduledReplica map[string]int64 `json:"scheduledReplica"`
 	// +optional
 	DiskUUID string `json:"diskUUID"`
@@ -82,8 +84,10 @@ type NodeSpec struct {
 // NodeStatus defines the observed state of the Longhorn node
 type NodeStatus struct {
 	// +optional
+	// +nullable
 	Conditions []Condition `json:"conditions"`
 	// +optional
+	// +nullable
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
 	// +optional
 	Region string `json:"region"`

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -133,6 +133,7 @@ type KubernetesStatus struct {
 	LastPVCRefAt string `json:"lastPVCRefAt"`
 	// determine if Pod/Workload is history or not
 	// +optional
+	// +nullable
 	WorkloadsStatus []WorkloadStatus `json:"workloadsStatus"`
 	// +optional
 	LastPodRefAt string `json:"lastPodRefAt"`
@@ -218,6 +219,7 @@ type VolumeStatus struct {
 	// +optional
 	KubernetesStatus KubernetesStatus `json:"kubernetesStatus"`
 	// +optional
+	// +nullable
 	Conditions []Condition `json:"conditions"`
 	// +optional
 	LastBackup string `json:"lastBackup"`

--- a/types/types.go
+++ b/types/types.go
@@ -627,6 +627,7 @@ func CreateDefaultDisk(dataPath string) (map[string]longhorn.DiskSpec, error) {
 			AllowScheduling:   true,
 			EvictionRequested: false,
 			StorageReserved:   diskInfo.StorageMaximum * 30 / 100,
+			Tags:              []string{},
 		},
 	}, nil
 }

--- a/upgrade/v1beta1/upgrade.go
+++ b/upgrade/v1beta1/upgrade.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/jinzhu/copier"
@@ -44,6 +45,21 @@ func UpgradeCRFromV1beta1ToV1beta2(config *restclient.Config, namespace string, 
 	if err := upgradeNodes(namespace, lhClient); err != nil {
 		return err
 	}
+	if err := upgradeRecurringJobs(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeBackups(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeBackingImageDataSources(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeBackingImageManagers(namespace, lhClient); err != nil {
+		return err
+	}
+	if err := upgradeBackingImages(namespace, lhClient); err != nil {
+		return err
+	}
 
 	logrus.Infof("%v completed", upgradeLogPrefix)
 	return nil
@@ -76,6 +92,10 @@ func CanUpgrade(config *restclient.Config, namespace string) (bool, error) {
 }
 
 func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupVolumes(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up volumes")
+	}
+
 	volumes, err := lhClient.LonghornV1beta1().Volumes(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
 	})
@@ -87,7 +107,7 @@ func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset) error {
 		new := longhorn.Volume{}
 
 		if err := copier.Copy(&new, &old); err != nil {
-			return err
+			return errors.Wrap(err, "fail to copy volume")
 		}
 
 		conditions, err := copyConditions(old.Status.Conditions)
@@ -120,6 +140,49 @@ func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset) error {
 	return nil
 }
 
+func fixupVolumes(namespace string, lhClient *lhclientset.Clientset) error {
+	volumes, err := lhClient.LonghornV1beta1().Volumes(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range volumes.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.DiskSelector == nil {
+			obj.Spec.DiskSelector = []string{}
+		}
+		if obj.Spec.NodeSelector == nil {
+			obj.Spec.NodeSelector = []string{}
+		}
+		if obj.Spec.RecurringJobs == nil {
+			obj.Spec.RecurringJobs = make([]longhornV1beta1.VolumeRecurringJobSpec, 0)
+		}
+		for i, src := range obj.Spec.RecurringJobs {
+			dst := longhornV1beta1.VolumeRecurringJobSpec{}
+			if err := copier.Copy(&dst, &src); err != nil {
+				return err
+			}
+			if dst.Groups == nil {
+				dst.Groups = []string{}
+			}
+			if dst.Labels == nil {
+				dst.Labels = make(map[string]string, 0)
+			}
+			obj.Spec.RecurringJobs[i] = dst
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().Volumes(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset) error {
 	engineImages, err := lhClient.LonghornV1beta1().EngineImages(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
@@ -132,7 +195,7 @@ func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset) erro
 		new := longhorn.EngineImage{}
 
 		if err := copier.Copy(&new, &old); err != nil {
-			return err
+			return errors.Wrap(err, "fail to copy engineImage")
 		}
 
 		conditions, err := copyConditions(old.Status.Conditions)
@@ -173,7 +236,7 @@ func upgradeBackupTargets(namespace string, lhClient *lhclientset.Clientset) err
 		new := longhorn.BackupTarget{}
 
 		if err := copier.Copy(&new, &old); err != nil {
-			return err
+			return errors.Wrap(err, "fail to copy backupTarget")
 		}
 
 		conditions, err := copyConditions(old.Status.Conditions)
@@ -199,6 +262,10 @@ func upgradeBackupTargets(namespace string, lhClient *lhclientset.Clientset) err
 }
 
 func upgradeNodes(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupNodes(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up nodes")
+	}
+
 	nodes, err := lhClient.LonghornV1beta1().Nodes(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
 	})
@@ -210,7 +277,7 @@ func upgradeNodes(namespace string, lhClient *lhclientset.Clientset) error {
 		new := longhorn.Node{}
 
 		if err := copier.Copy(&new, &old); err != nil {
-			return err
+			return errors.Wrap(err, "fail to copy node")
 		}
 
 		new.Status.Conditions, err = copyConditions(old.Status.Conditions)
@@ -231,11 +298,212 @@ func upgradeNodes(namespace string, lhClient *lhclientset.Clientset) error {
 		if err := tagCRLabelCRDAPIversion(obj); err != nil {
 			return errors.Wrapf(err, "failed to add label to %v %v", obj.Kind, obj.Name)
 		}
+
 		if _, err := lhClient.LonghornV1beta2().Nodes(namespace).Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
 			return errors.Wrapf(err, "failed to update for %v %v", obj.Kind, obj.Name)
 		}
 	}
 	logrus.Info("Finished upgrading nodes")
+	return nil
+}
+
+func fixupNodes(namespace string, lhClient *lhclientset.Clientset) error {
+	nodes, err := lhClient.LonghornV1beta1().Nodes(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range nodes.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.Disks == nil {
+			obj.Spec.Disks = make(map[string]longhornV1beta1.DiskSpec, 0)
+		}
+		for key, src := range obj.Spec.Disks {
+			if src.Tags == nil {
+				dst := longhornV1beta1.DiskSpec{}
+
+				if err := copier.Copy(&dst, &src); err != nil {
+					return err
+				}
+				dst.Tags = []string{}
+
+				obj.Spec.Disks[key] = dst
+			}
+		}
+		if obj.Spec.Tags == nil {
+			obj.Spec.Tags = []string{}
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().Nodes(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeRecurringJobs(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupRecurringJobs(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up recurringJobs")
+	}
+	return nil
+}
+
+func fixupRecurringJobs(namespace string, lhClient *lhclientset.Clientset) error {
+	recurringJobs, err := lhClient.LonghornV1beta1().RecurringJobs(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range recurringJobs.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.Groups == nil {
+			obj.Spec.Groups = []string{}
+		}
+		if obj.Spec.Labels == nil {
+			obj.Spec.Labels = make(map[string]string, 0)
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().RecurringJobs(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeBackups(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupBackups(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up backups")
+	}
+	return nil
+}
+
+func fixupBackups(namespace string, lhClient *lhclientset.Clientset) error {
+	backups, err := lhClient.LonghornV1beta1().Backups(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range backups.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.Labels == nil {
+			obj.Spec.Labels = make(map[string]string, 0)
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().Backups(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeBackingImageDataSources(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupBackingImageDataSources(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up backingImageDataSources")
+	}
+	return nil
+}
+
+func fixupBackingImageDataSources(namespace string, lhClient *lhclientset.Clientset) error {
+	backingImageDataSources, err := lhClient.LonghornV1beta1().BackingImageDataSources(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range backingImageDataSources.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.Parameters == nil {
+			obj.Spec.Parameters = make(map[string]string, 0)
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().BackingImageDataSources(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeBackingImageManagers(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupBackingImageManagers(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up backingImageManagers")
+	}
+	return nil
+}
+
+func fixupBackingImageManagers(namespace string, lhClient *lhclientset.Clientset) error {
+	backingImageManagers, err := lhClient.LonghornV1beta1().BackingImageManagers(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range backingImageManagers.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.BackingImages == nil {
+			obj.Spec.BackingImages = make(map[string]string, 0)
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().BackingImageManagers(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeBackingImages(namespace string, lhClient *lhclientset.Clientset) error {
+	if err := fixupBackingImages(namespace, lhClient); err != nil {
+		return errors.Wrapf(err, "unable to fix up backingImages")
+	}
+	return nil
+}
+
+func fixupBackingImages(namespace string, lhClient *lhclientset.Clientset) error {
+	backingImages, err := lhClient.LonghornV1beta1().BackingImages(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: getLabelSelectorNotEqualV1beta2APIVersion(),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range backingImages.Items {
+		existing := obj.DeepCopy()
+
+		if obj.Spec.Disks == nil {
+			obj.Spec.Disks = make(map[string]string, 0)
+		}
+		if obj.Spec.SourceParameters == nil {
+			obj.Spec.SourceParameters = make(map[string]string, 0)
+		}
+		if reflect.DeepEqual(&obj, existing) {
+			continue
+		}
+		if _, err = lhClient.LonghornV1beta1().BackingImages(namespace).Update(context.TODO(), &obj, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
- The null fields of CRs Spec are initialized correctly during creation.
- The old null fields of the CRs Spec are fixed up.
- The slices and maps in the CRs Status are set `// +nullable` because some of them are not set while calling Update.




Longhorn 3352

Signed-off-by: Derek Su <derek.su@suse.com>