### PR TITLE
[Backport][v1.1.4] Reducing the workqueue depth while still keeping the resync period as 30s

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -85,17 +85,17 @@ func NewBackingImageController(
 		DeleteFunc: bic.enqueueBackingImage,
 	})
 
-	backingImageManagerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	backingImageManagerInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    bic.enqueueBackingImageForBackingImageManager,
 		UpdateFunc: func(old, cur interface{}) { bic.enqueueBackingImageForBackingImageManager(cur) },
 		DeleteFunc: bic.enqueueBackingImageForBackingImageManager,
-	})
+	}, 0)
 
-	replicaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	replicaInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    bic.enqueueBackingImageForReplica,
 		UpdateFunc: func(old, cur interface{}) { bic.enqueueBackingImageForReplica(cur) },
 		DeleteFunc: bic.enqueueBackingImageForReplica,
-	})
+	}, 0)
 
 	return bic
 }

--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -141,25 +141,25 @@ func NewBackingImageManagerController(
 		DeleteFunc: c.enqueueBackingImageManager,
 	})
 
-	biInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	biInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueueForBackingImage,
 		UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImage(cur) },
 		DeleteFunc: c.enqueueForBackingImage,
-	})
+	}, 0)
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, cur interface{}) { c.enqueueForLonghornNode(cur) },
 		DeleteFunc: c.enqueueForLonghornNode,
-	})
+	}, 0)
 
-	pInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	pInformer.Informer().AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isBackingImageManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.enqueueForBackingImageManagerPod,
 			UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImageManagerPod(cur) },
 			DeleteFunc: c.enqueueForBackingImageManagerPod,
 		},
-	})
+	}, 0)
 
 	return c
 }

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -134,11 +134,11 @@ func NewEngineController(
 		UpdateFunc: func(old, cur interface{}) { ec.enqueueEngine(cur) },
 		DeleteFunc: ec.enqueueEngine,
 	})
-	instanceManagerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	instanceManagerInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ec.enqueueInstanceManagerChange,
 		UpdateFunc: func(old, cur interface{}) { ec.enqueueInstanceManagerChange(cur) },
 		DeleteFunc: ec.enqueueInstanceManagerChange,
-	})
+	}, 0)
 
 	return ec
 }

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -106,17 +106,17 @@ func NewEngineImageController(
 		DeleteFunc: ic.enqueueEngineImage,
 	})
 
-	volumeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	volumeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { ic.enqueueVolumes(obj) },
 		UpdateFunc: func(old, cur interface{}) { ic.enqueueVolumes(old, cur) },
 		DeleteFunc: func(obj interface{}) { ic.enqueueVolumes(obj) },
-	})
+	}, 0)
 
-	dsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	dsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ic.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { ic.enqueueControlleeChange(cur) },
 		DeleteFunc: ic.enqueueControlleeChange,
-	})
+	}, 0)
 
 	return ic
 }

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -145,19 +145,19 @@ func NewInstanceManagerController(
 		DeleteFunc: imc.enqueueInstanceManager,
 	})
 
-	pInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	pInformer.Informer().AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isInstanceManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    imc.enqueueInstanceManagerPod,
 			UpdateFunc: func(old, cur interface{}) { imc.enqueueInstanceManagerPod(cur) },
 			DeleteFunc: imc.enqueueInstanceManagerPod,
 		},
-	})
+	}, 0)
 
-	kubeNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	kubeNodeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, cur interface{}) { imc.enqueueKubernetesNode(cur) },
 		DeleteFunc: imc.enqueueKubernetesNode,
-	})
+	}, 0)
 
 	return imc
 }

--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -107,16 +107,16 @@ func NewKubernetesPVController(
 		},
 	})
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    kc.enqueuePodChange,
 		UpdateFunc: func(old, cur interface{}) { kc.enqueuePodChange(cur) },
 		DeleteFunc: kc.enqueuePodChange,
-	})
+	}, 0)
 
 	// after volume becomes detached, try to delete the VA of lost node
-	volumeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	volumeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { kc.enqueueVolumeChange(cur) },
-	})
+	}, 0)
 
 	return kc
 }

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -114,17 +114,16 @@ func NewNodeController(
 		DeleteFunc: nc.enqueueNode,
 	}, nodeControllerResyncPeriod)
 
-	settingInformer.Informer().AddEventHandler(
+	settingInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: nc.isResponsibleForSetting,
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    nc.enqueueSetting,
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueSetting(cur) },
 			},
-		},
-	)
+		}, 0)
 
-	replicaInformer.Informer().AddEventHandler(
+	replicaInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: nc.isResponsibleForReplica,
 			Handler: cache.ResourceEventHandlerFuncs{
@@ -132,10 +131,9 @@ func NewNodeController(
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueReplica(cur) },
 				DeleteFunc: nc.enqueueReplica,
 			},
-		},
-	)
+		}, 0)
 
-	podInformer.Informer().AddEventHandler(
+	podInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: isManagerPod,
 			Handler: cache.ResourceEventHandlerFuncs{
@@ -143,13 +141,12 @@ func NewNodeController(
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueManagerPod(cur) },
 				DeleteFunc: nc.enqueueManagerPod,
 			},
-		},
-	)
+		}, 0)
 
-	kubeNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	kubeNodeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { nc.enqueueKubernetesNode(cur) },
 		DeleteFunc: nc.enqueueKubernetesNode,
-	})
+	}, 0)
 
 	return nc
 }

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -105,23 +105,23 @@ func NewReplicaController(
 		DeleteFunc: rc.enqueueReplica,
 	})
 
-	instanceManagerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	instanceManagerInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueInstanceManagerChange,
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueInstanceManagerChange(cur) },
 		DeleteFunc: rc.enqueueInstanceManagerChange,
-	})
+	}, 0)
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueNodeChange,
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueNodeChange(cur) },
 		DeleteFunc: rc.enqueueNodeChange,
-	})
+	}, 0)
 
-	backingImageInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	backingImageInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueBackingImageChange,
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueBackingImageChange(cur) },
 		DeleteFunc: rc.enqueueBackingImageChange,
-	})
+	}, 0)
 
 	return rc
 }

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -134,10 +134,10 @@ func NewSettingController(
 		DeleteFunc: sc.enqueueSetting,
 	}, settingControllerResyncPeriod)
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sc.enqueueSettingForNode,
 		UpdateFunc: func(old, cur interface{}) { sc.enqueueSettingForNode(cur) },
-	})
+	}, 0)
 
 	return sc
 }

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -91,21 +91,21 @@ func NewShareManagerController(
 	})
 
 	// need information for volumes, to be able to claim them
-	volumeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	volumeInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueueShareManagerForVolume,
 		UpdateFunc: func(old, cur interface{}) { c.enqueueShareManagerForVolume(cur) },
 		DeleteFunc: c.enqueueShareManagerForVolume,
-	})
+	}, 0)
 
 	// we are only interested in pods for which we are responsible for managing
-	podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	podInformer.Informer().AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isShareManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.enqueueShareManagerForPod,
 			UpdateFunc: func(old, cur interface{}) { c.enqueueShareManagerForPod(cur) },
 			DeleteFunc: c.enqueueShareManagerForPod,
 		},
-	})
+	}, 0)
 
 	return c
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -132,21 +132,21 @@ func NewVolumeController(
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueVolume(cur) },
 		DeleteFunc: vc.enqueueVolume,
 	})
-	engineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	engineInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueControlleeChange(cur) },
 		DeleteFunc: vc.enqueueControlleeChange,
-	})
-	replicaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, 0)
+	replicaInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueControlleeChange(cur) },
 		DeleteFunc: vc.enqueueControlleeChange,
-	})
-	shareManagerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, 0)
+	shareManagerInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueVolumesForShareManager,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueVolumesForShareManager(cur) },
 		DeleteFunc: vc.enqueueVolumesForShareManager,
-	})
+	}, 0)
 	return vc
 }
 


### PR DESCRIPTION
For each controller, we only need to enable resync for the handler
that handles the events of its managed object. For example, the
volume controller only needs to enable resync for volumeInformer
event handler. By doing this, we reduce the workqueue depth of the
controller while still making sure that we resync every object
of the controller every resync period (30s)

longhorn/longhorn#3083
