### PR TITLE
Do not retry if failed to update node or disk using API

### DIFF
--- a/webhook/error/error.go
+++ b/webhook/error/error.go
@@ -85,3 +85,12 @@ func NewInternalError(message string) AdmitError {
 		reason:  metav1.StatusReasonInternalError,
 	}
 }
+
+// NewForbiddenError returns HTTP status code 403
+func NewForbiddenError(message string) AdmitError {
+	return AdmitError{
+		code:    http.StatusForbidden,
+		message: message,
+		reason:  metav1.StatusReasonForbidden,
+	}
+}

--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -73,7 +73,7 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 
 	// Ensure the node controller already syncs the disk spec and status.
 	if !isNodeDiskSpecAndStatusSynced(oldNode) {
-		return werror.NewConflict(fmt.Sprintf("spec and status of disks on node %v are being syncing and please retry later.", oldNode.Name))
+		return werror.NewForbiddenError(fmt.Sprintf("spec and status of disks on node %v are being syncing and please retry later.", oldNode.Name))
 	}
 
 	// We need to make sure the tags passed in are valid before updating the node.


### PR DESCRIPTION
Replace werror.NewConflict with werror.NewInvalidError to avoid the API retries because

1. The Conflict error leads to the retry in HandleError (api/router.go). The retry does apiContext.Read again and then trigger EOF error.

2. The maximum node disk synchronization duration is 60 seconds (30 seconds in node controller and 30 seconds in node monitor), while the API's maximum retry number is ten, with each 1 second retry interval. As a result, retries are rarely successful. Furthermore, the retries cause the UI to hang for 10 seconds and does not provide a nice user experience. Therefore, if updating disk/node fails, giving a clear message to users is better.

[Longhorn 3956](https://github.com/longhorn/longhorn/issues/3956)


Signed-off-by: Derek Su <derek.su@suse.com>