### PR TITLE
Fix for not reaching docker daemon on s390x pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -224,6 +224,9 @@ steps:
     tag: "${DRONE_BRANCH}-head-s390x"
     username:
       from_secret: docker_username
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
   when:
     event:
     - push
@@ -241,6 +244,9 @@ steps:
     tag: "${DRONE_TAG}-s390x"
     username:
       from_secret: docker_username
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
   when:
     event:
     - tag


### PR DESCRIPTION
Drone pipelines for `s390x` are failing due to the publish steps are not able to reach **docker dameon** 
https://drone-publish.longhorn.io/longhorn/longhorn-manager/706/3/4

Adding the volume should do the trick.