### PR TITLE
Fix potential bugs inside Longhorn CSI related to the CSI snapshot flow

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1290,6 +1290,14 @@ func toBackupResource(b *longhorn.Backup) *Backup {
 		logrus.Warnf("weird: nil backup")
 		return nil
 	}
+
+	getSnapshotNameFromBackup := func(b *longhorn.Backup) string {
+		if b.Spec.SnapshotName != "" {
+			return b.Spec.SnapshotName
+		}
+		return b.Status.SnapshotName
+	}
+
 	ret := &Backup{
 		Resource: client.Resource{
 			Id:    b.Name,
@@ -1301,7 +1309,7 @@ func toBackupResource(b *longhorn.Backup) *Backup {
 		Progress:               b.Status.Progress,
 		Error:                  b.Status.Error,
 		URL:                    b.Status.URL,
-		SnapshotName:           b.Status.SnapshotName,
+		SnapshotName:           getSnapshotNameFromBackup(b),
 		SnapshotCreated:        b.Status.SnapshotCreatedAt,
 		Created:                b.Status.BackupCreatedAt,
 		Size:                   b.Status.Size,

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -266,6 +266,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 		[]string{
 			"--v=2",
 			"--csi-address=$(ADDRESS)",
+			"--timeout=1m50s",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 		},


### PR DESCRIPTION
1. Specify a timeout for `csi-snapshotter` deployment to be 1:50s as other csi sidecar components
1. Probably we could change to set the [SnapshotName](https://github.com/longhorn/longhorn-manager/blob/da8ab84da751e90f858b69b6f3a77dca1f80fab2/api/model.go#L1292) to `b.Spec.SnapshotName` if `b.Spec.SnapshotName != ""`. Otherwise, set the `SnapshotName` to `b.Status.SnapshotName`. This reduces the waiting time. As long as there is a backup CR, we can safely set the `snapshotHandle` for the `VolumeSnapshotContent`
1. With the new backup design in 1.2.x, having a backup CR doesn't mean that the backup has finished. So we need to check the status of the backup. This code path needs to be updated to be compatible with the new design:
https://github.com/longhorn/longhorn-manager/blob/da8ab84da751e90f858b69b6f3a77dca1f80fab2/csi/controller_server.go#L568-L573
Since there is no evaluation on the backupStatus, instead previously we could assume if the file exists on the BS that the backup was completed. Now we have a BackupCRD that we need to evaluate just like with the waiting poller.

longhorn/longhorn#3378
