### PR TITLE
[BACKPORT][v1.3.1] Make sure the VolumeAttachment has gone first before force delete the statefulset/deployment  pod

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -195,7 +196,33 @@ func (kc *KubernetesPodController) handlePodDeletionIfNodeDown(pod *v1.Pod, node
 		return nil
 	}
 
-	if pod.DeletionTimestamp == nil || pod.DeletionTimestamp.After(time.Now()) {
+	if pod.DeletionTimestamp == nil {
+		return nil
+	}
+
+	// make sure the volumeattachments of the pods are gone first
+	// ref: https://github.com/longhorn/longhorn/issues/2947
+	vas, err := kc.getVolumeAttachmentsOfPod(pod)
+	if err != nil {
+		return err
+	}
+	for _, va := range vas {
+		if va.DeletionTimestamp == nil {
+			err := kc.kubeClient.StorageV1().VolumeAttachments().Delete(context.TODO(), va.Name, metav1.DeleteOptions{})
+			if err != nil {
+				if datastore.ErrorIsNotFound(err) {
+					continue
+				}
+				return err
+			}
+			kc.logger.Infof("%v: deleted volume attachment %v for pod %v on downed node %v", controllerAgentName, va.Name, pod.Name, nodeID)
+		}
+		// wait the volumeattachment object to be deleted
+		kc.logger.Infof("%v: wait for volume attachment %v for pod %v on downed node %v to be deleted", controllerAgentName, va.Name, pod.Name, nodeID)
+		return nil
+	}
+
+	if pod.DeletionTimestamp.After(time.Now()) {
 		return nil
 	}
 
@@ -209,6 +236,46 @@ func (kc *KubernetesPodController) handlePodDeletionIfNodeDown(pod *v1.Pod, node
 	kc.logger.Infof("%v: Forcefully deleted pod %v on downed node %v", controllerAgentName, pod.Name, nodeID)
 
 	return nil
+}
+
+func (kc *KubernetesPodController) getVolumeAttachmentsOfPod(pod *v1.Pod) ([]*storagev1.VolumeAttachment, error) {
+	res := []*storagev1.VolumeAttachment{}
+	vas, err := kc.ds.ListVolumeAttachmentsRO()
+	if err != nil {
+		return nil, err
+	}
+
+	pvs := make(map[string]bool)
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.VolumeSource.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc, err := kc.ds.GetPersistentVolumeClaimRO(pod.Namespace, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		if err != nil {
+			if datastore.ErrorIsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		pvs[pvc.Spec.VolumeName] = true
+	}
+
+	for _, va := range vas {
+		if va.Spec.Attacher != types.LonghornDriverName {
+			continue
+		}
+		if va.Spec.Source.PersistentVolumeName == nil {
+			continue
+		}
+		if _, ok := pvs[*va.Spec.Source.PersistentVolumeName]; !ok {
+			continue
+		}
+		res = append(res, va)
+	}
+
+	return res, nil
 }
 
 // handlePodDeletionIfVolumeRequestRemount will delete the pod which is using a volume that has requested remount.

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -77,6 +77,8 @@ type DataStore struct {
 	PersistentVolumeInformer      cache.SharedInformer
 	pvcLister                     corelisters.PersistentVolumeClaimLister
 	PersistentVolumeClaimInformer cache.SharedInformer
+	vaLister                      storagelisters_v1.VolumeAttachmentLister
+	VolumeAttachmentInformer      cache.SharedInformer
 	cfmLister                     corelisters.ConfigMapLister
 	ConfigMapInformer             cache.SharedInformer
 	secretLister                  corelisters.SecretLister
@@ -148,6 +150,8 @@ func NewDataStore(
 	cacheSyncs = append(cacheSyncs, persistentVolumeInformer.Informer().HasSynced)
 	persistentVolumeClaimInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	cacheSyncs = append(cacheSyncs, persistentVolumeClaimInformer.Informer().HasSynced)
+	volumeAttachmentInformer := kubeInformerFactory.Storage().V1().VolumeAttachments()
+	cacheSyncs = append(cacheSyncs, volumeAttachmentInformer.Informer().HasSynced)
 	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	cacheSyncs = append(cacheSyncs, configMapInformer.Informer().HasSynced)
 	secretInformer := kubeInformerFactory.Core().V1().Secrets()
@@ -223,6 +227,8 @@ func NewDataStore(
 		PersistentVolumeInformer:      persistentVolumeInformer.Informer(),
 		pvcLister:                     persistentVolumeClaimInformer.Lister(),
 		PersistentVolumeClaimInformer: persistentVolumeClaimInformer.Informer(),
+		vaLister:                      volumeAttachmentInformer.Lister(),
+		VolumeAttachmentInformer:      volumeAttachmentInformer.Informer(),
 		cfmLister:                     configMapInformer.Lister(),
 		ConfigMapInformer:             configMapInformer.Informer(),
 		secretLister:                  secretInformer.Lister(),

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -509,6 +509,13 @@ func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1
 	return resultRO.DeepCopy(), nil
 }
 
+// ListVolumeAttachmentsRO gets a list of volumeattachments
+// This function returns direct reference to the internal cache object and should not be mutated.
+// Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
+func (s *DataStore) ListVolumeAttachmentsRO() ([]*storagev1.VolumeAttachment, error) {
+	return s.vaLister.List(labels.Everything())
+}
+
 // GetConfigMapRO gets ConfigMap with the given name in s.namespace
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies


### PR DESCRIPTION
This fix prevents the pod from hitting the backoff period with error
Multi-Attach error. Thus, speeding up the recovery time when a node
is turned off

longhorn/longhorn#4225
