### PR TITLE
Implement mutation and validation logics of resources in the admission webhook

### DIFF
--- a/api/node.go
+++ b/api/node.go
@@ -67,12 +67,6 @@ func (s *Server) NodeUpdate(rw http.ResponseWriter, req *http.Request) error {
 		return errors.Wrap(err, "fail to get node ip")
 	}
 
-	// Only scheduling disabled node can be evicted
-	// Can not enable scheduling on an evicting node
-	if n.EvictionRequested && n.AllowScheduling {
-		return fmt.Errorf("need to disable scheduling on node %v for node eviction, or cancel eviction to enable scheduling on this node", n.Name)
-	}
-
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
 		node, err := s.m.GetNode(id)
 		if err != nil {
@@ -110,15 +104,6 @@ func (s *Server) DiskUpdate(rw http.ResponseWriter, req *http.Request) error {
 	nodeIPMap, err := s.m.GetManagerNodeIPMap()
 	if err != nil {
 		return errors.Wrap(err, "fail to get node ip")
-	}
-
-	// Only scheduling disabled disk can be evicted
-	// Can not enable scheduling on an evicting disk
-	for diskName, diskSpec := range diskUpdate.Disks {
-		if diskSpec.EvictionRequested &&
-			diskSpec.AllowScheduling {
-			return fmt.Errorf("need to disable scheduling on disk %v for disk eviction, or cancel eviction to enable scheduling on this disk", diskName)
-		}
 	}
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {

--- a/api/recurringjob.go
+++ b/api/recurringjob.go
@@ -53,10 +53,6 @@ func (s *Server) RecurringJobCreate(rw http.ResponseWriter, req *http.Request) e
 		return err
 	}
 
-	if input.Task != longhorn.RecurringJobTypeBackup && input.Task != longhorn.RecurringJobTypeSnapshot {
-		return fmt.Errorf("recurring job type %v is not valid", input.Task)
-	}
-
 	obj, err := s.m.CreateRecurringJob(&longhorn.RecurringJobSpec{
 		Name:        input.Name,
 		Groups:      input.Groups,
@@ -82,10 +78,6 @@ func (s *Server) RecurringJobUpdate(rw http.ResponseWriter, req *http.Request) e
 	}
 
 	name := mux.Vars(req)["name"]
-
-	if input.Task != longhorn.RecurringJobTypeBackup && input.Task != longhorn.RecurringJobTypeSnapshot {
-		return fmt.Errorf("recurring job type %v is not valid", input.Task)
-	}
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
 		return s.m.UpdateRecurringJob(longhorn.RecurringJobSpec{

--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -118,7 +118,7 @@ func recurringJob(c *cli.Context) error {
 	jobLabelMap[types.RecurringJobLabel] = recurringJob.Name
 	labelJSON, err := json.Marshal(jobLabelMap)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get JSON encoding for labels")
+		return errors.Wrap(err, "failed to get JSON encoding for labels")
 	}
 
 	var doBackup bool = false

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3214,9 +3214,6 @@ func (s *DataStore) RemoveFinalizerForBackup(backup *longhorn.Backup) error {
 // CreateRecurringJob creates a Longhorn RecurringJob resource and verifies
 // creation
 func (s *DataStore) CreateRecurringJob(recurringJob *longhorn.RecurringJob) (*longhorn.RecurringJob, error) {
-	if err := initRecurringJob(recurringJob); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().RecurringJobs(s.namespace).Create(context.TODO(), recurringJob, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -3237,16 +3234,6 @@ func (s *DataStore) CreateRecurringJob(recurringJob *longhorn.RecurringJob) (*lo
 	}
 
 	return ret.DeepCopy(), nil
-}
-
-func initRecurringJob(recurringJob *longhorn.RecurringJob) error {
-	if recurringJob.Spec.Groups == nil {
-		recurringJob.Spec.Groups = []string{}
-	}
-	if recurringJob.Spec.Labels == nil {
-		recurringJob.Spec.Labels = make(map[string]string, 0)
-	}
-	return nil
 }
 
 // ListRecurringJobs returns a map of RecurringJobPolicies indexed by name

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3081,9 +3081,6 @@ func (s *DataStore) RemoveFinalizerForBackupVolume(backupVolume *longhorn.Backup
 
 // CreateBackup creates a Longhorn Backup CR and verifies creation
 func (s *DataStore) CreateBackup(backup *longhorn.Backup, backupVolumeName string) (*longhorn.Backup, error) {
-	if err := initBackup(backup); err != nil {
-		return nil, err
-	}
 	if err := tagBackupVolumeLabel(backupVolumeName, backup); err != nil {
 		return nil, err
 	}
@@ -3109,13 +3106,6 @@ func (s *DataStore) CreateBackup(backup *longhorn.Backup, backupVolumeName strin
 		return nil, fmt.Errorf("BUG: datastore: verifyCreation returned wrong type for Backup")
 	}
 	return ret.DeepCopy(), nil
-}
-
-func initBackup(backup *longhorn.Backup) error {
-	if backup.Spec.Labels == nil {
-		backup.Spec.Labels = make(map[string]string, 0)
-	}
-	return nil
 }
 
 // ListBackupsWithBackupVolumeName returns an object contains all backups in the cluster Backups CR

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1798,9 +1798,6 @@ func GetOwnerReferencesForBackingImageDataSource(backingImageDataSource *longhor
 
 // CreateNode creates a Longhorn Node resource and verifies creation
 func (s *DataStore) CreateNode(node *longhorn.Node) (*longhorn.Node, error) {
-	if err := initNode(node); err != nil {
-		return nil, err
-	}
 	if err := util.AddFinalizer(longhornFinalizerKey, node); err != nil {
 		return nil, err
 	}
@@ -1824,26 +1821,6 @@ func (s *DataStore) CreateNode(node *longhorn.Node) (*longhorn.Node, error) {
 	}
 
 	return ret.DeepCopy(), nil
-}
-
-func initNode(node *longhorn.Node) error {
-	if node.Spec.Disks == nil {
-		node.Spec.Disks = make(map[string]longhorn.DiskSpec, 0)
-	}
-	for key, src := range node.Spec.Disks {
-		if src.Tags == nil {
-			dst := longhorn.DiskSpec{}
-			if err := copier.Copy(&dst, &src); err != nil {
-				return err
-			}
-			dst.Tags = []string{}
-			node.Spec.Disks[key] = dst
-		}
-	}
-	if node.Spec.Tags == nil {
-		node.Spec.Tags = []string{}
-	}
-	return nil
 }
 
 // CreateDefaultNode will create the default Disk at the value of the

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1266,9 +1266,6 @@ func (s *DataStore) CheckEngineImageReadyOnAllVolumeReplicas(image, volumeName, 
 // CreateBackingImage creates a Longhorn BackingImage resource and verifies
 // creation
 func (s *DataStore) CreateBackingImage(backingImage *longhorn.BackingImage) (*longhorn.BackingImage, error) {
-	if err := initBackingImage(backingImage); err != nil {
-		return nil, err
-	}
 	if err := util.AddFinalizer(longhornFinalizerKey, backingImage); err != nil {
 		return nil, err
 	}
@@ -1294,22 +1291,11 @@ func (s *DataStore) CreateBackingImage(backingImage *longhorn.BackingImage) (*lo
 	return ret.DeepCopy(), nil
 }
 
-func initBackingImage(backingImage *longhorn.BackingImage) error {
-	if backingImage.Spec.Disks == nil {
-		backingImage.Spec.Disks = make(map[string]string, 0)
-	}
-	if backingImage.Spec.SourceParameters == nil {
-		backingImage.Spec.SourceParameters = make(map[string]string, 0)
-	}
-	return nil
-}
-
 // UpdateBackingImage updates Longhorn BackingImage and verifies update
 func (s *DataStore) UpdateBackingImage(backingImage *longhorn.BackingImage) (*longhorn.BackingImage, error) {
 	if err := util.AddFinalizer(longhornFinalizerKey, backingImage); err != nil {
 		return nil, err
 	}
-
 	obj, err := s.lhClient.LonghornV1beta2().BackingImages(s.namespace).Update(context.TODO(), backingImage, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err

--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -1129,7 +1129,10 @@ spec:
             description: EngineImageSpec defines the desired state of the Longhorn engine image
             properties:
               image:
+                minLength: 1
                 type: string
+            required:
+            - image
             type: object
           status:
             description: EngineImageStatus defines the observed state of the Longhorn engine image

--- a/deploy/install/02-components/05-webhook.yaml
+++ b/deploy/install/02-components/05-webhook.yaml
@@ -120,6 +120,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 #      imagePullSecrets:
 #      - name: ""
 #      priorityClassName:

--- a/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engineimage.go
@@ -41,7 +41,7 @@ type EngineVersionDetails struct {
 
 // EngineImageSpec defines the desired state of the Longhorn engine image
 type EngineImageSpec struct {
-	// +optional
+	// +kubebuilder:validation:MinLength:=1
 	Image string `json:"image"`
 }
 

--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -12,11 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/longhorn/longhorn-manager/controller"
-	"github.com/longhorn/longhorn-manager/datastore"
-	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
-	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -72,67 +67,6 @@ func (m *VolumeManager) GetBackingImageDataSourcePod(name string) (*v1.Pod, erro
 }
 
 func (m *VolumeManager) CreateBackingImage(name, checksum, sourceType string, parameters map[string]string) (bi *longhorn.BackingImage, err error) {
-	name = util.AutoCorrectName(name, datastore.NameMaximumLength)
-	if !util.ValidateName(name) {
-		return nil, fmt.Errorf("invalid name %v", name)
-	}
-
-	if len(checksum) != 0 {
-		checksum = strings.TrimSpace(checksum)
-
-		if !util.ValidateChecksumSHA512(checksum) {
-			return nil, fmt.Errorf("invalid checksum %v", checksum)
-		}
-	}
-
-	for k, v := range parameters {
-		parameters[k] = strings.TrimSpace(v)
-	}
-
-	switch longhorn.BackingImageDataSourceType(sourceType) {
-	case longhorn.BackingImageDataSourceTypeDownload:
-		if parameters[longhorn.DataSourceTypeDownloadParameterURL] == "" {
-			return nil, fmt.Errorf("invalid parameter %+v for source type %v", parameters, sourceType)
-		}
-	case longhorn.BackingImageDataSourceTypeUpload:
-	case longhorn.BackingImageDataSourceTypeExportFromVolume:
-		volumeName := parameters[controller.DataSourceTypeExportFromVolumeParameterVolumeName]
-		if volumeName == "" {
-			return nil, fmt.Errorf("invalid parameter %+v for source type %v", parameters, sourceType)
-		}
-		v, err := m.ds.GetVolume(volumeName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get volume %v before exporting backing image", volumeName)
-		}
-		if v.Status.Robustness == longhorn.VolumeRobustnessFaulted {
-			return nil, fmt.Errorf("cannot export a backing image from faulted volume %v", volumeName)
-		}
-		eiName := types.GetEngineImageChecksumName(v.Status.CurrentImage)
-		ei, err := m.ds.GetEngineImage(eiName)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get then check engine image %v for volume %v before exporting backing image", eiName, volumeName)
-		}
-		if ei.Status.CLIAPIVersion < engineapi.CLIVersionFive {
-			return nil, fmt.Errorf("engine image %v CLI version %v doesn't support this feature, please upgrade engine for volume %v before exporting backing image from the volume", eiName, ei.Status.CLIAPIVersion, volumeName)
-		}
-		// By default the exported file type is raw.
-		if parameters[DataSourceTypeExportFromVolumeParameterExportType] == "" {
-			parameters[DataSourceTypeExportFromVolumeParameterExportType] = DataSourceTypeExportFromVolumeParameterExportTypeRAW
-		}
-		if parameters[DataSourceTypeExportFromVolumeParameterExportType] != DataSourceTypeExportFromVolumeParameterExportTypeRAW &&
-			parameters[DataSourceTypeExportFromVolumeParameterExportType] != DataSourceTypeExportFromVolumeParameterExportTypeQCOW2 {
-			return nil, fmt.Errorf("unsupported export type %v", parameters[DataSourceTypeExportFromVolumeParameterExportType])
-		}
-	default:
-		return nil, fmt.Errorf("unknown backing image source type %v", sourceType)
-	}
-
-	if _, err := m.ds.GetBackingImage(name); err == nil {
-		return nil, fmt.Errorf("backing image already exists")
-	} else if !apierrors.IsNotFound(err) {
-		return nil, errors.Wrapf(err, "failed to check backing image existence before creation")
-	}
-
 	bi = &longhorn.BackingImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -154,13 +88,6 @@ func (m *VolumeManager) CreateBackingImage(name, checksum, sourceType string, pa
 }
 
 func (m *VolumeManager) DeleteBackingImage(name string) error {
-	replicas, err := m.ds.ListReplicasByBackingImage(name)
-	if err != nil {
-		return err
-	}
-	if len(replicas) != 0 {
-		return fmt.Errorf("cannot delete backing image %v since there are replicas using it", name)
-	}
 	if err := m.ds.DeleteBackingImage(name); err != nil {
 		return err
 	}

--- a/manager/engineimage.go
+++ b/manager/engineimage.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -53,11 +51,6 @@ func (m *VolumeManager) GetEngineImageByImage(image string) (*longhorn.EngineIma
 }
 
 func (m *VolumeManager) CreateEngineImage(image string) (*longhorn.EngineImage, error) {
-	image = strings.TrimSpace(image)
-	if image == "" {
-		return nil, fmt.Errorf("cannot create engine image with empty image")
-	}
-
 	name := types.GetEngineImageChecksumName(image)
 	ei := &longhorn.EngineImage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -83,16 +76,6 @@ func (m *VolumeManager) DeleteEngineImageByName(name string) error {
 			return nil
 		}
 		return errors.Wrapf(err, "unable to get engine image '%s'", name)
-	}
-	defaultImage, err := m.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
-	if err != nil {
-		return errors.Wrap(err, "unable to delete engine image")
-	}
-	if ei.Spec.Image == defaultImage {
-		return fmt.Errorf("unable to delete the default engine image")
-	}
-	if ei.Status.RefCount != 0 {
-		return fmt.Errorf("unable to delete the engine image while being used")
 	}
 	if err := m.ds.DeleteEngineImage(name); err != nil {
 		return err

--- a/manager/node.go
+++ b/manager/node.go
@@ -1,11 +1,6 @@
 package manager
 
 import (
-	"fmt"
-	"math"
-
-	"github.com/longhorn/longhorn-manager/types"
-	"github.com/longhorn/longhorn-manager/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -65,43 +60,6 @@ func (m *VolumeManager) GetNodeTags() ([]string, error) {
 }
 
 func (m *VolumeManager) UpdateNode(n *longhorn.Node) (*longhorn.Node, error) {
-	// We need to make sure the tags passed in are valid before updating the node.
-	tags, err := util.ValidateTags(n.Spec.Tags)
-	if err != nil {
-		return nil, err
-	}
-	n.Spec.Tags = tags
-
-	if n.Spec.EngineManagerCPURequest < 0 || n.Spec.ReplicaManagerCPURequest < 0 {
-		return nil, fmt.Errorf("found invalid EngineManagerCPURequest %v or ReplicaManagerCPURequest %v during node %v update", n.Spec.EngineManagerCPURequest, n.Spec.ReplicaManagerCPURequest, n.Name)
-	}
-	if n.Spec.EngineManagerCPURequest != 0 || n.Spec.ReplicaManagerCPURequest != 0 {
-		kubeNode, err := m.ds.GetKubernetesNode(n.Name)
-		if err != nil {
-			return nil, err
-		}
-		allocatableCPU := float64(kubeNode.Status.Allocatable.Cpu().MilliValue())
-		engineManagerCPUSetting, err := m.ds.GetSetting(types.SettingNameGuaranteedEngineManagerCPU)
-		if err != nil {
-			return nil, err
-		}
-		engineManagerCPUInPercentage := engineManagerCPUSetting.Value
-		if n.Spec.EngineManagerCPURequest > 0 {
-			engineManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(n.Spec.EngineManagerCPURequest)/allocatableCPU*100.0))
-		}
-		replicaManagerCPUSetting, err := m.ds.GetSetting(types.SettingNameGuaranteedReplicaManagerCPU)
-		if err != nil {
-			return nil, err
-		}
-		replicaManagerCPUInPercentage := replicaManagerCPUSetting.Value
-		if n.Spec.ReplicaManagerCPURequest > 0 {
-			replicaManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(n.Spec.ReplicaManagerCPURequest)/allocatableCPU*100.0))
-		}
-		if err := types.ValidateCPUReservationValues(engineManagerCPUInPercentage, replicaManagerCPUInPercentage); err != nil {
-			return nil, err
-		}
-	}
-
 	node, err := m.ds.UpdateNode(n)
 	if err != nil {
 		return nil, err
@@ -145,29 +103,6 @@ func (m *VolumeManager) DiskUpdate(name string, updateDisks map[string]longhorn.
 		return nil, err
 	}
 
-	originDisks := node.Spec.Disks
-
-	for name, uDisk := range updateDisks {
-		if uDisk.StorageReserved < 0 {
-			return nil, fmt.Errorf("update disk on node %v error: The storageReserved setting of disk %v(%v) is not valid, should be positive and no more than storageMaximum and storageAvailable", name, name, uDisk.Path)
-		}
-
-		tags, err := util.ValidateTags(uDisk.Tags)
-		if err != nil {
-			return nil, err
-		}
-		uDisk.Tags = tags
-		updateDisks[name] = uDisk
-	}
-
-	// delete disks
-	for name, oDisk := range originDisks {
-		if _, ok := updateDisks[name]; !ok {
-			if oDisk.AllowScheduling || node.Status.DiskStatus[name].StorageScheduled != 0 {
-				return nil, fmt.Errorf("Delete Disk on node %v error: Please disable the disk %v and remove all replicas first ", name, oDisk.Path)
-			}
-		}
-	}
 	node.Spec.Disks = updateDisks
 
 	node, err = m.ds.UpdateNode(node)
@@ -179,28 +114,6 @@ func (m *VolumeManager) DiskUpdate(name string, updateDisks map[string]longhorn.
 }
 
 func (m *VolumeManager) DeleteNode(name string) error {
-	node, err := m.ds.GetNode(name)
-	if err != nil {
-		return err
-	}
-	// only remove node from longhorn without any volumes on it
-	replicas, err := m.ds.ListReplicasByNodeRO(name)
-	if err != nil {
-		return err
-	}
-	engines, err := m.ds.ListEnginesByNodeRO(name)
-	if err != nil {
-		return err
-	}
-	condition := types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady)
-	// Only could delete node from longhorn if kubernetes node missing or manager pod is missing
-	if condition.Status == longhorn.ConditionStatusTrue ||
-		(condition.Reason != longhorn.NodeConditionReasonKubernetesNodeGone &&
-			condition.Reason != longhorn.NodeConditionReasonManagerPodMissing) ||
-		node.Spec.AllowScheduling || len(replicas) > 0 || len(engines) > 0 {
-		return fmt.Errorf("could not delete node %v with node ready condition is %v, reason is %v, node schedulable %v, and %v replica, %v engine running on it", name,
-			condition.Status, condition.Reason, node.Spec.AllowScheduling, len(replicas), len(engines))
-	}
 	if err := m.ds.DeleteNode(name); err != nil {
 		return err
 	}

--- a/manager/recurringjob.go
+++ b/manager/recurringjob.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"fmt"
 	"reflect"
 	"sort"
 
@@ -38,24 +37,6 @@ func (m *VolumeManager) ListRecurringJobsSorted() ([]*longhorn.RecurringJob, err
 
 func (m *VolumeManager) CreateRecurringJob(spec *longhorn.RecurringJobSpec) (*longhorn.RecurringJob, error) {
 	name := util.AutoCorrectName(spec.Name, datastore.NameMaximumLength)
-	if !util.ValidateName(name) {
-		return nil, fmt.Errorf("invalid name %v", name)
-	}
-
-	jobs := []longhorn.RecurringJobSpec{
-		{
-			Name:        spec.Name,
-			Groups:      spec.Groups,
-			Task:        spec.Task,
-			Cron:        spec.Cron,
-			Retain:      spec.Retain,
-			Concurrency: spec.Concurrency,
-			Labels:      spec.Labels,
-		},
-	}
-	if err := datastore.ValidateRecurringJobs(jobs); err != nil {
-		return nil, err
-	}
 
 	job := &longhorn.RecurringJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,6 +44,7 @@ func (m *VolumeManager) CreateRecurringJob(spec *longhorn.RecurringJobSpec) (*lo
 		},
 		Spec: *spec,
 	}
+
 	job, err := m.ds.CreateRecurringJob(job)
 	if err != nil {
 		return nil, err
@@ -76,21 +58,6 @@ func (m *VolumeManager) UpdateRecurringJob(spec longhorn.RecurringJobSpec) (*lon
 	defer func() {
 		err = errors.Wrapf(err, "unable to update %v recurring job", spec.Name)
 	}()
-
-	jobs := []longhorn.RecurringJobSpec{
-		{
-			Name:        spec.Name,
-			Groups:      spec.Groups,
-			Task:        spec.Task,
-			Cron:        spec.Cron,
-			Retain:      spec.Retain,
-			Concurrency: spec.Concurrency,
-			Labels:      spec.Labels,
-		},
-	}
-	if err = datastore.ValidateRecurringJobs(jobs); err != nil {
-		return nil, err
-	}
 
 	recurringJob, err := m.ds.GetRecurringJob(spec.Name)
 	if err != nil {

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -14,10 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/longhorn/backupstore"
-
 	"github.com/longhorn/longhorn-manager/datastore"
-	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/scheduler"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
@@ -146,14 +143,6 @@ func (m *VolumeManager) GetReplicasSorted(vName string) ([]*longhorn.Replica, er
 	return replicas, nil
 }
 
-func (m *VolumeManager) getDefaultReplicaCount() (int, error) {
-	c, err := m.ds.GetSettingAsInt(types.SettingNameDefaultReplicaCount)
-	if err != nil {
-		return 0, err
-	}
-	return int(c), nil
-}
-
 func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurringJobSelector []longhorn.VolumeRecurringJob) (v *longhorn.Volume, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "unable to create volume %v", name)
@@ -161,118 +150,6 @@ func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurring
 			logrus.Errorf("manager: unable to create volume %v: %+v: %v", name, spec, err)
 		}
 	}()
-
-	name = util.AutoCorrectName(name, datastore.NameMaximumLength)
-	if !util.ValidateName(name) {
-		return nil, fmt.Errorf("invalid name %v", name)
-	}
-
-	size := spec.Size
-	if spec.FromBackup != "" {
-		bName, bvName, _, err := backupstore.DecodeBackupURL(spec.FromBackup)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get backup and volume name from backup URL %v: %v", spec.FromBackup, err)
-		}
-
-		bv, err := m.ds.GetBackupVolumeRO(bvName)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get backup volume %s: %v", bvName, err)
-		}
-		if bv != nil && bv.Status.BackingImageName != "" {
-			if spec.BackingImage == "" {
-				spec.BackingImage = bv.Status.BackingImageName
-				logrus.Debugf("Since the backing image is not specified during the restore, "+
-					"the previous backing image %v used by backup volume %v will be set for volume %v creation",
-					bv.Status.BackingImageName, bvName, name)
-			}
-			bi, err := m.GetBackingImage(spec.BackingImage)
-			if err != nil {
-				return nil, err
-			}
-			// Validate the checksum only when the chosen backing image name is the same as the record in the backup volume.
-			// If user picks up a backing image different from `backupVolume.BackingImageName`, there is no need to do verification.
-			if spec.BackingImage == bv.Status.BackingImageName {
-				if bv.Status.BackingImageChecksum != "" && bi.Status.Checksum != "" &&
-					bv.Status.BackingImageChecksum != bi.Status.Checksum {
-					return nil, fmt.Errorf("backing image %v current checksum doesn't match the recoreded checksum in backup volume", spec.BackingImage)
-				}
-			}
-		}
-
-		backup, err := m.ds.GetBackupRO(bName)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get backup %s: %v", bName, err)
-		}
-
-		logrus.Infof("Override size of volume %v to %v because it's from backup", name, backup.Status.VolumeSize)
-		// formalize the final size to the unit in bytes
-		size, err = util.ConvertSize(backup.Status.VolumeSize)
-		if err != nil {
-			return nil, fmt.Errorf("get invalid size for volume %v: %v", backup.Status.VolumeSize, err)
-		}
-	}
-
-	// make sure it's multiples of 4096
-	size = util.RoundUpSize(size)
-
-	if spec.NumberOfReplicas == 0 {
-		spec.NumberOfReplicas, err = m.getDefaultReplicaCount()
-		if err != nil {
-			return nil, errors.Wrap(err, "BUG: cannot get valid number for setting default replica count")
-		}
-		logrus.Infof("Use the default number of replicas %v", spec.NumberOfReplicas)
-	}
-
-	if string(spec.ReplicaAutoBalance) == "" {
-		spec.ReplicaAutoBalance = longhorn.ReplicaAutoBalanceIgnored
-		logrus.Infof("Use the %v to inherit global replicas auto-balance setting", spec.ReplicaAutoBalance)
-	}
-	if err := types.ValidateReplicaAutoBalance(spec.ReplicaAutoBalance); err != nil {
-		return nil, errors.Wrapf(err, "cannot create volume with replica auto-balance %v", spec.ReplicaAutoBalance)
-	}
-
-	if string(spec.DataLocality) == "" {
-		defaultDataLocality, err := m.GetSettingValueExisted(types.SettingNameDefaultDataLocality)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot get valid mode for setting default data locality for volume: %v", name)
-		}
-		spec.DataLocality = longhorn.DataLocality(defaultDataLocality)
-	}
-	if err := types.ValidateDataLocality(spec.DataLocality); err != nil {
-		return nil, errors.Wrapf(err, "cannot create volume with data locality %v", spec.DataLocality)
-	}
-
-	if string(spec.AccessMode) == "" {
-		spec.AccessMode = longhorn.AccessModeReadWriteOnce
-	}
-
-	if spec.Migratable && spec.AccessMode != longhorn.AccessModeReadWriteMany {
-		return nil, fmt.Errorf("migratable volumes are only supported in ReadWriteMany (rwx) access mode")
-	}
-
-	defaultEngineImage, err := m.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
-	if defaultEngineImage == "" {
-		return nil, fmt.Errorf("BUG: Invalid empty Setting.EngineImage")
-	}
-
-	// Check engine version before disable revision counter
-	if spec.RevisionCounterDisabled {
-		if ok, err := m.canDisableRevisionCounter(defaultEngineImage); !ok {
-			return nil, errors.Wrapf(err, "can not create volume with current engine image that doesn't support disable revision counter")
-		}
-	}
-
-	if !spec.Standby {
-		if spec.Frontend != longhorn.VolumeFrontendBlockDev && spec.Frontend != longhorn.VolumeFrontendISCSI {
-			return nil, fmt.Errorf("invalid volume frontend specified: %v", spec.Frontend)
-		}
-	}
-
-	if spec.BackingImage != "" {
-		if _, err := m.ds.GetBackingImage(spec.BackingImage); err != nil {
-			return nil, err
-		}
-	}
 
 	labels := map[string]string{}
 	for _, job := range recurringJobSelector {
@@ -284,24 +161,18 @@ func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurring
 		labels[key] = types.LonghornLabelValueEnabled
 	}
 
-	if spec.DataSource != "" {
-		if err := m.verifyDataSourceForVolumeCreation(spec.DataSource, size); err != nil {
-			return nil, err
-		}
-	}
-
 	v = &longhorn.Volume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
 		Spec: longhorn.VolumeSpec{
-			Size:                    size,
+			Size:                    spec.Size,
 			AccessMode:              spec.AccessMode,
 			Migratable:              spec.Migratable,
 			Encrypted:               spec.Encrypted,
 			Frontend:                spec.Frontend,
-			EngineImage:             defaultEngineImage,
+			EngineImage:             "",
 			FromBackup:              spec.FromBackup,
 			DataSource:              spec.DataSource,
 			NumberOfReplicas:        spec.NumberOfReplicas,
@@ -322,34 +193,6 @@ func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurring
 	}
 	logrus.Debugf("Created volume %v: %+v", v.Name, v.Spec)
 	return v, nil
-}
-
-func (m *VolumeManager) verifyDataSourceForVolumeCreation(dataSource longhorn.VolumeDataSource, requestSize int64) (err error) {
-	defer func() {
-		err = errors.Wrapf(err, "failed to verify data source")
-	}()
-
-	if !types.IsValidVolumeDataSource(dataSource) {
-		return fmt.Errorf("in valid value for data source: %v", dataSource)
-	}
-
-	if types.IsDataFromVolume(dataSource) {
-		srcVolName := types.GetVolumeName(dataSource)
-		srcVol, err := m.ds.GetVolume(srcVolName)
-		if err != nil {
-			return err
-		}
-		if requestSize != srcVol.Spec.Size {
-			return fmt.Errorf("size of target volume (%v bytes) is different than size of source volume (%v bytes)", requestSize, srcVol.Spec.Size)
-		}
-
-		if snapName := types.GetSnapshotName(dataSource); snapName != "" {
-			if _, err := m.GetSnapshot(snapName, srcVolName); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (m *VolumeManager) Delete(name string) error {
@@ -1004,10 +847,6 @@ func (m *VolumeManager) UpdateReplicaCount(name string, count int) (v *longhorn.
 		err = errors.Wrapf(err, "unable to update replica count for volume %v", name)
 	}()
 
-	if err := types.ValidateReplicaCount(count); err != nil {
-		return nil, err
-	}
-
 	v, err = m.ds.GetVolume(name)
 	if err != nil {
 		return nil, err
@@ -1039,10 +878,6 @@ func (m *VolumeManager) UpdateReplicaAutoBalance(name string, inputSpec longhorn
 		err = errors.Wrapf(err, "unable to update replica auto-balance for volume %v", name)
 	}()
 
-	if err = types.ValidateReplicaAutoBalance(inputSpec); err != nil {
-		return nil, err
-	}
-
 	v, err = m.ds.GetVolume(name)
 	if err != nil {
 		return nil, err
@@ -1068,10 +903,6 @@ func (m *VolumeManager) UpdateDataLocality(name string, dataLocality longhorn.Da
 	defer func() {
 		err = errors.Wrapf(err, "unable to update data locality for volume %v", name)
 	}()
-
-	if err := types.ValidateDataLocality(dataLocality); err != nil {
-		return nil, err
-	}
 
 	v, err = m.ds.GetVolume(name)
 	if err != nil {
@@ -1099,10 +930,6 @@ func (m *VolumeManager) UpdateAccessMode(name string, accessMode longhorn.Access
 		err = errors.Wrapf(err, "unable to update access mode for volume %v", name)
 	}()
 
-	if err := types.ValidateAccessMode(accessMode); err != nil {
-		return nil, err
-	}
-
 	v, err = m.ds.GetVolume(name)
 	if err != nil {
 		return nil, err
@@ -1126,16 +953,4 @@ func (m *VolumeManager) UpdateAccessMode(name string, accessMode longhorn.Access
 
 	logrus.Infof("Updated volume %v access mode from %v to %v", v.Name, oldAccessMode, accessMode)
 	return v, nil
-}
-
-func (m *VolumeManager) canDisableRevisionCounter(engineImage string) (bool, error) {
-	cliAPIVersion, err := m.ds.GetEngineImageCLIAPIVersion(engineImage)
-	if err != nil {
-		return false, err
-	}
-	if cliAPIVersion < engineapi.CLIVersionFour {
-		return false, fmt.Errorf("current engine image version %v doesn't support disable revision counter", cliAPIVersion)
-	}
-
-	return true, nil
 }

--- a/webhook/resources/backingimage/mutator.go
+++ b/webhook/resources/backingimage/mutator.go
@@ -1,14 +1,21 @@
 package backingimage
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/manager"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+	"github.com/pkg/errors"
 )
 
 type backingImageMutator struct {
@@ -35,18 +42,69 @@ func (b *backingImageMutator) Resource() admission.Resource {
 }
 
 func (b *backingImageMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackingImage(newObj)
-}
-
-func (b *backingImageMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackingImage(newObj)
-}
-
-func mutateBackingImage(newObj runtime.Object) (admission.PatchOps, error) {
 	var patchOps admission.PatchOps
 
 	backingImage := newObj.(*longhorn.BackingImage)
 
+	name := util.AutoCorrectName(backingImage.Name, datastore.NameMaximumLength)
+	if name != backingImage.Name {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, name))
+	}
+
+	checksum := strings.TrimSpace(backingImage.Spec.Checksum)
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/checksum", "value": "%s"}`, checksum))
+
+	// Handle Spec.SourceParameters
+	parameters := make(map[string]string, 0)
+	for k, v := range backingImage.Spec.SourceParameters {
+		parameters[k] = strings.TrimSpace(v)
+	}
+
+	if longhorn.BackingImageDataSourceType(backingImage.Spec.SourceType) == longhorn.BackingImageDataSourceTypeExportFromVolume {
+		// By default the exported file type is raw.
+		if parameters[manager.DataSourceTypeExportFromVolumeParameterExportType] == "" {
+			parameters[manager.DataSourceTypeExportFromVolumeParameterExportType] = manager.DataSourceTypeExportFromVolumeParameterExportTypeRAW
+		}
+	}
+
+	bytes, err := json.Marshal(parameters)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to get JSON encoding for backing image %v sourceParameters", backingImage.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/sourceParameters", "value": %s}`, string(bytes)))
+
+	// Handle Spec.Disks
+	if backingImage.Spec.Disks == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/disks", "value": {}}`)
+	}
+
+	// Merge the user created and longhorn specific labels
+	labels := backingImage.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	longhornLabels := types.GetBackingImageLabels()
+	for k, v := range longhornLabels {
+		labels[k] = v
+	}
+	bytes, err = json.Marshal(labels)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to get JSON encoding for backing image %v labels", backingImage.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/labels", "value": %v}`, string(bytes)))
+
+	return patchOps, nil
+}
+
+func (b *backingImageMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backingImage := newObj.(*longhorn.BackingImage)
+
+	// Backward compatibility
+	// SourceType is set to "download" if it is empty
 	if backingImage.Spec.SourceType == "" {
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/sourceType", "value": "%s"}`, longhorn.BackingImageDataSourceTypeDownload))
 	}

--- a/webhook/resources/backingimage/validator.go
+++ b/webhook/resources/backingimage/validator.go
@@ -1,0 +1,103 @@
+package backingimage
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/controller"
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/engineapi"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/manager"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type backingImageValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &backingImageValidator{ds: ds}
+}
+
+func (b *backingImageValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backingimages",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackingImage{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Delete,
+		},
+	}
+}
+
+func (b *backingImageValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	backingImage := newObj.(*longhorn.BackingImage)
+
+	if !util.ValidateName(backingImage.Name) {
+		return werror.NewInvalidError(fmt.Sprintf("invalid name %v", backingImage.Name), "")
+	}
+
+	if len(backingImage.Spec.Checksum) != 0 {
+		if !util.ValidateChecksumSHA512(backingImage.Spec.Checksum) {
+			return werror.NewInvalidError(fmt.Sprintf("invalid checksum %v", backingImage.Spec.Checksum), "")
+		}
+	}
+
+	switch longhorn.BackingImageDataSourceType(backingImage.Spec.SourceType) {
+	case longhorn.BackingImageDataSourceTypeDownload:
+		if backingImage.Spec.SourceParameters[longhorn.DataSourceTypeDownloadParameterURL] == "" {
+			return werror.NewInvalidError(fmt.Sprintf("invalid parameter %+v for source type %v", backingImage.Spec.SourceParameters, backingImage.Spec.SourceType), "")
+		}
+	case longhorn.BackingImageDataSourceTypeUpload:
+	case longhorn.BackingImageDataSourceTypeExportFromVolume:
+		volumeName := backingImage.Spec.SourceParameters[controller.DataSourceTypeExportFromVolumeParameterVolumeName]
+		if volumeName == "" {
+			return werror.NewInvalidError(fmt.Sprintf("invalid parameter %+v for source type %v", backingImage.Spec.SourceParameters, backingImage.Spec.SourceType), "")
+		}
+		v, err := b.ds.GetVolume(volumeName)
+		if err != nil {
+			return werror.NewInvalidError(fmt.Sprintf("failed to get volume %v before exporting backing image", volumeName), "")
+		}
+		if v.Status.Robustness == longhorn.VolumeRobustnessFaulted {
+			return werror.NewInvalidError(fmt.Sprintf("cannot export a backing image from faulted volume %v", volumeName), "")
+		}
+		eiName := types.GetEngineImageChecksumName(v.Status.CurrentImage)
+		ei, err := b.ds.GetEngineImage(eiName)
+		if err != nil {
+			return werror.NewInvalidError(fmt.Sprintf("failed to get then check engine image %v for volume %v before exporting backing image", eiName, volumeName), "")
+		}
+		if ei.Status.CLIAPIVersion < engineapi.CLIVersionFive {
+			return werror.NewInvalidError(fmt.Sprintf("engine image %v CLI version %v doesn't support this feature, please upgrade engine for volume %v before exporting backing image from the volume", eiName, ei.Status.CLIAPIVersion, volumeName), "")
+		}
+
+		if backingImage.Spec.SourceParameters[manager.DataSourceTypeExportFromVolumeParameterExportType] != manager.DataSourceTypeExportFromVolumeParameterExportTypeRAW &&
+			backingImage.Spec.SourceParameters[manager.DataSourceTypeExportFromVolumeParameterExportType] != manager.DataSourceTypeExportFromVolumeParameterExportTypeQCOW2 {
+			return werror.NewInvalidError(fmt.Sprintf("unsupported export type %v", backingImage.Spec.SourceParameters[manager.DataSourceTypeExportFromVolumeParameterExportType]), "")
+		}
+	}
+
+	return nil
+}
+
+func (b *backingImageValidator) Delete(request *admission.Request, oldObj runtime.Object) error {
+	backingImage := oldObj.(*longhorn.BackingImage)
+
+	replicas, err := b.ds.ListReplicasByBackingImage(backingImage.Name)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("cannot delete backing image %v since the error %v", backingImage.Name, err.Error()), "")
+	}
+	if len(replicas) != 0 {
+		return werror.NewInvalidError(fmt.Sprintf("cannot delete backing image %v since there are replicas using it", backingImage.Name), "")
+	}
+	return nil
+}

--- a/webhook/resources/engineimage/mutator.go
+++ b/webhook/resources/engineimage/mutator.go
@@ -1,0 +1,73 @@
+package engineimage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+	"github.com/pkg/errors"
+)
+
+type engineImageMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &engineImageMutator{ds: ds}
+}
+
+func (e *engineImageMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "engineimages",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.EngineImage{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (e *engineImageMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	engineImage := newObj.(*longhorn.EngineImage)
+
+	image := strings.TrimSpace(engineImage.Spec.Image)
+	if image != engineImage.Spec.Image {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/image", "value": "%s"}`, image))
+	}
+
+	name := types.GetEngineImageChecksumName(image)
+	if name != engineImage.Name {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, name))
+	}
+
+	// Merge the user created and longhorn specific labels
+	labels := engineImage.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	longhornLabels := types.GetEngineImageLabels(name)
+	for k, v := range longhornLabels {
+		labels[k] = v
+	}
+	bytes, err := json.Marshal(labels)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to get JSON encoding for engine image %v labels", engineImage.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/labels", "value": %v}`, string(bytes)))
+
+	return patchOps, nil
+}

--- a/webhook/resources/engineimage/validator.go
+++ b/webhook/resources/engineimage/validator.go
@@ -1,0 +1,54 @@
+package engineimage
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type engineImageValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &engineImageValidator{ds: ds}
+}
+
+func (e *engineImageValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "engineimages",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.EngineImage{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Delete,
+		},
+	}
+}
+
+func (e *engineImageValidator) Delete(request *admission.Request, oldObj runtime.Object) error {
+	engineImage := oldObj.(*longhorn.EngineImage)
+
+	defaultImage, err := e.ds.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
+	if err != nil {
+		err = errors.Wrap(err, "unable to delete engine image")
+		return werror.NewInvalidError(err.Error(), "")
+	}
+	if engineImage.Spec.Image == defaultImage {
+		return werror.NewInvalidError("unable to delete the default engine image", "")
+	}
+	if engineImage.Status.RefCount != 0 {
+		return werror.NewInvalidError(fmt.Sprintf("unable to delete the engine image while being used and refCount is %v", engineImage.Status.RefCount), "")
+	}
+	return nil
+}

--- a/webhook/resources/node/mutator.go
+++ b/webhook/resources/node/mutator.go
@@ -1,7 +1,9 @@
 package node
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -9,6 +11,8 @@ import (
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+	"github.com/pkg/errors"
 )
 
 type nodeMutator struct {
@@ -35,31 +39,69 @@ func (n *nodeMutator) Resource() admission.Resource {
 }
 
 func (n *nodeMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateNode(newObj)
+	newNode := newObj.(*longhorn.Node)
+
+	return mutateNode(newNode)
 }
 
 func (n *nodeMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateNode(newObj)
+	newNode := newObj.(*longhorn.Node)
+
+	return mutateNode(newNode)
 }
 
-func mutateNode(newObj runtime.Object) (admission.PatchOps, error) {
+func mutateNode(node *longhorn.Node) (admission.PatchOps, error) {
 	var patchOps admission.PatchOps
-
-	node := newObj.(*longhorn.Node)
 
 	if node.Spec.Tags == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/tags", "value": []}`)
+	} else {
+		if len(node.Spec.Tags) > 0 {
+			tags := deduplicateTags(node.Spec.Tags)
+			bytes, err := json.Marshal(tags)
+			if err != nil {
+				err = errors.Wrapf(err, "failed to get JSON encoding for node %v tags", node.Name)
+				return nil, werror.NewInvalidError(err.Error(), "")
+			}
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/tags", "value": %s}`, string(bytes)))
+		}
 	}
 
 	if node.Spec.Disks == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/disks", "value": {}}`)
-	}
-
-	for name, disk := range node.Spec.Disks {
-		if disk.Tags == nil {
-			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/disks/%s/tags", "value": []}`, name))
+	} else {
+		for name, disk := range node.Spec.Disks {
+			if disk.Tags == nil {
+				patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/disks/%s/tags", "value": []}`, name))
+			} else {
+				if len(disk.Tags) > 0 {
+					tags := deduplicateTags(disk.Tags)
+					bytes, err := json.Marshal(tags)
+					if err != nil {
+						err = errors.Wrapf(err, "failed to get JSON encoding for node %v disk labels", node.Name)
+						return nil, werror.NewInvalidError(err.Error(), "")
+					}
+					patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/disks/%s/tags", "value": %s}`, name, string(bytes)))
+				}
+			}
 		}
 	}
 
 	return patchOps, nil
+}
+
+func deduplicateTags(inputTags []string) []string {
+	foundTags := make(map[string]struct{})
+	var tags []string
+	for _, tag := range inputTags {
+		if _, ok := foundTags[tag]; ok {
+			continue
+		}
+		foundTags[tag] = struct{}{}
+		tags = append(tags, tag)
+	}
+
+	sort.Strings(tags)
+
+	return tags
 }

--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -1,0 +1,144 @@
+package node
+
+import (
+	"fmt"
+	"math"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+	"github.com/sirupsen/logrus"
+)
+
+type nodeValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &nodeValidator{ds: ds}
+}
+
+func (n *nodeValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "nodes",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Node{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Update,
+			admissionregv1.Delete,
+		},
+	}
+}
+
+func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	oldNode := oldObj.(*longhorn.Node)
+	newNode := newObj.(*longhorn.Node)
+
+	// Only scheduling disabled node can be evicted
+	// Can not enable scheduling on an evicting node
+	if newNode.Spec.EvictionRequested && newNode.Spec.AllowScheduling {
+		return werror.NewInvalidError(fmt.Sprintf("need to disable scheduling on node %v for node eviction, or cancel eviction to enable scheduling on this node",
+			oldNode.Name), "")
+	}
+
+	// We need to make sure the tags passed in are valid before updating the node.
+	_, err := util.ValidateTags(newNode.Spec.Tags)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if newNode.Spec.EngineManagerCPURequest != 0 || newNode.Spec.ReplicaManagerCPURequest != 0 {
+		kubeNode, err := n.ds.GetKubernetesNode(oldNode.Name)
+		if err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+		allocatableCPU := float64(kubeNode.Status.Allocatable.Cpu().MilliValue())
+		engineManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedEngineManagerCPU)
+		if err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+		engineManagerCPUInPercentage := engineManagerCPUSetting.Value
+		if newNode.Spec.EngineManagerCPURequest > 0 {
+			engineManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.EngineManagerCPURequest)/allocatableCPU*100.0))
+		}
+		replicaManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedReplicaManagerCPU)
+		if err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+		replicaManagerCPUInPercentage := replicaManagerCPUSetting.Value
+		if newNode.Spec.ReplicaManagerCPURequest > 0 {
+			replicaManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.ReplicaManagerCPURequest)/allocatableCPU*100.0))
+		}
+		if err := types.ValidateCPUReservationValues(engineManagerCPUInPercentage, replicaManagerCPUInPercentage); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	// Only scheduling disabled disk can be evicted
+	// Can not enable scheduling on an evicting disk
+	for diskName, diskSpec := range newNode.Spec.Disks {
+		if diskSpec.EvictionRequested && diskSpec.AllowScheduling {
+			return werror.NewInvalidError(fmt.Sprintf("need to disable scheduling on disk %v for disk eviction, or cancel eviction to enable scheduling on this disk",
+				diskName), "")
+		}
+	}
+
+	// Validate StorageReserved and Disk.Tags
+	for name, disk := range newNode.Spec.Disks {
+		if disk.StorageReserved < 0 {
+			return werror.NewInvalidError(fmt.Sprintf("update disk on node %v error: The storageReserved setting of disk %v(%v) is not valid, should be positive and no more than storageMaximum and storageAvailable",
+				name, name, disk.Path), "")
+		}
+		_, err := util.ValidateTags(disk.Tags)
+		if err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	// Validate delete disks
+	for name, disk := range oldNode.Spec.Disks {
+		if _, ok := newNode.Spec.Disks[name]; !ok {
+			if disk.AllowScheduling || oldNode.Status.DiskStatus[name].StorageScheduled != 0 {
+				logrus.Infof("Delete Disk on node %v error: Please disable the disk %v and remove all replicas first ", name, disk.Path)
+				return werror.NewInvalidError(fmt.Sprintf("Delete Disk on node %v error: Please disable the disk %v and remove all replicas first ", name, disk.Path), "")
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n *nodeValidator) Delete(request *admission.Request, oldObj runtime.Object) error {
+	node := oldObj.(*longhorn.Node)
+
+	// Only remove node from longhorn without any volumes on it
+	replicas, err := n.ds.ListReplicasByNodeRO(node.Name)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("could not delete node %v since listing replicas encountered %v", node.Name, err.Error()), "")
+	}
+	engines, err := n.ds.ListEnginesByNodeRO(node.Name)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("could not delete node %v since listing engines encountered %v", node.Name, err.Error()), "")
+	}
+
+	condition := types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady)
+	// Only could delete node from longhorn if kubernetes node missing or manager pod is missing
+	if condition.Status == longhorn.ConditionStatusTrue ||
+		(condition.Reason != longhorn.NodeConditionReasonKubernetesNodeGone &&
+			condition.Reason != longhorn.NodeConditionReasonManagerPodMissing) ||
+		node.Spec.AllowScheduling || len(replicas) > 0 || len(engines) > 0 {
+		return werror.NewInvalidError(fmt.Sprintf("could not delete node %v with node ready condition is %v, reason is %v, node schedulable %v, and %v replica, %v engine running on it", node.Name,
+			condition.Status, condition.Reason, node.Spec.AllowScheduling, len(replicas), len(engines)), "")
+	}
+
+	return nil
+}

--- a/webhook/resources/recurringjob/validator.go
+++ b/webhook/resources/recurringjob/validator.go
@@ -1,0 +1,84 @@
+package recurringjob
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type recurringJobValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &recurringJobValidator{ds: ds}
+}
+
+func (r *recurringJobValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "recurringjobs",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.RecurringJob{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (r *recurringJobValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	recurringJob := newObj.(*longhorn.RecurringJob)
+
+	if !util.ValidateName(recurringJob.Name) {
+		return werror.NewInvalidError(fmt.Sprintf("invalid name %v", recurringJob.Name), "")
+	}
+
+	jobs := []longhorn.RecurringJobSpec{
+		{
+			Name:        recurringJob.Spec.Name,
+			Groups:      recurringJob.Spec.Groups,
+			Task:        recurringJob.Spec.Task,
+			Cron:        recurringJob.Spec.Cron,
+			Retain:      recurringJob.Spec.Retain,
+			Concurrency: recurringJob.Spec.Concurrency,
+			Labels:      recurringJob.Spec.Labels,
+		},
+	}
+	if err := datastore.ValidateRecurringJobs(jobs); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	return nil
+
+}
+
+func (r *recurringJobValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	newRecurringJob := newObj.(*longhorn.RecurringJob)
+
+	jobs := []longhorn.RecurringJobSpec{
+		{
+			Name:        newRecurringJob.Spec.Name,
+			Groups:      newRecurringJob.Spec.Groups,
+			Task:        newRecurringJob.Spec.Task,
+			Cron:        newRecurringJob.Spec.Cron,
+			Retain:      newRecurringJob.Spec.Retain,
+			Concurrency: newRecurringJob.Spec.Concurrency,
+			Labels:      newRecurringJob.Spec.Labels,
+		},
+	}
+	if err := datastore.ValidateRecurringJobs(jobs); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	return nil
+}

--- a/webhook/resources/volume/mutator.go
+++ b/webhook/resources/volume/mutator.go
@@ -1,14 +1,22 @@
 package volume
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/longhorn/backupstore"
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type volumeMutator struct {
@@ -35,14 +43,144 @@ func (v *volumeMutator) Resource() admission.Resource {
 }
 
 func (v *volumeMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateVolume(newObj)
+	var patchOps admission.PatchOps
+
+	volume := newObj.(*longhorn.Volume)
+
+	name := util.AutoCorrectName(volume.Name, datastore.NameMaximumLength)
+	if name != volume.Name {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, name))
+	}
+
+	if volume.Spec.ReplicaAutoBalance == "" {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/replicaAutoBalance", "value": "ignored"}`)
+	}
+
+	if volume.Spec.DiskSelector == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/diskSelector", "value": []}`)
+	}
+
+	if volume.Spec.NodeSelector == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/nodeSelector", "value": []}`)
+	}
+
+	if volume.Spec.RecurringJobs == nil {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/recurringJobs", "value": []}`)
+	}
+
+	for id, job := range volume.Spec.RecurringJobs {
+		if job.Groups == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/recurringJobs/%d/groups", "value": []}`, id))
+		}
+		if job.Labels == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/recurringJobs/%d/labels", "value": {}}`, id))
+		}
+	}
+
+	if volume.Spec.NumberOfReplicas == 0 {
+		numberOfReplicas, err := v.getDefaultReplicaCount()
+		if err != nil {
+			err = errors.Wrap(err, "BUG: cannot get valid number for setting default replica count")
+			return nil, werror.NewInvalidError(err.Error(), "")
+		}
+		logrus.Infof("Use the default number of replicas %v", numberOfReplicas)
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/numberOfReplicas", "value": %v}`, numberOfReplicas))
+	}
+
+	if string(volume.Spec.ReplicaAutoBalance) == "" {
+		replicaAutoBalance := longhorn.ReplicaAutoBalanceIgnored
+		logrus.Infof("Use the %v to inherit global replicas auto-balance setting", replicaAutoBalance)
+
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/replicaAutoBalance", "value": "%s"}`, string(replicaAutoBalance)))
+	}
+
+	if string(volume.Spec.DataLocality) == "" {
+		defaultDataLocality, err := v.ds.GetSettingValueExisted(types.SettingNameDefaultDataLocality)
+		if err != nil {
+			err = errors.Wrapf(err, "cannot get valid mode for setting default data locality for volume: %v", name)
+			return nil, werror.NewInvalidError(err.Error(), "")
+		}
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/dataLocality", "value": "%s"}`, defaultDataLocality))
+	}
+
+	if string(volume.Spec.AccessMode) == "" {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/accessMode", "value": "%s"}`, string(longhorn.AccessModeReadWriteOnce)))
+	}
+
+	size := volume.Spec.Size
+	if volume.Spec.FromBackup != "" {
+		bName, bvName, _, err := backupstore.DecodeBackupURL(volume.Spec.FromBackup)
+		if err != nil {
+			return nil, werror.NewInvalidError(fmt.Sprintf("cannot get backup and volume name from backup URL %v: %v", volume.Spec.FromBackup, err), "")
+		}
+
+		bv, err := v.ds.GetBackupVolumeRO(bvName)
+		if err != nil {
+			return nil, werror.NewInvalidError(fmt.Sprintf("cannot get backup volume %s: %v", bvName, err), "")
+		}
+		if bv != nil && bv.Status.BackingImageName != "" {
+			if volume.Spec.BackingImage == "" {
+				volume.Spec.BackingImage = bv.Status.BackingImageName
+				patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/backingImage", "value": "%s"}`, bv.Status.BackingImageName))
+				logrus.Debugf("Since the backing image is not specified during the restore, "+
+					"the previous backing image %v used by backup volume %v will be set for volume %v creation",
+					bv.Status.BackingImageName, bvName, name)
+			}
+			bi, err := v.ds.GetBackingImage(volume.Spec.BackingImage)
+			if err != nil {
+				err = errors.Wrapf(err, "failed to get backing image %v", volume.Spec.BackingImage)
+				return nil, werror.NewInvalidError(err.Error(), "")
+			}
+			// Validate the checksum only when the chosen backing image name is the same as the record in the backup volume.
+			// If user picks up a backing image different from `backupVolume.BackingImageName`, there is no need to do verification.
+			if volume.Spec.BackingImage == bv.Status.BackingImageName {
+				if bv.Status.BackingImageChecksum != "" && bi.Status.Checksum != "" &&
+					bv.Status.BackingImageChecksum != bi.Status.Checksum {
+					return nil, werror.NewInvalidError(fmt.Sprintf("backing image %v current checksum doesn't match the recoreded checksum in backup volume", volume.Spec.BackingImage), "")
+				}
+			}
+		}
+
+		backup, err := v.ds.GetBackupRO(bName)
+		if err != nil {
+			return nil, werror.NewInvalidError(fmt.Sprintf("cannot get backup %s: %v", bName, err), "")
+		}
+
+		logrus.Infof("Override size of volume %v to %v because it's from backup", name, backup.Status.VolumeSize)
+		// formalize the final size to the unit in bytes
+		size, err = util.ConvertSize(backup.Status.VolumeSize)
+		if err != nil {
+			return nil, werror.NewInvalidError(fmt.Sprintf("get invalid size for volume %v: %v", backup.Status.VolumeSize, err), "")
+		}
+
+		// Add backup volume name label to the restore/DR volume
+		labels := volume.Labels
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[types.LonghornLabelBackupVolume] = bvName
+
+		bytes, err := json.Marshal(labels)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to get JSON encoding for volume %v labels", volume.Name)
+			return nil, werror.NewInvalidError(err.Error(), "")
+		}
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/metadata/labels", "value": %v}`, string(bytes)))
+	}
+
+	size = util.RoundUpSize(size)
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/size", "value": "%v"}`, strconv.FormatInt(size, 10)))
+
+	defaultEngineImage, _ := v.ds.GetSettingValueExisted(types.SettingNameDefaultEngineImage)
+	if defaultEngineImage == "" {
+		return nil, werror.NewInvalidError("BUG: Invalid empty Setting.EngineImage", "")
+	}
+	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/engineImage", "value": "%s"}`, defaultEngineImage))
+
+	return patchOps, nil
 }
 
 func (v *volumeMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateVolume(newObj)
-}
-
-func mutateVolume(newObj runtime.Object) (admission.PatchOps, error) {
 	var patchOps admission.PatchOps
 
 	volume := newObj.(*longhorn.Volume)
@@ -68,5 +206,17 @@ func mutateVolume(newObj runtime.Object) (admission.PatchOps, error) {
 		}
 	}
 
+	size := util.RoundUpSize(volume.Spec.Size)
+	if size != volume.Spec.Size {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/size", "value": "%s"}`, strconv.FormatInt(size, 10)))
+	}
 	return patchOps, nil
+}
+
+func (v *volumeMutator) getDefaultReplicaCount() (int, error) {
+	c, err := v.ds.GetSettingAsInt(types.SettingNameDefaultReplicaCount)
+	if err != nil {
+		return 0, err
+	}
+	return int(c), nil
 }

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -1,0 +1,227 @@
+package volume
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/engineapi"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type volumeValidator struct {
+	admission.DefaultValidator
+	ds            *datastore.DataStore
+	currentNodeID string
+}
+
+func NewValidator(ds *datastore.DataStore, currentNodeID string) admission.Validator {
+	return &volumeValidator{ds: ds, currentNodeID: currentNodeID}
+}
+
+func (v *volumeValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "volumes",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.Volume{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *volumeValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	volume := newObj.(*longhorn.Volume)
+
+	if !util.ValidateName(volume.Name) {
+		return werror.NewInvalidError(fmt.Sprintf("invalid name %v", volume.Name), "")
+	}
+
+	if err := types.ValidateDataLocality(volume.Spec.DataLocality); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateAccessMode(volume.Spec.AccessMode); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateReplicaCount(volume.Spec.NumberOfReplicas); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateReplicaAutoBalance(volume.Spec.ReplicaAutoBalance); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if volume.Spec.BackingImage != "" {
+		if _, err := v.ds.GetBackingImage(volume.Spec.BackingImage); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	if volume.Spec.EngineImage == "" {
+		return werror.NewInvalidError("BUG: Invalid empty Setting.EngineImage", "")
+	}
+
+	if !volume.Spec.Standby {
+		if volume.Spec.Frontend != longhorn.VolumeFrontendBlockDev && volume.Spec.Frontend != longhorn.VolumeFrontendISCSI {
+			return werror.NewInvalidError(fmt.Sprintf("invalid volume frontend specified: %v", volume.Spec.Frontend), "")
+		}
+	}
+
+	if volume.Spec.Migratable && volume.Spec.AccessMode != longhorn.AccessModeReadWriteMany {
+		return werror.NewInvalidError("migratable volumes are only supported in ReadWriteMany (rwx) access mode", "")
+	}
+
+	// Check engine version before disable revision counter
+	if volume.Spec.RevisionCounterDisabled {
+		if ok, err := v.canDisableRevisionCounter(volume.Spec.EngineImage); !ok {
+			err := errors.Wrapf(err, "can not create volume with current engine image that doesn't support disable revision counter")
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	if volume.Spec.DataSource != "" {
+		if err := v.verifyDataSourceForVolumeCreation(v.currentNodeID, volume.Spec.DataSource, volume.Spec.Size); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	if err := datastore.CheckVolume(volume); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	return nil
+}
+
+func (v *volumeValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	newVolume := newObj.(*longhorn.Volume)
+
+	if err := types.ValidateDataLocality(newVolume.Spec.DataLocality); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateAccessMode(newVolume.Spec.AccessMode); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateReplicaCount(newVolume.Spec.NumberOfReplicas); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := types.ValidateReplicaAutoBalance(newVolume.Spec.ReplicaAutoBalance); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := datastore.CheckVolume(newVolume); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *volumeValidator) canDisableRevisionCounter(engineImage string) (bool, error) {
+	cliAPIVersion, err := v.ds.GetEngineImageCLIAPIVersion(engineImage)
+	if err != nil {
+		return false, err
+	}
+	if cliAPIVersion < engineapi.CLIVersionFour {
+		return false, fmt.Errorf("current engine image version %v doesn't support disable revision counter", cliAPIVersion)
+	}
+
+	return true, nil
+}
+
+func (v *volumeValidator) verifyDataSourceForVolumeCreation(currentNodeID string, dataSource longhorn.VolumeDataSource, requestSize int64) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "failed to verify data source")
+	}()
+
+	if !types.IsValidVolumeDataSource(dataSource) {
+		return fmt.Errorf("in valid value for data source: %v", dataSource)
+	}
+
+	if types.IsDataFromVolume(dataSource) {
+		srcVolName := types.GetVolumeName(dataSource)
+		srcVol, err := v.ds.GetVolume(srcVolName)
+		if err != nil {
+			return err
+		}
+		if requestSize != srcVol.Spec.Size {
+			return fmt.Errorf("size of target volume (%v bytes) is different than size of source volume (%v bytes)", requestSize, srcVol.Spec.Size)
+		}
+
+		if snapName := types.GetSnapshotName(dataSource); snapName != "" {
+			if _, err := v.getSnapshot(currentNodeID, snapName, srcVolName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (v *volumeValidator) getSnapshot(currentNodeID, snapshotName, volumeName string) (*longhorn.Snapshot, error) {
+	if currentNodeID == "" || volumeName == "" || snapshotName == "" {
+		return nil, fmt.Errorf("currentNodeID, volume and snapshot name required")
+	}
+	engine, err := v.getEngineClient(currentNodeID, volumeName)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := engine.SnapshotGet(snapshotName)
+	if err != nil {
+		return nil, err
+	}
+	if snapshot == nil {
+		return nil, fmt.Errorf("cannot find snapshot '%s' for volume '%s'", snapshotName, volumeName)
+	}
+	return snapshot, nil
+}
+
+func (v *volumeValidator) getEngineClient(currentNodeID, volumeName string) (client engineapi.EngineClient, err error) {
+	var e *longhorn.Engine
+
+	defer func() {
+		err = errors.Wrapf(err, "cannot get client for volume %v", volumeName)
+	}()
+	es, err := v.ds.ListVolumeEngines(volumeName)
+	if err != nil {
+		return nil, err
+	}
+	if len(es) == 0 {
+		return nil, fmt.Errorf("cannot find engine")
+	}
+	if len(es) != 1 {
+		return nil, fmt.Errorf("more than one engine exists")
+	}
+	for _, e = range es {
+		break
+	}
+	if e.Status.CurrentState != longhorn.InstanceStateRunning {
+		return nil, fmt.Errorf("engine is not running")
+	}
+	if isReady, err := v.ds.CheckEngineImageReadiness(e.Status.CurrentImage, currentNodeID); !isReady {
+		if err != nil {
+			return nil, fmt.Errorf("cannot get engine client with image %v: %v", e.Status.CurrentImage, err)
+		}
+		return nil, fmt.Errorf("cannot get engine client with image %v because it isn't deployed on this node", e.Status.CurrentImage)
+	}
+
+	engineCollection := &engineapi.EngineCollection{}
+	return engineCollection.NewEngineClient(&engineapi.EngineClientRequest{
+		VolumeName:  e.Spec.VolumeName,
+		EngineImage: e.Status.CurrentImage,
+		IP:          e.Status.IP,
+		Port:        e.Status.Port,
+	})
+}

--- a/webhook/server/mutation.go
+++ b/webhook/server/mutation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backup"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engine"
+	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
 	"github.com/longhorn/longhorn-manager/webhook/resources/volume"
@@ -28,6 +29,7 @@ func Mutation(client *client.Client) (http.Handler, []admission.Resource, error)
 		volume.NewMutator(client.Datastore),
 		engine.NewMutator(client.Datastore),
 		recurringjob.NewMutator(client.Datastore),
+		engineimage.NewMutator(client.Datastore),
 	}
 
 	router := webhook.NewRouter()

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/client"
+	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/setting"
 )
@@ -16,6 +17,7 @@ func Validation(client *client.Client) (http.Handler, []admission.Resource, erro
 	validators := []admission.Validator{
 		node.NewValidator(client.Datastore),
 		setting.NewValidator(client.Datastore),
+		engineimage.NewValidator(client.Datastore),
 	}
 
 	router := webhook.NewRouter()

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/client"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
+	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
 	"github.com/longhorn/longhorn-manager/webhook/resources/setting"
 )
 
@@ -18,6 +19,7 @@ func Validation(client *client.Client) (http.Handler, []admission.Resource, erro
 		node.NewValidator(client.Datastore),
 		setting.NewValidator(client.Datastore),
 		engineimage.NewValidator(client.Datastore),
+		recurringjob.NewValidator(client.Datastore),
 	}
 
 	router := webhook.NewRouter()

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/client"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backingimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
@@ -20,6 +21,7 @@ func Validation(client *client.Client) (http.Handler, []admission.Resource, erro
 		setting.NewValidator(client.Datastore),
 		engineimage.NewValidator(client.Datastore),
 		recurringjob.NewValidator(client.Datastore),
+		backingimage.NewValidator(client.Datastore),
 	}
 
 	router := webhook.NewRouter()

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/wrangler/pkg/webhook"
 
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/client"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimage"
@@ -12,9 +14,15 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
 	"github.com/longhorn/longhorn-manager/webhook/resources/setting"
+	"github.com/longhorn/longhorn-manager/webhook/resources/volume"
 )
 
 func Validation(client *client.Client) (http.Handler, []admission.Resource, error) {
+	currentNodeID, err := util.GetRequiredEnv(types.EnvNodeName)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	resources := []admission.Resource{}
 	validators := []admission.Validator{
 		node.NewValidator(client.Datastore),
@@ -22,6 +30,7 @@ func Validation(client *client.Client) (http.Handler, []admission.Resource, erro
 		engineimage.NewValidator(client.Datastore),
 		recurringjob.NewValidator(client.Datastore),
 		backingimage.NewValidator(client.Datastore),
+		volume.NewValidator(client.Datastore, currentNodeID),
 	}
 
 	router := webhook.NewRouter()

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/client"
+	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/setting"
 )
 
 func Validation(client *client.Client) (http.Handler, []admission.Resource, error) {
 	resources := []admission.Resource{}
 	validators := []admission.Validator{
+		node.NewValidator(client.Datastore),
 		setting.NewValidator(client.Datastore),
 	}
 


### PR DESCRIPTION
The general mutation and validation logics in HTTP API functions are moved or re-implemented in the admission webhook.

[longhorn #3562](https://github.com/longhorn/longhorn/issues/3562)