### PR TITLE
Fix customize default settings while upgrade/update

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -120,7 +120,7 @@ func startManager(c *cli.Context) error {
 			return fmt.Errorf("cannot find customized default setting file on %v: %v", defaultSettingPath, err)
 		}
 	}
-	if err := types.OverwriteBuiltInSettingsWithCustomizedValues(); err != nil {
+	if err := types.OverwriteBuiltInSettingsWithCustomizedValues(kubeconfigPath); err != nil {
 		return fmt.Errorf("failed to overwrite built-in settings with customized values: %v", err)
 	}
 
@@ -168,7 +168,6 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
-	// Initialize the rest settings
 	if err := ds.InitSettings(); err != nil {
 		return err
 	}
@@ -238,6 +237,10 @@ func createOrUpdateDefaultImageSetting(m *manager.VolumeManager, settingName typ
 		settingDefaultImage.Value = image
 		if _, err := m.CreateOrUpdateSetting(settingDefaultImage); err != nil {
 			return err
+		}
+		if definition, exist := types.SettingDefinitions[settingName]; exist {
+			definition.Default = image
+			types.SettingDefinitions[settingName] = definition
 		}
 	}
 	return nil

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -107,10 +107,21 @@ func startManager(c *cli.Context) error {
 	}
 	kubeconfigPath := c.String(FlagKubeConfig)
 
+	defaultSettingPath := os.Getenv(types.EnvDefaultSettingPath)
+
 	if err := environmentCheck(); err != nil {
 		logrus.Errorf("Failed environment check, please make sure you " +
 			"have iscsiadm/open-iscsi installed on the host")
 		return fmt.Errorf("environment check failed: %v", err)
+	}
+
+	if defaultSettingPath != "" {
+		if _, err := os.Stat(defaultSettingPath); err != nil {
+			return fmt.Errorf("cannot find customized default setting file on %v: %v", defaultSettingPath, err)
+		}
+	}
+	if err := types.OverwriteBuiltInSettingsWithCustomizedValues(); err != nil {
+		return fmt.Errorf("failed to overwrite built-in settings with customized values: %v", err)
 	}
 
 	currentNodeID, err := util.GetRequiredEnv(types.EnvNodeName)

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -43,27 +43,54 @@ var (
 
 // InitSettings creates all Settings in SettingNameList if not already exist
 func (s *DataStore) InitSettings() error {
+	logrus.Debugf("Updating customized default settings")
+
 	for _, sName := range types.SettingNameList {
 		definition, ok := types.SettingDefinitions[sName]
 		if !ok {
 			return fmt.Errorf("BUG: setting %v is not defined", sName)
 		}
-		if _, err := s.sLister.Settings(s.namespace).Get(string(sName)); err != nil {
-			if ErrorIsNotFound(err) {
-				setting := &longhorn.Setting{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: string(sName),
-					},
-					Value: definition.Default,
-				}
-				if _, err := s.CreateSetting(setting); err != nil && !apierrors.IsAlreadyExists(err) {
-					return err
-				}
-			} else {
-				return err
-			}
+
+		err := s.CreateOrUpdateSetting(sName, definition)
+		if err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func (s *DataStore) CreateOrUpdateSetting(name types.SettingName, definition types.SettingDefinition) error {
+	setting, err := s.sLister.Settings(s.namespace).Get(string(name))
+	if err != nil {
+		if !ErrorIsNotFound(err) {
+			return err
+		}
+		setting = &longhorn.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: string(name),
+			},
+			Value:                    definition.Default,
+			ConfigMapResourceVersion: definition.ConfigMapResourceVersion,
+		}
+		_, err := s.CreateSetting(setting)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}
+
+	if definition.Default == "" {
+		return nil
+	}
+
+	if setting.Value != definition.Default {
+		setting.Value = definition.Default
+		setting.ConfigMapResourceVersion = definition.ConfigMapResourceVersion
+
+		_, err = s.UpdateSetting(setting)
+		return err
+	}
+
 	return nil
 }
 

--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -2420,6 +2420,8 @@ spec:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
+          configMapResourceVersion:
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
@@ -2428,6 +2430,7 @@ spec:
           value:
             type: string
         required:
+        - configMapResourceVersion
         - value
         type: object
     served: true

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -1,266 +1,45 @@
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: backup-target
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: backup-target-credential-secret
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: allow-recurring-job-while-volume-detached
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: create-default-disk-labeled-nodes
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: default-data-path
-#  namespace: longhorn-system
-#value: "/var/lib/longhorn/"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: replica-soft-anti-affinity
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: replica-auto-balance
-#  namespace: longhorn-system
-#value: "disabled"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: storage-over-provisioning-percentage
-#  namespace: longhorn-system
-#value: "200"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: storage-minimal-available-percentage
-#  namespace: longhorn-system
-#value: "25"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: upgrade-checker
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: default-replica-count
-#  namespace: longhorn-system
-#value: "3"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: default-data-locality
-#  namespace: longhorn-system
-#value: "disabled"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: default-longhorn-static-storage-class
-#  namespace: longhorn-system
-#value: "longhorn-static"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: backupstore-poll-interval
-#  namespace: longhorn-system
-#value: "300"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: taint-toleration
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: system-managed-components-node-selector
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: priority-class
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: auto-salvage
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: auto-delete-pod-when-volume-detached-unexpectedly
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: disable-scheduling-on-cordoned-node
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: replica-zone-soft-anti-affinity
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: node-down-pod-deletion-policy
-#  namespace: longhorn-system
-#value: "do-nothing"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: allow-node-drain-with-last-healthy-replica
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: mkfs-ext4-parameters
-#  namespace: longhorn-system
-#value: ""
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: disable-replica-rebuild
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: replica-replenishment-wait-interval
-#  namespace: longhorn-system
-#value: "600"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: concurrent-replica-rebuild-per-node-limit
-#  namespace: longhorn-system
-#value: "5"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: disable-revision-counter
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: system-managed-pods-image-pull-policy
-#  namespace: longhorn-system
-#value: "if-not-present"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: allow-volume-creation-with-degraded-availability
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: auto-cleanup-system-generated-snapshot
-#  namespace: longhorn-system
-#value: "true"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: concurrent-automatic-engine-upgrade-per-node-limit
-#  namespace: longhorn-system
-#value: "0"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: backing-image-cleanup-wait-interval
-#  namespace: longhorn-system
-#value: "60"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: backing-image-recovery-wait-interval
-#  namespace: longhorn-system
-#value: "300"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: guaranteed-engine-manager-cpu
-#  namespace: longhorn-system
-#value: "12"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: guaranteed-replica-manager-cpu
-#  namespace: longhorn-system
-#value: "12"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: kubernetes-cluster-autoscaler-enabled
-#  namespace: longhorn-system
-#value: "false"
-#---
-#apiVersion: longhorn.io/v1beta2
-#kind: Setting
-#metadata:
-#  name: orphan-auto-deletion
-#  namespace: longhorn-system
-#value: "false"
-#---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-setting
+  namespace: longhorn-system
+data:
+  default-setting.yaml: |-
+    backup-target:
+    backup-target-credential-secret:
+    allow-recurring-job-while-volume-detached:
+    create-default-disk-labeled-nodes:
+    default-data-path:
+    replica-soft-anti-affinity:
+    replica-auto-balance:
+    storage-over-provisioning-percentage:
+    storage-minimal-available-percentage:
+    upgrade-checker:
+    default-replica-count:
+    default-data-locality:
+    default-longhorn-static-storage-class:
+    backupstore-poll-interval:
+    taint-toleration:
+    system-managed-components-node-selector:
+    priority-class:
+    auto-salvage:
+    auto-delete-pod-when-volume-detached-unexpectedly:
+    disable-scheduling-on-cordoned-node:
+    replica-zone-soft-anti-affinity:
+    node-down-pod-deletion-policy:
+    allow-node-drain-with-last-healthy-replica:
+    mkfs-ext4-parameters:
+    disable-replica-rebuild:
+    replica-replenishment-wait-interval:
+    concurrent-replica-rebuild-per-node-limit:
+    disable-revision-counter:
+    system-managed-pods-image-pull-policy:
+    allow-volume-creation-with-degraded-availability:
+    auto-cleanup-system-generated-snapshot:
+    concurrent-automatic-engine-upgrade-per-node-limit:
+    backing-image-cleanup-wait-interval:
+    backing-image-recovery-wait-interval:
+    guaranteed-engine-manager-cpu:
+    guaranteed-replica-manager-cpu:
+    kubernetes-cluster-autoscaler-enabled:
+    orphan-auto-deletion:

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -54,6 +54,8 @@ spec:
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
+        - name: longhorn-default-setting
+          mountPath: /var/lib/longhorn-setting/
         - name: longhorn-grpc-tls
           mountPath: /tls-files/
         env:
@@ -69,6 +71,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        # Should be: mount path of the volume longhorn-default-setting + the key of the configmap data in 04-default-setting.yaml
+        - name: DEFAULT_SETTING_PATH
+          value: /var/lib/longhorn-setting/default-setting.yaml
       volumes:
       - name: dev
         hostPath:
@@ -79,6 +84,9 @@ spec:
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/
+      - name: longhorn-default-setting
+        configMap:
+          name: longhorn-default-setting
       - name: longhorn-grpc-tls
         secret:
           secretName: longhorn-grpc-tls

--- a/deploy/install/02-components/01-manager.yaml
+++ b/deploy/install/02-components/01-manager.yaml
@@ -74,6 +74,8 @@ spec:
         # Should be: mount path of the volume longhorn-default-setting + the key of the configmap data in 04-default-setting.yaml
         - name: DEFAULT_SETTING_PATH
           value: /var/lib/longhorn-setting/default-setting.yaml
+        - name: DEFAULT_SETTING_CONFIGMAP
+          value: longhorn-default-setting
       volumes:
       - name: dev
         hostPath:

--- a/k8s/pkg/apis/longhorn/v1beta2/setting.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/setting.go
@@ -15,7 +15,8 @@ type Setting struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Value string `json:"value"`
+	ConfigMapResourceVersion string `json:"configMapResourceVersion"`
+	Value                    string `json:"value"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/types/setting.go
+++ b/types/setting.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -12,9 +13,16 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	"github.com/longhorn/longhorn-manager/meta"
 	"github.com/longhorn/longhorn-manager/util"
 )
@@ -149,14 +157,15 @@ const (
 )
 
 type SettingDefinition struct {
-	DisplayName string          `json:"displayName"`
-	Description string          `json:"description"`
-	Category    SettingCategory `json:"category"`
-	Type        SettingType     `json:"type"`
-	Required    bool            `json:"required"`
-	ReadOnly    bool            `json:"readOnly"`
-	Default     string          `json:"default"`
-	Choices     []string        `json:"options,omitempty"` // +optional
+	DisplayName              string          `json:"displayName"`
+	Description              string          `json:"description"`
+	Category                 SettingCategory `json:"category"`
+	Type                     SettingType     `json:"type"`
+	Required                 bool            `json:"required"`
+	ReadOnly                 bool            `json:"readOnly"`
+	Default                  string          `json:"default"`
+	Choices                  []string        `json:"options,omitempty"`                  // +optional
+	ConfigMapResourceVersion string          `json:"configMapResourceVersion,omitempty"` // +optional
 }
 
 var (
@@ -1010,9 +1019,41 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 	return defaultSettings, nil
 }
 
-func OverwriteBuiltInSettingsWithCustomizedValues() error {
+func OverwriteBuiltInSettingsWithCustomizedValues(kubeconfigPath string) error {
 	logrus.Infof("Start overwriting built-in settings with customized values")
+	namespace := os.Getenv(EnvPodNamespace)
+	if namespace == "" {
+		logrus.Warnf("Cannot detect pod namespace, environment variable %v is missing, "+
+			"using default namespace", EnvPodNamespace)
+		namespace = corev1.NamespaceDefault
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to get client config")
+	}
+
+	kubeClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "unable to get k8s client")
+	}
+
+	lhClient, err := lhclientset.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "unable to get clientset")
+	}
+
+	scheme := runtime.NewScheme()
+	if err := longhorn.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return errors.Wrap(err, "unable to create scheme")
+	}
+
 	customizedDefaultSettings, err := GetCustomizedDefaultSettings()
+	if err != nil {
+		return err
+	}
+
+	defaultSettingConfigMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "longhorn-default-setting", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -1023,11 +1064,24 @@ func OverwriteBuiltInSettingsWithCustomizedValues() error {
 			return fmt.Errorf("BUG: setting %v is not defined", sName)
 		}
 
-		value, exists := customizedDefaultSettings[string(sName)]
-		if exists && value != "" {
-			definition.Default = value
-			SettingDefinitions[sName] = definition
+		s, err := lhClient.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(sName), metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		} else {
+			definition.Default = s.Value
 		}
+
+		if err != nil || s.ConfigMapResourceVersion != defaultSettingConfigMap.ResourceVersion {
+			value, exists := customizedDefaultSettings[string(sName)]
+			if exists && value != "" {
+				definition.Default = value
+				definition.ConfigMapResourceVersion = defaultSettingConfigMap.ResourceVersion
+			}
+		}
+
+		SettingDefinitions[sName] = definition
 	}
 
 	return nil

--- a/types/setting.go
+++ b/types/setting.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	EnvDefaultSettingPath = "DEFAULT_SETTING_PATH"
+	EnvDefaultSettingPath      = "DEFAULT_SETTING_PATH"
+	EnvDefaultSettingConfigMap = "DEFAULT_SETTING_CONFIGMAP"
 )
 
 type SettingType string
@@ -1053,7 +1054,12 @@ func OverwriteBuiltInSettingsWithCustomizedValues(kubeconfigPath string) error {
 		return err
 	}
 
-	defaultSettingConfigMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "longhorn-default-setting", metav1.GetOptions{})
+	defaultSettingConfigMapName := os.Getenv(EnvDefaultSettingConfigMap)
+	if defaultSettingConfigMapName == "" {
+		return fmt.Errorf("cannot detect environment variable %v is missing", EnvDefaultSettingConfigMap)
+	}
+
+	defaultSettingConfigMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), defaultSettingConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/types/setting.go
+++ b/types/setting.go
@@ -2,17 +2,25 @@ package types
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	v1 "k8s.io/api/core/v1"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/meta"
 	"github.com/longhorn/longhorn-manager/util"
+)
+
+const (
+	EnvDefaultSettingPath = "DEFAULT_SETTING_PATH"
 )
 
 type SettingType string
@@ -937,6 +945,92 @@ func isValidChoice(choices []string, value string) bool {
 		}
 	}
 	return len(choices) == 0
+}
+
+func GetCustomizedDefaultSettings() (map[string]string, error) {
+	settingPath := os.Getenv(EnvDefaultSettingPath)
+	defaultSettings := map[string]string{}
+	if settingPath != "" {
+		data, err := ioutil.ReadFile(settingPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read default setting file %v: %v", settingPath, err)
+		}
+
+		// `yaml.Unmarshal()` can return a partial result. We shouldn't allow it
+		if err := yaml.Unmarshal(data, &defaultSettings); err != nil {
+			logrus.Errorf("Failed to unmarshal customized default settings from yaml data %v, will give up using them: %v", string(data), err)
+			defaultSettings = map[string]string{}
+		}
+	}
+
+	// won't accept partially valid result
+	for name, value := range defaultSettings {
+		value = strings.Trim(value, " ")
+		definition, exist := SettingDefinitions[SettingName(name)]
+		if !exist {
+			logrus.Errorf("Customized settings are invalid, will give up using them: undefined setting %v", name)
+			defaultSettings = map[string]string{}
+			break
+		}
+		if value == "" {
+			continue
+		}
+		// Make sure the value of boolean setting is always "true" or "false" in Longhorn.
+		// Otherwise the Longhorn UI cannot display the boolean setting correctly.
+		if definition.Type == SettingTypeBool {
+			result, err := strconv.ParseBool(value)
+			if err != nil {
+				logrus.Errorf("Invalid value %v for the boolean setting %v: %v", value, name, err)
+				defaultSettings = map[string]string{}
+				break
+			}
+			value = strconv.FormatBool(result)
+		}
+		if err := ValidateSetting(name, value); err != nil {
+			logrus.Errorf("Customized settings are invalid, will give up using them: the value of customized setting %v is invalid: %v", name, err)
+			defaultSettings = map[string]string{}
+			break
+		}
+		defaultSettings[name] = value
+	}
+
+	guaranteedEngineManagerCPU := SettingDefinitionGuaranteedEngineManagerCPU.Default
+	if defaultSettings[string(SettingNameGuaranteedEngineManagerCPU)] != "" {
+		guaranteedEngineManagerCPU = defaultSettings[string(SettingNameGuaranteedEngineManagerCPU)]
+	}
+	guaranteedReplicaManagerCPU := SettingDefinitionGuaranteedReplicaManagerCPU.Default
+	if defaultSettings[string(SettingNameGuaranteedReplicaManagerCPU)] != "" {
+		guaranteedReplicaManagerCPU = defaultSettings[string(SettingNameGuaranteedReplicaManagerCPU)]
+	}
+	if err := ValidateCPUReservationValues(guaranteedEngineManagerCPU, guaranteedReplicaManagerCPU); err != nil {
+		logrus.Errorf("Customized settings GuaranteedEngineManagerCPU and GuaranteedReplicaManagerCPU are invalid, will give up using them: %v", err)
+		defaultSettings = map[string]string{}
+	}
+
+	return defaultSettings, nil
+}
+
+func OverwriteBuiltInSettingsWithCustomizedValues() error {
+	logrus.Infof("Start overwriting built-in settings with customized values")
+	customizedDefaultSettings, err := GetCustomizedDefaultSettings()
+	if err != nil {
+		return err
+	}
+
+	for _, sName := range SettingNameList {
+		definition, ok := SettingDefinitions[sName]
+		if !ok {
+			return fmt.Errorf("BUG: setting %v is not defined", sName)
+		}
+
+		value, exists := customizedDefaultSettings[string(sName)]
+		if exists && value != "" {
+			definition.Default = value
+			SettingDefinitions[sName] = definition
+		}
+	}
+
+	return nil
 }
 
 func ValidateAndUnmarshalToleration(s string) (*v1.Toleration, error) {


### PR DESCRIPTION
Introduce ConfigMap resourceVersion into Setting
    
Record the resourceVersion of the ConfigMap, longhorn-default-setting,
in the Setting CR if the value is from ConfigMap.
    
During upgrade or longhorn-manager restart, if the resourceVersion of the
ConfigMap is different than the one in the Setting CR, update the Setting CR
using the latest value in the ConfigMap.
    
https://github.com/longhorn/longhorn/issues/2570

Signed-off-by: Derek Su <derek.su@suse.com>