### PR TITLE
[Backport] [v1.2.5] Fixed throttling issue with the client-go rest client inside Longhorn manager

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -46,6 +46,9 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		return nil, nil, errors.Wrap(err, "unable to get client config")
 	}
 
+	config.Burst = 100
+	config.QPS = 50
+
 	kubeClient, err := clientset.NewForConfig(config)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get k8s client")

--- a/monitoring/client_go_adapter/metrics.go
+++ b/monitoring/client_go_adapter/metrics.go
@@ -1,0 +1,98 @@
+package client_go_adaper
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+
+	"github.com/longhorn/longhorn-manager/monitoring/registry"
+)
+
+// this file contains setup logic to initialize the myriad of places
+// that client-go registers metrics.  We copy the names and formats
+// from Kubernetes so that we match the core controllers.
+const (
+	LonghornName = "longhorn"
+)
+
+var (
+	// client metrics
+	clientGoRestClientSubsystem = "rest_client"
+
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: LonghornName,
+			Subsystem: clientGoRestClientSubsystem,
+			Name:      "request_latency_seconds",
+			Help:      "Request latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+		},
+		[]string{"verb", "url"},
+	)
+
+	rateLimiterLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: LonghornName,
+			Subsystem: clientGoRestClientSubsystem,
+			Name:      "rate_limiter_latency_seconds",
+			Help:      "Rate limiter latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+		},
+		[]string{"verb", "url"},
+	)
+
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: LonghornName,
+			Subsystem: clientGoRestClientSubsystem,
+			Name:      "requests_total",
+			Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
+		},
+		[]string{"code", "method", "host"},
+	)
+)
+
+func init() {
+	registerClientMetrics()
+}
+
+// registerClientMetrics sets up the client latency metrics from client-go
+func registerClientMetrics() {
+	// register the metrics with our registry
+	registry.Register(requestLatency)
+	registry.Register(requestResult)
+	registry.Register(rateLimiterLatency)
+
+	// register the metrics with client-go
+	clientmetrics.Register(clientmetrics.RegisterOpts{
+		RequestLatency:     &latencyAdapter{metric: requestLatency},
+		RequestResult:      &resultAdapter{metric: requestResult},
+		RateLimiterLatency: &latencyAdapter{metric: rateLimiterLatency},
+	})
+}
+
+// this section contains adapters, implementations, and other sundry organic, artisanally
+// hand-crafted syntax trees required to convince client-go that it actually wants to let
+// someone use its metrics.
+
+// Client metrics adapters (method #1 for client-go metrics),
+// copied (more-or-less directly) from k8s.io/kubernetes setup code
+// (which isn't anywhere in an easily-importable place).
+
+type latencyAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
+	l.metric.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+}
+
+type resultAdapter struct {
+	metric *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(code, method, host string) {
+	r.metric.WithLabelValues(code, method, host).Inc()
+}

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -11,8 +11,10 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/longhorn/longhorn-manager/datastore"
+	_ "github.com/longhorn/longhorn-manager/monitoring/client_go_adapter" // load the client-go metrics
 	"github.com/longhorn/longhorn-manager/monitoring/registry"
 	_ "github.com/longhorn/longhorn-manager/monitoring/workqueue" // load the workqueue metrics
+
 	"github.com/longhorn/longhorn-manager/types"
 )
 

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -53,6 +53,11 @@ func Upgrade(kubeconfigPath, currentNodeID string) error {
 		return errors.Wrap(err, "unable to get client config")
 	}
 
+	// There is only one leading Longhorn manager that is doing modification to the CRs.
+	// Increase this value so that leading Longhorn manager can finish upgrading faster
+	config.Burst = 1000
+	config.QPS = 1000
+
 	kubeClient, err := clientset.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "unable to get k8s client")


### PR DESCRIPTION
Items:
1. Fixed throttling issue with the client-go rest client inside Longhorn manager. This is the reason for the long upgrading time from v1.2.3 to v1.2.4 when the cluster have a lot of backups
2. Add metrics for the client-go rest client inside Longhorn manager

longhorn/longhorn#3980

ref: https://github.com/rancher/support-bundle-kit/pull/23