### PR TITLE
Update PV annotation according to volume scheduled condition

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3611,6 +3611,9 @@ func (vc *VolumeController) checkVolumeNotInMigration(volume *longhorn.Volume) e
 func (vc *VolumeController) updatePVAnnotation(volume *longhorn.Volume, annotationKey, annotationVal string) error {
 	pv, err := vc.ds.GetPersistentVolume(volume.Status.KubernetesStatus.PVName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1042,15 +1042,18 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 	}
 
 	scheduled := true
+	aggregatedReplicaScheduledError := util.NewMultiError()
 	for _, r := range rs {
 		// check whether the replica need to be scheduled
 		if r.Spec.NodeID != "" {
 			continue
 		}
-		scheduledReplica, err := vc.scheduler.ScheduleReplica(r, rs, v)
+		scheduledReplica, multiError, err := vc.scheduler.ScheduleReplica(r, rs, v)
 		if err != nil {
 			return err
 		}
+		aggregatedReplicaScheduledError.Append(multiError)
+
 		if scheduledReplica == nil {
 			if r.Spec.HardNodeAffinity == "" {
 				log.WithField("replica", r.Name).Error("unable to schedule replica")
@@ -1068,6 +1071,8 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 			rs[r.Name] = scheduledReplica
 		}
 	}
+
+	failureMessage := ""
 	if scheduled {
 		v.Status.Conditions = types.SetCondition(v.Status.Conditions,
 			longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusTrue, "", "")
@@ -1091,6 +1096,23 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 				scheduled = true
 			}
 		}
+
+		if !scheduled {
+			if len(aggregatedReplicaScheduledError) == 0 {
+				aggregatedReplicaScheduledError.Append(util.NewMultiError(longhorn.ErrorReplicaScheduleSchedulingFailed))
+			}
+			failureMessage = aggregatedReplicaScheduledError.Join()
+			scheduledCondition := types.GetCondition(v.Status.Conditions, longhorn.VolumeConditionTypeScheduled)
+			if scheduledCondition.Status == longhorn.ConditionStatusFalse {
+				v.Status.Conditions = types.SetCondition(v.Status.Conditions,
+					longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusFalse,
+					scheduledCondition.Reason, failureMessage)
+			}
+		}
+	}
+
+	if err := vc.updatePVAnnotation(v, types.PVAnnotationLonghornVolumeSchedulingError, failureMessage); err != nil {
+		log.Warnf("Cannot update PV annotation for volume %v", v.Name)
 	}
 
 	if err := vc.reconcileVolumeSize(v, e, rs); err != nil {
@@ -3584,4 +3606,26 @@ func (vc *VolumeController) checkVolumeNotInMigration(volume *longhorn.Volume) e
 		return fmt.Errorf("cannot operate during migration")
 	}
 	return nil
+}
+
+func (vc *VolumeController) updatePVAnnotation(volume *longhorn.Volume, annotationKey, annotationVal string) error {
+	pv, err := vc.ds.GetPersistentVolume(volume.Status.KubernetesStatus.PVName)
+	if err != nil {
+		return err
+	}
+
+	if pv.Annotations == nil {
+		pv.Annotations = map[string]string{}
+	}
+
+	val, ok := pv.Annotations[annotationKey]
+	if ok && val == annotationVal {
+		return nil
+	}
+
+	pv.Annotations[annotationKey] = annotationVal
+
+	_, err = vc.ds.UpdatePersistentVolume(pv)
+
+	return err
 }

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -190,7 +190,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.EngineImage
 	tc.expectVolume.Status.Robustness = longhorn.VolumeRobustnessUnknown
 	tc.expectVolume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.expectVolume.Status.Conditions,
-		longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusFalse, longhorn.VolumeConditionReasonReplicaSchedulingFailure, "")
+		longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusFalse, longhorn.VolumeConditionReasonReplicaSchedulingFailure, longhorn.ErrorReplicaScheduleNodeUnavailable)
 	testCases["volume create - replica scheduling failure"] = tc
 
 	// after creation, volume in detached state

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -31,6 +31,19 @@ const (
 	DiskConditionReasonDiskNotReady          = "DiskNotReady"
 )
 
+const (
+	ErrorReplicaScheduleInsufficientStorage              = "insufficient storage"
+	ErrorReplicaScheduleDiskNotFound                     = "disk not found"
+	ErrorReplicaScheduleDiskUnavailable                  = "disks are unavailable"
+	ErrorReplicaScheduleSchedulingSettingsRetrieveFailed = "failed to retrieve scheduling settings failed to retrieve"
+	ErrorReplicaScheduleTagsNotFulfilled                 = "tags not fulfilled"
+	ErrorReplicaScheduleNodeNotFound                     = "node not found"
+	ErrorReplicaScheduleNodeUnavailable                  = "nodes are unavailable"
+	ErrorReplicaScheduleEngineImageNotReady              = "none of the node candidates contains a ready engine image"
+	ErrorReplicaScheduleHardNodeAffinityNotSatisfied     = "hard affinity cannot be satisfied"
+	ErrorReplicaScheduleSchedulingFailed                 = "replica scheduling failed"
+)
+
 type DiskSpec struct {
 	Path              string   `json:"path"`
 	AllowScheduling   bool     `json:"allowScheduling"`

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -745,7 +745,7 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 			c.Assert(r, NotNil)
 			rIndexer.Add(r)
 
-			sr, err := s.ScheduleReplica(r, tc.replicas, volume)
+			sr, _, err := s.ScheduleReplica(r, tc.replicas, volume)
 			if tc.err {
 				c.Assert(err, NotNil)
 			} else {

--- a/types/types.go
+++ b/types/types.go
@@ -105,6 +105,8 @@ const (
 	ControlPlaneName                 = "longhorn-manager"
 
 	DefaultRecurringJobConcurrency = 10
+
+	PVAnnotationLonghornVolumeSchedulingError = "longhorn.io/volume-scheduling-error"
 )
 
 const (

--- a/util/multierror.go
+++ b/util/multierror.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"strings"
+)
+
+type MultiError map[string]struct{}
+
+func NewMultiError(errs ...string) MultiError {
+	multiError := MultiError{}
+	for _, err := range errs {
+		multiError[err] = struct{}{}
+	}
+
+	return multiError
+}
+
+func (me MultiError) Append(errs MultiError) {
+	for err := range errs {
+		me[err] = struct{}{}
+	}
+}
+
+func (me MultiError) Join() string {
+	keys := make([]string, 0, len(me))
+	for err := range me {
+		keys = append(keys, err)
+	}
+
+	return strings.Join(keys, ";")
+}


### PR DESCRIPTION
Currently, the Condition["Schedule"].message is still empty even if there is a scheduling failure. We can update it with a verbose error message which is a combination of the errors, e.g. insufficient storage or insufficient storage, disk not found. Then, the verbose error message is updated to PV annotation.

https://github.com/longhorn/longhorn/issues/3529
https://github.com/longhorn/longhorn/issues/3933

Signed-off-by: Derek Su <derek.su@suse.com>