### PR TITLE
Fix BackingImageManager version request leaked grpc connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
-	github.com/longhorn/backing-image-manager v0.0.0-20220318061141-6bcb81541be8
+	github.com/longhorn/backing-image-manager v0.0.0-20220414053138-691e27b07b7e
 	github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 	github.com/longhorn/longhorn-instance-manager v0.0.0-20220412150124-6cc9d60a9c8e

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/longhorn/backing-image-manager v0.0.0-20220318061141-6bcb81541be8 h1:1jN1CXXkFM9K16WHOHKCW5VF5T4BQoS6rCCfYEbho58=
-github.com/longhorn/backing-image-manager v0.0.0-20220318061141-6bcb81541be8/go.mod h1:J6PTXyXw5Dvzx+0Aeixl+7TPBWPWQzdIQHh+GeSCjsg=
+github.com/longhorn/backing-image-manager v0.0.0-20220414053138-691e27b07b7e h1:KQv5SFnaY9+VUIPEIm39lCWCgNv85yg2XeTANPqHg0A=
+github.com/longhorn/backing-image-manager v0.0.0-20220414053138-691e27b07b7e/go.mod h1:J6PTXyXw5Dvzx+0Aeixl+7TPBWPWQzdIQHh+GeSCjsg=
 github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d h1:pj7Gmj7aQbesCQth+t2X9TN2zv2GdPqgdBzh4pwF4i4=
 github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d/go.mod h1:FUjQNWqcEXSFIrQpfWLxFFHXywk14mM5w9TNRuBrKzY=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=

--- a/vendor/github.com/longhorn/backing-image-manager/pkg/client/manager_client.go
+++ b/vendor/github.com/longhorn/backing-image-manager/pkg/client/manager_client.go
@@ -174,6 +174,7 @@ func (cli *BackingImageManagerClient) VersionGet() (*meta.VersionOutput, error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect backing image manager service to %v: %v", cli.Address, err)
 	}
+	defer conn.Close()
 
 	client := rpc.NewBackingImageManagerServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/json-iterator/go
 github.com/kr/text
 # github.com/kubernetes-csi/csi-lib-utils v0.6.1
 github.com/kubernetes-csi/csi-lib-utils/protosanitizer
-# github.com/longhorn/backing-image-manager v0.0.0-20220318061141-6bcb81541be8
+# github.com/longhorn/backing-image-manager v0.0.0-20220414053138-691e27b07b7e
 github.com/longhorn/backing-image-manager/api
 github.com/longhorn/backing-image-manager/pkg/client
 github.com/longhorn/backing-image-manager/pkg/meta


### PR DESCRIPTION
Depends on https://github.com/longhorn/backing-image-manager/pull/48

https://github.com/longhorn/longhorn/issues/3838


Signed-off-by: Derek Su <derek.su@suse.com>