### PR TITLE
example: add longhorn webhook network policy yaml manifest

### DIFF
--- a/examples/network-policy/webhook-network-policy.yaml
+++ b/examples/network-policy/webhook-network-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-webhook
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-webhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443


### PR DESCRIPTION
#### Proposal Change

The traffic from/to the longhorn webhook server is the kube-apiserver.
The only way we could add restriction is to add the network policy of
the ingress port because we can't know each Kubernetes distro default
kube-apiserver Pod's label. Therefore, we can't add the label selector
in the network policy rule to restrict the traffic that comes from the
kube-apiserver is able to access to the longhorn webhook server.

#### Issue
https://github.com/longhorn/longhorn/issues/3513
