### PR TITLE
Fetch the engine backup name and replica address

### DIFF
--- a/engineapi/backup_monitor.go
+++ b/engineapi/backup_monitor.go
@@ -70,18 +70,16 @@ func NewBackupMonitor(logger logrus.FieldLogger,
 	}
 
 	// Call engine API snapshot backup
-	if backup.Status.State == longhorn.BackupStateNew {
-		engineBackupName, replicaAddress, err := engineClient.SnapshotBackup(backup.Name, backup.Spec.SnapshotName,
-			backupTargetClient.URL, volume.Spec.BackingImage, biChecksum,
-			backup.Spec.Labels, backupTargetClient.Credential)
-		if err != nil {
-			m.logger.WithError(err).Warn("Cannot take snapshot backup")
-			return nil, err
-		}
-
-		m.engineBackupName = engineBackupName
-		m.replicaAddress = replicaAddress
+	engineBackupName, replicaAddress, err := engineClient.SnapshotBackup(backup.Name, backup.Spec.SnapshotName,
+		backupTargetClient.URL, volume.Spec.BackingImage, biChecksum,
+		backup.Spec.Labels, backupTargetClient.Credential)
+	if err != nil {
+		m.logger.WithError(err).Warn("Cannot take snapshot backup")
+		return nil, err
 	}
+
+	m.engineBackupName = engineBackupName
+	m.replicaAddress = replicaAddress
 
 	// Create a goroutine to monitor the replica backup state/progress
 	go m.monitorBackups()


### PR DESCRIPTION
The key to query the engine's backup status is the engine backup name + replica address.
If the backup monitor resource disappeared, call the engine's SnapshotBackup to get the engine backup name and replica address.

If the engine's snapshot backup is in progress, calling the engine's SnapshotBackup would not create a new backup.

https://github.com/longhorn/longhorn/issues/3690