### PR TITLE
Fix IM restart failure related to non TLS im client closure

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -82,7 +82,7 @@ func updateInstanceManagerVersion(im *longhorn.InstanceManager) error {
 	if err != nil {
 		return err
 	}
-	cli.Close()
+	defer cli.Close()
 	apiMinVersion, apiVersion, err := cli.VersionGet()
 	if err != nil {
 		return err


### PR DESCRIPTION
The failure happened due to a missed deffer statement for the client closure of one of the one shot clients.
We plan on refactoring the one shot client mechanisms in the future after the im proxy PR's are merged.

longhorn/longhorn#3922