### PR TITLE
Handle the failure of the upgrade to v1beta2

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -84,6 +84,7 @@ const (
 	LonghornLabelBackupVolume             = "backup-volume"
 	LonghornLabelRecurringJob             = "job"
 	LonghornLabelRecurringJobGroup        = "job-group"
+	LonghornLabelCRDAPIVersion            = "crd-api-version"
 
 	LonghornLabelValueEnabled = "enabled"
 
@@ -254,6 +255,10 @@ func GetBaseLabelsForSystemManagedComponent() map[string]string {
 
 func GetLonghornLabelComponentKey() string {
 	return GetLonghornLabelKey("component")
+}
+
+func GetLonghornLabelCRDAPIVersionKey() string {
+	return GetLonghornLabelKey(LonghornLabelCRDAPIVersion)
 }
 
 func GetEngineImageLabels(engineImageName string) map[string]string {


### PR DESCRIPTION
Add the label to the upgraded CRs.
The re-run upgrade process only needs to process the non-upgraded CRs.

Longhorn 3354

Signed-off-by: Derek Su <derek.su@suse.com>