### PR TITLE
Set verbose error message in volume scheduled condition

### DIFF
--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -181,7 +181,8 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.EngineImage
 	tc.expectVolume.Status.Robustness = types.VolumeRobustnessUnknown
 	tc.expectVolume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.expectVolume.Status.Conditions,
-		types.VolumeConditionTypeScheduled, types.ConditionStatusFalse, types.VolumeConditionReasonReplicaSchedulingFailure, "")
+		types.VolumeConditionTypeScheduled, types.ConditionStatusFalse, types.VolumeConditionReasonReplicaSchedulingFailure,
+		types.ErrorReplicaScheduleNodeUnavailable)
 	testCases["volume create - replica scheduling failure"] = tc
 
 	// after creation, volume in detached state

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/informers"
@@ -739,7 +739,7 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 			c.Assert(r, NotNil)
 			rIndexer.Add(r)
 
-			sr, err := s.ScheduleReplica(r, tc.replicas, volume)
+			sr, _, err := s.ScheduleReplica(r, tc.replicas, volume)
 			if tc.err {
 				c.Assert(err, NotNil)
 			} else {

--- a/types/resource.go
+++ b/types/resource.go
@@ -342,6 +342,19 @@ const (
 	DiskConditionReasonDiskNotReady          = "DiskNotReady"
 )
 
+const (
+	ErrorReplicaScheduleInsufficientStorage              = "insufficient storage"
+	ErrorReplicaScheduleDiskNotFound                     = "disk not found"
+	ErrorReplicaScheduleDiskUnavailable                  = "disks are unavailable"
+	ErrorReplicaScheduleSchedulingSettingsRetrieveFailed = "failed to retrieve scheduling settings failed to retrieve"
+	ErrorReplicaScheduleTagsNotFulfilled                 = "tags not fulfilled"
+	ErrorReplicaScheduleNodeNotFound                     = "node not found"
+	ErrorReplicaScheduleNodeUnavailable                  = "nodes are unavailable"
+	ErrorReplicaScheduleEngineImageNotReady              = "none of the node candidates contains a ready engine image"
+	ErrorReplicaScheduleHardNodeAffinityNotSatisfied     = "hard affinity cannot be satisfied"
+	ErrorReplicaScheduleSchedulingFailed                 = "replica scheduling failed"
+)
+
 type NodeStatus struct {
 	Conditions map[string]Condition   `json:"conditions"`
 	DiskStatus map[string]*DiskStatus `json:"diskStatus"`

--- a/types/types.go
+++ b/types/types.go
@@ -86,6 +86,8 @@ const (
 	DefaultStorageClassConfigMapName = "longhorn-storageclass"
 	DefaultStorageClassName          = "longhorn"
 	ControlPlaneName                 = "longhorn-manager"
+
+	PVAnnotationLonghornVolumeSchedulingError = "longhorn.io/volume-scheduling-error"
 )
 
 const (

--- a/util/multierror.go
+++ b/util/multierror.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"strings"
+)
+
+type MultiError map[string]struct{}
+
+func NewMultiError(errs ...string) MultiError {
+	multiError := MultiError{}
+	for _, err := range errs {
+		multiError[err] = struct{}{}
+	}
+
+	return multiError
+}
+
+func (me MultiError) Append(errs MultiError) {
+	for err := range errs {
+		me[err] = struct{}{}
+	}
+}
+
+func (me MultiError) Join() string {
+	keys := make([]string, 0, len(me))
+	for err := range me {
+		keys = append(keys, err)
+	}
+
+	return strings.Join(keys, ";")
+}


### PR DESCRIPTION
Collect and aggregate the replica scheduling failure cauases and then
set them to the volume scheduled condition.

Then, update volume scheduled condition to PV annotation.

https://github.com/longhorn/longhorn/issues/3529
https://github.com/longhorn/longhorn/issues/3934

Signed-off-by: Derek Su <derek.su@suse.com>