### PR TITLE
[CSI Sanity] Add host mount /tmp dir to longhorn-csi-plugin

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -457,6 +457,10 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 									MountPath: "/sys",
 								},
 								{
+									Name:      "host-tmp", // path is required to pass csi-sanity
+									MountPath: "/tmp",
+								},
+								{
 									Name:             "host",
 									MountPath:        "/rootfs", // path is required for namespaced mounter
 									MountPropagation: &MountPropagationBidirectional,
@@ -519,6 +523,14 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, ma
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
 									Path: "/sys",
+								},
+							},
+						},
+						{
+							Name: "host-tmp",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/tmp",
 								},
 							},
 						},


### PR DESCRIPTION
CSI sanity uses [defaultCheckPath](https://github.com/kubernetes-csi/csi-test/blob/db65255108c0649001a55df9f0a09dfcec62b183/pkg/sanity/sanity.go#L543-L544) to check target path existence. Running the test from the host currently does not know about the pod /tmp directory(default target root) where csi-mount and csi-staging gets created, hence the `should remove target path`
test fails.

Add host mount /tmp directory in longhorn-csi-plugin for host to have access to
/tmp/csi-mount/ and /tmp/csi-staging/.

https://github.com/longhorn/longhorn/issues/2271