### PR TITLE
Move minimum and maximum CRD schema validation to validating webhook

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -1804,14 +1804,12 @@ spec:
                   type: object
                 type: object
               engineManagerCPURequest:
-                minimum: 0
                 type: integer
               evictionRequested:
                 type: boolean
               name:
                 type: string
               replicaManagerCPURequest:
-                minimum: 0
                 type: integer
               tags:
                 items:
@@ -2025,7 +2023,6 @@ spec:
             properties:
               concurrency:
                 description: The concurrency of taking the snapshot/backup.
-                minimum: 1
                 type: integer
               cron:
                 description: The cron setting.
@@ -2045,8 +2042,6 @@ spec:
                 type: string
               retain:
                 description: The retain count of the snapshot/backup.
-                maximum: 50
-                minimum: 1
                 type: integer
               task:
                 description: The recurring job type. Can be "snapshot" or "backup".
@@ -2621,7 +2616,6 @@ spec:
                   type: string
                 type: array
               numberOfReplicas:
-                minimum: 1
                 type: integer
               recurringJobs:
                 description: Deprecated. Replaced by a separate resource named "RecurringJob"

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -73,10 +73,8 @@ type NodeSpec struct {
 	EvictionRequested bool `json:"evictionRequested"`
 	// +optional
 	Tags []string `json:"tags"`
-	// +kubebuilder:validation:Minimum=0
 	// +optional
 	EngineManagerCPURequest int `json:"engineManagerCPURequest"`
-	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ReplicaManagerCPURequest int `json:"replicaManagerCPURequest"`
 }

--- a/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
@@ -33,12 +33,9 @@ type RecurringJobSpec struct {
 	// +optional
 	Cron string `json:"cron"`
 	// The retain count of the snapshot/backup.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=50
 	// +optional
 	Retain int `json:"retain"`
 	// The concurrency of taking the snapshot/backup.
-	// +kubebuilder:validation:Minimum=1
 	// +optional
 	Concurrency int `json:"concurrency"`
 	// The label of the snapshot/backup.

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -191,7 +191,6 @@ type VolumeSpec struct {
 	Migratable bool `json:"migratable"`
 	// +optional
 	Encrypted bool `json:"encrypted"`
-	// +kubebuilder:validation:Minimum=1
 	// +optional
 	NumberOfReplicas int `json:"numberOfReplicas"`
 	// +optional

--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -38,9 +38,31 @@ func (n *nodeValidator) Resource() admission.Resource {
 	}
 }
 
+func (n *nodeValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	node := newObj.(*longhorn.Node)
+
+	if node.Spec.EngineManagerCPURequest < 0 {
+		return werror.NewInvalidError("engineManagerCPURequest should be greater than or equal to 0", "")
+	}
+
+	if node.Spec.ReplicaManagerCPURequest < 0 {
+		return werror.NewInvalidError("replicaManagerCPURequest should be greater than or equal to 0", "")
+	}
+
+	return nil
+}
+
 func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldNode := oldObj.(*longhorn.Node)
 	newNode := newObj.(*longhorn.Node)
+
+	if newNode.Spec.EngineManagerCPURequest < 0 {
+		return werror.NewInvalidError("engineManagerCPURequest should be greater than or equal to 0", "")
+	}
+
+	if newNode.Spec.ReplicaManagerCPURequest < 0 {
+		return werror.NewInvalidError("replicaManagerCPURequest should be greater than or equal to 0", "")
+	}
 
 	// Only scheduling disabled node can be evicted
 	// Can not enable scheduling on an evicting node

--- a/webhook/resources/recurringjob/validator.go
+++ b/webhook/resources/recurringjob/validator.go
@@ -43,6 +43,10 @@ func (r *recurringJobValidator) Create(request *admission.Request, newObj runtim
 		return werror.NewInvalidError(fmt.Sprintf("invalid name %v", recurringJob.Name), "")
 	}
 
+	if recurringJob.Spec.Retain < 1 || recurringJob.Spec.Retain > datastore.MaxRecurringJobRetain {
+		return werror.NewInvalidError(fmt.Sprintf("retain in body should be less than or equal to %v", datastore.MaxRecurringJobRetain), "")
+	}
+
 	jobs := []longhorn.RecurringJobSpec{
 		{
 			Name:        recurringJob.Spec.Name,
@@ -64,6 +68,10 @@ func (r *recurringJobValidator) Create(request *admission.Request, newObj runtim
 
 func (r *recurringJobValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newRecurringJob := newObj.(*longhorn.RecurringJob)
+
+	if newRecurringJob.Spec.Retain < 1 || newRecurringJob.Spec.Retain > datastore.MaxRecurringJobRetain {
+		return werror.NewInvalidError(fmt.Sprintf("retain in body should be less than or equal to %v", datastore.MaxRecurringJobRetain), "")
+	}
 
 	jobs := []longhorn.RecurringJobSpec{
 		{


### PR DESCRIPTION
Fix the helm upgrade failure on kuberenetes v1.18.
Root cause: https://github.com/kubernetes/kubernetes/issues/87675
    
[Longhorn 3631](https://github.com/longhorn/longhorn/issues/3631)