### PR TITLE
MTLS auth

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -557,7 +557,7 @@ func (ec *EngineController) GetInstance(obj interface{}) (*longhorn.InstanceProc
 	return c.ProcessGet(e.Name)
 }
 
-func (ec *EngineController) LogInstance(obj interface{}) (*imapi.LogStream, error) {
+func (ec *EngineController) LogInstance(ctx context.Context, obj interface{}) (*imapi.LogStream, error) {
 	e, ok := obj.(*longhorn.Engine)
 	if !ok {
 		return nil, fmt.Errorf("BUG: invalid object for engine process log: %v", obj)
@@ -572,7 +572,7 @@ func (ec *EngineController) LogInstance(obj interface{}) (*imapi.LogStream, erro
 		return nil, err
 	}
 
-	return c.ProcessLog(e.Name)
+	return c.ProcessLog(ctx, e.Name)
 }
 
 func (ec *EngineController) isMonitoring(e *longhorn.Engine) bool {

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -396,6 +396,7 @@ func (ec *EngineController) CreateInstance(obj interface{}) (*longhorn.InstanceP
 	if err != nil {
 		return nil, err
 	}
+	defer c.Close()
 
 	return c.EngineProcessCreate(e.Name, e.Spec.VolumeName, e.Spec.EngineImage, frontend, e.Status.CurrentReplicaAddressMap, e.Spec.RevisionCounterDisabled, e.Spec.SalvageRequested)
 }
@@ -462,6 +463,7 @@ func (ec *EngineController) DeleteInstance(obj interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer c.Close()
 	if err := c.ProcessDelete(e.Name); err != nil && !types.ErrorIsNotFound(err) {
 		return err
 	}
@@ -553,6 +555,7 @@ func (ec *EngineController) GetInstance(obj interface{}) (*longhorn.InstanceProc
 	if err != nil {
 		return nil, err
 	}
+	defer c.Close()
 
 	return c.ProcessGet(e.Name)
 }
@@ -1452,6 +1455,7 @@ func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine) error {
 	if err != nil {
 		return err
 	}
+	defer c.Close()
 
 	engineProcess, err := c.EngineProcessUpgrade(e.Name, e.Spec.VolumeName, e.Spec.EngineImage, frontend, e.Spec.UpgradedReplicaAddressMap)
 	if err != nil {

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -68,7 +68,7 @@ func (imh *MockInstanceManagerHandler) DeleteInstance(obj interface{}) error {
 	return nil
 }
 
-func (imh *MockInstanceManagerHandler) LogInstance(obj interface{}) (*imapi.LogStream, error) {
+func (imh *MockInstanceManagerHandler) LogInstance(ctx context.Context, obj interface{}) (*imapi.LogStream, error) {
 	return nil, fmt.Errorf("LogInstance is not mocked")
 }
 

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/longhorn/longhorn-manager/engineapi"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -68,8 +69,8 @@ func (imh *MockInstanceManagerHandler) DeleteInstance(obj interface{}) error {
 	return nil
 }
 
-func (imh *MockInstanceManagerHandler) LogInstance(ctx context.Context, obj interface{}) (*imapi.LogStream, error) {
-	return nil, fmt.Errorf("LogInstance is not mocked")
+func (imh *MockInstanceManagerHandler) LogInstance(ctx context.Context, obj interface{}) (*engineapi.InstanceManagerClient, *imapi.LogStream, error) {
+	return nil, nil, fmt.Errorf("LogInstance is not mocked")
 }
 
 func newEngine(name, currentImage, imName, nodeName, ip string, port int, started bool, currentState, desireState longhorn.InstanceState) *longhorn.Engine {

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -91,6 +91,7 @@ func updateInstanceManagerVersion(im *longhorn.InstanceManager) error {
 	if err != nil {
 		return err
 	}
+	cli.Close()
 	apiMinVersion, apiVersion, err := cli.VersionGet()
 	if err != nil {
 		return err

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -652,7 +652,7 @@ func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstancePro
 	return c.ProcessGet(r.Name)
 }
 
-func (rc *ReplicaController) LogInstance(obj interface{}) (*imapi.LogStream, error) {
+func (rc *ReplicaController) LogInstance(ctx context.Context, obj interface{}) (*imapi.LogStream, error) {
 	r, ok := obj.(*longhorn.Replica)
 	if !ok {
 		return nil, fmt.Errorf("BUG: invalid object for replica process log: %v", obj)
@@ -667,7 +667,7 @@ func (rc *ReplicaController) LogInstance(obj interface{}) (*imapi.LogStream, err
 		return nil, err
 	}
 
-	return c.ProcessLog(r.Name)
+	return c.ProcessLog(ctx, r.Name)
 }
 
 func (rc *ReplicaController) enqueueInstanceManagerChange(obj interface{}) {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -394,6 +394,7 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 	if err != nil {
 		return nil, err
 	}
+	defer c.Close()
 
 	return c.ReplicaProcessCreate(r.Name, r.Spec.EngineImage, dataPath, backingImagePath, r.Spec.VolumeSize, r.Spec.RevisionCounterDisabled)
 }
@@ -548,6 +549,7 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer c.Close()
 	if err := c.ProcessDelete(r.Name); err != nil && !types.ErrorIsNotFound(err) {
 		return err
 	}
@@ -648,6 +650,7 @@ func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstancePro
 	if err != nil {
 		return nil, err
 	}
+	defer c.Close()
 
 	return c.ProcessGet(r.Name)
 }

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -54,6 +54,8 @@ spec:
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
+        - name: longhorn-grpc-tls
+          mountPath: /tls-files/
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -77,6 +79,11 @@ spec:
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/
+      - name: longhorn-grpc-tls
+        secret:
+          secretName: longhorn-grpc-tls
+          optional: true
+
 #      imagePullSecrets:
 #      - name: ""
 #      priorityClassName:

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -31,7 +31,7 @@ spec:
         - --engine-image
         - longhornio/longhorn-engine:master-head
         - --instance-manager-image
-        - longhornio/longhorn-instance-manager:v1_20220303
+        - longhornio/longhorn-instance-manager:v1_20220504
         - --share-manager-image
         - longhornio/longhorn-share-manager:v1_20211020
         - --backing-image-manager-image

--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -5,7 +5,7 @@ longhornio/csi-snapshotter:v3.0.3
 longhornio/csi-node-driver-registrar:v2.3.0
 longhornio/backing-image-manager:v3_20220318
 longhornio/longhorn-engine:master-head
-longhornio/longhorn-instance-manager:v1_20220303
+longhornio/longhorn-instance-manager:v1_20220504
 longhornio/longhorn-manager:master-head
 longhornio/longhorn-share-manager:v1_20211020
 longhornio/longhorn-ui:master-head

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/longhorn/backing-image-manager v0.0.0-20220414053138-691e27b07b7e
 	github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
-	github.com/longhorn/longhorn-instance-manager v0.0.0-20220412150124-6cc9d60a9c8e
+	github.com/longhorn/longhorn-instance-manager v0.0.0-20220504100825-15efa9ba0759
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d/go.mod h1:FUj
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/longhorn-engine v1.2.0-preview1.0.20210818142058-32cb7dfd0630/go.mod h1:mtvBHZBmXJIHBcLL828FY5mGq4hoh7bV2EFK6LFLmhE=
-github.com/longhorn/longhorn-instance-manager v0.0.0-20220412150124-6cc9d60a9c8e h1:BdJX+l/8B2uA0SrTkbDe8nkQMDyKqCMoNYXhg5C2B60=
-github.com/longhorn/longhorn-instance-manager v0.0.0-20220412150124-6cc9d60a9c8e/go.mod h1:UF1Wt3JB2lWRhDQriGeTXN8CGET3b1MURV9sLikU1TQ=
+github.com/longhorn/longhorn-instance-manager v0.0.0-20220504100825-15efa9ba0759 h1:V9kTujjoEpCqhhAcKG8KdGvKuKEdyJsH2+jUWR+DqsY=
+github.com/longhorn/longhorn-instance-manager v0.0.0-20220504100825-15efa9ba0759/go.mod h1:UF1Wt3JB2lWRhDQriGeTXN8CGET3b1MURV9sLikU1TQ=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/sparse-tools v0.0.0-20210729195155-a0fb4226a960/go.mod h1:BWM7yTPb1DulG18EE/Jy20LVIySzIYoZpiOYFtAGwZo=
 github.com/longhorn/sparse-tools v0.0.0-20211229004436-663d2f697e2a/go.mod h1:BWM7yTPb1DulG18EE/Jy20LVIySzIYoZpiOYFtAGwZo=

--- a/types/types.go
+++ b/types/types.go
@@ -52,6 +52,12 @@ const (
 	BackingImageManagerDirectory = "/backing-images/"
 	BackingImageFileName         = "backing"
 
+	TLSDirectoryInContainer = "/tls-files/"
+	TLSSecretName           = "longhorn-grpc-tls"
+	TLSCAFile               = "ca.crt"
+	TLSCertFile             = "tls.crt"
+	TLSKeyFile              = "tls.key"
+
 	DefaultBackupTargetName = "default"
 
 	LonghornNodeKey     = "longhornnode"

--- a/vendor/github.com/longhorn/longhorn-instance-manager/pkg/api/types.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/pkg/api/types.go
@@ -1,11 +1,6 @@
 package api
 
 import (
-	"context"
-
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
-
 	rpc "github.com/longhorn/longhorn-instance-manager/pkg/imrpc"
 )
 
@@ -57,25 +52,13 @@ func RPCToProcessStatus(obj *rpc.ProcessStatus) ProcessStatus {
 }
 
 type ProcessStream struct {
-	conn      *grpc.ClientConn
-	ctxCancel context.CancelFunc
-	stream    rpc.ProcessManagerService_ProcessWatchClient
+	stream rpc.ProcessManagerService_ProcessWatchClient
 }
 
-func NewProcessStream(conn *grpc.ClientConn, ctxCancel context.CancelFunc, stream rpc.ProcessManagerService_ProcessWatchClient) *ProcessStream {
+func NewProcessStream(stream rpc.ProcessManagerService_ProcessWatchClient) *ProcessStream {
 	return &ProcessStream{
-		conn,
-		ctxCancel,
 		stream,
 	}
-}
-
-func (s *ProcessStream) Close() error {
-	s.ctxCancel()
-	if err := s.conn.Close(); err != nil {
-		return errors.Wrapf(err, "error closing process watcher gRPC connection")
-	}
-	return nil
 }
 
 func (s *ProcessStream) Recv() (*Process, error) {
@@ -86,26 +69,14 @@ func (s *ProcessStream) Recv() (*Process, error) {
 	return RPCToProcess(resp), nil
 }
 
-func NewLogStream(conn *grpc.ClientConn, ctxCancel context.CancelFunc, stream rpc.ProcessManagerService_ProcessLogClient) *LogStream {
+func NewLogStream(stream rpc.ProcessManagerService_ProcessLogClient) *LogStream {
 	return &LogStream{
-		conn,
-		ctxCancel,
 		stream,
 	}
 }
 
 type LogStream struct {
-	conn      *grpc.ClientConn
-	ctxCancel context.CancelFunc
-	stream    rpc.ProcessManagerService_ProcessLogClient
-}
-
-func (s *LogStream) Close() error {
-	s.ctxCancel()
-	if err := s.conn.Close(); err != nil {
-		return errors.Wrapf(err, "error closing logs gRPC connection")
-	}
-	return nil
+	stream rpc.ProcessManagerService_ProcessLogClient
 }
 
 func (s *LogStream) Recv() (string, error) {

--- a/vendor/github.com/longhorn/longhorn-instance-manager/pkg/client/process_manager.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/pkg/client/process_manager.go
@@ -1,41 +1,83 @@
 package client
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/longhorn/longhorn-instance-manager/pkg/api"
 	rpc "github.com/longhorn/longhorn-instance-manager/pkg/imrpc"
 	"github.com/longhorn/longhorn-instance-manager/pkg/meta"
 	"github.com/longhorn/longhorn-instance-manager/pkg/types"
+	"github.com/longhorn/longhorn-instance-manager/pkg/util"
 )
 
-type ProcessManagerClient struct {
-	Address string
+type ProcessManagerServiceContext struct {
+	cc      *grpc.ClientConn
+	service rpc.ProcessManagerServiceClient
 }
 
-func NewProcessManagerClient(address string) *ProcessManagerClient {
-	return &ProcessManagerClient{
-		Address: address,
+func (c ProcessManagerServiceContext) Close() error {
+	if c.cc == nil {
+		return nil
 	}
+	return c.cc.Close()
 }
 
-func (cli *ProcessManagerClient) ProcessCreate(name, binary string, portCount int, args, portArgs []string) (*api.Process, error) {
+func (c *ProcessManagerClient) getControllerServiceClient() rpc.ProcessManagerServiceClient {
+	return c.service
+}
+
+type ProcessManagerClient struct {
+	serviceURL string
+	tlsConfig  *tls.Config
+	ProcessManagerServiceContext
+}
+
+func NewProcessManagerClient(serviceURL string, tlsConfig *tls.Config) (*ProcessManagerClient, error) {
+	getProcessManagerServiceContext := func(serviceUrl string, tlsConfig *tls.Config) (ProcessManagerServiceContext, error) {
+		connection, err := util.Connect(serviceUrl, tlsConfig)
+		if err != nil {
+			return ProcessManagerServiceContext{}, fmt.Errorf("cannot connect to ProcessManagerService %v: %v", serviceUrl, err)
+		}
+
+		return ProcessManagerServiceContext{
+			cc:      connection,
+			service: rpc.NewProcessManagerServiceClient(connection),
+		}, nil
+	}
+
+	serviceContext, err := getProcessManagerServiceContext(serviceURL, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProcessManagerClient{
+		serviceURL:                   serviceURL,
+		tlsConfig:                    tlsConfig,
+		ProcessManagerServiceContext: serviceContext,
+	}, nil
+}
+
+func NewProcessManagerClientWithTLS(serviceURL, caFile, certFile, keyFile, peerName string) (*ProcessManagerClient, error) {
+	tlsConfig, err := util.LoadClientTLS(caFile, certFile, keyFile, peerName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load tls key pair from file")
+	}
+
+	return NewProcessManagerClient(serviceURL, tlsConfig)
+}
+
+func (c *ProcessManagerClient) ProcessCreate(name, binary string, portCount int, args, portArgs []string) (*api.Process, error) {
 	if name == "" || binary == "" {
 		return nil, fmt.Errorf("failed to start process: missing required parameter")
 	}
 
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 
@@ -54,18 +96,12 @@ func (cli *ProcessManagerClient) ProcessCreate(name, binary string, portCount in
 	return api.RPCToProcess(p), nil
 }
 
-func (cli *ProcessManagerClient) ProcessDelete(name string) (*api.Process, error) {
+func (c *ProcessManagerClient) ProcessDelete(name string) (*api.Process, error) {
 	if name == "" {
 		return nil, fmt.Errorf("failed to delete process: missing required parameter name")
 	}
 
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 
@@ -78,18 +114,12 @@ func (cli *ProcessManagerClient) ProcessDelete(name string) (*api.Process, error
 	return api.RPCToProcess(p), nil
 }
 
-func (cli *ProcessManagerClient) ProcessGet(name string) (*api.Process, error) {
+func (c *ProcessManagerClient) ProcessGet(name string) (*api.Process, error) {
 	if name == "" {
 		return nil, fmt.Errorf("failed to get process: missing required parameter name")
 	}
 
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 
@@ -102,14 +132,8 @@ func (cli *ProcessManagerClient) ProcessGet(name string) (*api.Process, error) {
 	return api.RPCToProcess(p), nil
 }
 
-func (cli *ProcessManagerClient) ProcessList() (map[string]*api.Process, error) {
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+func (c *ProcessManagerClient) ProcessList() (map[string]*api.Process, error) {
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 
@@ -120,62 +144,32 @@ func (cli *ProcessManagerClient) ProcessList() (map[string]*api.Process, error) 
 	return api.RPCToProcessList(ps), nil
 }
 
-func (cli *ProcessManagerClient) ProcessLog(name string) (*api.LogStream, error) {
+func (c *ProcessManagerClient) ProcessLog(ctx context.Context, name string) (*api.LogStream, error) {
 	if name == "" {
 		return nil, fmt.Errorf("failed to get process: missing required parameter name")
 	}
 
-	var err error
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
-	defer func() {
-		if err != nil {
-			cancel()
-			conn.Close()
-		}
-	}()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	stream, err := client.ProcessLog(ctx, &rpc.LogRequest{
 		Name: name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get process log of %v: %v", name, err)
 	}
-	return api.NewLogStream(conn, cancel, stream), nil
+	return api.NewLogStream(stream), nil
 }
 
-func (cli *ProcessManagerClient) ProcessWatch() (*api.ProcessStream, error) {
-	var err error
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		if err != nil {
-			cancel()
-			conn.Close()
-		}
-	}()
-
-	// Don't cleanup the Client here, we don't know when the user will be done with the Stream. Pass it to the wrapper
-	// and allow the user to take care of it.
-	client := rpc.NewProcessManagerServiceClient(conn)
+func (c *ProcessManagerClient) ProcessWatch(ctx context.Context) (*api.ProcessStream, error) {
+	client := c.getControllerServiceClient()
 	stream, err := client.ProcessWatch(ctx, &empty.Empty{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open process update stream")
 	}
 
-	return api.NewProcessStream(conn, cancel, stream), nil
+	return api.NewProcessStream(stream), nil
 }
 
-func (cli *ProcessManagerClient) ProcessReplace(name, binary string, portCount int, args, portArgs []string, terminateSignal string) (*api.Process, error) {
+func (c *ProcessManagerClient) ProcessReplace(name, binary string, portCount int, args, portArgs []string, terminateSignal string) (*api.Process, error) {
 	if name == "" || binary == "" {
 		return nil, fmt.Errorf("failed to start process: missing required parameter")
 	}
@@ -183,13 +177,7 @@ func (cli *ProcessManagerClient) ProcessReplace(name, binary string, portCount i
 		return nil, fmt.Errorf("Unsupported terminate signal %v", terminateSignal)
 	}
 
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
-
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 
@@ -209,14 +197,9 @@ func (cli *ProcessManagerClient) ProcessReplace(name, binary string, portCount i
 	return api.RPCToProcess(p), nil
 }
 
-func (cli *ProcessManagerClient) VersionGet() (*meta.VersionOutput, error) {
-	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
-	}
-	defer conn.Close()
+func (c *ProcessManagerClient) VersionGet() (*meta.VersionOutput, error) {
 
-	client := rpc.NewProcessManagerServiceClient(conn)
+	client := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
 	defer cancel()
 

--- a/vendor/github.com/longhorn/longhorn-instance-manager/pkg/util/grpcutil.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/pkg/util/grpcutil.go
@@ -1,0 +1,221 @@
+package util
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+)
+
+func unixDialer(ctx context.Context, addr string) (net.Conn, error) {
+	dialer := net.Dialer{}
+	return dialer.DialContext(ctx, "unix", addr)
+}
+
+//Connect is a helper function to initiate a grpc client connection to server running at endpoint using tlsConfig
+func Connect(endpoint string, tlsConfig *tls.Config, dialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+	proto, address, err := parseEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	dialOptions = append(dialOptions, grpc.WithBackoffMaxDelay(time.Second))
+	if tlsConfig != nil {
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	} else {
+		dialOptions = append(dialOptions, grpc.WithInsecure())
+	}
+
+	if proto == "unix" {
+		dialOptions = append(dialOptions, grpc.WithContextDialer(unixDialer))
+	}
+	// This is necessary when connecting via TCP and does not hurt
+	// when using Unix domain sockets. It ensures that gRPC detects a dead connection
+	// in a timely manner.
+	// Code lifted from https://github.com/kubernetes-csi/csi-test/commit/6b8830bf5959a1c51c6e98fe514b22818b51eeeb
+	dialOptions = append(dialOptions, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 30 * time.Second, PermitWithoutStream: true}))
+
+	return grpc.Dial(address, dialOptions...)
+}
+
+// NewServer is a helper function to start a grpc server at the given endpoint.
+func NewServer(endpoint string, tlsConfig *tls.Config, opts ...grpc.ServerOption) (*grpc.Server, net.Listener, error) {
+	proto, addr, err := parseEndpoint(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if proto == "unix" {
+		if err = os.Remove(addr); err != nil && !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+	}
+
+	listener, err := net.Listen(proto, addr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if tlsConfig != nil {
+		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+	}
+
+	return grpc.NewServer(opts...), listener, nil
+}
+
+// ServerTLS prepares the TLS configuration needed for a server with given
+// encoded certficate and private key.
+func ServerTLS(caCert, cert, key []byte, peerName string) (*tls.Config, error) {
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("failed to append CA certificate to pool")
+	}
+
+	certificate, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return serverConfig(certPool, &certificate, peerName), nil
+}
+
+// LoadServerTLS prepares the TLS configuration needed for a server with the given certificate files.
+// peerName is either the name that the client is expected to have a certificate for or empty,
+// in which case any client is allowed to connect.
+func LoadServerTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, error) {
+	certPool, peerCert, err := loadCertificate(caFile, certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	return serverConfig(certPool, peerCert, peerName), nil
+}
+
+func serverConfig(certPool *x509.CertPool, peerCert *tls.Certificate, peerName string) *tls.Config {
+	return &tls.Config{
+		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+			if info == nil {
+				return nil, errors.New("nil client info passed")
+			}
+
+			config := &tls.Config{
+				MinVersion:    tls.VersionTLS13,
+				Renegotiation: tls.RenegotiateNever,
+				Certificates:  []tls.Certificate{*peerCert},
+				ClientCAs:     certPool,
+				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					// Common name check when accepting a connection from a client.
+					if peerName == "" {
+						// All names allowed.
+						return nil
+					}
+
+					if len(verifiedChains) == 0 ||
+						len(verifiedChains[0]) == 0 {
+						return errors.New("no valid certificate")
+					}
+
+					for _, name := range verifiedChains[0][0].DNSNames {
+						if name == peerName {
+							return nil
+						}
+					}
+					// For compatibility - using CN as hostName
+					commonName := verifiedChains[0][0].Subject.CommonName
+					if commonName == peerName {
+						return nil
+					}
+					return fmt.Errorf("certificate is not signed for %q hostname", peerName)
+				},
+			}
+			if peerName != "" {
+				config.ClientAuth = tls.RequireAndVerifyClientCert
+			}
+			return config, nil
+		},
+	}
+}
+
+// ClientTLS prepares the TLS configuration that can be used by a client while connecting to a server
+// with given encoded certificate and private key.
+// peerName must be provided when expecting the server to offer a certificate with that CommonName.
+func ClientTLS(caCert, cert, key []byte, peerName string) (*tls.Config, error) {
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("failed to append CA certificate to pool")
+	}
+
+	certificate, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientConfig(certPool, &certificate, peerName), nil
+}
+
+// LoadClientTLS prepares the TLS configuration that can be used by a client while connecting to a server.
+// peerName must be provided when expecting the server to offer a certificate with that CommonName. caFile, certFile, and keyFile are all optional.
+func LoadClientTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, error) {
+	certPool, peerCert, err := loadCertificate(caFile, certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientConfig(certPool, peerCert, peerName), nil
+}
+
+func clientConfig(certPool *x509.CertPool, peerCert *tls.Certificate, peerName string) *tls.Config {
+	tlsConfig := &tls.Config{
+		MinVersion:    tls.VersionTLS13,
+		Renegotiation: tls.RenegotiateNever,
+		ServerName:    peerName,
+		RootCAs:       certPool,
+	}
+	if peerCert != nil {
+		tlsConfig.Certificates = append(tlsConfig.Certificates, *peerCert)
+	}
+	return tlsConfig
+}
+
+func loadCertificate(caFile, certFile, keyFile string) (certPool *x509.CertPool, peerCert *tls.Certificate, err error) {
+	if certFile != "" || keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		peerCert = &cert
+	}
+
+	if caFile != "" {
+		caCert, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		certPool = x509.NewCertPool()
+		if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+			return nil, nil, fmt.Errorf("failed to append certs from %s", caFile)
+		}
+	}
+
+	return
+}
+
+func parseEndpoint(ep string) (string, string, error) {
+	if strings.HasPrefix(strings.ToLower(ep), "unix://") || strings.HasPrefix(strings.ToLower(ep), "tcp://") {
+		s := strings.SplitN(ep, "://", 2)
+		if s[1] != "" {
+			return s[0], s[1], nil
+		}
+	}
+	return "", "", fmt.Errorf("invalid endpoint: %v", ep)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/longhorn/backupstore/util
 github.com/longhorn/go-iscsi-helper/iscsi
 github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
-# github.com/longhorn/longhorn-instance-manager v0.0.0-20220412150124-6cc9d60a9c8e
+# github.com/longhorn/longhorn-instance-manager v0.0.0-20220504100825-15efa9ba0759
 github.com/longhorn/longhorn-instance-manager/pkg/api
 github.com/longhorn/longhorn-instance-manager/pkg/client
 github.com/longhorn/longhorn-instance-manager/pkg/imrpc


### PR DESCRIPTION
tracking issue longhorn/longhorn#3839

Currently running core tests, my confidence in the manager <-> im communication isn't as high as it should be.
I would prefer if we clean up the monitoring + im communication in general before we add additional complexity to it.
The previous code/architecture wasn't built with peristent connections in mind and instead is completly built as one shot commands, which is highly inefficient.

Since for each grpc call: 
- a single connection is setup (tcp handshake + co) 
- then grpc call is triggered
- connection teardown

Some of the code smells surrounding the manager <-> im communication:

- im monitor
- instance-handler usage, same one shot idea.
- im notifier / updater (I removed these wrappers and replaced them with a direct call to the im client)

Generally In the future I would like our code base to become more testable, for example we can mock on the im monitor/client level then the full im controller should be testable same with engine/replica controller.

I left most of these refactorings for longhorn/longhorn#2441