### PR TITLE
Initialize backingimage and backingimagedatasource sourceType

### DIFF
--- a/webhook/resources/backingimage/mutator.go
+++ b/webhook/resources/backingimage/mutator.go
@@ -1,6 +1,8 @@
 package backingimage
 
 import (
+	"fmt"
+
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -44,6 +46,10 @@ func mutateBackingImage(newObj runtime.Object) (admission.PatchOps, error) {
 	var patchOps admission.PatchOps
 
 	backingImage := newObj.(*longhorn.BackingImage)
+
+	if backingImage.Spec.SourceType == "" {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/sourceType", "value": "%s"}`, longhorn.BackingImageDataSourceTypeDownload))
+	}
 
 	if backingImage.Spec.Disks == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/disks", "value": {}}`)

--- a/webhook/resources/backingimagedatasource/mutator.go
+++ b/webhook/resources/backingimagedatasource/mutator.go
@@ -1,6 +1,8 @@
 package backingimagedatasource
 
 import (
+	"fmt"
+
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -44,6 +46,10 @@ func mutateBackingImageDatasource(newObj runtime.Object) (admission.PatchOps, er
 	var patchOps admission.PatchOps
 
 	backingimagedatasource := newObj.(*longhorn.BackingImageDataSource)
+
+	if backingimagedatasource.Spec.SourceType == "" {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/sourceType", "value": "%s"}`, longhorn.BackingImageDataSourceTypeDownload))
+	}
 
 	if backingimagedatasource.Spec.Parameters == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/parameters", "value": {}}`)


### PR DESCRIPTION
Fix upgrade failure from v1.1.x to master-head.
The sourceType of backingimage and backingimagedatasource in v1.1.x is "", so initialize it in the mutating webhook.

Signed-off-by: Derek Su <derek.su@suse.com>