### PR TITLE
Revert the resync back to 30s

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -67,8 +67,8 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	//  lead to scalability problems, since we dump the whole cache of each object back in to the reconciler every 30 seconds.
 	//  if a specific controller requires a periodic resync, one enable it only for that informer, add a resync to the event handler, go routine, etc.
 	//  some refs to look at: https://github.com/kubernetes-sigs/controller-runtime/issues/521
-	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Hour)
-	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Hour)
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
+	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Second*30)
 
 	replicaInformer := lhInformerFactory.Longhorn().V1beta1().Replicas()
 	engineInformer := lhInformerFactory.Longhorn().V1beta1().Engines()


### PR DESCRIPTION
Change the resync back to 30s for v1.1.4 and v1.2.4 since there are potentially conner cases that we cannot catch before releasing. Those are stable releases so we don't want to have mistakes. The scalability is still improved significantly even without changing the resync.

longhorn/longhorn#3609