### PR TITLE
backup: retry deletion after failing to acquire the lock

### DIFF
--- a/controller/base_controller.go
+++ b/controller/base_controller.go
@@ -6,6 +6,15 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+var (
+	// maxRetries is the number of times a deployment will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times
+	// a deployment is going to be requeued:
+	//
+	// 5ms, 10ms, 20ms
+	maxRetries = 3
+)
+
 type baseController struct {
 	name   string
 	logger logrus.FieldLogger

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -34,15 +34,6 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
-var (
-	// maxRetries is the number of times a deployment will be retried before it is dropped out of the queue.
-	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times
-	// a deployment is going to be requeued:
-	//
-	// 5ms, 10ms, 20ms
-	maxRetries = 3
-)
-
 type ReplicaController struct {
 	*baseController
 


### PR DESCRIPTION
The resync period of the backingimage is one hour and the maxRetries is
3. Thus, the deletion of the backup in error state caused by the
shutdown of the replica during backing up will fail.

The workaround is to increase the maxRetries number and to retry the
deletion until the lock acquisition of the backup is timeout after 150
seconds.

maxRetriesOnAcquireLockError should guarantee the cumulative retry time
is larger than 150 seconds.

Longhorn 3620

Signed-off-by: Derek Su <derek.su@suse.com>