### PR TITLE
[BACKPORT-v1.2.x] Do not print error log when backup in progress

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -339,7 +340,9 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	backupURL := backupstore.EncodeBackupURL(backup.Name, backupVolumeName, backupTargetClient.URL)
 	backupInfo, err := backupTargetClient.InspectBackupConfig(backupURL)
 	if err != nil {
-		log.WithError(err).Error("Error inspecting backup config")
+		if !strings.Contains(err.Error(), "in progress") {
+			log.WithError(err).Error("Error inspecting backup config")
+		}
 		return nil // Ignore error to prevent enqueue
 	}
 	if backupInfo == nil {


### PR DESCRIPTION
#### Proposal Change

If we have 2 cluster points to the same backup store.
When cluster 1 makes snapshot backup to the remote backup store and
cluster 2 starts to inspect the backup config from the remote backup, it
will print the error message that the backup is still in progress.

We should skip printing the in-progress backup to the console.

#### Issue
https://github.com/longhorn/longhorn/issues/3405