### PR TITLE
fix a crush bug

### DIFF
--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -727,7 +727,9 @@ func (s *DataStore) GetStorageIPFromPod(pod *corev1.Pod) string {
 		}
 
 		sort.Strings(net.IPs)
-		return net.IPs[0]
+		if net.IPs != nil {
+			return net.IPs[0]
+		}
 	}
 
 	logrus.Warnf("Failed to get storage IP from %v pod, use IP %v", pod.Name, pod.Status.PodIP)


### PR DESCRIPTION
If Longhorn config the Storage Network, and the  cni is use ovs-cni, in the instance-manager pod there is no ip address for the cni net. in this situation net.IPs is nil, and return net.IPs[0] will make a panic, and the longhorn-manager pod will always in the CrashLoopBackOff state, so if we add a check of the net.IPs will solve the problem.
