### PR TITLE
Add CRD conversion webhook

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -52,51 +52,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source
-            properties:
-              checksum:
-                type: string
-              diskPath:
-                type: string
-              diskUUID:
-                type: string
-              fileTransferred:
-                type: boolean
-              nodeID:
-                type: string
-              parameters:
-                additionalProperties:
-                  type: string
-                type: object
-              sourceType:
-                enum:
-                - download
-                - upload
-                - export-from-volume
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageDataSourceStatus defines the observed state of the Longhorn backing image data source
-            properties:
-              checksum:
-                type: string
-              currentState:
-                type: string
-              message:
-                type: string
-              ownerID:
-                type: string
-              progress:
-                type: integer
-              runningParameters:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              size:
-                format: int64
-                type: integer
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -251,69 +209,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageManagerSpec defines the desired state of the Longhorn backing image manager
-            properties:
-              backingImages:
-                additionalProperties:
-                  type: string
-                type: object
-              diskPath:
-                type: string
-              diskUUID:
-                type: string
-              image:
-                type: string
-              nodeID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageManagerStatus defines the observed state of the Longhorn backing image manager
-            properties:
-              apiMinVersion:
-                type: integer
-              apiVersion:
-                type: integer
-              backingImageFileMap:
-                additionalProperties:
-                  properties:
-                    currentChecksum:
-                      type: string
-                    directory:
-                      description: 'Deprecated: This field is useless.'
-                      type: string
-                    downloadProgress:
-                      description: 'Deprecated: This field is renamed to `Progress`.'
-                      type: integer
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    progress:
-                      type: integer
-                    senderManagerAddress:
-                      type: string
-                    sendingReference:
-                      type: integer
-                    size:
-                      format: int64
-                      type: integer
-                    state:
-                      type: string
-                    url:
-                      description: 'Deprecated: This field is useless now. The manager of backing image files doesn''t care if a file is downloaded and how.'
-                      type: string
-                    uuid:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentState:
-                type: string
-              ip:
-                type: string
-              ownerID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -474,73 +372,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageSpec defines the desired state of the Longhorn backing image
-            properties:
-              checksum:
-                type: string
-              disks:
-                additionalProperties:
-                  type: string
-                type: object
-              imageURL:
-                description: 'Deprecated: This kind of info will be included in the related BackingImageDataSource.'
-                type: string
-              sourceParameters:
-                additionalProperties:
-                  type: string
-                type: object
-              sourceType:
-                enum:
-                - download
-                - upload
-                - export-from-volume
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackingImageStatus defines the observed state of the Longhorn backing image status
-            properties:
-              checksum:
-                type: string
-              diskDownloadProgressMap:
-                additionalProperties:
-                  type: integer
-                description: 'Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.'
-                nullable: true
-                type: object
-              diskDownloadStateMap:
-                additionalProperties:
-                  description: BackingImageDownloadState is replaced by BackingImageState.
-                  type: string
-                description: 'Deprecated: Replaced by field `State` in `DiskFileStatusMap`.'
-                nullable: true
-                type: object
-              diskFileStatusMap:
-                additionalProperties:
-                  properties:
-                    lastStateTransitionTime:
-                      type: string
-                    message:
-                      type: string
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              diskLastRefAtMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              ownerID:
-                type: string
-              size:
-                format: int64
-                type: integer
-              uuid:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -702,85 +536,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupSpec defines the desired state of the Longhorn backup
-            properties:
-              labels:
-                additionalProperties:
-                  type: string
-                description: The labels of snapshot backup.
-                type: object
-              snapshotName:
-                description: The snapshot name.
-                type: string
-              syncRequestedAt:
-                description: The time to request run sync the remote backup.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupStatus defines the observed state of the Longhorn backup
-            properties:
-              backupCreatedAt:
-                description: The snapshot backup upload finished time.
-                type: string
-              error:
-                description: The error message when taking the snapshot backup.
-                type: string
-              labels:
-                additionalProperties:
-                  type: string
-                description: The labels of snapshot backup.
-                nullable: true
-                type: object
-              lastSyncedAt:
-                description: The last time that the backup was synced with the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-              messages:
-                additionalProperties:
-                  type: string
-                description: The error messages when calling longhorn engine on listing or inspecting backups.
-                nullable: true
-                type: object
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup CR.
-                type: string
-              progress:
-                description: The snapshot backup progress.
-                type: integer
-              replicaAddress:
-                description: The address of the replica that runs snapshot backup.
-                type: string
-              size:
-                description: The snapshot size.
-                type: string
-              snapshotCreatedAt:
-                description: The snapshot creation time.
-                type: string
-              snapshotName:
-                description: The snapshot name.
-                type: string
-              state:
-                description: The backup creation state. Can be "", "InProgress", "Completed", "Error", "Unknown".
-                type: string
-              url:
-                description: The snapshot backup URL.
-                type: string
-              volumeBackingImageName:
-                description: The volume's backing image name.
-                type: string
-              volumeCreated:
-                description: The volume creation time.
-                type: string
-              volumeName:
-                description: The volume name.
-                type: string
-              volumeSize:
-                description: The volume size.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -967,63 +725,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupTargetSpec defines the desired state of the Longhorn backup target
-            properties:
-              backupTargetURL:
-                description: The backup target URL.
-                type: string
-              credentialSecret:
-                description: The backup target credential secret.
-                type: string
-              pollInterval:
-                description: The interval that the cluster needs to run sync with the backup target.
-                type: string
-              syncRequestedAt:
-                description: The time to request run sync the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupTargetStatus defines the observed state of the Longhorn backup target
-            properties:
-              available:
-                description: Available indicates if the remote backup target is available or not.
-                type: boolean
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                description: Records the reason on why the backup target is unavailable.
-                nullable: true
-                type: object
-              lastSyncedAt:
-                description: The last time that the controller synced with the remote backup target.
-                format: date-time
-                nullable: true
-                type: string
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup target CR.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1184,64 +888,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupVolumeSpec defines the desired state of the Longhorn backup volume
-            properties:
-              syncRequestedAt:
-                description: The time to request run sync the remote backup volume.
-                format: date-time
-                nullable: true
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: BackupVolumeStatus defines the observed state of the Longhorn backup volume
-            properties:
-              backingImageChecksum:
-                description: the backing image checksum.
-                type: string
-              backingImageName:
-                description: The backing image name.
-                type: string
-              createdAt:
-                description: The backup volume creation time.
-                type: string
-              dataStored:
-                description: The backup volume block count.
-                type: string
-              labels:
-                additionalProperties:
-                  type: string
-                description: The backup volume labels.
-                nullable: true
-                type: object
-              lastBackupAt:
-                description: The latest volume backup time.
-                type: string
-              lastBackupName:
-                description: The latest volume backup name.
-                type: string
-              lastModificationTime:
-                description: The backup volume config last modification time.
-                format: date-time
-                nullable: true
-                type: string
-              lastSyncedAt:
-                description: The last time that the backup volume was synced into the cluster.
-                format: date-time
-                nullable: true
-                type: string
-              messages:
-                additionalProperties:
-                  type: string
-                description: The error messages when call longhorn engine on list or inspect backup volumes.
-                nullable: true
-                type: object
-              ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup volume CR.
-                type: string
-              size:
-                description: The backup volume size.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1402,70 +1051,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: EngineImageSpec defines the desired state of the Longhorn engine image
-            properties:
-              image:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: EngineImageStatus defines the observed state of the Longhorn engine image
-            properties:
-              buildDate:
-                type: string
-              cliAPIMinVersion:
-                type: integer
-              cliAPIVersion:
-                type: integer
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              controllerAPIMinVersion:
-                type: integer
-              controllerAPIVersion:
-                type: integer
-              dataFormatMinVersion:
-                type: integer
-              dataFormatVersion:
-                type: integer
-              gitCommit:
-                type: string
-              noRefSince:
-                type: string
-              nodeDeploymentMap:
-                additionalProperties:
-                  type: boolean
-                nullable: true
-                type: object
-              ownerID:
-                type: string
-              refCount:
-                type: integer
-              state:
-                type: string
-              version:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -1635,211 +1223,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: EngineSpec defines the desired state of the Longhorn engine
-            properties:
-              active:
-                type: boolean
-              backupVolume:
-                type: string
-              desireState:
-                type: string
-              disableFrontend:
-                type: boolean
-              engineImage:
-                type: string
-              frontend:
-                enum:
-                - blockdev
-                - iscsi
-                - ""
-                type: string
-              logRequested:
-                type: boolean
-              nodeID:
-                type: string
-              replicaAddressMap:
-                additionalProperties:
-                  type: string
-                type: object
-              requestedBackupRestore:
-                type: string
-              requestedDataSource:
-                type: string
-              revisionCounterDisabled:
-                type: boolean
-              salvageRequested:
-                type: boolean
-              upgradedReplicaAddressMap:
-                additionalProperties:
-                  type: string
-                type: object
-              volumeName:
-                type: string
-              volumeSize:
-                format: int64
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: EngineStatus defines the observed state of the Longhorn engine
-            properties:
-              backupStatus:
-                additionalProperties:
-                  properties:
-                    backupURL:
-                      type: string
-                    error:
-                      type: string
-                    progress:
-                      type: integer
-                    replicaAddress:
-                      type: string
-                    snapshotName:
-                      type: string
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              cloneStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    fromReplicaAddress:
-                      type: string
-                    isCloning:
-                      type: boolean
-                    progress:
-                      type: integer
-                    snapshotName:
-                      type: string
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentImage:
-                type: string
-              currentReplicaAddressMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              currentSize:
-                format: int64
-                type: string
-              currentState:
-                type: string
-              endpoint:
-                type: string
-              instanceManagerName:
-                type: string
-              ip:
-                type: string
-              isExpanding:
-                type: boolean
-              lastExpansionError:
-                type: string
-              lastExpansionFailedAt:
-                type: string
-              lastRestoredBackup:
-                type: string
-              logFetched:
-                type: boolean
-              ownerID:
-                type: string
-              port:
-                type: integer
-              purgeStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    isPurging:
-                      type: boolean
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              rebuildStatus:
-                additionalProperties:
-                  properties:
-                    error:
-                      type: string
-                    fromReplicaAddress:
-                      type: string
-                    isRebuilding:
-                      type: boolean
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              replicaModeMap:
-                additionalProperties:
-                  type: string
-                nullable: true
-                type: object
-              restoreStatus:
-                additionalProperties:
-                  properties:
-                    backupURL:
-                      type: string
-                    currentRestoringBackup:
-                      type: string
-                    error:
-                      type: string
-                    filename:
-                      type: string
-                    isRestoring:
-                      type: boolean
-                    lastRestored:
-                      type: string
-                    progress:
-                      type: integer
-                    state:
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              salvageExecuted:
-                type: boolean
-              snapshots:
-                additionalProperties:
-                  properties:
-                    children:
-                      additionalProperties:
-                        type: boolean
-                      type: object
-                    created:
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    name:
-                      type: string
-                    parent:
-                      type: string
-                    removed:
-                      type: boolean
-                    size:
-                      type: string
-                    usercreated:
-                      type: boolean
-                  type: object
-                nullable: true
-                type: object
-              snapshotsError:
-                type: string
-              started:
-                type: boolean
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2146,68 +1532,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstanceManagerSpec defines the desired state of the Longhorn instancer manager
-            properties:
-              engineImage:
-                description: 'TODO: deprecate this field'
-                type: string
-              image:
-                type: string
-              nodeID:
-                type: string
-              type:
-                enum:
-                - engine
-                - replica
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: InstanceManagerStatus defines the observed state of the Longhorn instance manager
-            properties:
-              apiMinVersion:
-                type: integer
-              apiVersion:
-                type: integer
-              currentState:
-                type: string
-              instances:
-                additionalProperties:
-                  properties:
-                    spec:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    status:
-                      properties:
-                        endpoint:
-                          type: string
-                        errorMsg:
-                          type: string
-                        listen:
-                          type: string
-                        portEnd:
-                          format: int32
-                          type: integer
-                        portStart:
-                          format: int32
-                          type: integer
-                        resourceVersion:
-                          format: int64
-                          type: integer
-                        state:
-                          type: string
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                nullable: true
-                type: object
-              ip:
-                type: string
-              ownerID:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2367,122 +1694,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: NodeSpec defines the desired state of the Longhorn node
-            properties:
-              allowScheduling:
-                type: boolean
-              disks:
-                additionalProperties:
-                  properties:
-                    allowScheduling:
-                      type: boolean
-                    evictionRequested:
-                      type: boolean
-                    path:
-                      type: string
-                    storageReserved:
-                      format: int64
-                      type: integer
-                    tags:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: object
-              engineManagerCPURequest:
-                minimum: 0
-                type: integer
-              evictionRequested:
-                type: boolean
-              name:
-                type: string
-              replicaManagerCPURequest:
-                minimum: 0
-                type: integer
-              tags:
-                items:
-                  type: string
-                type: array
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: NodeStatus defines the observed state of the Longhorn node
-            properties:
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              diskStatus:
-                additionalProperties:
-                  properties:
-                    conditions:
-                      additionalProperties:
-                        properties:
-                          lastProbeTime:
-                            description: Last time we probed the condition.
-                            type: string
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
-                            type: string
-                          message:
-                            description: Human-readable message indicating details about last transition.
-                            type: string
-                          reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status is the status of the condition. Can be True, False, Unknown.
-                            type: string
-                          type:
-                            description: Type is the type of the condition.
-                            type: string
-                        type: object
-                      nullable: true
-                      type: object
-                    diskUUID:
-                      type: string
-                    scheduledReplica:
-                      additionalProperties:
-                        format: int64
-                        type: integer
-                      nullable: true
-                      type: object
-                    storageAvailable:
-                      format: int64
-                      type: integer
-                    storageMaximum:
-                      format: int64
-                      type: integer
-                    storageScheduled:
-                      format: int64
-                      type: integer
-                  type: object
-                nullable: true
-                type: object
-              region:
-                type: string
-              zone:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2708,47 +1922,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: RecurringJobSpec defines the desired state of the Longhorn recurring job
-            properties:
-              concurrency:
-                description: The concurrency of taking the snapshot/backup.
-                minimum: 1
-                type: integer
-              cron:
-                description: The cron setting.
-                type: string
-              groups:
-                description: The recurring job group.
-                items:
-                  type: string
-                type: array
-              labels:
-                additionalProperties:
-                  type: string
-                description: The label of the snapshot/backup.
-                type: object
-              name:
-                description: The recurring job name.
-                type: string
-              retain:
-                description: The retain count of the snapshot/backup.
-                maximum: 50
-                minimum: 1
-                type: integer
-              task:
-                description: The recurring job type. Can be "snapshot" or "backup".
-                enum:
-                - snapshot
-                - backup
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: RecurringJobStatus defines the observed state of the Longhorn recurring job
-            properties:
-              ownerID:
-                description: The owner ID which is responsible to reconcile this recurring job CR.
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -2907,76 +2083,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ReplicaSpec defines the desired state of the Longhorn replica
-            properties:
-              active:
-                type: boolean
-              backingImage:
-                type: string
-              baseImage:
-                description: Deprecated. Rename to BackingImage
-                type: string
-              dataDirectoryName:
-                type: string
-              dataPath:
-                description: Deprecated
-                type: string
-              desireState:
-                type: string
-              diskID:
-                type: string
-              diskPath:
-                type: string
-              engineImage:
-                type: string
-              engineName:
-                type: string
-              failedAt:
-                type: string
-              hardNodeAffinity:
-                type: string
-              healthyAt:
-                type: string
-              logRequested:
-                type: boolean
-              nodeID:
-                type: string
-              rebuildRetryCount:
-                type: integer
-              revisionCounterDisabled:
-                type: boolean
-              salvageRequested:
-                type: boolean
-              volumeName:
-                type: string
-              volumeSize:
-                format: int64
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: ReplicaStatus defines the observed state of the Longhorn replica
-            properties:
-              currentImage:
-                type: string
-              currentState:
-                type: string
-              evictionRequested:
-                type: boolean
-              instanceManagerName:
-                type: string
-              ip:
-                type: string
-              logFetched:
-                type: boolean
-              ownerID:
-                type: string
-              port:
-                type: integer
-              salvageExecuted:
-                type: boolean
-              started:
-                type: boolean
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -3235,21 +2344,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ShareManagerSpec defines the desired state of the Longhorn share manager
-            properties:
-              image:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: ShareManagerStatus defines the observed state of the Longhorn share manager
-            properties:
-              endpoint:
-                type: string
-              ownerID:
-                type: string
-              state:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false
@@ -3366,208 +2463,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: VolumeSpec defines the desired state of the Longhorn volume
-            properties:
-              Standby:
-                type: boolean
-              accessMode:
-                enum:
-                - rwo
-                - rwx
-                type: string
-              backingImage:
-                type: string
-              baseImage:
-                description: Deprecated. Rename to BackingImage
-                type: string
-              dataLocality:
-                enum:
-                - disabled
-                - best-effort
-                type: string
-              dataSource:
-                type: string
-              disableFrontend:
-                type: boolean
-              diskSelector:
-                items:
-                  type: string
-                type: array
-              encrypted:
-                type: boolean
-              engineImage:
-                type: string
-              fromBackup:
-                type: string
-              frontend:
-                enum:
-                - blockdev
-                - iscsi
-                - ""
-                type: string
-              lastAttachedBy:
-                type: string
-              migratable:
-                type: boolean
-              migrationNodeID:
-                type: string
-              nodeID:
-                type: string
-              nodeSelector:
-                items:
-                  type: string
-                type: array
-              numberOfReplicas:
-                minimum: 1
-                type: integer
-              recurringJobs:
-                description: Deprecated. Replaced by a separate resource named "RecurringJob"
-                items:
-                  description: 'VolumeRecurringJobSpec is a deprecated struct. TODO: Should be removed when recurringJobs gets removed from the volume       spec.'
-                  properties:
-                    concurrency:
-                      type: integer
-                    cron:
-                      type: string
-                    groups:
-                      items:
-                        type: string
-                      type: array
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    name:
-                      type: string
-                    retain:
-                      type: integer
-                    task:
-                      enum:
-                      - snapshot
-                      - backup
-                      type: string
-                  type: object
-                type: array
-              replicaAutoBalance:
-                enum:
-                - ignored
-                - disabled
-                - least-effort
-                - best-effort
-                type: string
-              revisionCounterDisabled:
-                type: boolean
-              size:
-                format: int64
-                type: string
-              staleReplicaTimeout:
-                type: integer
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
-            description: VolumeStatus defines the observed state of the Longhorn volume
-            properties:
-              actualSize:
-                format: int64
-                type: integer
-              cloneStatus:
-                properties:
-                  snapshot:
-                    type: string
-                  sourceVolume:
-                    type: string
-                  state:
-                    type: string
-                type: object
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                nullable: true
-                type: object
-              currentImage:
-                type: string
-              currentNodeID:
-                type: string
-              expansionRequired:
-                type: boolean
-              frontendDisabled:
-                type: boolean
-              isStandby:
-                type: boolean
-              kubernetesStatus:
-                properties:
-                  lastPVCRefAt:
-                    type: string
-                  lastPodRefAt:
-                    type: string
-                  namespace:
-                    description: determine if PVC/Namespace is history or not
-                    type: string
-                  pvName:
-                    type: string
-                  pvStatus:
-                    type: string
-                  pvcName:
-                    type: string
-                  workloadsStatus:
-                    description: determine if Pod/Workload is history or not
-                    items:
-                      properties:
-                        podName:
-                          type: string
-                        podStatus:
-                          type: string
-                        workloadName:
-                          type: string
-                        workloadType:
-                          type: string
-                      type: object
-                    nullable: true
-                    type: array
-                type: object
-              lastBackup:
-                type: string
-              lastBackupAt:
-                type: string
-              lastDegradedAt:
-                type: string
-              ownerID:
-                type: string
-              pendingNodeID:
-                type: string
-              remountRequestedAt:
-                type: string
-              restoreInitiated:
-                type: boolean
-              restoreRequired:
-                type: boolean
-              robustness:
-                type: string
-              shareEndpoint:
-                type: string
-              shareState:
-                type: string
-              state:
-                type: string
-            type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: false

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: longhorn-manager
     spec:
+      initContainers:
+      - name: wait-longhorn-webhook
+        image: longhornio/longhorn-manager:master-head
+        command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" -k https://longhorn-webhook:9443/v1/healthz) != "200" ]; do echo waiting; sleep 2; done']
       containers:
       - name: longhorn-manager
         image: longhornio/longhorn-manager:master-head

--- a/go.mod
+++ b/go.mod
@@ -71,5 +71,6 @@ require (
 	k8s.io/metrics v0.18.19
 	k8s.io/mount-utils v0.22.2
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
+	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -548,7 +548,6 @@ github.com/rancher/dynamiclistener v0.3.1 h1:dx4r+K7uZm5jsOvkD0I+fSMAQdGUcQCGjRi
 github.com/rancher/dynamiclistener v0.3.1/go.mod h1:k+C1+rfUr5SlIyEQnDxSpu0NaBlmTLKc1s3KmyS8gXA=
 github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c h1:qOpIX3tKM+qjUXCiy52DOXm0EmeA6/SJeApK2tyKbVE=
 github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c/go.mod h1:7oQvGNiJsGvrUgB+7AH8bmdzuR0uhULfwKb43Ht0hUk=
-github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/lasso v0.0.0-20211217013041-3c6118a30611 h1:JZIc0g9A1blYZUBIk6nIqja0ZhtddvmeDXbB8i6vkGM=
 github.com/rancher/lasso v0.0.0-20211217013041-3c6118a30611/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
@@ -993,6 +992,7 @@ rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7 h1:uuHDyjllyzRyCIvvn0OBjiRB0SgBZGqHNYAmjR7fO50=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/cli-utils v0.16.0/go.mod h1:9Jqm9K2W6ShhCxsEuaz6HSRKKOXigPUx3ZfypGgxBLY=
+sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/kyaml v0.4.0/go.mod h1:XJL84E6sOFeNrQ7CADiemc1B0EjIxHo3OhW4o1aJYNw=

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -31,7 +31,7 @@ type BackingImageDiskFileStatus struct {
 // BackingImageSpec defines the desired state of the Longhorn backing image
 type BackingImageSpec struct {
 	// +optional
-	Disks map[string]string `json:"disks"`
+	Disks map[string]struct{} `json:"disks"`
 	// +optional
 	Checksum string `json:"checksum"`
 	// +optional
@@ -81,7 +81,11 @@ type BackingImage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackingImageSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackingImageSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackingImageStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -18,54 +18,35 @@ const (
 )
 
 type BackingImageDiskFileStatus struct {
-	// +optional
-	State BackingImageState `json:"state"`
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	Message string `json:"message"`
-	// +optional
-	LastStateTransitionTime string `json:"lastStateTransitionTime"`
+	State                   BackingImageState `json:"state"`
+	Progress                int               `json:"progress"`
+	Message                 string            `json:"message"`
+	LastStateTransitionTime string            `json:"lastStateTransitionTime"`
 }
 
 // BackingImageSpec defines the desired state of the Longhorn backing image
 type BackingImageSpec struct {
-	// +optional
-	Disks map[string]struct{} `json:"disks"`
-	// +optional
-	Checksum string `json:"checksum"`
-	// +optional
-	SourceType BackingImageDataSourceType `json:"sourceType"`
-	// +optional
-	SourceParameters map[string]string `json:"sourceParameters"`
+	Disks            map[string]struct{}        `json:"disks"`
+	Checksum         string                     `json:"checksum"`
+	SourceType       BackingImageDataSourceType `json:"sourceType"`
+	SourceParameters map[string]string          `json:"sourceParameters"`
+
 	// Deprecated: This kind of info will be included in the related BackingImageDataSource.
-	// +optional
 	ImageURL string `json:"imageURL"`
 }
 
 // BackingImageStatus defines the observed state of the Longhorn backing image status
 type BackingImageStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	UUID string `json:"uuid"`
-	// +optional
-	Size int64 `json:"size"`
-	// +optional
-	Checksum string `json:"checksum"`
-	// +optional
-	// +nullable
+	OwnerID           string                                 `json:"ownerID"`
+	UUID              string                                 `json:"uuid"`
+	Size              int64                                  `json:"size"`
+	Checksum          string                                 `json:"checksum"`
 	DiskFileStatusMap map[string]*BackingImageDiskFileStatus `json:"diskFileStatusMap"`
-	// +optional
-	// +nullable
-	DiskLastRefAtMap map[string]string `json:"diskLastRefAtMap"`
+	DiskLastRefAtMap  map[string]string                      `json:"diskLastRefAtMap"`
+
 	// Deprecated: Replaced by field `State` in `DiskFileStatusMap`.
-	// +optional
-	// +nullable
 	DiskDownloadStateMap map[string]BackingImageDownloadState `json:"diskDownloadStateMap"`
 	// Deprecated: Replaced by field `Progress` in `DiskFileStatusMap`.
-	// +optional
-	// +nullable
 	DiskDownloadProgressMap map[string]int `json:"diskDownloadProgressMap"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
@@ -67,7 +67,11 @@ type BackingImageDataSource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackingImageDataSourceSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackingImageDataSourceSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackingImageDataSourceStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
@@ -6,7 +6,6 @@ const (
 	DataSourceTypeDownloadParameterURL = "url"
 )
 
-// +kubebuilder:validation:Enum=download;upload;export-from-volume
 type BackingImageDataSourceType string
 
 const (
@@ -17,39 +16,24 @@ const (
 
 // BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source
 type BackingImageDataSourceSpec struct {
-	// +optional
-	NodeID string `json:"nodeID"`
-	// +optional
-	DiskUUID string `json:"diskUUID"`
-	// +optional
-	DiskPath string `json:"diskPath"`
-	// +optional
-	Checksum string `json:"checksum"`
-	// +optional
-	SourceType BackingImageDataSourceType `json:"sourceType"`
-	// +optional
-	Parameters map[string]string `json:"parameters"`
-	// +optional
-	FileTransferred bool `json:"fileTransferred"`
+	NodeID          string                     `json:"nodeID"`
+	DiskUUID        string                     `json:"diskUUID"`
+	DiskPath        string                     `json:"diskPath"`
+	Checksum        string                     `json:"checksum"`
+	SourceType      BackingImageDataSourceType `json:"sourceType"`
+	Parameters      map[string]string          `json:"parameters"`
+	FileTransferred bool                       `json:"fileTransferred"`
 }
 
 // BackingImageDataSourceStatus defines the observed state of the Longhorn backing image data source
 type BackingImageDataSourceStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	// +nullable
+	OwnerID           string            `json:"ownerID"`
 	RunningParameters map[string]string `json:"runningParameters"`
-	// +optional
-	CurrentState BackingImageState `json:"currentState"`
-	// +optional
-	Size int64 `json:"size"`
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	Checksum string `json:"checksum"`
-	// +optional
-	Message string `json:"message"`
+	CurrentState      BackingImageState `json:"currentState"`
+	Size              int64             `json:"size"`
+	Progress          int               `json:"progress"`
+	Checksum          string            `json:"checksum"`
+	Message           string            `json:"message"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
@@ -13,64 +13,41 @@ const (
 )
 
 type BackingImageFileInfo struct {
-	// +optional
-	Name string `json:"name"`
-	// +optional
-	UUID string `json:"uuid"`
-	// +optional
-	Size int64 `json:"size"`
-	// +optional
-	State BackingImageState `json:"state"`
-	// +optional
-	CurrentChecksum string `json:"currentChecksum"`
-	// +optional
-	Message string `json:"message"`
-	// +optional
-	SendingReference int `json:"sendingReference"`
-	// +optional
-	SenderManagerAddress string `json:"senderManagerAddress"`
-	// +optional
-	Progress int `json:"progress"`
+	Name                 string            `json:"name"`
+	UUID                 string            `json:"uuid"`
+	Size                 int64             `json:"size"`
+	State                BackingImageState `json:"state"`
+	CurrentChecksum      string            `json:"currentChecksum"`
+	Message              string            `json:"message"`
+	SendingReference     int               `json:"sendingReference"`
+	SenderManagerAddress string            `json:"senderManagerAddress"`
+	Progress             int               `json:"progress"`
+
 	// Deprecated: This field is useless now. The manager of backing image files doesn't care if a file is downloaded and how.
-	// +optional
 	URL string `json:"url"`
 	// Deprecated: This field is useless.
-	// +optional
 	Directory string `json:"directory"`
 	// Deprecated: This field is renamed to `Progress`.
-	// +optional
 	DownloadProgress int `json:"downloadProgress"`
 }
 
 // BackingImageManagerSpec defines the desired state of the Longhorn backing image manager
 type BackingImageManagerSpec struct {
-	// +optional
-	Image string `json:"image"`
-	// +optional
-	NodeID string `json:"nodeID"`
-	// +optional
-	DiskUUID string `json:"diskUUID"`
-	// +optional
-	DiskPath string `json:"diskPath"`
-	// +optional
+	Image         string            `json:"image"`
+	NodeID        string            `json:"nodeID"`
+	DiskUUID      string            `json:"diskUUID"`
+	DiskPath      string            `json:"diskPath"`
 	BackingImages map[string]string `json:"backingImages"`
 }
 
 // BackingImageManagerStatus defines the observed state of the Longhorn backing image manager
 type BackingImageManagerStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	CurrentState BackingImageManagerState `json:"currentState"`
-	// +optional
-	// +nullable
+	OwnerID             string                          `json:"ownerID"`
+	CurrentState        BackingImageManagerState        `json:"currentState"`
 	BackingImageFileMap map[string]BackingImageFileInfo `json:"backingImageFileMap"`
-	// +optional
-	IP string `json:"ip"`
-	// +optional
-	APIMinVersion int `json:"apiMinVersion"`
-	// +optional
-	APIVersion int `json:"apiVersion"`
+	IP                  string                          `json:"ip"`
+	APIMinVersion       int                             `json:"apiMinVersion"`
+	APIVersion          int                             `json:"apiVersion"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
@@ -89,7 +89,11 @@ type BackingImageManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackingImageManagerSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackingImageManagerSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackingImageManagerStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -100,7 +100,11 @@ type Backup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackupSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackupSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackupStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -15,73 +15,49 @@ const (
 // BackupSpec defines the desired state of the Longhorn backup
 type BackupSpec struct {
 	// The time to request run sync the remote backup.
-	// +optional
-	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 	// The snapshot name.
-	// +optional
 	SnapshotName string `json:"snapshotName"`
 	// The labels of snapshot backup.
-	// +optional
 	Labels map[string]string `json:"labels"`
 }
 
 // BackupStatus defines the observed state of the Longhorn backup
 type BackupStatus struct {
 	// The node ID on which the controller is responsible to reconcile this backup CR.
-	// +optional
 	OwnerID string `json:"ownerID"`
 	// The backup creation state.
 	// Can be "", "InProgress", "Completed", "Error", "Unknown".
-	// +optional
 	State BackupState `json:"state"`
 	// The snapshot backup progress.
-	// +optional
 	Progress int `json:"progress"`
 	// The address of the replica that runs snapshot backup.
-	// +optional
 	ReplicaAddress string `json:"replicaAddress"`
 	// The error message when taking the snapshot backup.
-	// +optional
 	Error string `json:"error,omitempty"`
 	// The snapshot backup URL.
-	// +optional
 	URL string `json:"url"`
 	// The snapshot name.
-	// +optional
 	SnapshotName string `json:"snapshotName"`
 	// The snapshot creation time.
-	// +optional
 	SnapshotCreatedAt string `json:"snapshotCreatedAt"`
 	// The snapshot backup upload finished time.
-	// +optional
 	BackupCreatedAt string `json:"backupCreatedAt"`
 	// The snapshot size.
-	// +optional
 	Size string `json:"size"`
 	// The labels of snapshot backup.
-	// +optional
-	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The error messages when calling longhorn engine on listing or inspecting backups.
-	// +optional
-	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The volume name.
-	// +optional
 	VolumeName string `json:"volumeName"`
 	// The volume size.
-	// +optional
 	VolumeSize string `json:"volumeSize"`
 	// The volume creation time.
-	// +optional
 	VolumeCreated string `json:"volumeCreated"`
 	// The volume's backing image name.
-	// +optional
 	VolumeBackingImageName string `json:"volumeBackingImageName"`
 	// The last time that the backup was synced with the remote backup target.
-	// +optional
-	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
@@ -58,7 +58,11 @@ type BackupTarget struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackupTargetSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackupTargetSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackupTargetStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
@@ -11,35 +11,24 @@ const (
 // BackupTargetSpec defines the desired state of the Longhorn backup target
 type BackupTargetSpec struct {
 	// The backup target URL.
-	// +optional
 	BackupTargetURL string `json:"backupTargetURL"`
 	// The backup target credential secret.
-	// +optional
 	CredentialSecret string `json:"credentialSecret"`
 	// The interval that the cluster needs to run sync with the backup target.
-	// +optional
 	PollInterval metav1.Duration `json:"pollInterval"`
 	// The time to request run sync the remote backup target.
-	// +optional
-	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
 // BackupTargetStatus defines the observed state of the Longhorn backup target
 type BackupTargetStatus struct {
 	// The node ID on which the controller is responsible to reconcile this backup target CR.
-	// +optional
 	OwnerID string `json:"ownerID"`
 	// Available indicates if the remote backup target is available or not.
-	// +optional
 	Available bool `json:"available"`
 	// Records the reason on why the backup target is unavailable.
-	// +optional
-	// +nullable
 	Conditions map[string]Condition `json:"conditions"`
 	// The last time that the controller synced with the remote backup target.
-	// +optional
-	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
@@ -68,7 +68,11 @@ type BackupVolume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackupVolumeSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec BackupVolumeSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status BackupVolumeStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
@@ -5,52 +5,34 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // BackupVolumeSpec defines the desired state of the Longhorn backup volume
 type BackupVolumeSpec struct {
 	// The time to request run sync the remote backup volume.
-	// +optional
-	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
 }
 
 // BackupVolumeStatus defines the observed state of the Longhorn backup volume
 type BackupVolumeStatus struct {
 	// The node ID on which the controller is responsible to reconcile this backup volume CR.
-	// +optional
 	OwnerID string `json:"ownerID"`
 	// The backup volume config last modification time.
-	// +optional
-	// +nullable
 	LastModificationTime metav1.Time `json:"lastModificationTime"`
 	// The backup volume size.
-	// +optional
 	Size string `json:"size"`
 	// The backup volume labels.
-	// +optional
-	// +nullable
 	Labels map[string]string `json:"labels"`
 	// The backup volume creation time.
-	// +optional
 	CreatedAt string `json:"createdAt"`
 	// The latest volume backup name.
-	// +optional
 	LastBackupName string `json:"lastBackupName"`
 	// The latest volume backup time.
-	// +optional
 	LastBackupAt string `json:"lastBackupAt"`
 	// The backup volume block count.
-	// +optional
 	DataStored string `json:"dataStored"`
 	// The error messages when call longhorn engine on list or inspect backup volumes.
-	// +optional
-	// +nullable
 	Messages map[string]string `json:"messages"`
 	// The backing image name.
-	// +optional
 	BackingImageName string `json:"backingImageName"`
 	// the backing image checksum.
-	// +optional
 	BackingImageChecksum string `json:"backingImageChecksum"`
 	// The last time that the backup volume was synced into the cluster.
-	// +optional
-	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/conversion.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/conversion.go
@@ -1,0 +1,31 @@
+package v1beta1
+
+import (
+	"github.com/jinzhu/copier"
+
+	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func copyConditionsFromMapToSlice(srcConditions map[string]Condition) ([]v1beta2.Condition, error) {
+	dstConditions := []v1beta2.Condition{}
+	for _, src := range srcConditions {
+		dst := v1beta2.Condition{}
+		if err := copier.Copy(&dst, &src); err != nil {
+			return nil, err
+		}
+		dstConditions = append(dstConditions, dst)
+	}
+	return dstConditions, nil
+}
+
+func copyConditionFromSliceToMap(srcConditions []v1beta2.Condition) (map[string]Condition, error) {
+	dstConditions := make(map[string]Condition, 0)
+	for _, src := range srcConditions {
+		dst := Condition{}
+		if err := copier.Copy(&dst, &src); err != nil {
+			return nil, err
+		}
+		dstConditions[dst.Type] = dst
+	}
+	return dstConditions, nil
+}

--- a/k8s/pkg/apis/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engine.go
@@ -11,162 +11,92 @@ const (
 )
 
 type EngineBackupStatus struct {
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	BackupURL string `json:"backupURL,omitempty"`
-	// +optional
-	Error string `json:"error,omitempty"`
-	// +optional
-	SnapshotName string `json:"snapshotName"`
-	// +optional
-	State string `json:"state"`
-	// +optional
+	Progress       int    `json:"progress"`
+	BackupURL      string `json:"backupURL,omitempty"`
+	Error          string `json:"error,omitempty"`
+	SnapshotName   string `json:"snapshotName"`
+	State          string `json:"state"`
 	ReplicaAddress string `json:"replicaAddress"`
 }
 
 type RestoreStatus struct {
-	// +optional
-	IsRestoring bool `json:"isRestoring"`
-	// +optional
-	LastRestored string `json:"lastRestored"`
-	// +optional
+	IsRestoring            bool   `json:"isRestoring"`
+	LastRestored           string `json:"lastRestored"`
 	CurrentRestoringBackup string `json:"currentRestoringBackup"`
-	// +optional
-	Progress int `json:"progress,omitempty"`
-	// +optional
-	Error string `json:"error,omitempty"`
-	// +optional
-	Filename string `json:"filename,omitempty"`
-	// +optional
-	State string `json:"state"`
-	// +optional
-	BackupURL string `json:"backupURL"`
+	Progress               int    `json:"progress,omitempty"`
+	Error                  string `json:"error,omitempty"`
+	Filename               string `json:"filename,omitempty"`
+	State                  string `json:"state"`
+	BackupURL              string `json:"backupURL"`
 }
 
 type PurgeStatus struct {
-	// +optional
-	Error string `json:"error"`
-	// +optional
-	IsPurging bool `json:"isPurging"`
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	State string `json:"state"`
+	Error     string `json:"error"`
+	IsPurging bool   `json:"isPurging"`
+	Progress  int    `json:"progress"`
+	State     string `json:"state"`
 }
 
 type RebuildStatus struct {
-	// +optional
-	Error string `json:"error"`
-	// +optional
-	IsRebuilding bool `json:"isRebuilding"`
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	State string `json:"state"`
-	// +optional
+	Error              string `json:"error"`
+	IsRebuilding       bool   `json:"isRebuilding"`
+	Progress           int    `json:"progress"`
+	State              string `json:"state"`
 	FromReplicaAddress string `json:"fromReplicaAddress"`
 }
 
 type SnapshotCloneStatus struct {
-	// +optional
-	IsCloning bool `json:"isCloning"`
-	// +optional
-	Error string `json:"error"`
-	// +optional
-	Progress int `json:"progress"`
-	// +optional
-	State string `json:"state"`
-	// +optional
+	IsCloning          bool   `json:"isCloning"`
+	Error              string `json:"error"`
+	Progress           int    `json:"progress"`
+	State              string `json:"state"`
 	FromReplicaAddress string `json:"fromReplicaAddress"`
-	// +optional
-	SnapshotName string `json:"snapshotName"`
+	SnapshotName       string `json:"snapshotName"`
 }
 
 type Snapshot struct {
-	// +optional
-	Name string `json:"name"`
-	// +optional
-	Parent string `json:"parent"`
-	// +optional
-	Children map[string]bool `json:"children"`
-	// +optional
-	Removed bool `json:"removed"`
-	// +optional
-	UserCreated bool `json:"usercreated"`
-	// +optional
-	Created string `json:"created"`
-	// +optional
-	Size string `json:"size"`
-	// +optional
-	Labels map[string]string `json:"labels"`
+	Name        string            `json:"name"`
+	Parent      string            `json:"parent"`
+	Children    map[string]bool   `json:"children"`
+	Removed     bool              `json:"removed"`
+	UserCreated bool              `json:"usercreated"`
+	Created     string            `json:"created"`
+	Size        string            `json:"size"`
+	Labels      map[string]string `json:"labels"`
 }
 
 // EngineSpec defines the desired state of the Longhorn engine
 type EngineSpec struct {
-	InstanceSpec `json:""`
-	// +optional
-	Frontend VolumeFrontend `json:"frontend"`
-	// +optional
-	ReplicaAddressMap map[string]string `json:"replicaAddressMap"`
-	// +optional
+	InstanceSpec              `json:""`
+	Frontend                  VolumeFrontend    `json:"frontend"`
+	ReplicaAddressMap         map[string]string `json:"replicaAddressMap"`
 	UpgradedReplicaAddressMap map[string]string `json:"upgradedReplicaAddressMap"`
-	// +optional
-	BackupVolume string `json:"backupVolume"`
-	// +optional
-	RequestedBackupRestore string `json:"requestedBackupRestore"`
-	// +optional
-	RequestedDataSource VolumeDataSource `json:"requestedDataSource"`
-	// +optional
-	DisableFrontend bool `json:"disableFrontend"`
-	// +optional
-	RevisionCounterDisabled bool `json:"revisionCounterDisabled"`
-	// +optional
-	Active bool `json:"active"`
+	BackupVolume              string            `json:"backupVolume"`
+	RequestedBackupRestore    string            `json:"requestedBackupRestore"`
+	RequestedDataSource       VolumeDataSource  `json:"requestedDataSource"`
+	DisableFrontend           bool              `json:"disableFrontend"`
+	RevisionCounterDisabled   bool              `json:"revisionCounterDisabled"`
+	Active                    bool              `json:"active"`
 }
 
 // EngineStatus defines the observed state of the Longhorn engine
 type EngineStatus struct {
-	InstanceStatus `json:""`
-	// +kubebuilder:validation:Type=string
-	// +optional
-	CurrentSize int64 `json:"currentSize,string"`
-	// +optional
-	// +nullable
-	CurrentReplicaAddressMap map[string]string `json:"currentReplicaAddressMap"`
-	// +optional
-	// +nullable
-	ReplicaModeMap map[string]ReplicaMode `json:"replicaModeMap"`
-	// +optional
-	Endpoint string `json:"endpoint"`
-	// +optional
-	LastRestoredBackup string `json:"lastRestoredBackup"`
-	// +optional
-	// +nullable
-	BackupStatus map[string]*EngineBackupStatus `json:"backupStatus"`
-	// +optional
-	// +nullable
-	RestoreStatus map[string]*RestoreStatus `json:"restoreStatus"`
-	// +optional
-	// +nullable
-	PurgeStatus map[string]*PurgeStatus `json:"purgeStatus"`
-	// +optional
-	// +nullable
-	RebuildStatus map[string]*RebuildStatus `json:"rebuildStatus"`
-	// +optional
-	// +nullable
-	CloneStatus map[string]*SnapshotCloneStatus `json:"cloneStatus"`
-	// +optional
-	// +nullable
-	Snapshots map[string]*Snapshot `json:"snapshots"`
-	// +optional
-	SnapshotsError string `json:"snapshotsError"`
-	// +optional
-	IsExpanding bool `json:"isExpanding"`
-	// +optional
-	LastExpansionError string `json:"lastExpansionError"`
-	// +optional
-	LastExpansionFailedAt string `json:"lastExpansionFailedAt"`
+	InstanceStatus           `json:""`
+	CurrentSize              int64                           `json:"currentSize,string"`
+	CurrentReplicaAddressMap map[string]string               `json:"currentReplicaAddressMap"`
+	ReplicaModeMap           map[string]ReplicaMode          `json:"replicaModeMap"`
+	Endpoint                 string                          `json:"endpoint"`
+	LastRestoredBackup       string                          `json:"lastRestoredBackup"`
+	BackupStatus             map[string]*EngineBackupStatus  `json:"backupStatus"`
+	RestoreStatus            map[string]*RestoreStatus       `json:"restoreStatus"`
+	PurgeStatus              map[string]*PurgeStatus         `json:"purgeStatus"`
+	RebuildStatus            map[string]*RebuildStatus       `json:"rebuildStatus"`
+	CloneStatus              map[string]*SnapshotCloneStatus `json:"cloneStatus"`
+	Snapshots                map[string]*Snapshot            `json:"snapshots"`
+	SnapshotsError           string                          `json:"snapshotsError"`
+	IsExpanding              bool                            `json:"isExpanding"`
+	LastExpansionError       string                          `json:"lastExpansionError"`
+	LastExpansionFailedAt    string                          `json:"lastExpansionFailedAt"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engine.go
@@ -184,7 +184,11 @@ type Engine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   EngineSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec EngineSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status EngineStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
@@ -19,48 +19,32 @@ const (
 )
 
 type EngineVersionDetails struct {
-	// +optional
-	Version string `json:"version"`
-	// +optional
+	Version   string `json:"version"`
 	GitCommit string `json:"gitCommit"`
-	// +optional
 	BuildDate string `json:"buildDate"`
-	// +optional
-	CLIAPIVersion int `json:"cliAPIVersion"`
-	// +optional
-	CLIAPIMinVersion int `json:"cliAPIMinVersion"`
-	// +optional
-	ControllerAPIVersion int `json:"controllerAPIVersion"`
-	// +optional
+
+	CLIAPIVersion           int `json:"cliAPIVersion"`
+	CLIAPIMinVersion        int `json:"cliAPIMinVersion"`
+	ControllerAPIVersion    int `json:"controllerAPIVersion"`
 	ControllerAPIMinVersion int `json:"controllerAPIMinVersion"`
-	// +optional
-	DataFormatVersion int `json:"dataFormatVersion"`
-	// +optional
-	DataFormatMinVersion int `json:"dataFormatMinVersion"`
+	DataFormatVersion       int `json:"dataFormatVersion"`
+	DataFormatMinVersion    int `json:"dataFormatMinVersion"`
 }
 
 // EngineImageSpec defines the desired state of the Longhorn engine image
 type EngineImageSpec struct {
-	// +optional
 	Image string `json:"image"`
 }
 
 // EngineImageStatus defines the observed state of the Longhorn engine image
 type EngineImageStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	State EngineImageState `json:"state"`
-	// +optional
-	RefCount int `json:"refCount"`
-	// +optional
-	NoRefSince string `json:"noRefSince"`
-	// +optional
-	// +nullable
-	Conditions map[string]Condition `json:"conditions"`
-	// +optional
-	// +nullable
-	NodeDeploymentMap    map[string]bool `json:"nodeDeploymentMap"`
+	OwnerID           string               `json:"ownerID"`
+	State             EngineImageState     `json:"state"`
+	RefCount          int                  `json:"refCount"`
+	NoRefSince        string               `json:"noRefSince"`
+	Conditions        map[string]Condition `json:"conditions"`
+	NodeDeploymentMap map[string]bool      `json:"nodeDeploymentMap"`
+
 	EngineVersionDetails `json:""`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
@@ -79,7 +79,11 @@ type EngineImage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   EngineImageSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec EngineImageSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status EngineImageStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
@@ -19,7 +19,6 @@ const (
 	InstanceManagerStateUnknown  = InstanceManagerState("unknown")
 )
 
-// +kubebuilder:validation:Enum=engine;replica
 type InstanceManagerType string
 
 const (
@@ -28,14 +27,11 @@ const (
 )
 
 type InstanceProcess struct {
-	// +optional
-	Spec InstanceProcessSpec `json:"spec"`
-	// +optional
+	Spec   InstanceProcessSpec   `json:"spec"`
 	Status InstanceProcessStatus `json:"status"`
 }
 
 type InstanceProcessSpec struct {
-	// +optional
 	Name string `json:"name"`
 }
 
@@ -51,91 +47,56 @@ const (
 )
 
 type InstanceSpec struct {
-	// +optional
-	VolumeName string `json:"volumeName"`
-	// +kubebuilder:validation:Type=string
-	// +optional
-	VolumeSize int64 `json:"volumeSize,string"`
-	// +optional
-	NodeID string `json:"nodeID"`
-	// +optional
-	EngineImage string `json:"engineImage"`
-	// +optional
-	DesireState InstanceState `json:"desireState"`
-	// +optional
-	LogRequested bool `json:"logRequested"`
-	// +optional
-	SalvageRequested bool `json:"salvageRequested"`
+	VolumeName       string        `json:"volumeName"`
+	VolumeSize       int64         `json:"volumeSize,string"`
+	NodeID           string        `json:"nodeID"`
+	EngineImage      string        `json:"engineImage"`
+	DesireState      InstanceState `json:"desireState"`
+	LogRequested     bool          `json:"logRequested"`
+	SalvageRequested bool          `json:"salvageRequested"`
 }
 
 type InstanceStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	InstanceManagerName string `json:"instanceManagerName"`
-	// +optional
-	CurrentState InstanceState `json:"currentState"`
-	// +optional
-	CurrentImage string `json:"currentImage"`
-	// +optional
-	IP string `json:"ip"`
-	// +optional
-	Port int `json:"port"`
-	// +optional
-	Started bool `json:"started"`
-	// +optional
-	LogFetched bool `json:"logFetched"`
-	// +optional
-	SalvageExecuted bool `json:"salvageExecuted"`
+	OwnerID             string        `json:"ownerID"`
+	InstanceManagerName string        `json:"instanceManagerName"`
+	CurrentState        InstanceState `json:"currentState"`
+	CurrentImage        string        `json:"currentImage"`
+	IP                  string        `json:"ip"`
+	Port                int           `json:"port"`
+	Started             bool          `json:"started"`
+	LogFetched          bool          `json:"logFetched"`
+	SalvageExecuted     bool          `json:"salvageExecuted"`
 }
 
 type InstanceProcessStatus struct {
-	// +optional
-	Endpoint string `json:"endpoint"`
-	// +optional
-	ErrorMsg string `json:"errorMsg"`
-	// +optional
-	Listen string `json:"listen"`
-	// +optional
-	PortEnd int32 `json:"portEnd"`
-	// +optional
-	PortStart int32 `json:"portStart"`
-	// +optional
-	State InstanceState `json:"state"`
-	// +optional
-	Type InstanceType `json:"type"`
-	// +optional
-	ResourceVersion int64 `json:"resourceVersion"`
+	Endpoint        string        `json:"endpoint"`
+	ErrorMsg        string        `json:"errorMsg"`
+	Listen          string        `json:"listen"`
+	PortEnd         int32         `json:"portEnd"`
+	PortStart       int32         `json:"portStart"`
+	State           InstanceState `json:"state"`
+	Type            InstanceType  `json:"type"`
+	ResourceVersion int64         `json:"resourceVersion"`
 }
 
 // InstanceManagerSpec defines the desired state of the Longhorn instancer manager
 type InstanceManagerSpec struct {
-	// +optional
-	Image string `json:"image"`
-	// +optional
-	NodeID string `json:"nodeID"`
-	// +optional
-	Type InstanceManagerType `json:"type"`
+	Image  string              `json:"image"`
+	NodeID string              `json:"nodeID"`
+	Type   InstanceManagerType `json:"type"`
+
 	// TODO: deprecate this field
-	// +optional
 	EngineImage string `json:"engineImage"`
 }
 
 // InstanceManagerStatus defines the observed state of the Longhorn instance manager
 type InstanceManagerStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	CurrentState InstanceManagerState `json:"currentState"`
-	// +optional
-	// +nullable
-	Instances map[string]InstanceProcess `json:"instances"`
-	// +optional
-	IP string `json:"ip"`
-	// +optional
-	APIMinVersion int `json:"apiMinVersion"`
-	// +optional
-	APIVersion int `json:"apiVersion"`
+	OwnerID       string                     `json:"ownerID"`
+	CurrentState  InstanceManagerState       `json:"currentState"`
+	Instances     map[string]InstanceProcess `json:"instances"`
+	IP            string                     `json:"ip"`
+	APIMinVersion int                        `json:"apiMinVersion"`
+	APIVersion    int                        `json:"apiVersion"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
@@ -152,7 +152,11 @@ type InstanceManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   InstanceManagerSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec InstanceManagerSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status InstanceManagerStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/misc.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/misc.go
@@ -10,22 +10,16 @@ const (
 
 type Condition struct {
 	// Type is the type of the condition.
-	// +optional
 	Type string `json:"type"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	// +optional
 	Status ConditionStatus `json:"status"`
 	// Last time we probed the condition.
-	// +optional
 	LastProbeTime string `json:"lastProbeTime"`
 	// Last time the condition transitioned from one status to another.
-	// +optional
 	LastTransitionTime string `json:"lastTransitionTime"`
 	// Unique, one-word, CamelCase reason for the condition's last transition.
-	// +optional
 	Reason string `json:"reason"`
 	// Human-readable message indicating details about last transition.
-	// +optional
 	Message string `json:"message"`
 }

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -109,7 +109,11 @@ type Node struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NodeSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec NodeSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status NodeStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -32,67 +32,39 @@ const (
 )
 
 type DiskSpec struct {
-	// +optional
-	Path string `json:"path"`
-	// +optional
-	AllowScheduling bool `json:"allowScheduling"`
-	// +optional
-	EvictionRequested bool `json:"evictionRequested"`
-	// +optional
-	StorageReserved int64 `json:"storageReserved"`
-	// +optional
-	Tags []string `json:"tags"`
+	Path              string   `json:"path"`
+	AllowScheduling   bool     `json:"allowScheduling"`
+	EvictionRequested bool     `json:"evictionRequested"`
+	StorageReserved   int64    `json:"storageReserved"`
+	Tags              []string `json:"tags"`
 }
 
 type DiskStatus struct {
-	// +optional
-	// +nullable
-	Conditions map[string]Condition `json:"conditions"`
-	// +optional
-	StorageAvailable int64 `json:"storageAvailable"`
-	// +optional
-	StorageScheduled int64 `json:"storageScheduled"`
-	// +optional
-	StorageMaximum int64 `json:"storageMaximum"`
-	// +optional
-	// +nullable
-	ScheduledReplica map[string]int64 `json:"scheduledReplica"`
-	// +optional
-	DiskUUID string `json:"diskUUID"`
+	Conditions       map[string]Condition `json:"conditions"`
+	StorageAvailable int64                `json:"storageAvailable"`
+	StorageScheduled int64                `json:"storageScheduled"`
+	StorageMaximum   int64                `json:"storageMaximum"`
+	ScheduledReplica map[string]int64     `json:"scheduledReplica"`
+	DiskUUID         string               `json:"diskUUID"`
 }
 
 // NodeSpec defines the desired state of the Longhorn node
 type NodeSpec struct {
-	// +optional
-	Name string `json:"name"`
-	// +optional
-	Disks map[string]DiskSpec `json:"disks"`
-	// +optional
-	AllowScheduling bool `json:"allowScheduling"`
-	// +optional
-	EvictionRequested bool `json:"evictionRequested"`
-	// +optional
-	Tags []string `json:"tags"`
-	// +kubebuilder:validation:Minimum=0
-	// +optional
-	EngineManagerCPURequest int `json:"engineManagerCPURequest"`
-	// +kubebuilder:validation:Minimum=0
-	// +optional
-	ReplicaManagerCPURequest int `json:"replicaManagerCPURequest"`
+	Name                     string              `json:"name"`
+	Disks                    map[string]DiskSpec `json:"disks"`
+	AllowScheduling          bool                `json:"allowScheduling"`
+	EvictionRequested        bool                `json:"evictionRequested"`
+	Tags                     []string            `json:"tags"`
+	EngineManagerCPURequest  int                 `json:"engineManagerCPURequest"`
+	ReplicaManagerCPURequest int                 `json:"replicaManagerCPURequest"`
 }
 
 // NodeStatus defines the observed state of the Longhorn node
 type NodeStatus struct {
-	// +optional
-	// +nullable
-	Conditions map[string]Condition `json:"conditions"`
-	// +optional
-	// +nullable
+	Conditions map[string]Condition   `json:"conditions"`
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`
-	// +optional
-	Region string `json:"region"`
-	// +optional
-	Zone string `json:"zone"`
+	Region     string                 `json:"region"`
+	Zone       string                 `json:"zone"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
@@ -2,7 +2,6 @@ package v1beta1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +kubebuilder:validation:Enum=snapshot;backup
 type RecurringJobType string
 
 const (
@@ -20,36 +19,25 @@ type VolumeRecurringJob struct {
 // RecurringJobSpec defines the desired state of the Longhorn recurring job
 type RecurringJobSpec struct {
 	// The recurring job name.
-	// +optional
 	Name string `json:"name"`
 	// The recurring job group.
-	// +optional
 	Groups []string `json:"groups,omitempty"`
 	// The recurring job type.
 	// Can be "snapshot" or "backup".
-	// +optional
 	Task RecurringJobType `json:"task"`
 	// The cron setting.
-	// +optional
 	Cron string `json:"cron"`
 	// The retain count of the snapshot/backup.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=50
-	// +optional
 	Retain int `json:"retain"`
 	// The concurrency of taking the snapshot/backup.
-	// +kubebuilder:validation:Minimum=1
-	// +optional
 	Concurrency int `json:"concurrency"`
 	// The label of the snapshot/backup.
-	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // RecurringJobStatus defines the observed state of the Longhorn recurring job
 type RecurringJobStatus struct {
 	// The owner ID which is responsible to reconcile this recurring job CR.
-	// +optional
 	OwnerID string `json:"ownerID"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
@@ -70,7 +70,11 @@ type RecurringJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   RecurringJobSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec RecurringJobSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status RecurringJobStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/replica.go
@@ -4,41 +4,28 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ReplicaSpec defines the desired state of the Longhorn replica
 type ReplicaSpec struct {
-	InstanceSpec `json:""`
-	// +optional
-	EngineName string `json:"engineName"`
-	// +optional
-	HealthyAt string `json:"healthyAt"`
-	// +optional
-	FailedAt string `json:"failedAt"`
-	// +optional
-	DiskID string `json:"diskID"`
-	// +optional
-	DiskPath string `json:"diskPath"`
-	// +optional
-	DataDirectoryName string `json:"dataDirectoryName"`
-	// +optional
-	BackingImage string `json:"backingImage"`
-	// +optional
-	Active bool `json:"active"`
-	// +optional
-	HardNodeAffinity string `json:"hardNodeAffinity"`
-	// +optional
-	RevisionCounterDisabled bool `json:"revisionCounterDisabled"`
-	// +optional
+	InstanceSpec            `json:""`
+	EngineName              string `json:"engineName"`
+	HealthyAt               string `json:"healthyAt"`
+	FailedAt                string `json:"failedAt"`
+	DiskID                  string `json:"diskID"`
+	DiskPath                string `json:"diskPath"`
+	DataDirectoryName       string `json:"dataDirectoryName"`
+	BackingImage            string `json:"backingImage"`
+	Active                  bool   `json:"active"`
+	HardNodeAffinity        string `json:"hardNodeAffinity"`
+	RevisionCounterDisabled bool   `json:"revisionCounterDisabled"`
+
 	RebuildRetryCount int `json:"rebuildRetryCount"`
 	// Deprecated
-	// +optional
 	DataPath string `json:"dataPath"`
 	// Deprecated. Rename to BackingImage
-	// +optional
 	BaseImage string `json:"baseImage"`
 }
 
 // ReplicaStatus defines the observed state of the Longhorn replica
 type ReplicaStatus struct {
-	InstanceStatus `json:""`
-	// +optional
+	InstanceStatus    `json:""`
 	EvictionRequested bool `json:"evictionRequested"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/replica.go
@@ -58,7 +58,11 @@ type Replica struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ReplicaSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec ReplicaSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status ReplicaStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
@@ -15,18 +15,14 @@ const (
 
 // ShareManagerSpec defines the desired state of the Longhorn share manager
 type ShareManagerSpec struct {
-	// +optional
 	Image string `json:"image"`
 }
 
 // ShareManagerStatus defines the observed state of the Longhorn share manager
 type ShareManagerStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	State ShareManagerState `json:"state"`
-	// +optional
-	Endpoint string `json:"endpoint"`
+	OwnerID  string            `json:"ownerID"`
+	State    ShareManagerState `json:"state"`
+	Endpoint string            `json:"endpoint"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
@@ -42,7 +42,11 @@ type ShareManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ShareManagerSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec ShareManagerSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status ShareManagerStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/volume.go
@@ -22,7 +22,6 @@ const (
 	VolumeRobustnessUnknown  = VolumeRobustness("unknown")
 )
 
-// +kubebuilder:validation:Enum=blockdev;iscsi;""
 type VolumeFrontend string
 
 const (
@@ -41,7 +40,6 @@ const (
 	VolumeDataSourceTypeVolume   = VolumeDataSourceType("volume")
 )
 
-// +kubebuilder:validation:Enum=disabled;best-effort
 type DataLocality string
 
 const (
@@ -49,7 +47,6 @@ const (
 	DataLocalityBestEffort = DataLocality("best-effort")
 )
 
-// +kubebuilder:validation:Enum=rwo;rwx
 type AccessMode string
 
 const (
@@ -57,7 +54,6 @@ const (
 	AccessModeReadWriteMany = AccessMode("rwx")
 )
 
-// +kubebuilder:validation:Enum=ignored;disabled;least-effort;best-effort
 type ReplicaAutoBalance string
 
 const (
@@ -77,12 +73,9 @@ const (
 )
 
 type VolumeCloneStatus struct {
-	// +optional
-	SourceVolume string `json:"sourceVolume"`
-	// +optional
-	Snapshot string `json:"snapshot"`
-	// +optional
-	State VolumeCloneState `json:"state"`
+	SourceVolume string           `json:"sourceVolume"`
+	Snapshot     string           `json:"snapshot"`
+	State        VolumeCloneState `json:"state"`
 }
 
 const (
@@ -103,152 +96,92 @@ const (
 // TODO: Should be removed when recurringJobs gets removed from the volume
 //       spec.
 type VolumeRecurringJobSpec struct {
-	// +optional
-	Name string `json:"name"`
-	// +optional
-	Groups []string `json:"groups,omitempty"`
-	// +optional
-	Task RecurringJobType `json:"task"`
-	// +optional
-	Cron string `json:"cron"`
-	// +optional
-	Retain int `json:"retain"`
-	// +optional
-	Concurrency int `json:"concurrency"`
-	// +optional
-	Labels map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Groups      []string          `json:"groups,omitempty"`
+	Task        RecurringJobType  `json:"task"`
+	Cron        string            `json:"cron"`
+	Retain      int               `json:"retain"`
+	Concurrency int               `json:"concurrency"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type KubernetesStatus struct {
-	// +optional
-	PVName string `json:"pvName"`
-	// +optional
+	PVName   string `json:"pvName"`
 	PVStatus string `json:"pvStatus"`
+
 	// determine if PVC/Namespace is history or not
-	// +optional
-	Namespace string `json:"namespace"`
-	// +optional
-	PVCName string `json:"pvcName"`
-	// +optional
+	Namespace    string `json:"namespace"`
+	PVCName      string `json:"pvcName"`
 	LastPVCRefAt string `json:"lastPVCRefAt"`
+
 	// determine if Pod/Workload is history or not
-	// +optional
-	// +nullable
 	WorkloadsStatus []WorkloadStatus `json:"workloadsStatus"`
-	// +optional
-	LastPodRefAt string `json:"lastPodRefAt"`
+	LastPodRefAt    string           `json:"lastPodRefAt"`
 }
 
 type WorkloadStatus struct {
-	// +optional
-	PodName string `json:"podName"`
-	// +optional
-	PodStatus string `json:"podStatus"`
-	// +optional
+	PodName      string `json:"podName"`
+	PodStatus    string `json:"podStatus"`
 	WorkloadName string `json:"workloadName"`
-	// +optional
 	WorkloadType string `json:"workloadType"`
 }
 
 // VolumeSpec defines the desired state of the Longhorn volume
 type VolumeSpec struct {
-	// +kubebuilder:validation:Type=string
-	// +optional
-	Size int64 `json:"size,string"`
-	// +optional
-	Frontend VolumeFrontend `json:"frontend"`
-	// +optional
-	FromBackup string `json:"fromBackup"`
-	// +optional
-	DataSource VolumeDataSource `json:"dataSource"`
-	// +optional
-	DataLocality DataLocality `json:"dataLocality"`
-	// +optional
-	StaleReplicaTimeout int `json:"staleReplicaTimeout"`
-	// +optional
-	NodeID string `json:"nodeID"`
-	// +optional
-	MigrationNodeID string `json:"migrationNodeID"`
-	// +optional
-	EngineImage string `json:"engineImage"`
-	// +optional
-	BackingImage string `json:"backingImage"`
-	// +optional
-	Standby bool `json:"Standby"`
-	// +optional
-	DiskSelector []string `json:"diskSelector"`
-	// +optional
-	NodeSelector []string `json:"nodeSelector"`
-	// +optional
-	DisableFrontend bool `json:"disableFrontend"`
-	// +optional
-	RevisionCounterDisabled bool `json:"revisionCounterDisabled"`
-	// +optional
-	LastAttachedBy string `json:"lastAttachedBy"`
-	// +optional
-	AccessMode AccessMode `json:"accessMode"`
-	// +optional
-	Migratable bool `json:"migratable"`
-	// +optional
+	Size                    int64            `json:"size,string"`
+	Frontend                VolumeFrontend   `json:"frontend"`
+	FromBackup              string           `json:"fromBackup"`
+	DataSource              VolumeDataSource `json:"dataSource"`
+	DataLocality            DataLocality     `json:"dataLocality"`
+	StaleReplicaTimeout     int              `json:"staleReplicaTimeout"`
+	NodeID                  string           `json:"nodeID"`
+	MigrationNodeID         string           `json:"migrationNodeID"`
+	EngineImage             string           `json:"engineImage"`
+	BackingImage            string           `json:"backingImage"`
+	Standby                 bool             `json:"Standby"`
+	DiskSelector            []string         `json:"diskSelector"`
+	NodeSelector            []string         `json:"nodeSelector"`
+	DisableFrontend         bool             `json:"disableFrontend"`
+	RevisionCounterDisabled bool             `json:"revisionCounterDisabled"`
+	LastAttachedBy          string           `json:"lastAttachedBy"`
+	AccessMode              AccessMode       `json:"accessMode"`
+	Migratable              bool             `json:"migratable"`
+
 	Encrypted bool `json:"encrypted"`
-	// +kubebuilder:validation:Minimum=1
-	// +optional
-	NumberOfReplicas int `json:"numberOfReplicas"`
-	// +optional
+
+	NumberOfReplicas   int                `json:"numberOfReplicas"`
 	ReplicaAutoBalance ReplicaAutoBalance `json:"replicaAutoBalance"`
+
 	// Deprecated. Rename to BackingImage
-	// +optional
 	BaseImage string `json:"baseImage"`
+
 	// Deprecated. Replaced by a separate resource named "RecurringJob"
-	// +optional
 	RecurringJobs []VolumeRecurringJobSpec `json:"recurringJobs,omitempty"`
 }
 
 // VolumeStatus defines the observed state of the Longhorn volume
 type VolumeStatus struct {
-	// +optional
-	OwnerID string `json:"ownerID"`
-	// +optional
-	State VolumeState `json:"state"`
-	// +optional
-	Robustness VolumeRobustness `json:"robustness"`
-	// +optional
-	CurrentNodeID string `json:"currentNodeID"`
-	// +optional
-	CurrentImage string `json:"currentImage"`
-	// +optional
-	KubernetesStatus KubernetesStatus `json:"kubernetesStatus"`
-	// +optional
-	// +nullable
-	Conditions map[string]Condition `json:"conditions"`
-	// +optional
-	LastBackup string `json:"lastBackup"`
-	// +optional
-	LastBackupAt string `json:"lastBackupAt"`
-	// +optional
-	PendingNodeID string `json:"pendingNodeID"`
-	// +optional
-	FrontendDisabled bool `json:"frontendDisabled"`
-	// +optional
-	RestoreRequired bool `json:"restoreRequired"`
-	// +optional
-	RestoreInitiated bool `json:"restoreInitiated"`
-	// +optional
-	CloneStatus VolumeCloneStatus `json:"cloneStatus"`
-	// +optional
-	RemountRequestedAt string `json:"remountRequestedAt"`
-	// +optional
-	ExpansionRequired bool `json:"expansionRequired"`
-	// +optional
-	IsStandby bool `json:"isStandby"`
-	// +optional
-	ActualSize int64 `json:"actualSize"`
-	// +optional
-	LastDegradedAt string `json:"lastDegradedAt"`
-	// +optional
-	ShareEndpoint string `json:"shareEndpoint"`
-	// +optional
-	ShareState ShareManagerState `json:"shareState"`
+	OwnerID            string               `json:"ownerID"`
+	State              VolumeState          `json:"state"`
+	Robustness         VolumeRobustness     `json:"robustness"`
+	CurrentNodeID      string               `json:"currentNodeID"`
+	CurrentImage       string               `json:"currentImage"`
+	KubernetesStatus   KubernetesStatus     `json:"kubernetesStatus"`
+	Conditions         map[string]Condition `json:"conditions"`
+	LastBackup         string               `json:"lastBackup"`
+	LastBackupAt       string               `json:"lastBackupAt"`
+	PendingNodeID      string               `json:"pendingNodeID"`
+	FrontendDisabled   bool                 `json:"frontendDisabled"`
+	RestoreRequired    bool                 `json:"restoreRequired"`
+	RestoreInitiated   bool                 `json:"restoreInitiated"`
+	CloneStatus        VolumeCloneStatus    `json:"cloneStatus"`
+	RemountRequestedAt string               `json:"remountRequestedAt"`
+	ExpansionRequired  bool                 `json:"expansionRequired"`
+	IsStandby          bool                 `json:"isStandby"`
+	ActualSize         int64                `json:"actualSize"`
+	LastDegradedAt     string               `json:"lastDegradedAt"`
+	ShareEndpoint      string               `json:"shareEndpoint"`
+	ShareState         ShareManagerState    `json:"shareState"`
 }
 
 // +genclient

--- a/k8s/pkg/apis/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/volume.go
@@ -267,7 +267,11 @@ type Volume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VolumeSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec VolumeSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status VolumeStatus `json:"status,omitempty"`
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta1/zz_generated.deepcopy.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/zz_generated.deepcopy.go
@@ -337,7 +337,7 @@ func (in *BackingImageSpec) DeepCopyInto(out *BackingImageSpec) {
 	*out = *in
 	if in.Disks != nil {
 		in, out := &in.Disks, &out.Disks
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]struct{}, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
@@ -94,3 +94,7 @@ type BackingImageList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []BackingImage `json:"items"`
 }
+
+// Hub defines the current version (v1beta2) is the storage version
+// so mark this as Hub
+func (bi *BackingImage) Hub() {}

--- a/k8s/pkg/apis/longhorn/v1beta2/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backuptarget.go
@@ -71,3 +71,7 @@ type BackupTargetList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []BackupTarget `json:"items"`
 }
+
+// Hub defines the current version (v1beta2) is the storage version
+// so mark this as Hub
+func (bt *BackupTarget) Hub() {}

--- a/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
@@ -92,3 +92,7 @@ type EngineImageList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EngineImage `json:"items"`
 }
+
+// Hub defines the current version (v1beta2) is the storage version
+// so mark this as Hub
+func (ei *EngineImage) Hub() {}

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -122,3 +122,7 @@ type NodeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Node `json:"items"`
 }
+
+// Hub defines the current version (v1beta2) is the storage version
+// so mark this as Hub
+func (n *Node) Hub() {}

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -280,3 +280,7 @@ type VolumeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Volume `json:"items"`
 }
+
+// Hub defines the current version (v1beta2) is the storage version
+// so mark this as Hub
+func (v *Volume) Hub() {}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -192,7 +192,7 @@ func doAPIVersionUpgrade(namespace string, config *restclient.Config, lhClient *
 		}
 	case types.CRDAPIVersionV1beta1:
 		logrus.Infof("Upgrading from %v to %v", types.CRDAPIVersionV1beta1, types.CurrentCRDAPIVersion)
-		if err := v1beta1.UpgradeCRFromV1beta1ToV1beta2(config, namespace, lhClient); err != nil {
+		if err := v1beta1.FixupCRs(config, namespace, lhClient); err != nil {
 			return err
 		}
 		crdAPIVersionSetting.Value = types.CRDAPIVersionV1beta2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -685,6 +685,8 @@ k8s.io/utils/net
 k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/trace
+# sigs.k8s.io/controller-runtime v0.4.0
+sigs.k8s.io/controller-runtime/pkg/conversion
 # sigs.k8s.io/structured-merge-diff/v3 v3.0.1
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0

--- a/vendor/sigs.k8s.io/controller-runtime/LICENSE
+++ b/vendor/sigs.k8s.io/controller-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/conversion/conversion.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/conversion/conversion.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package conversion provides interface definitions that an API Type needs to
+implement for it to be supported by the generic conversion webhook handler
+defined under pkg/webhook/conversion.
+*/
+package conversion
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// Convertible defines capability of a type to convertible i.e. it can be converted to/from a hub type.
+type Convertible interface {
+	runtime.Object
+	ConvertTo(dst Hub) error
+	ConvertFrom(src Hub) error
+}
+
+// Hub marks that a given type is the hub type for conversion. This means that
+// all conversions will first convert to the hub type, then convert from the hub
+// type to the destination type. All types besides the hub type should implement
+// Convertible.
+type Hub interface {
+	runtime.Object
+	Hub()
+}

--- a/webhook/conversion/conversion.go
+++ b/webhook/conversion/conversion.go
@@ -1,0 +1,221 @@
+package conversion
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	longhornV1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+type Handler struct {
+	scheme  *runtime.Scheme
+	decoder *Decoder
+}
+
+func NewHandler() (*Handler, error) {
+	scheme := runtime.NewScheme()
+	if err := longhornV1beta1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := longhorn.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	return &Handler{
+		scheme:  scheme,
+		decoder: NewDecoder(scheme),
+	}, nil
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	var body []byte
+	if req.Body != nil {
+		if data, err := ioutil.ReadAll(req.Body); err == nil {
+			body = data
+		}
+	}
+	convertReview := apiextv1.ConversionReview{}
+
+	err := h.decoder.DecodeInto(body, &convertReview)
+	if err != nil {
+		logrus.WithError(err).Error("error decoding conversion request")
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	convertReview.Response = h.handleConvertRequest(convertReview.Request)
+	convertReview.Response.UID = convertReview.Request.UID
+
+	err = json.NewEncoder(rw).Encode(&convertReview)
+	if err != nil {
+		logrus.WithError(err).Error("error encoding conversion request")
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+// handleConvertRequest handles a version conversion request.
+func (h *Handler) handleConvertRequest(req *apiextv1.ConversionRequest) *apiextv1.ConversionResponse {
+	var convertedObjects []runtime.RawExtension
+	for _, obj := range req.Objects {
+		src, gvk, err := h.decoder.Decode(obj.Raw)
+		if err != nil {
+			logrus.WithError(err).Error("error decoding src object")
+		}
+		logrus.Debugf("decoding incoming obj: src %v gvk %v src type %v", src, gvk, fmt.Sprintf("%T", src))
+
+		dst, err := getTargetObject(h.scheme, req.DesiredAPIVersion, gvk.Kind)
+		if err != nil {
+			logrus.WithError(err).Error("error getting destination object")
+			return conversionResponseFailureWithMessagef("error converting object")
+		}
+		err = h.convertObject(src, dst)
+		if err != nil {
+			logrus.WithError(err).Error("error converting object")
+			return conversionResponseFailureWithMessagef("error converting object")
+		}
+		convertedObjects = append(convertedObjects, runtime.RawExtension{Object: dst})
+	}
+	return &apiextv1.ConversionResponse{
+		ConvertedObjects: convertedObjects,
+		Result:           statusSucceed(),
+	}
+}
+
+func (h *Handler) convertObject(src, dst runtime.Object) error {
+	if src.GetObjectKind().GroupVersionKind().String() == dst.GetObjectKind().GroupVersionKind().String() {
+		return fmt.Errorf("conversion is not allowed between same type %T", src)
+	}
+
+	srcIsHub, dstIsHub := isHub(src), isHub(dst)
+	srcIsConvertible, dstIsConvertible := isConvertible(src), isConvertible(dst)
+
+	if srcIsHub {
+		if dstIsConvertible {
+			return dst.(conversion.Convertible).ConvertFrom(src.(conversion.Hub))
+		}
+		// this is error case.
+		return fmt.Errorf("%T is not convertible to", src)
+	}
+
+	if dstIsHub {
+		if srcIsConvertible {
+			return src.(conversion.Convertible).ConvertTo(dst.(conversion.Hub))
+		}
+		// this is error case.
+		return fmt.Errorf("%T is not convertible", src)
+	}
+
+	// neigher src nor dst are Hub, means both of them are spoke, so lets get the hub
+	// version type.
+	hub, err := getHub(h.scheme, src)
+	if err != nil {
+		return err
+	}
+
+	// src and dst needs to be convertible for it to work
+	if !srcIsConvertible || !dstIsConvertible {
+		return fmt.Errorf("%T and %T needs to be both convertible", src, dst)
+	}
+
+	err = src.(conversion.Convertible).ConvertTo(hub)
+	if err != nil {
+		return fmt.Errorf("%T failed to convert to hub version %T : %v", src, hub, err)
+	}
+
+	err = dst.(conversion.Convertible).ConvertFrom(hub)
+	if err != nil {
+		return fmt.Errorf("%T failed to convert from hub version %T : %v", dst, hub, err)
+	}
+
+	return nil
+}
+
+func getHub(scheme *runtime.Scheme, obj runtime.Object) (conversion.Hub, error) {
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, fmt.Errorf("error retriving object kinds for given object : %v", err)
+	}
+
+	var hub conversion.Hub
+	hubFoundAlready := false
+	var isHub bool
+	for _, gvk := range gvks {
+		o, _ := scheme.New(gvk)
+		if hub, isHub = o.(conversion.Hub); isHub {
+			if hubFoundAlready {
+				// multiple hub found, error case
+				return nil, fmt.Errorf("multiple hub version defined")
+			}
+			hubFoundAlready = true
+		}
+	}
+	return hub, nil
+}
+
+func getTargetObject(scheme *runtime.Scheme, apiVersion, kind string) (runtime.Object, error) {
+	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+	obj, err := scheme.New(gvk)
+	if err != nil {
+		return obj, err
+	}
+
+	t, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return obj, err
+	}
+
+	t.SetAPIVersion(apiVersion)
+	t.SetKind(kind)
+	return obj, nil
+}
+
+// conversionResponseFailureWithMessagef is a helper function to create an ConversionResponse
+// with a formatted embedded error message
+func conversionResponseFailureWithMessagef(msg string, params ...interface{}) *apiextv1.ConversionResponse {
+	return &apiextv1.ConversionResponse{
+		Result: metav1.Status{
+			Message: fmt.Sprintf(msg, params...),
+			Status:  metav1.StatusFailure,
+		},
+	}
+
+}
+
+// statusErrorWithMessage is a helper function to create an metav1 failure status
+// with an error message
+func statusErrorWithMessage(msg string, params ...interface{}) metav1.Status {
+	return metav1.Status{
+		Message: fmt.Sprintf(msg, params...),
+		Status:  metav1.StatusFailure,
+	}
+}
+
+// statusSucceed is a helper function to createa an metav1 success status
+func statusSucceed() metav1.Status {
+	return metav1.Status{Status: metav1.StatusSuccess}
+}
+
+// isHub is a function to identify the runtime object is a hub or not
+func isHub(obj runtime.Object) bool {
+	_, yes := obj.(conversion.Hub)
+	return yes
+}
+
+// isConvertible is a function to identify the runtime object is convertible or not
+func isConvertible(obj runtime.Object) bool {
+	_, yes := obj.(conversion.Convertible)
+	return yes
+}

--- a/webhook/conversion/decoder.go
+++ b/webhook/conversion/decoder.go
@@ -1,0 +1,30 @@
+package conversion
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+// Decoder knows how to decode the contents of a CRD version conversion
+// request into a concrete object.
+type Decoder struct {
+	codecs serializer.CodecFactory
+}
+
+// NewDecoder creates a Decoder given the runtime.Scheme
+func NewDecoder(scheme *runtime.Scheme) *Decoder {
+	return &Decoder{codecs: serializer.NewCodecFactory(scheme)}
+}
+
+// Decode decodes the inlined object.
+func (d *Decoder) Decode(content []byte) (runtime.Object, *schema.GroupVersionKind, error) {
+	deserializer := d.codecs.UniversalDeserializer()
+	return deserializer.Decode(content, nil, nil)
+}
+
+// DecodeInto decodes the inlined object in the into the passed-in runtime.Object.
+func (d *Decoder) DecodeInto(content []byte, into runtime.Object) error {
+	deserializer := d.codecs.UniversalDeserializer()
+	return runtime.DecodeInto(deserializer, content, into)
+}

--- a/webhook/resources/backingimage/conversion.go
+++ b/webhook/resources/backingimage/conversion.go
@@ -1,0 +1,7 @@
+package backingimage
+
+import "github.com/longhorn/longhorn-manager/controller"
+
+func NewConversion() string {
+	return controller.CRDBackingImageName
+}

--- a/webhook/resources/backuptarget/conversion.go
+++ b/webhook/resources/backuptarget/conversion.go
@@ -1,0 +1,7 @@
+package backuptarget
+
+import "github.com/longhorn/longhorn-manager/controller"
+
+func NewConversion() string {
+	return controller.CRDBackupTargetName
+}

--- a/webhook/resources/engineimage/conversion.go
+++ b/webhook/resources/engineimage/conversion.go
@@ -1,0 +1,7 @@
+package engineimage
+
+import "github.com/longhorn/longhorn-manager/controller"
+
+func NewConversion() string {
+	return controller.CRDEngineImageName
+}

--- a/webhook/resources/node/conversion.go
+++ b/webhook/resources/node/conversion.go
@@ -1,0 +1,7 @@
+package node
+
+import "github.com/longhorn/longhorn-manager/controller"
+
+func NewConversion() string {
+	return controller.CRDNodeName
+}

--- a/webhook/resources/volume/conversion.go
+++ b/webhook/resources/volume/conversion.go
@@ -1,0 +1,7 @@
+package volume
+
+import "github.com/longhorn/longhorn-manager/controller"
+
+func NewConversion() string {
+	return controller.CRDVolumeName
+}

--- a/webhook/server/conversion.go
+++ b/webhook/server/conversion.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/longhorn/longhorn-manager/webhook/conversion"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backingimage"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backuptarget"
+	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
+	"github.com/longhorn/longhorn-manager/webhook/resources/node"
+	"github.com/longhorn/longhorn-manager/webhook/resources/volume"
+)
+
+func Conversion() (http.Handler, []string, error) {
+	conversions := []string{
+		backingimage.NewConversion(),
+		backuptarget.NewConversion(),
+		engineimage.NewConversion(),
+		node.NewConversion(),
+		volume.NewConversion(),
+	}
+
+	router, err := conversion.NewHandler()
+	if err != nil {
+		return nil, nil, err
+	}
+	return router, conversions, nil
+}

--- a/webhook/server/handler.go
+++ b/webhook/server/handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/http"
 	"reflect"
 
 	"github.com/rancher/wrangler/pkg/webhook"
@@ -14,4 +15,16 @@ func addHandler(router *webhook.Router, admissionType string, admitter admission
 	kind := reflect.Indirect(reflect.ValueOf(rsc.ObjectType)).Type().Name()
 	router.Kind(kind).Group(rsc.APIGroup).Type(rsc.ObjectType).Handle(admission.NewHandler(admitter, admissionType))
 	logrus.Infof("Add %s handler for %s.%s (%s)", admissionType, rsc.Name, rsc.APIGroup, kind)
+}
+
+type healthzHandler struct {
+}
+
+func newhealthzHandler() *healthzHandler {
+	return &healthzHandler{}
+}
+
+func (h *healthzHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	return
 }

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rancher/dynamiclistener"
@@ -92,9 +91,6 @@ func (s *WebhookServer) listenAndServe(client *client.Client, handler http.Handl
 		if secret == nil || secret.Name != caName || secret.Namespace != s.namespace || len(secret.Data[corev1.TLSCertKey]) == 0 {
 			return nil, nil
 		}
-		logrus.Info("Sleeping for 15 seconds then applying webhook config")
-		// Sleep here to make sure server is listening and all caches are primed
-		time.Sleep(15 * time.Second)
 
 		port := int32(types.DefaultWebhookServerPort)
 

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -150,7 +150,7 @@ func (s *WebhookServer) listenAndServe(client *client.Client, handler http.Handl
 					Rules:                   validationRules,
 					FailurePolicy:           &failPolicyFail,
 					SideEffects:             &sideEffectClassNone,
-					AdmissionReviewVersions: []string{"v1", "v1beta1"},
+					AdmissionReviewVersions: []string{"v1"},
 				},
 			},
 		}
@@ -174,7 +174,7 @@ func (s *WebhookServer) listenAndServe(client *client.Client, handler http.Handl
 					Rules:                   mutationRules,
 					FailurePolicy:           &failPolicyIgnore,
 					SideEffects:             &sideEffectClassNone,
-					AdmissionReviewVersions: []string{"v1", "v1beta1"},
+					AdmissionReviewVersions: []string{"v1"},
 				},
 			},
 		}

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -75,6 +75,8 @@ func (s *WebhookServer) ListenAndServe() error {
 	}
 
 	router := mux.NewRouter()
+
+	router.Handle("/v1/healthz", newhealthzHandler())
 	router.Handle(conversionPath, conversionHandler)
 	router.Handle(validationPath, validationHandler)
 	router.Handle(mutationPath, mutationHandler)


### PR DESCRIPTION
#### Proposal Change
- Reference to the [kubebuilder Hub and Spoke doc](https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts.html), [Kubernetes CRD versioning doc](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/), [design](https://github.com/kubernetes-sigs/kubebuilder/blob/8076235/designs/crd_version_conversion.md) and [code](https://github.com/droot/crd-conversion-example) to implement the CRD conversion webhook.
- Generate the schemaless for longhorn.io/v1beta1 CRD.
- Add the conversion webook for 
  - BackupTarget/EngineImage/Node/Volume CRs: `status.conditions` conversion between `map` (v1beta1) to `slice` (v1beta2).
  - BackingImage CR: `spec.disks` conversion between `map[string]struct{}` (v1beta1) to `map[string]string` (v1beta2).
- Remove the upgrade `status.conditions` from the map to slice code in the upgrade path because it should be handled by the CRD conversion webhook.
- Add `initContainers` in the longhorn manager DaemonSet to delay start until the longhorn webhook server is ready.

#### Issues
- https://github.com/longhorn/longhorn/issues/3265
- https://github.com/longhorn/longhorn/issues/3523
- https://github.com/longhorn/longhorn/issues/3295
- https://github.com/longhorn/longhorn/issues/3407
- https://github.com/longhorn/longhorn/issues/3410