### PR TITLE
Records engine backup name in Backup CR status

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -519,6 +519,7 @@ func (bc *BackupController) syncWithMonitor(backup *longhorn.Backup, volume *lon
 	existingBackupState := backup.Status.State
 
 	backupStatus := monitor.GetBackupStatus()
+	backup.Status.EngineBackupName = backupStatus.EngineBackupName
 	backup.Status.Progress = backupStatus.Progress
 	backup.Status.URL = backupStatus.URL
 	backup.Status.Error = backupStatus.Error

--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -612,6 +612,9 @@ spec:
               backupCreatedAt:
                 description: The snapshot backup upload finished time.
                 type: string
+              engineBackupName:
+                description: The backup name is generated inside the longhorn engine. It is for backward compatibility with the longhorn engine < 1.2.0. This field can be deprecated once the longhorn manager no longer supports the longhorn engine < 1.2.0.
+                type: string
               error:
                 description: The error message when taking the snapshot backup.
                 type: string

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -35,6 +35,12 @@ type BackupStatus struct {
 	// Can be "", "InProgress", "Completed", "Error", "Unknown".
 	// +optional
 	State BackupState `json:"state"`
+	// The backup name is generated inside the longhorn engine.
+	// It is for backward compatibility with the longhorn engine < 1.2.0.
+	// This field can be deprecated once the longhorn manager no longer
+	// supports the longhorn engine < 1.2.0.
+	// +optional
+	EngineBackupName string `json:"engineBackupName"`
 	// The snapshot backup progress.
 	// +optional
 	Progress int `json:"progress"`


### PR DESCRIPTION
The longhorn engine < 1.2.0, the backup name is generated within the longhorn engine. Therefore, the longhorn manager >= 1.2.3 generated Backup CR is not the same as the longhorn engine < 1.2.0 generated backup name.

To support longhorn manager >= 1.2.3 backwards compatible to longhorn engine < 1.2.0, records the engine generated backup name in Backup CR. Then, use this name to query the longhorn engine backup status to make sure both the backward compatible and forward compatible.

Note that, the Backup CR status `engineBackupName` could be deprecated once the longhorn manager no longhorn supports longhorn engine < 1.2.0.

https://github.com/longhorn/longhorn/issues/3621