### PR TITLE
feat adding backup metrics

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -2590,7 +2590,6 @@ func (s *DataStore) GetInstanceManagerByInstance(obj interface{}) (*longhorn.Ins
 		for _, im := range imMap {
 			return im, nil
 		}
-
 	}
 	return nil, fmt.Errorf("can not find the only available instance manager for instance %v, node %v, instance manager image %v, type %v", name, nodeID, image, imType)
 }
@@ -3127,6 +3126,11 @@ func (s *DataStore) ListBackups() (map[string]*longhorn.Backup, error) {
 		itemMap[itemRO.Name] = itemRO.DeepCopy()
 	}
 	return itemMap, nil
+}
+
+// ListBackupsRO returns a list of all Backups for the given namespace
+func (s *DataStore) ListBackupsRO() ([]*longhorn.Backup, error) {
+	return s.bLister.Backups(s.namespace).List(labels.Everything())
 }
 
 // GetBackupRO returns the Backup with the given backup name in the cluster

--- a/monitoring/backup_collector.go
+++ b/monitoring/backup_collector.go
@@ -1,0 +1,69 @@
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+type backupCollector struct {
+	*baseCollector
+
+	stateMetric *metricInfo
+}
+
+func NewBackupCollector(logger logrus.FieldLogger, nodeID string, ds *datastore.DataStore) prometheus.Collector {
+	return &backupCollector{
+		baseCollector: newBaseCollector(subsystemBackup, logger, nodeID, ds),
+		stateMetric: &metricInfo{
+			Desc: prometheus.NewDesc(
+				prometheus.BuildFQName(longhornName, subsystemBackup, "state"),
+				"State of this backup",
+				[]string{nodeLabel, backupLabel},
+				nil,
+			),
+			Type: prometheus.GaugeValue,
+		},
+	}
+}
+
+func (bc *backupCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- bc.stateMetric.Desc
+}
+
+func (bc *backupCollector) Collect(ch chan<- prometheus.Metric) {
+	backups, err := bc.ds.ListBackups()
+	if err != nil {
+		bc.logger.WithError(err).Warn("error during scrape")
+		return
+	}
+
+	for name, backup := range backups {
+		ch <- prometheus.MustNewConstMetric(
+			bc.stateMetric.Desc,
+			bc.stateMetric.Type,
+			float64(convertBackupState(backup.Status.State)),
+			bc.currentNodeID,
+			name,
+		)
+	}
+}
+
+func convertBackupState(state v1beta2.BackupState) int {
+	switch state {
+	case v1beta2.BackupStateInProgress:
+		return 1
+	case v1beta2.BackupStateCompleted:
+		return 2
+	case v1beta2.BackupStateError:
+		return 3
+	case v1beta2.BackupStateUnknown:
+		return 4
+	default:
+		// case default == case v1beta2.BackupStateNew
+		// because BackupStateNew == BackupState("")
+		return 0
+	}
+}

--- a/monitoring/backup_collector.go
+++ b/monitoring/backup_collector.go
@@ -1,27 +1,40 @@
 package monitoring
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
 )
 
 type backupCollector struct {
 	*baseCollector
 
-	stateMetric *metricInfo
+	stateMetric metricInfo
+	sizeMetric  metricInfo
 }
 
 func NewBackupCollector(logger logrus.FieldLogger, nodeID string, ds *datastore.DataStore) prometheus.Collector {
 	return &backupCollector{
 		baseCollector: newBaseCollector(subsystemBackup, logger, nodeID, ds),
-		stateMetric: &metricInfo{
+		stateMetric: metricInfo{
 			Desc: prometheus.NewDesc(
 				prometheus.BuildFQName(longhornName, subsystemBackup, "state"),
 				"State of this backup",
-				[]string{nodeLabel, backupLabel},
+				[]string{backupLabel, backupVolumeLabel},
+				nil,
+			),
+			Type: prometheus.GaugeValue,
+		},
+		sizeMetric: metricInfo{
+			Desc: prometheus.NewDesc(
+				prometheus.BuildFQName(longhornName, subsystemBackup, "actual_size_bytes"),
+				"Actual size of this backup",
+				[]string{backupLabel, backupVolumeLabel},
 				nil,
 			),
 			Type: prometheus.GaugeValue,
@@ -31,22 +44,48 @@ func NewBackupCollector(logger logrus.FieldLogger, nodeID string, ds *datastore.
 
 func (bc *backupCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- bc.stateMetric.Desc
+	ch <- bc.sizeMetric.Desc
 }
 
 func (bc *backupCollector) Collect(ch chan<- prometheus.Metric) {
-	backups, err := bc.ds.ListBackups()
+	defer func() {
+		if err := recover(); err != nil {
+			bc.logger.WithField("error", err).Warn("panic during collecting metrics")
+		}
+	}()
+
+	backups, err := bc.ds.ListBackupsRO()
 	if err != nil {
 		bc.logger.WithError(err).Warn("error during scrape")
 		return
 	}
 
-	for name, backup := range backups {
+	for _, backup := range backups {
+		backupVolName, ok := backup.Labels[types.LonghornLabelBackupVolume]
+		if !ok {
+			bc.logger.Warnf("error when getting %q backup volume name", backup.Name)
+			continue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			bc.stateMetric.Desc,
 			bc.stateMetric.Type,
 			float64(convertBackupState(backup.Status.State)),
-			bc.currentNodeID,
-			name,
+			backup.Name,
+			backupVolName,
+		)
+
+		size, err := strconv.ParseFloat(backup.Status.Size, 64)
+		if err != nil {
+			bc.logger.WithError(err).Warnf("error when parsing %q backup size", backup.Name)
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			bc.sizeMetric.Desc,
+			bc.sizeMetric.Type,
+			size,
+			backup.Name,
+			backupVolName,
 		)
 	}
 }

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -19,6 +19,7 @@ import (
 func InitMonitoringSystem(logger logrus.FieldLogger, currentNodeID string, ds *datastore.DataStore, kubeconfigPath string) {
 	vc := NewVolumeCollector(logger, currentNodeID, ds)
 	dc := NewDiskCollector(logger, currentNodeID, ds)
+	bc := NewBackupCollector(logger, currentNodeID, ds)
 
 	if err := registry.Register(vc); err != nil {
 		logger.WithField("collector", subsystemVolume).WithError(err).Warn("failed to register collector")
@@ -26,6 +27,10 @@ func InitMonitoringSystem(logger logrus.FieldLogger, currentNodeID string, ds *d
 
 	if err := registry.Register(dc); err != nil {
 		logger.WithField("collector", subsystemDisk).WithError(err).Warn("failed to register collector")
+	}
+
+	if err := registry.Register(bc); err != nil {
+		logger.WithField("collector", subsystemBackup).WithError(err).Warn("failed to register collector")
 	}
 
 	namespace := os.Getenv(types.EnvPodNamespace)
@@ -52,7 +57,6 @@ func InitMonitoringSystem(logger logrus.FieldLogger, currentNodeID string, ds *d
 			logger.WithField("collector", subsystemManager).WithError(err).Warn("failed to register collector")
 		}
 	}
-
 }
 
 func buildMetricClientFromConfigPath(kubeconfigPath string) (*metricsclientset.Clientset, error) {

--- a/monitoring/types.go
+++ b/monitoring/types.go
@@ -20,6 +20,7 @@ const (
 	diskLabel            = "disk"
 	volumeLabel          = "volume"
 	backupLabel          = "backup"
+	backupVolumeLabel    = "backup_volume"
 	conditionLabel       = "condition"
 	conditionReasonLabel = "condition_reason"
 	instanceManagerLabel = "instance_manager"

--- a/monitoring/types.go
+++ b/monitoring/types.go
@@ -14,10 +14,12 @@ const (
 	subsystemDisk            = "disk"
 	subsystemInstanceManager = "instance_manager"
 	subsystemManager         = "manager"
+	subsystemBackup          = "backup"
 
 	nodeLabel            = "node"
 	diskLabel            = "disk"
 	volumeLabel          = "volume"
+	backupLabel          = "backup"
 	conditionLabel       = "condition"
 	conditionReasonLabel = "condition_reason"
 	instanceManagerLabel = "instance_manager"


### PR DESCRIPTION
addressing issue https://github.com/longhorn/longhorn/issues/2940
adding backup metrics.

please using
```bash
docker pull tommady/longhorn-manager:d39f1bf0-dirty
```
for testing purposes.

pod describe
```bash
Containers:
  longhorn-manager:
    Container ID:  containerd://20852bac14989c9a6bec43745cbebd9d521f32eead6a79a70aaea531ee0a3eff
    Image:         tommady/longhorn-manager:d39f1bf0-dirty
    Image ID:      docker.io/tommady/longhorn-manager@sha256:89836baee704d948a3523dac362c2e54e2b569ccba5e28b2b1f037a5b168bfd5
    Port:          9500/TCP
    Host Port:     0/TCP
    Command:
      longhorn-manager
      -d
      daemon
      --engine-image
      longhornio/longhorn-engine:master-head
      --instance-manager-image
      longhornio/longhorn-instance-manager:v1_20210731
      --share-manager-image
      longhornio/longhorn-share-manager:v1_20211020
      --backing-image-manager-image
      longhornio/backing-image-manager:v2_20210820
      --manager-image
      longhornio/longhorn-manager:master-head
      --service-account
      longhorn-service-account
    State:          Running
      Started:      Sun, 20 Feb 2022 23:05:56 +0800
    Ready:          True
```

results:
```bash
> curl 10.244.0.6:9500/metrics
# HELP longhorn_backup_actual_size_bytes Actual size of this backup
# TYPE longhorn_backup_actual_size_bytes gauge
longhorn_backup_actual_size_bytes{backup="backup-2e284b14ea774fe4",backup_volume="testing-der-lah-0"} 0
# HELP longhorn_backup_state State of this backup
# TYPE longhorn_backup_state gauge
longhorn_backup_state{backup="backup-2e284b14ea774fe4",backup_volume="testing-der-lah-0"} 2
```

