### PR TITLE
Use apiextension V1 API to access the recurring job CRD

### DIFF
--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -146,7 +146,7 @@ func NewUninstallController(
 		ds.BackupInformer.AddEventHandler(c.controlleeHandler())
 		cacheSyncs = append(cacheSyncs, ds.BackupInformer.HasSynced)
 	}
-	if _, err := extensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), CRDRecurringJobName, metav1.GetOptions{}); err == nil {
+	if _, err := extensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), CRDRecurringJobName, metav1.GetOptions{}); err == nil {
 		ds.RecurringJobInformer.AddEventHandler(c.controlleeHandler())
 		cacheSyncs = append(cacheSyncs, ds.RecurringJobInformer.HasSynced)
 	}


### PR DESCRIPTION
No related issue, just read thru. the code and saw the potential risk to use old apiextension v1beta1 API to access the recurring job CRD in the uninstallation controller.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>