### PR TITLE
Create Longhorn finalizer in the mutating webhook

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1036,9 +1036,6 @@ func GetOwnerReferencesForEngineImage(ei *longhorn.EngineImage) []metav1.OwnerRe
 // CreateEngineImage creates a Longhorn EngineImage resource and verifies
 // creation
 func (s *DataStore) CreateEngineImage(img *longhorn.EngineImage) (*longhorn.EngineImage, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, img); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().EngineImages(s.namespace).Create(context.TODO(), img, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -1218,9 +1215,6 @@ func (s *DataStore) CheckEngineImageReadyOnAllVolumeReplicas(image, volumeName, 
 // CreateBackingImage creates a Longhorn BackingImage resource and verifies
 // creation
 func (s *DataStore) CreateBackingImage(backingImage *longhorn.BackingImage) (*longhorn.BackingImage, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImage); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().BackingImages(s.namespace).Create(context.TODO(), backingImage, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -1350,9 +1344,6 @@ func GetOwnerReferencesForBackingImage(backingImage *longhorn.BackingImage) []me
 // creation
 func (s *DataStore) CreateBackingImageManager(backingImageManager *longhorn.BackingImageManager) (*longhorn.BackingImageManager, error) {
 	if err := initBackingImageManager(backingImageManager); err != nil {
-		return nil, err
-	}
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImageManager); err != nil {
 		return nil, err
 	}
 	if err := tagLonghornNodeLabel(backingImageManager.Spec.NodeID, backingImageManager); err != nil {
@@ -1736,9 +1727,6 @@ func GetOwnerReferencesForBackingImageDataSource(backingImageDataSource *longhor
 
 // CreateNode creates a Longhorn Node resource and verifies creation
 func (s *DataStore) CreateNode(node *longhorn.Node) (*longhorn.Node, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, node); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().Nodes(s.namespace).Create(context.TODO(), node, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -2741,9 +2729,6 @@ func GetOwnerReferencesForShareManager(sm *longhorn.ShareManager, isController b
 // CreateShareManager creates a Longhorn ShareManager resource and
 // verifies creation
 func (s *DataStore) CreateShareManager(sm *longhorn.ShareManager) (*longhorn.ShareManager, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, sm); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().ShareManagers(s.namespace).Create(context.TODO(), sm, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -2931,9 +2916,6 @@ func (s *DataStore) DeleteBackupTarget(backupTargetName string) error {
 
 // CreateBackupVolume creates a Longhorn BackupVolumes CR and verifies creation
 func (s *DataStore) CreateBackupVolume(backupVolume *longhorn.BackupVolume) (*longhorn.BackupVolume, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, backupVolume); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().BackupVolumes(s.namespace).Create(context.TODO(), backupVolume, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -3042,9 +3024,6 @@ func (s *DataStore) RemoveFinalizerForBackupVolume(backupVolume *longhorn.Backup
 // CreateBackup creates a Longhorn Backup CR and verifies creation
 func (s *DataStore) CreateBackup(backup *longhorn.Backup, backupVolumeName string) (*longhorn.Backup, error) {
 	if err := tagBackupVolumeLabel(backupVolumeName, backup); err != nil {
-		return nil, err
-	}
-	if err := util.AddFinalizer(longhornFinalizerKey, backup); err != nil {
 		return nil, err
 	}
 	ret, err := s.lhClient.LonghornV1beta2().Backups(s.namespace).Create(context.TODO(), backup, metav1.CreateOptions{})

--- a/webhook/common/common.go
+++ b/webhook/common/common.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/util"
+)
+
+var (
+	longhornFinalizerKey = longhorn.SchemeGroupVersion.Group
+)
+
+func GetLonghornFinalizerPatchOp(obj runtime.Object) (string, error) {
+	if err := util.AddFinalizer(longhornFinalizerKey, obj); err != nil {
+		return "", err
+	}
+
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	finalizers := metadata.GetFinalizers()
+	if finalizers == nil {
+		finalizers = []string{}
+	}
+	bytes, err := json.Marshal(finalizers)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get JSON encoding for backup %v finalizers", metadata.GetName())
+	}
+
+	return fmt.Sprintf(`{"op": "replace", "path": "/metadata/finalizers", "value": %v}`, string(bytes)), nil
+}
+
+func GetLonghornLabelsPatchOp(obj runtime.Object, longhornLabels map[string]string) (string, error) {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	labels := metadata.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	for k, v := range longhornLabels {
+		labels[k] = v
+	}
+
+	bytes, err := json.Marshal(labels)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get JSON encoding for %v labels", metadata.GetName())
+	}
+
+	return fmt.Sprintf(`{"op": "replace", "path": "/metadata/labels", "value": %v}`, string(bytes)), nil
+}

--- a/webhook/resources/backingimagemanager/mutator.go
+++ b/webhook/resources/backingimagemanager/mutator.go
@@ -1,12 +1,15 @@
 package backingimagemanager
 
 import (
+	"github.com/pkg/errors"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	common "github.com/longhorn/longhorn-manager/webhook/common"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
 )
 
 type backingImageManagerMutator struct {
@@ -33,17 +36,30 @@ func (b *backingImageManagerMutator) Resource() admission.Resource {
 }
 
 func (b *backingImageManagerMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackingImageManager(newObj)
+	backingImageManager := newObj.(*longhorn.BackingImageManager)
+
+	patchOps, err := mutate(newObj)
+	if err != nil {
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+
+	patchOp, err := common.GetLonghornFinalizerPatchOp(backingImageManager)
+	if err != nil {
+		err := errors.Wrapf(err, "failed to get finalizer patch for backingImageManager %v", backingImageManager.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, patchOp)
+
+	return patchOps, nil
 }
 
 func (b *backingImageManagerMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackingImageManager(newObj)
+	return mutate(newObj)
 }
 
-func mutateBackingImageManager(newObj runtime.Object) (admission.PatchOps, error) {
-	var patchOps admission.PatchOps
-
+func mutate(newObj runtime.Object) (admission.PatchOps, error) {
 	backingImageManager := newObj.(*longhorn.BackingImageManager)
+	var patchOps admission.PatchOps
 
 	if backingImageManager.Spec.BackingImages == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/backingImages", "value": {}}`)

--- a/webhook/resources/backup/mutator.go
+++ b/webhook/resources/backup/mutator.go
@@ -1,12 +1,15 @@
 package backup
 
 import (
+	"github.com/pkg/errors"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	common "github.com/longhorn/longhorn-manager/webhook/common"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
 )
 
 type backupMutator struct {
@@ -33,17 +36,30 @@ func (b *backupMutator) Resource() admission.Resource {
 }
 
 func (b *backupMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackup(newObj)
+	backup := newObj.(*longhorn.Backup)
+
+	patchOps, err := mutate(newObj)
+	if err != nil {
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+
+	patchOp, err := common.GetLonghornFinalizerPatchOp(backup)
+	if err != nil {
+		err := errors.Wrapf(err, "failed to get finalizer patch for backup %v", backup.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, patchOp)
+
+	return patchOps, nil
 }
 
 func (b *backupMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	return mutateBackup(newObj)
+	return mutate(newObj)
 }
 
-func mutateBackup(newObj runtime.Object) (admission.PatchOps, error) {
-	var patchOps admission.PatchOps
-
+func mutate(newObj runtime.Object) (admission.PatchOps, error) {
 	backup := newObj.(*longhorn.Backup)
+	var patchOps admission.PatchOps
 
 	if backup.Spec.Labels == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/labels", "value": {}}`)

--- a/webhook/resources/backupvolume/mutator.go
+++ b/webhook/resources/backupvolume/mutator.go
@@ -1,0 +1,50 @@
+package backupvolume
+
+import (
+	"github.com/pkg/errors"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	common "github.com/longhorn/longhorn-manager/webhook/common"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type backupVolumeMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backupVolumeMutator{ds: ds}
+}
+
+func (b *backupVolumeMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backupvolumes",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackupVolume{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (b *backupVolumeMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	var patchOps admission.PatchOps
+
+	backupVolume := newObj.(*longhorn.BackupVolume)
+
+	patchOp, err := common.GetLonghornFinalizerPatchOp(backupVolume)
+	if err != nil {
+		err := errors.Wrapf(err, "failed to get finalizer patch for backupVolume %v", backupVolume.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, patchOp)
+
+	return patchOps, nil
+}

--- a/webhook/resources/sharemanager/mutator.go
+++ b/webhook/resources/sharemanager/mutator.go
@@ -1,0 +1,49 @@
+package sharemanager
+
+import (
+	"github.com/pkg/errors"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+	common "github.com/longhorn/longhorn-manager/webhook/common"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type shareManagerMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &shareManagerMutator{ds: ds}
+}
+
+func (s *shareManagerMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "sharemanagers",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.ShareManager{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (s *shareManagerMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	shareManager := newObj.(*longhorn.ShareManager)
+	var patchOps admission.PatchOps
+
+	patchOp, err := common.GetLonghornFinalizerPatchOp(shareManager)
+	if err != nil {
+		err := errors.Wrapf(err, "failed to get finalizer patch for shareManager %v", shareManager.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	patchOps = append(patchOps, patchOp)
+
+	return patchOps, nil
+}

--- a/webhook/server/mutation.go
+++ b/webhook/server/mutation.go
@@ -11,11 +11,13 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagedatasource"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backup"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backupvolume"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engine"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/orphan"
 	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
+	"github.com/longhorn/longhorn-manager/webhook/resources/sharemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/volume"
 )
 
@@ -32,6 +34,8 @@ func Mutation(client *client.Client) (http.Handler, []admission.Resource, error)
 		recurringjob.NewMutator(client.Datastore),
 		engineimage.NewMutator(client.Datastore),
 		orphan.NewMutator(client.Datastore),
+		sharemanager.NewMutator(client.Datastore),
+		backupvolume.NewMutator(client.Datastore),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
CreateXXX, e.g. CreateBackup, adds Longhorn finalizer to new created resource.
To make the behavior consistent between API and Resource operation using CLI, we can move the longhorn finalizer creation logic to the mutating webhook.

[Longhorn 1315](https://github.com/longhorn/longhorn/issues/3918)

Signed-off-by: Derek Su <derek.su@suse.com>