### PR TITLE
[BACKPORT][v1.2.5] Make sure the VolumeAttachment has gone first before force delete the statefulset/deployment  pod

### DIFF
--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -100,6 +100,7 @@ func uninstall(c *cli.Context) error {
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
@@ -117,7 +118,7 @@ func uninstall(c *cli.Context) error {
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -93,6 +93,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
@@ -113,7 +114,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh chan struct{}, controlle
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/engine_image_controller_test.go
+++ b/controller/engine_image_controller_test.go
@@ -69,6 +69,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
@@ -93,7 +94,7 @@ func newTestEngineImageController(lhInformerFactory lhinformerfactory.SharedInfo
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -463,6 +463,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
@@ -481,7 +482,7 @@ func newTestInstanceHandler(lhInformerFactory lhinformerfactory.SharedInformerFa
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -80,6 +80,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
@@ -98,7 +99,7 @@ func newTestInstanceManagerController(lhInformerFactory lhinformerfactory.Shared
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -8,7 +8,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -213,7 +214,33 @@ func (kc *KubernetesPodController) handlePodDeletionIfNodeDown(pod *v1.Pod, node
 		return nil
 	}
 
-	if pod.DeletionTimestamp == nil || pod.DeletionTimestamp.After(time.Now()) {
+	if pod.DeletionTimestamp == nil {
+		return nil
+	}
+
+	// make sure the volumeattachments of the pods are gone first
+	// ref: https://github.com/longhorn/longhorn/issues/2947
+	vas, err := kc.getVolumeAttachmentsOfPod(pod)
+	if err != nil {
+		return err
+	}
+	for _, va := range vas {
+		if va.DeletionTimestamp == nil {
+			err := kc.kubeClient.StorageV1().VolumeAttachments().Delete(context.TODO(), va.Name, metav1.DeleteOptions{})
+			if err != nil {
+				if datastore.ErrorIsNotFound(err) {
+					continue
+				}
+				return err
+			}
+			kc.logger.Infof("%v: deleted volume attachment %v for pod %v on downed node %v", controllerAgentName, va.Name, pod.Name, nodeID)
+		}
+		// wait the volumeattachment object to be deleted
+		kc.logger.Infof("%v: wait for volume attachment %v for pod %v on downed node %v to be deleted", controllerAgentName, va.Name, pod.Name, nodeID)
+		return nil
+	}
+
+	if pod.DeletionTimestamp.After(time.Now()) {
 		return nil
 	}
 
@@ -227,6 +254,46 @@ func (kc *KubernetesPodController) handlePodDeletionIfNodeDown(pod *v1.Pod, node
 	kc.logger.Infof("%v: Forcefully deleted pod %v on downed node %v", controllerAgentName, pod.Name, nodeID)
 
 	return nil
+}
+
+func (kc *KubernetesPodController) getVolumeAttachmentsOfPod(pod *v1.Pod) ([]*storagev1.VolumeAttachment, error) {
+	res := []*storagev1.VolumeAttachment{}
+	vas, err := kc.ds.ListVolumeAttachmentsRO()
+	if err != nil {
+		return nil, err
+	}
+
+	pvs := make(map[string]bool)
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.VolumeSource.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc, err := kc.ds.GetPersistentVolumeClaimRO(pod.Namespace, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		if err != nil {
+			if datastore.ErrorIsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		pvs[pvc.Spec.VolumeName] = true
+	}
+
+	for _, va := range vas {
+		if va.Spec.Attacher != types.LonghornDriverName {
+			continue
+		}
+		if va.Spec.Source.PersistentVolumeName == nil {
+			continue
+		}
+		if _, ok := pvs[*va.Spec.Source.PersistentVolumeName]; !ok {
+			continue
+		}
+		res = append(res, va)
+	}
+
+	return res, nil
 }
 
 // handlePodDeletionIfVolumeRequestRemount will delete the pod which is using a volume that has requested remount.

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -182,6 +182,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
@@ -203,7 +204,7 @@ func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInf
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -72,6 +72,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	priorityClassInformer := kubeInformerFactory.Scheduling().V1().PriorityClasses()
@@ -89,7 +90,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -86,6 +86,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
@@ -104,7 +105,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -76,6 +76,8 @@ type DataStore struct {
 	pvStoreSynced      cache.InformerSynced
 	pvcLister          corelisters.PersistentVolumeClaimLister
 	pvcStoreSynced     cache.InformerSynced
+	vaLister           storagelisters_v1.VolumeAttachmentLister
+	vaStoreSynced      cache.InformerSynced
 	cfmLister          corelisters.ConfigMapLister
 	cfmStoreSynced     cache.InformerSynced
 	secretLister       corelisters.SecretLister
@@ -119,6 +121,7 @@ func NewDataStore(
 	deploymentInformer appsinformers.DeploymentInformer,
 	persistentVolumeInformer coreinformers.PersistentVolumeInformer,
 	persistentVolumeClaimInformer coreinformers.PersistentVolumeClaimInformer,
+	volumeAttachmentInformer storageinformers_v1.VolumeAttachmentInformer,
 	configMapInformer coreinformers.ConfigMapInformer,
 	secretInformer coreinformers.SecretInformer,
 	kubeNodeInformer coreinformers.NodeInformer,
@@ -130,7 +133,6 @@ func NewDataStore(
 
 	kubeClient clientset.Interface,
 	namespace string) *DataStore {
-
 	return &DataStore{
 		namespace: namespace,
 
@@ -179,6 +181,8 @@ func NewDataStore(
 		pvStoreSynced:      persistentVolumeInformer.Informer().HasSynced,
 		pvcLister:          persistentVolumeClaimInformer.Lister(),
 		pvcStoreSynced:     persistentVolumeClaimInformer.Informer().HasSynced,
+		vaLister:           volumeAttachmentInformer.Lister(),
+		vaStoreSynced:      volumeAttachmentInformer.Informer().HasSynced,
 		cfmLister:          configMapInformer.Lister(),
 		cfmStoreSynced:     configMapInformer.Informer().HasSynced,
 		secretLister:       secretInformer.Lister(),
@@ -210,6 +214,7 @@ func (s *DataStore) Sync(stopCh <-chan struct{}) bool {
 		s.pdbStoreSynced, s.smStoreSynced, s.svStoreSynced,
 		s.biStoreSynced, s.bimStoreSynced, s.bidsStoreSynced,
 		s.btStoreSynced, s.bvStoreSynced, s.bStoreSynced,
+		s.vaStoreSynced,
 	)
 }
 

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -487,6 +487,13 @@ func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1
 	return resultRO.DeepCopy(), nil
 }
 
+// ListVolumeAttachmentsRO gets a list of volumeattachments
+// This function returns direct reference to the internal cache object and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) ListVolumeAttachmentsRO() ([]*storagev1.VolumeAttachment, error) {
+	return s.vaLister.List(labels.Everything())
+}
+
 // GetConfigMapRO gets ConfigMap with the given name in s.namespace
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -79,6 +79,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	persistentVolumeInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
@@ -97,7 +98,7 @@ func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFacto
 		recurringJobInformer,
 		lhClient,
 		podInformer, cronJobInformer, daemonSetInformer,
-		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer,
+		deploymentInformer, persistentVolumeInformer, persistentVolumeClaimInformer, volumeAttachmentInformer,
 		configMapInformer, secretInformer, kubeNodeInformer, priorityClassInformer,
 		csiDriverInformer, storageclassInformer,
 		pdbInformer,


### PR DESCRIPTION
This fix prevents the pod from hitting the backoff period with error
Multi-Attach error. Thus, speeding up the recovery time when a node
is turned off

longhorn/longhorn#4224
