### PR TITLE
Fix cache.DeletedFinalStateUnknown value type instead of pointer type

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -792,7 +792,7 @@ func (bic *BackingImageController) enqueueBackingImage(obj interface{}) {
 func (bic *BackingImageController) enqueueBackingImageForBackingImageManager(obj interface{}) {
 	bim, isBIM := obj.(*longhorn.BackingImageManager)
 	if !isBIM {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -822,7 +822,7 @@ func (bic *BackingImageController) enqueueBackingImageForBackingImageDataSource(
 func (bic *BackingImageController) enqueueBackingImageForReplica(obj interface{}) {
 	replica, isReplica := obj.(*longhorn.Replica)
 	if !isReplica {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -714,7 +714,7 @@ func (c *BackingImageDataSourceController) enqueueBackingImageDataSource(backing
 func isBackingImageDataSourcePod(obj interface{}) bool {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -732,7 +732,7 @@ func isBackingImageDataSourcePod(obj interface{}) bool {
 func (c *BackingImageDataSourceController) enqueueForBackingImage(obj interface{}) {
 	backingImage, ok := obj.(*longhorn.BackingImage)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -760,7 +760,7 @@ func (c *BackingImageDataSourceController) enqueueForBackingImage(obj interface{
 func (c *BackingImageDataSourceController) enqueueForVolume(obj interface{}) {
 	volume, ok := obj.(*longhorn.Volume)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -787,7 +787,7 @@ func (c *BackingImageDataSourceController) enqueueForVolume(obj interface{}) {
 func (c *BackingImageDataSourceController) enqueueForLonghornNode(obj interface{}) {
 	node, ok := obj.(*longhorn.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -830,7 +830,7 @@ func (c *BackingImageDataSourceController) enqueueForLonghornNode(obj interface{
 func (c *BackingImageDataSourceController) enqueueForBackingImageDataSourcePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -855,7 +855,7 @@ func (c *BackingImageManagerController) enqueueBackingImageManager(backingImageM
 func isBackingImageManagerPod(obj interface{}) bool {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -876,7 +876,7 @@ func isBackingImageManagerPod(obj interface{}) bool {
 func (c *BackingImageManagerController) enqueueForBackingImage(obj interface{}) {
 	backingImage, ok := obj.(*longhorn.BackingImage)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -919,7 +919,7 @@ func (c *BackingImageManagerController) enqueueForBackingImage(obj interface{}) 
 func (c *BackingImageManagerController) enqueueForLonghornNode(obj interface{}) {
 	node, ok := obj.(*longhorn.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -962,7 +962,7 @@ func (c *BackingImageManagerController) enqueueForLonghornNode(obj interface{}) 
 func (c *BackingImageManagerController) enqueueForBackingImageManagerPod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -336,7 +336,7 @@ func (ec *EngineController) enqueueEngine(obj interface{}) {
 func (ec *EngineController) enqueueInstanceManagerChange(obj interface{}) {
 	im, isInstanceManager := obj.(*longhorn.InstanceManager)
 	if !isInstanceManager {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -615,7 +615,7 @@ func (ic *EngineImageController) enqueueVolumes(volumes ...interface{}) {
 	for _, obj := range volumes {
 		v, isVolume := obj.(*longhorn.Volume)
 		if !isVolume {
-			deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+			deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 			if !ok {
 				utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 				continue
@@ -649,7 +649,7 @@ func (ic *EngineImageController) enqueueVolumes(volumes ...interface{}) {
 }
 
 func (ic *EngineImageController) enqueueControlleeChange(obj interface{}) {
-	if deletedState, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = deletedState.Obj
 	}
 

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -157,7 +157,7 @@ func NewInstanceManagerController(
 func isInstanceManagerPod(obj interface{}) bool {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -669,7 +669,7 @@ func (imc *InstanceManagerController) enqueueInstanceManager(instanceManager int
 func (imc *InstanceManagerController) enqueueInstanceManagerPod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -698,7 +698,7 @@ func (imc *InstanceManagerController) enqueueInstanceManagerPod(obj interface{})
 func (imc *InstanceManagerController) enqueueKubernetesNode(obj interface{}) {
 	kubernetesNode, ok := obj.(*v1.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/kubernetes_node_controller.go
+++ b/controller/kubernetes_node_controller.go
@@ -92,7 +92,7 @@ func NewKubernetesNodeController(
 func isSettingCreateDefaultDiskLabeledNodes(obj interface{}) bool {
 	setting, ok := obj.(*longhorn.Setting)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -234,7 +234,7 @@ func (knc *KubernetesNodeController) enqueueSetting(obj interface{}) {
 func (knc *KubernetesNodeController) enqueueLonghornNode(obj interface{}) {
 	lhNode, ok := obj.(*longhorn.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -297,7 +297,7 @@ func (kc *KubernetesPodController) enqueuePodChange(obj interface{}) {
 
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -277,7 +277,7 @@ func (kc *KubernetesPVController) enqueuePersistentVolume(obj interface{}) {
 func (kc *KubernetesPVController) enqueuePodChange(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -316,7 +316,7 @@ func (kc *KubernetesPVController) enqueuePodChange(obj interface{}) {
 func (kc *KubernetesPVController) enqueueVolumeChange(obj interface{}) {
 	volume, ok := obj.(*longhorn.Volume)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -344,7 +344,7 @@ func (kc *KubernetesPVController) enqueueVolumeChange(obj interface{}) {
 func (kc *KubernetesPVController) enqueuePVDeletion(obj interface{}) {
 	pv, ok := obj.(*v1.PersistentVolume)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -140,7 +140,7 @@ func NewNodeController(
 func (nc *NodeController) isResponsibleForSetting(obj interface{}) bool {
 	setting, ok := obj.(*longhorn.Setting)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -159,7 +159,7 @@ func (nc *NodeController) isResponsibleForSetting(obj interface{}) bool {
 func (nc *NodeController) isResponsibleForReplica(obj interface{}) bool {
 	replica, ok := obj.(*longhorn.Replica)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -177,7 +177,7 @@ func (nc *NodeController) isResponsibleForReplica(obj interface{}) bool {
 func isManagerPod(obj interface{}) bool {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}
@@ -471,7 +471,7 @@ func (nc *NodeController) enqueueSetting(obj interface{}) {
 func (nc *NodeController) enqueueReplica(obj interface{}) {
 	replica, ok := obj.(*longhorn.Replica)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -510,7 +510,7 @@ func (nc *NodeController) enqueueManagerPod(obj interface{}) {
 func (nc *NodeController) enqueueKubernetesNode(obj interface{}) {
 	kubernetesNode, ok := obj.(*v1.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -682,7 +682,7 @@ func (rc *ReplicaController) LogInstance(obj interface{}) (*imapi.LogStream, err
 func (rc *ReplicaController) enqueueInstanceManagerChange(obj interface{}) {
 	im, isInstanceManager := obj.(*longhorn.InstanceManager)
 	if !isInstanceManager {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -717,7 +717,7 @@ func (rc *ReplicaController) enqueueInstanceManagerChange(obj interface{}) {
 func (rc *ReplicaController) enqueueNodeChange(obj interface{}) {
 	node, ok := obj.(*longhorn.Node)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -748,7 +748,7 @@ func (rc *ReplicaController) enqueueNodeChange(obj interface{}) {
 func (rc *ReplicaController) enqueueBackingImageChange(obj interface{}) {
 	backingImage, ok := obj.(*longhorn.BackingImage)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -780,7 +780,7 @@ func (rc *ReplicaController) enqueueBackingImageChange(obj interface{}) {
 func (rc *ReplicaController) enqueueSettingChange(obj interface{}) {
 	setting, ok := obj.(*longhorn.Setting)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -127,7 +127,7 @@ func (c *ShareManagerController) enqueueShareManager(obj interface{}) {
 func (c *ShareManagerController) enqueueShareManagerForVolume(obj interface{}) {
 	volume, isVolume := obj.(*longhorn.Volume)
 	if !isVolume {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -154,7 +154,7 @@ func (c *ShareManagerController) enqueueShareManagerForVolume(obj interface{}) {
 func (c *ShareManagerController) enqueueShareManagerForPod(obj interface{}) {
 	pod, isPod := obj.(*v1.Pod)
 	if !isPod {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -180,7 +180,7 @@ func (c *ShareManagerController) enqueueShareManagerForPod(obj interface{}) {
 func isShareManagerPod(obj interface{}) bool {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return false
 		}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2773,7 +2773,7 @@ func (vc *VolumeController) enqueueVolume(obj interface{}) {
 }
 
 func (vc *VolumeController) enqueueControlleeChange(obj interface{}) {
-	if deletedState, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = deletedState.Obj
 	}
 
@@ -3298,7 +3298,7 @@ func (vc *VolumeController) deleteEngine(e *longhorn.Engine, es map[string]*long
 func (vc *VolumeController) enqueueVolumesForShareManager(obj interface{}) {
 	sm, isShareManager := obj.(*longhorn.ShareManager)
 	if !isShareManager {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -3397,7 +3397,7 @@ func (vc *VolumeController) createShareManagerForVolume(volume *longhorn.Volume,
 func (vc *VolumeController) enqueueVolumesForBackupVolume(obj interface{}) {
 	bv, isBackupVolume := obj.(*longhorn.BackupVolume)
 	if !isBackupVolume {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return
@@ -3439,7 +3439,7 @@ func (vc *VolumeController) enqueueVolumesForBackupVolume(obj interface{}) {
 func (vc *VolumeController) enqueueVolumesForBackingImageDataSource(obj interface{}) {
 	bids, isBackingImageDataSource := obj.(*longhorn.BackingImageDataSource)
 	if !isBackingImageDataSource {
-		deletedState, ok := obj.(*cache.DeletedFinalStateUnknown)
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("received unexpected obj: %#v", obj))
 			return


### PR DESCRIPTION
When the object is gone from the cache, and the deletion event has been
missed, the unknown state struct gets pushed as a copy into the worker
instead of as a pointer.

https://github.com/longhorn/longhorn/issues/3417