### PR TITLE
Fix CRD upgrade and conversion failures

### DIFF
--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -102,6 +102,7 @@ func (bi *BackingImage) ConvertTo(dst conversion.Hub) error {
 		}
 
 		// Copy spec.disks from map[string]struct{} to map[string]string
+		biV1beta2.Spec.Disks = make(map[string]string)
 		for name := range bi.Spec.Disks {
 			biV1beta2.Spec.Disks[name] = ""
 		}
@@ -125,6 +126,7 @@ func (bi *BackingImage) ConvertFrom(src conversion.Hub) error {
 		}
 
 		// Copy spec.disks from map[string]string to map[string]struct{}
+		bi.Spec.Disks = make(map[string]struct{})
 		for name := range biV1beta2.Spec.Disks {
 			bi.Spec.Disks[name] = struct{}{}
 		}

--- a/upgrade/v1beta1/upgrade.go
+++ b/upgrade/v1beta1/upgrade.go
@@ -94,6 +94,9 @@ func fixupVolumes(namespace string, lhClient *lhclientset.Clientset) error {
 	for _, obj := range volumes.Items {
 		existing := obj.DeepCopy()
 
+		if obj.Spec.ReplicaAutoBalance == "" {
+			obj.Spec.ReplicaAutoBalance = longhornV1beta1.ReplicaAutoBalanceIgnored
+		}
 		if obj.Spec.DiskSelector == nil {
 			obj.Spec.DiskSelector = []string{}
 		}


### PR DESCRIPTION
1. CRD conversion failure of backingimages  because of the initialized variable
2. Upgrade failure from v1.1.x or below because of the empty string of volume.Spec.ReplicaAutoBalance
 
Longhorn 3265