### PR TITLE
Fix upgrade failure because of the wrong conversion strategy 

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -335,11 +335,22 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: backingimages.longhorn.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9443
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: longhorn.io
   names:
     kind: BackingImage
@@ -675,11 +686,22 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: backuptargets.longhorn.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9443
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: longhorn.io
   names:
     kind: BackupTarget
@@ -1002,11 +1024,22 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: engineimages.longhorn.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9443
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: longhorn.io
   names:
     kind: EngineImage
@@ -1651,11 +1684,22 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: nodes.longhorn.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9443
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: longhorn.io
   names:
     kind: Node
@@ -2412,11 +2456,22 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: volumes.longhorn.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9443
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: longhorn.io
   names:
     kind: Volume

--- a/k8s/generate_code.sh
+++ b/k8s/generate_code.sh
@@ -60,6 +60,10 @@ controller-gen crd paths=${APIS_DIR}/... output:crd:dir=${CRDS_DIR}
 pushd ${CRDS_DIR}
 kustomize create --autodetect 2>/dev/null || true
 kustomize edit add label longhorn-manager: 2>/dev/null || true
+if [ -e ${GOPATH}/src/${LH_MANAGER_DIR}/k8s/patches/crd ]; then
+  cp -a ${GOPATH}/src/${LH_MANAGER_DIR}/k8s/patches/crd patches
+  find patches -type f | xargs -i sh -c 'kustomize edit add patch --path {}'
+fi
 popd
 kustomize build ${CRDS_DIR} > ${GOPATH}/src/${LH_MANAGER_DIR}/deploy/install/01-prerequisite/03-crd.yaml
 rm -r ${CRDS_DIR}

--- a/k8s/patches/crd/webhook_in_backingimage.yaml
+++ b/k8s/patches/crd/webhook_in_backingimage.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: backingimages.longhorn.io
+spec:
+ conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta2","v1beta1"]
+      clientConfig:
+        service:
+          namespace: longhorn-system
+          name: longhorn-conversion-webhook
+          path: /v1/webhook/conversion
+          port: 9443

--- a/k8s/patches/crd/webhook_in_backuptarget.yaml
+++ b/k8s/patches/crd/webhook_in_backuptarget.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: backuptargets.longhorn.io
+spec:
+ conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta2","v1beta1"]
+      clientConfig:
+        service:
+          namespace: longhorn-system
+          name: longhorn-conversion-webhook
+          path: /v1/webhook/conversion
+          port: 9443

--- a/k8s/patches/crd/webhook_in_engineimage.yaml
+++ b/k8s/patches/crd/webhook_in_engineimage.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: engineimages.longhorn.io
+spec:
+ conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta2","v1beta1"]
+      clientConfig:
+        service:
+          namespace: longhorn-system
+          name: longhorn-conversion-webhook
+          path: /v1/webhook/conversion
+          port: 9443
+          

--- a/k8s/patches/crd/webhook_in_node.yaml
+++ b/k8s/patches/crd/webhook_in_node.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodes.longhorn.io
+spec:
+ conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta2","v1beta1"]
+      clientConfig:
+        service:
+          namespace: longhorn-system
+          name: longhorn-conversion-webhook
+          path: /v1/webhook/conversion
+          port: 9443
+          

--- a/k8s/patches/crd/webhook_in_volume.yaml
+++ b/k8s/patches/crd/webhook_in_volume.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.longhorn.io
+spec:
+ conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta2","v1beta1"]
+      clientConfig:
+        service:
+          namespace: longhorn-system
+          name: longhorn-conversion-webhook
+          path: /v1/webhook/conversion
+          port: 9443
+          


### PR DESCRIPTION
Fix upgrade failure because of the wrong conversion strategy in crd.yaml.
The conversion strategy and webhook settings are patched while generating the CRD manifest, and the `caBundle` will be dynamically generated in the conversion webhook.

Longrhorn 3631