### PR TITLE
Mark backup to Pending state if encounter the engine RPC error code DeadlineExceeded

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -505,6 +505,7 @@ func (bc *BackupController) checkMonitor(backup *longhorn.Backup, volume *longho
 	if err != nil {
 		backup.Status.Error = err.Error()
 		backup.Status.State = longhorn.BackupStateError
+		backup.Status.LastSyncedAt = metav1.Time{Time: time.Now().UTC()}
 		return nil, err
 	}
 	return monitor, nil

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -338,7 +338,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		}
 
 		switch backup.Status.State {
-		case longhorn.BackupStateNew, longhorn.BackupStateInProgress:
+		case longhorn.BackupStateNew, longhorn.BackupStatePending, longhorn.BackupStateInProgress:
 			return nil
 		case longhorn.BackupStateCompleted:
 			bc.disableBackupMonitor(backup.Name)

--- a/engineapi/backup_monitor.go
+++ b/engineapi/backup_monitor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -17,12 +18,15 @@ import (
 
 const (
 	BackupMonitorSyncPeriod = 2 * time.Second
+
+	// BackupMonitorMaxRetryPeriod is the maximum retry period when backup monitor routine
+	// encounters an error and backup stays in Pending state
+	BackupMonitorMaxRetryPeriod = 24 * time.Hour
 )
 
 type BackupMonitor struct {
 	logger logrus.FieldLogger
 
-	namespace      string
 	backupName     string
 	snapshotName   string
 	replicaAddress string
@@ -32,9 +36,12 @@ type BackupMonitor struct {
 	backupStatusLock sync.RWMutex
 
 	syncCallback func(key string)
+	callbackKey  string
 
 	ctx  context.Context
 	quit context.CancelFunc
+
+	retryCount int
 }
 
 func NewBackupMonitor(logger logrus.FieldLogger,
@@ -42,9 +49,8 @@ func NewBackupMonitor(logger logrus.FieldLogger,
 	biChecksum string, engineClient EngineClient, syncCallback func(key string)) (*BackupMonitor, error) {
 	ctx, quit := context.WithCancel(context.Background())
 	m := &BackupMonitor{
-		logger: logger,
+		logger: logger.WithFields(logrus.Fields{"backup": backup.Name}),
 
-		namespace:    backup.Namespace,
 		backupName:   backup.Name,
 		snapshotName: backup.Spec.SnapshotName,
 		engineClient: engineClient,
@@ -52,6 +58,7 @@ func NewBackupMonitor(logger logrus.FieldLogger,
 		backupStatusLock: sync.RWMutex{},
 
 		syncCallback: syncCallback,
+		callbackKey:  backup.Namespace + "/" + backup.Name,
 
 		ctx:  ctx,
 		quit: quit,
@@ -96,51 +103,115 @@ func NewBackupMonitor(logger logrus.FieldLogger,
 }
 
 func (m *BackupMonitor) monitorBackups() {
+	// If backup.status.state = Pending, use exponential backoff timer to monitor engine/replica backup status
+	// Otherwise, use liner timer to monitor engine/replica backup status
+	useLinerTimer := true
+	if m.backupStatus.State == longhorn.BackupStatePending {
+		useLinerTimer = m.exponentialBackOffTimer()
+	}
+	if useLinerTimer {
+		m.linerTimer()
+	}
+}
+
+// linerTimer runs a periodically liner timer to sync backup status from engine/replica
+func (m *BackupMonitor) linerTimer() {
 	wait.PollUntil(BackupMonitorSyncPeriod, func() (done bool, err error) {
-		if err := m.syncBackups(); err != nil {
-			m.logger.Errorf("Stop monitoring because of %v", err)
-			m.Close()
-			return false, err
+		currentBackupStatus, err := m.syncBackupStatusFromEngineReplica()
+		if err != nil {
+			currentBackupStatus.State = longhorn.BackupStateError
+			currentBackupStatus.Error = err.Error()
 		}
+		m.syncCallBack(currentBackupStatus)
 		return false, nil
 	}, m.ctx.Done())
 }
 
-func (m *BackupMonitor) syncBackups() error {
+// exponentialBackOffTimer runs a exponential backoff timer to sync backup status from engine/replica
+func (m *BackupMonitor) exponentialBackOffTimer() bool {
+	var (
+		initBackoff   = BackupMonitorSyncPeriod
+		maxBackoff    = 10 * time.Minute
+		resetDuration = BackupMonitorMaxRetryPeriod
+		backoffFactor = 2.0
+		jitter        = 0.0
+		clock         = clock.RealClock{}
+		retryCount    = 0
+	)
+	// The exponential backoff timer 2s/4s/8s/16s/.../10mins
+	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
+	defer backoffMgr.Backoff().Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), BackupMonitorMaxRetryPeriod)
+	defer cancel()
+
+	m.logger.Info("Exponential backoff timer")
+
+	for {
+		select {
+		case <-backoffMgr.Backoff().C():
+			retryCount++
+			m.logger.Debugf("Within exponential backoff timer retry count %d", retryCount)
+			_, err := m.syncBackupStatusFromEngineReplica()
+			if err == nil {
+				m.logger.Info("Change to liner timer to monitor it")
+				// Change to liner timer to monitor it
+				return true
+			}
+			// Keep in exponential backoff timer
+		case <-ctx.Done():
+			// Give it the last try to prevent if the snapshot backup succeed between
+			// the last trigged backoff time and the max retry period
+			currentBackupStatus, err := m.syncBackupStatusFromEngineReplica()
+			if err == nil {
+				m.logger.Info("Change to liner timer to monitor it")
+				// Change to liner timer to monitor it
+				return true
+			}
+
+			// Set to Error state
+			err = fmt.Errorf("Max retry period %s reached in exponential backoff timer", BackupMonitorMaxRetryPeriod)
+			m.logger.Error(err)
+
+			currentBackupStatus.State = longhorn.BackupStateError
+			currentBackupStatus.Error = err.Error()
+			m.syncCallBack(currentBackupStatus)
+			// Let the backup controller closes this backup monitor routine
+		case <-m.ctx.Done():
+			m.logger.Info("Close backup monitor routine")
+			return false
+		}
+	}
+}
+
+func (m *BackupMonitor) syncCallBack(currentBackupStatus longhorn.BackupStatus) {
+	// new information, request a resync for this backup
+	m.backupStatusLock.Lock()
+	defer m.backupStatusLock.Unlock()
+	if !reflect.DeepEqual(m.backupStatus, currentBackupStatus) {
+		m.backupStatus = currentBackupStatus
+		m.syncCallback(m.callbackKey)
+	}
+}
+
+func (m *BackupMonitor) syncBackupStatusFromEngineReplica() (longhorn.BackupStatus, error) {
 	currentBackupStatus := longhorn.BackupStatus{}
 
 	m.backupStatusLock.RLock()
 	m.backupStatus.DeepCopyInto(&currentBackupStatus)
 	m.backupStatusLock.RUnlock()
 
-	var err error
-	defer func() {
-		if err != nil && currentBackupStatus.Error == "" {
-			currentBackupStatus.Error = err.Error()
-			currentBackupStatus.State = longhorn.BackupStateError
-		}
-
-		// new information, request a resync for this backup
-		m.backupStatusLock.Lock()
-		defer m.backupStatusLock.Unlock()
-		if !reflect.DeepEqual(m.backupStatus, currentBackupStatus) {
-			m.backupStatus = currentBackupStatus
-			key := m.namespace + "/" + m.backupName
-			m.syncCallback(key)
-		}
-	}()
-
 	engineBackupStatus, err := m.engineClient.SnapshotBackupStatus(m.backupName, m.replicaAddress)
 	if err != nil {
-		return err
+		return currentBackupStatus, err
 	}
 	if engineBackupStatus == nil {
 		err = fmt.Errorf("cannot find backup %s status in longhorn engine", m.backupName)
-		return err
+		return currentBackupStatus, err
 	}
 	if engineBackupStatus.SnapshotName != m.snapshotName {
 		err = fmt.Errorf("cannot find matched snapshot %s/%s of backup %s status in longhorn engine", engineBackupStatus.SnapshotName, m.snapshotName, m.backupName)
-		return err
+		return currentBackupStatus, err
 	}
 
 	currentBackupStatus.Progress = engineBackupStatus.Progress
@@ -149,7 +220,7 @@ func (m *BackupMonitor) syncBackups() error {
 	currentBackupStatus.SnapshotName = engineBackupStatus.SnapshotName
 	currentBackupStatus.State = ConvertEngineBackupState(engineBackupStatus.State)
 	currentBackupStatus.ReplicaAddress = engineBackupStatus.ReplicaAddress
-	return nil
+	return currentBackupStatus, nil
 }
 
 func (m *BackupMonitor) GetBackupStatus() longhorn.BackupStatus {

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -6,6 +6,7 @@ type BackupState string
 
 const (
 	BackupStateNew        = BackupState("")
+	BackupStatePending    = BackupState("Pending")
 	BackupStateInProgress = BackupState("InProgress")
 	BackupStateCompleted  = BackupState("Completed")
 	BackupStateError      = BackupState("Error")

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -6,6 +6,7 @@ type BackupState string
 
 const (
 	BackupStateNew        = BackupState("")
+	BackupStatePending    = BackupState("Pending")
 	BackupStateInProgress = BackupState("InProgress")
 	BackupStateCompleted  = BackupState("Completed")
 	BackupStateError      = BackupState("Error")

--- a/monitoring/backup_collector.go
+++ b/monitoring/backup_collector.go
@@ -90,14 +90,16 @@ func getBackupStateValue(v *longhorn.Backup) int {
 	switch v.Status.State {
 	case longhorn.BackupStateNew:
 		stateValue = 0
-	case longhorn.BackupStateInProgress:
+	case longhorn.BackupStatePending:
 		stateValue = 1
-	case longhorn.BackupStateCompleted:
+	case longhorn.BackupStateInProgress:
 		stateValue = 2
-	case longhorn.BackupStateError:
+	case longhorn.BackupStateCompleted:
 		stateValue = 3
-	case longhorn.BackupStateUnknown:
+	case longhorn.BackupStateError:
 		stateValue = 4
+	case longhorn.BackupStateUnknown:
+		stateValue = 5
 	}
 	return stateValue
 }


### PR DESCRIPTION
Mark backup to **Pending** state if the engine SnapshotBackup API call returns RPC error code DeadlineExceeded.
The sync agent replica server _probably_ perform snapshot backup initialization succeeded in the end.

For this case, we create a backup monitor routine to periodically (2 seconds) fetch the backup status to see if the snapshot backup change initialization in the end (state change to InProgress/Completed) or keeps in an Error state. We have a maximum retry period of 10 minutes for the Pending state.

https://github.com/longhorn/longhorn/issues/3545