### PR TITLE
Revert the resync back to 30s

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -76,25 +76,25 @@ func NewBackingImageController(
 	})
 	bic.cacheSyncs = append(bic.cacheSyncs, ds.BackingImageInformer.HasSynced)
 
-	ds.BackingImageManagerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageManagerInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    bic.enqueueBackingImageForBackingImageManager,
 		UpdateFunc: func(old, cur interface{}) { bic.enqueueBackingImageForBackingImageManager(cur) },
 		DeleteFunc: bic.enqueueBackingImageForBackingImageManager,
-	})
+	}, 0)
 	bic.cacheSyncs = append(bic.cacheSyncs, ds.BackingImageManagerInformer.HasSynced)
 
-	ds.BackingImageDataSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageDataSourceInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    bic.enqueueBackingImageForBackingImageDataSource,
 		UpdateFunc: func(old, cur interface{}) { bic.enqueueBackingImageForBackingImageDataSource(cur) },
 		DeleteFunc: bic.enqueueBackingImageForBackingImageDataSource,
-	})
+	}, 0)
 	bic.cacheSyncs = append(bic.cacheSyncs, ds.BackingImageDataSourceInformer.HasSynced)
 
-	ds.ReplicaInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.ReplicaInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    bic.enqueueBackingImageForReplica,
 		UpdateFunc: func(old, cur interface{}) { bic.enqueueBackingImageForReplica(cur) },
 		DeleteFunc: bic.enqueueBackingImageForReplica,
-	})
+	}, 0)
 	bic.cacheSyncs = append(bic.cacheSyncs, ds.ReplicaInformer.HasSynced)
 
 	return bic

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -113,32 +113,32 @@ func NewBackingImageDataSourceController(
 	})
 	c.cacheSyncs = append(c.cacheSyncs, ds.BackingImageDataSourceInformer.HasSynced)
 
-	ds.BackingImageInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueueForBackingImage,
 		UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImage(cur) },
 		DeleteFunc: c.enqueueForBackingImage,
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.BackingImageInformer.HasSynced)
 
-	ds.VolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.VolumeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { c.enqueueForVolume(cur) },
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.VolumeInformer.HasSynced)
 
-	ds.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.NodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, cur interface{}) { c.enqueueForLonghornNode(cur) },
 		DeleteFunc: c.enqueueForLonghornNode,
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.NodeInformer.HasSynced)
 
-	ds.PodInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isBackingImageDataSourcePod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.enqueueForBackingImageDataSourcePod,
 			UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImageDataSourcePod(cur) },
 			DeleteFunc: c.enqueueForBackingImageDataSourcePod,
 		},
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.PodInformer.HasSynced)
 
 	return c

--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -132,27 +132,27 @@ func NewBackingImageManagerController(
 	})
 	c.cacheSyncs = append(c.cacheSyncs, ds.BackingImageManagerInformer.HasSynced)
 
-	ds.BackingImageInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueueForBackingImage,
 		UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImage(cur) },
 		DeleteFunc: c.enqueueForBackingImage,
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.BackingImageInformer.HasSynced)
 
-	ds.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.NodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, cur interface{}) { c.enqueueForLonghornNode(cur) },
 		DeleteFunc: c.enqueueForLonghornNode,
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.NodeInformer.HasSynced)
 
-	ds.PodInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isBackingImageManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.enqueueForBackingImageManagerPod,
 			UpdateFunc: func(old, cur interface{}) { c.enqueueForBackingImageManagerPod(cur) },
 			DeleteFunc: c.enqueueForBackingImageManagerPod,
 		},
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.PodInformer.HasSynced)
 
 	return c

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -78,7 +78,7 @@ func NewBackupTargetController(
 	})
 	btc.cacheSyncs = append(btc.cacheSyncs, ds.BackupTargetInformer.HasSynced)
 
-	ds.EngineImageInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.EngineImageInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) {
 			oldEI := old.(*longhorn.EngineImage)
 			curEI := cur.(*longhorn.EngineImage)
@@ -90,7 +90,7 @@ func NewBackupTargetController(
 			}
 			btc.enqueueEngineImage(cur)
 		},
-	})
+	}, 0)
 	btc.cacheSyncs = append(btc.cacheSyncs, ds.EngineImageInformer.HasSynced)
 
 	return btc

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -67,8 +67,8 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	//  lead to scalability problems, since we dump the whole cache of each object back in to the reconciler every 30 seconds.
 	//  if a specific controller requires a periodic resync, one enable it only for that informer, add a resync to the event handler, go routine, etc.
 	//  some refs to look at: https://github.com/kubernetes-sigs/controller-runtime/issues/521
-	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Hour)
-	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Hour)
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
+	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Second*30)
 
 	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, namespace)
 	rc := NewReplicaController(logger, ds, scheme, kubeClient, namespace, controllerID)

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -130,11 +130,11 @@ func NewEngineController(
 	})
 	ec.cacheSyncs = append(ec.cacheSyncs, ds.EngineInformer.HasSynced)
 
-	ds.InstanceManagerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.InstanceManagerInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ec.enqueueInstanceManagerChange,
 		UpdateFunc: func(old, cur interface{}) { ec.enqueueInstanceManagerChange(cur) },
 		DeleteFunc: ec.enqueueInstanceManagerChange,
-	})
+	}, 0)
 	ec.cacheSyncs = append(ec.cacheSyncs, ds.InstanceManagerInformer.HasSynced)
 
 	return ec

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -97,18 +97,18 @@ func NewEngineImageController(
 	})
 	ic.cacheSyncs = append(ic.cacheSyncs, ds.EngineImageInformer.HasSynced)
 
-	ds.VolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.VolumeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { ic.enqueueVolumes(obj) },
 		UpdateFunc: func(old, cur interface{}) { ic.enqueueVolumes(old, cur) },
 		DeleteFunc: func(obj interface{}) { ic.enqueueVolumes(obj) },
-	})
+	}, 0)
 	ic.cacheSyncs = append(ic.cacheSyncs, ds.VolumeInformer.HasSynced)
 
-	ds.DaemonSetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.DaemonSetInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ic.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { ic.enqueueControlleeChange(cur) },
 		DeleteFunc: ic.enqueueControlleeChange,
-	})
+	}, 0)
 	ic.cacheSyncs = append(ic.cacheSyncs, ds.DaemonSetInformer.HasSynced)
 
 	return ic

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -133,20 +133,20 @@ func NewInstanceManagerController(
 	})
 	imc.cacheSyncs = append(imc.cacheSyncs, ds.InstanceManagerInformer.HasSynced)
 
-	ds.PodInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isInstanceManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    imc.enqueueInstanceManagerPod,
 			UpdateFunc: func(old, cur interface{}) { imc.enqueueInstanceManagerPod(cur) },
 			DeleteFunc: imc.enqueueInstanceManagerPod,
 		},
-	})
+	}, 0)
 	imc.cacheSyncs = append(imc.cacheSyncs, ds.PodInformer.HasSynced)
 
-	ds.KubeNodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.KubeNodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, cur interface{}) { imc.enqueueKubernetesNode(cur) },
 		DeleteFunc: imc.enqueueKubernetesNode,
-	})
+	}, 0)
 	imc.cacheSyncs = append(imc.cacheSyncs, ds.KubeNodeInformer.HasSynced)
 
 	return imc

--- a/controller/kubernetes_configmap_controller.go
+++ b/controller/kubernetes_configmap_controller.go
@@ -74,15 +74,14 @@ func NewKubernetesConfigMapController(
 		DeleteFunc: kc.enqueueConfigMapChange,
 	})
 
-	ds.StorageClassInformer.AddEventHandler(
+	ds.StorageClassInformer.AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: isLonghornStorageClass,
 			Handler: cache.ResourceEventHandlerFuncs{
 				UpdateFunc: func(old, cur interface{}) { kc.enqueueConfigMapForStorageClassChange(cur) },
 				DeleteFunc: kc.enqueueConfigMapForStorageClassChange,
 			},
-		},
-	)
+		}, 0)
 
 	kc.cacheSyncs = append(kc.cacheSyncs, ds.ConfigMapInformer.HasSynced, ds.StorageClassInformer.HasSynced)
 

--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -84,11 +84,11 @@ func NewKubernetesPVController(
 	})
 	kc.cacheSyncs = append(kc.cacheSyncs, ds.PersistentVolumeInformer.HasSynced)
 
-	ds.PodInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    kc.enqueuePodChange,
 		UpdateFunc: func(old, cur interface{}) { kc.enqueuePodChange(cur) },
 		DeleteFunc: kc.enqueuePodChange,
-	})
+	}, 0)
 	kc.cacheSyncs = append(kc.cacheSyncs, ds.PodInformer.HasSynced)
 
 	return kc

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -98,18 +98,17 @@ func NewNodeController(
 
 	nc.cacheSyncs = append(nc.cacheSyncs, ds.NodeInformer.HasSynced)
 
-	ds.SettingInformer.AddEventHandler(
+	ds.SettingInformer.AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: nc.isResponsibleForSetting,
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    nc.enqueueSetting,
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueSetting(cur) },
 			},
-		},
-	)
+		}, 0)
 	nc.cacheSyncs = append(nc.cacheSyncs, ds.SettingInformer.HasSynced)
 
-	ds.ReplicaInformer.AddEventHandler(
+	ds.ReplicaInformer.AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: nc.isResponsibleForReplica,
 			Handler: cache.ResourceEventHandlerFuncs{
@@ -117,11 +116,10 @@ func NewNodeController(
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueReplica(cur) },
 				DeleteFunc: nc.enqueueReplica,
 			},
-		},
-	)
+		}, 0)
 	nc.cacheSyncs = append(nc.cacheSyncs, ds.ReplicaInformer.HasSynced)
 
-	ds.PodInformer.AddEventHandler(
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: isManagerPod,
 			Handler: cache.ResourceEventHandlerFuncs{
@@ -129,14 +127,13 @@ func NewNodeController(
 				UpdateFunc: func(old, cur interface{}) { nc.enqueueManagerPod(cur) },
 				DeleteFunc: nc.enqueueManagerPod,
 			},
-		},
-	)
+		}, 0)
 	nc.cacheSyncs = append(nc.cacheSyncs, ds.PodInformer.HasSynced)
 
-	ds.KubeNodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.KubeNodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { nc.enqueueKubernetesNode(cur) },
 		DeleteFunc: nc.enqueueKubernetesNode,
-	})
+	}, 0)
 	nc.cacheSyncs = append(nc.cacheSyncs, ds.KubeNodeInformer.HasSynced)
 
 	return nc

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -98,30 +98,30 @@ func NewReplicaController(
 	})
 	rc.cacheSyncs = append(rc.cacheSyncs, ds.ReplicaInformer.HasSynced)
 
-	ds.InstanceManagerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.InstanceManagerInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueInstanceManagerChange,
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueInstanceManagerChange(cur) },
 		DeleteFunc: rc.enqueueInstanceManagerChange,
-	})
+	}, 0)
 	rc.cacheSyncs = append(rc.cacheSyncs, ds.InstanceManagerInformer.HasSynced)
 
-	ds.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.NodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueNodeAddOrDelete,
 		UpdateFunc: rc.enqueueNodeChange,
 		DeleteFunc: rc.enqueueNodeAddOrDelete,
-	})
+	}, 0)
 	rc.cacheSyncs = append(rc.cacheSyncs, ds.NodeInformer.HasSynced)
 
-	ds.BackingImageInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.enqueueBackingImageChange,
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueBackingImageChange(cur) },
 		DeleteFunc: rc.enqueueBackingImageChange,
-	})
+	}, 0)
 	rc.cacheSyncs = append(rc.cacheSyncs, ds.BackingImageInformer.HasSynced)
 
-	ds.SettingInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.SettingInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { rc.enqueueSettingChange(cur) },
-	})
+	}, 0)
 	rc.cacheSyncs = append(rc.cacheSyncs, ds.SettingInformer.HasSynced)
 
 	return rc

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -123,16 +123,16 @@ func NewSettingController(
 	}, settingControllerResyncPeriod)
 	sc.cacheSyncs = append(sc.cacheSyncs, ds.SettingInformer.HasSynced)
 
-	ds.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.NodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sc.enqueueSettingForNode,
 		UpdateFunc: func(old, cur interface{}) { sc.enqueueSettingForNode(cur) },
 		DeleteFunc: sc.enqueueSettingForNode,
-	})
+	}, 0)
 	sc.cacheSyncs = append(sc.cacheSyncs, ds.NodeInformer.HasSynced)
 
-	ds.BackupTargetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackupTargetInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: sc.enqueueSettingForBackupTarget,
-	})
+	}, 0)
 	sc.cacheSyncs = append(sc.cacheSyncs, ds.BackupTargetInformer.HasSynced)
 
 	return sc

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -82,22 +82,22 @@ func NewShareManagerController(
 	c.cacheSyncs = append(c.cacheSyncs, ds.ShareManagerInformer.HasSynced)
 
 	// need information for volumes, to be able to claim them
-	ds.VolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.VolumeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueueShareManagerForVolume,
 		UpdateFunc: func(old, cur interface{}) { c.enqueueShareManagerForVolume(cur) },
 		DeleteFunc: c.enqueueShareManagerForVolume,
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.VolumeInformer.HasSynced)
 
 	// we are only interested in pods for which we are responsible for managing
-	ds.PodInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+	ds.PodInformer.AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
 		FilterFunc: isShareManagerPod,
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.enqueueShareManagerForPod,
 			UpdateFunc: func(old, cur interface{}) { c.enqueueShareManagerForPod(cur) },
 			DeleteFunc: c.enqueueShareManagerForPod,
 		},
-	})
+	}, 0)
 	c.cacheSyncs = append(c.cacheSyncs, ds.PodInformer.HasSynced)
 
 	return c

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -115,45 +115,45 @@ func NewVolumeController(
 	})
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.VolumeInformer.HasSynced)
 
-	ds.EngineInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.EngineInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueControlleeChange(cur) },
 		DeleteFunc: vc.enqueueControlleeChange,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.EngineInformer.HasSynced)
 
-	ds.ReplicaInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.ReplicaInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueControlleeChange,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueControlleeChange(cur) },
 		DeleteFunc: vc.enqueueControlleeChange,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.ReplicaInformer.HasSynced)
 
-	ds.ShareManagerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.ShareManagerInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueVolumesForShareManager,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueVolumesForShareManager(cur) },
 		DeleteFunc: vc.enqueueVolumesForShareManager,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.ShareManagerInformer.HasSynced)
 
-	ds.BackupVolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackupVolumeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueVolumesForBackupVolume(cur) },
 		DeleteFunc: vc.enqueueVolumesForBackupVolume,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.BackupVolumeInformer.HasSynced)
 
-	ds.BackingImageDataSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.BackingImageDataSourceInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueVolumesForBackingImageDataSource,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueVolumesForBackingImageDataSource(cur) },
 		DeleteFunc: vc.enqueueVolumesForBackingImageDataSource,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.BackingImageDataSourceInformer.HasSynced)
 
-	ds.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ds.NodeInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vc.enqueueNodeChange,
 		UpdateFunc: func(old, cur interface{}) { vc.enqueueNodeChange(cur) },
 		DeleteFunc: vc.enqueueNodeChange,
-	})
+	}, 0)
 	vc.cacheSyncs = append(vc.cacheSyncs, ds.NodeInformer.HasSynced)
 
 	return vc


### PR DESCRIPTION
Revert the resync back to 30s for Longhorn v1.3.0 since there are conner cases that we cannot solve in time.

We can retry increasing the resync in the v1.4.0 release. The effort is tracked at https://github.com/longhorn/longhorn/issues/3629