### PR TITLE
node controller: fix the incorrect update of disk status

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -426,8 +426,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 		return nil
 	}
 
-	alignDiskSpecAndStatus(node)
-
 	mon, err := nc.checkMonitor(nc.controllerID)
 	if err != nil {
 		return err
@@ -561,6 +559,8 @@ func (nc *NodeController) enqueueKubernetesNode(obj interface{}) {
 }
 
 func (nc *NodeController) syncDiskStatus(node *longhorn.Node, collectedDataInfo map[string]*monitor.CollectedDiskInfo) error {
+	alignDiskSpecAndStatus(node)
+
 	notReadyDiskInfoMap, readyDiskInfoMap := nc.findNotReadyAndReadyDiskMaps(node, collectedDataInfo)
 
 	for _, diskInfoMap := range notReadyDiskInfoMap {


### PR DESCRIPTION
This bug is found by test_node.py.

Before syncing with the node monitor, don't update the storage data in diskStatus. The cleanup of the old storage data should happen when the updates of ready/scheduled conditions are available.
The incorrect update leads to the wrong StorageMaximum and StorageAvailable until next successful syncWithMonitor.

Longhorn 685

Signed-off-by: Derek Su <derek.su@suse.com>