### PR TITLE
Fix bug  `nullable` field is empty in  snapshots.spec.label

### DIFF
--- a/deploy/install/01-prerequisite/03-crd.yaml
+++ b/deploy/install/01-prerequisite/03-crd.yaml
@@ -2625,6 +2625,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: The labels of snapshot
+                nullable: true
                 type: object
               volume:
                 description: the volume that this snapshot belongs to. This field is immutable after creation. Required

--- a/k8s/pkg/apis/longhorn/v1beta2/snapshot.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/snapshot.go
@@ -15,6 +15,7 @@ type SnapshotSpec struct {
 	CreateSnapshot bool `json:"createSnapshot"`
 	// The labels of snapshot
 	// +optional
+	// +nullable
 	Labels map[string]string `json:"labels"`
 }
 


### PR DESCRIPTION
longhorn/longhorn#4022