### PR TITLE
Fix CRD validation failure due to the null field(s)

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -1445,12 +1445,14 @@ spec:
                     children:
                       additionalProperties:
                         type: boolean
+                      nullable: true
                       type: object
                     created:
                       type: string
                     labels:
                       additionalProperties:
                         type: string
+                      nullable: true
                       type: object
                     name:
                       type: string

--- a/k8s/pkg/apis/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engine.go
@@ -89,6 +89,7 @@ type Snapshot struct {
 	// +optional
 	Parent string `json:"parent"`
 	// +optional
+	// +nullable
 	Children map[string]bool `json:"children"`
 	// +optional
 	Removed bool `json:"removed"`
@@ -99,6 +100,7 @@ type Snapshot struct {
 	// +optional
 	Size string `json:"size"`
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 }
 

--- a/webhook/resources/backingimage/mutator.go
+++ b/webhook/resources/backingimage/mutator.go
@@ -1,0 +1,56 @@
+package backingimage
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type backingImageMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backingImageMutator{ds: ds}
+}
+
+func (b *backingImageMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backingimages",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackingImage{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (b *backingImageMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImage(newObj)
+}
+
+func (b *backingImageMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImage(newObj)
+}
+
+func mutateBackingImage(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backingImage := newObj.(*longhorn.BackingImage)
+
+	if backingImage.Spec.Disks == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/disks", "value": {}}`)
+	}
+	if backingImage.Spec.SourceParameters == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/sourceParameters", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/backingimagedatasource/mutator.go
+++ b/webhook/resources/backingimagedatasource/mutator.go
@@ -1,0 +1,53 @@
+package backingimagedatasource
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type backingImageDataSourceMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backingImageDataSourceMutator{ds: ds}
+}
+
+func (b *backingImageDataSourceMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backingimagedatasources",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackingImageDataSource{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (b *backingImageDataSourceMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImageDatasource(newObj)
+}
+
+func (b *backingImageDataSourceMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImageDatasource(newObj)
+}
+
+func mutateBackingImageDatasource(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backingimagedatasource := newObj.(*longhorn.BackingImageDataSource)
+
+	if backingimagedatasource.Spec.Parameters == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/parameters", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/backingimagemanager/mutator.go
+++ b/webhook/resources/backingimagemanager/mutator.go
@@ -1,0 +1,53 @@
+package backingimagemanager
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type backingImageManagerMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backingImageManagerMutator{ds: ds}
+}
+
+func (b *backingImageManagerMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backingImageManagers",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackingImageManager{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (b *backingImageManagerMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImageManager(newObj)
+}
+
+func (b *backingImageManagerMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackingImageManager(newObj)
+}
+
+func mutateBackingImageManager(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backingImageManager := newObj.(*longhorn.BackingImageManager)
+
+	if backingImageManager.Spec.BackingImages == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/backingImages", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/backup/mutator.go
+++ b/webhook/resources/backup/mutator.go
@@ -1,0 +1,53 @@
+package backup
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type backupMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backupMutator{ds: ds}
+}
+
+func (b *backupMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backups",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Backup{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (b *backupMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackup(newObj)
+}
+
+func (b *backupMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateBackup(newObj)
+}
+
+func mutateBackup(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backup := newObj.(*longhorn.Backup)
+
+	if backup.Spec.Labels == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/labels", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/engine/mutator.go
+++ b/webhook/resources/engine/mutator.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type engineMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &engineMutator{ds: ds}
+}
+
+func (e *engineMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "engines",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Engine{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (e *engineMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateEngine(newObj)
+}
+
+func (e *engineMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateEngine(newObj)
+}
+
+func mutateEngine(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	engine := newObj.(*longhorn.Engine)
+
+	if engine.Spec.ReplicaAddressMap == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/replicaAddressMap", "value": {}}`)
+	}
+
+	if engine.Spec.UpgradedReplicaAddressMap == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/upgradedReplicaAddressMap", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/node/mutator.go
+++ b/webhook/resources/node/mutator.go
@@ -1,0 +1,65 @@
+package node
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type nodeMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &nodeMutator{ds: ds}
+}
+
+func (n *nodeMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "nodes",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Node{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (n *nodeMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateNode(newObj)
+}
+
+func (n *nodeMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateNode(newObj)
+}
+
+func mutateNode(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	node := newObj.(*longhorn.Node)
+
+	if node.Spec.Tags == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/tags", "value": []}`)
+	}
+
+	if node.Spec.Disks == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/disks", "value": {}}`)
+	}
+
+	for name, disk := range node.Spec.Disks {
+		if disk.Tags == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/disks/%s/tags", "value": []}`, name))
+		}
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/recurringjob/mutator.go
+++ b/webhook/resources/recurringjob/mutator.go
@@ -1,0 +1,56 @@
+package recurringjob
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type recurringJobMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &recurringJobMutator{ds: ds}
+}
+
+func (r *recurringJobMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "recurringjobs",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.RecurringJob{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (r *recurringJobMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateRecurringJob(newObj)
+}
+
+func (r *recurringJobMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateRecurringJob(newObj)
+}
+
+func mutateRecurringJob(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	recurringjob := newObj.(*longhorn.RecurringJob)
+
+	if recurringjob.Spec.Groups == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/groups", "value": []}`)
+	}
+	if recurringjob.Spec.Labels == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/labels", "value": {}}`)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/volume/mutator.go
+++ b/webhook/resources/volume/mutator.go
@@ -1,0 +1,72 @@
+package volume
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+)
+
+type volumeMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &volumeMutator{ds: ds}
+}
+
+func (v *volumeMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "volumes",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Volume{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *volumeMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateVolume(newObj)
+}
+
+func (v *volumeMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutateVolume(newObj)
+}
+
+func mutateVolume(newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	volume := newObj.(*longhorn.Volume)
+
+	if volume.Spec.ReplicaAutoBalance == "" {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/replicaAutoBalance", "value": "ignored"}`)
+	}
+	if volume.Spec.DiskSelector == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/diskSelector", "value": []}`)
+	}
+	if volume.Spec.NodeSelector == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/nodeSelector", "value": []}`)
+	}
+	if volume.Spec.RecurringJobs == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/recurringJobs", "value": []}`)
+	}
+	for id, job := range volume.Spec.RecurringJobs {
+		if job.Groups == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/recurringJobs/%d/groups", "value": []}`, id))
+		}
+		if job.Labels == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/recurringJobs/%d/labels", "value": {}}`, id))
+		}
+	}
+
+	return patchOps, nil
+}

--- a/webhook/server/mutation.go
+++ b/webhook/server/mutation.go
@@ -7,11 +7,28 @@ import (
 
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/client"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backingimage"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagedatasource"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagemanager"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backup"
+	"github.com/longhorn/longhorn-manager/webhook/resources/engine"
+	"github.com/longhorn/longhorn-manager/webhook/resources/node"
+	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
+	"github.com/longhorn/longhorn-manager/webhook/resources/volume"
 )
 
 func Mutation(client *client.Client) (http.Handler, []admission.Resource, error) {
 	resources := []admission.Resource{}
-	mutators := []admission.Mutator{}
+	mutators := []admission.Mutator{
+		backup.NewMutator(client.Datastore),
+		backingimage.NewMutator(client.Datastore),
+		backingimagemanager.NewMutator(client.Datastore),
+		backingimagedatasource.NewMutator(client.Datastore),
+		node.NewMutator(client.Datastore),
+		volume.NewMutator(client.Datastore),
+		engine.NewMutator(client.Datastore),
+		recurringjob.NewMutator(client.Datastore),
+	}
 
 	router := webhook.NewRouter()
 	for _, m := range mutators {


### PR DESCRIPTION
- mutating webhook
  Replace the invalid values on APIs and other interfaces with valid ones.
- upgrade path
  The purpose of fix up functions are fixing the invalid fields in old CRs. The strategy is listing the CRs and then update the them. Before updating, the mutating webhook will check the invalid values and fix them.

Signed-off-by: Derek Su <derek.su@suse.com>