### PR TITLE
upgrade: autofill replica storage IP

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -34,6 +34,7 @@ import (
 	"github.com/longhorn/longhorn-manager/upgrade/v111to120"
 	"github.com/longhorn/longhorn-manager/upgrade/v120to121"
 	"github.com/longhorn/longhorn-manager/upgrade/v122to123"
+	"github.com/longhorn/longhorn-manager/upgrade/v12xto130"
 	"github.com/longhorn/longhorn-manager/upgrade/v1beta1"
 )
 
@@ -281,6 +282,12 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.2.3") < 0 {
 		logrus.Debugf("Walking through the upgrade path v1.2.2 to v1.2.3")
 		if err := v122to123.UpgradeResources(namespace, lhClient); err != nil {
+			return err
+		}
+	}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.3.0") < 0 {
+		logrus.Debugf("Walking through the upgrade path v1.2.x to v1.3.0")
+		if err := v12xto130.UpgradeResources(namespace, lhClient, kubeClient); err != nil {
 			return err
 		}
 	}

--- a/upgrade/v12xto130/upgrade.go
+++ b/upgrade/v12xto130/upgrade.go
@@ -1,0 +1,59 @@
+package v12xto130
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.2.x to v1.3.0: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset) error {
+	if err := upgradeReplicas(namespace, lhClient); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade replica failed")
+	}()
+
+	replicas, err := lhClient.LonghornV1beta2().Replicas(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn replicas during the replica upgrade")
+	}
+
+	for _, r := range replicas.Items {
+		if r.Status.IP == "" {
+			continue
+		}
+
+		if r.Status.StorageIP != "" {
+			continue
+		}
+
+		r.Status.StorageIP = r.Status.IP
+		_, err = lhClient.LonghornV1beta2().Replicas(namespace).Update(context.TODO(), &r, metav1.UpdateOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to update %v storage IP", r.Name)
+		}
+
+		logrus.Debugf(upgradeLogPrefix+"Updated %v storage IP to %v", r.Name, r.Status.StorageIP)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When unexpectedly removed a node during an upgrade from v1.2.x to v1.3.0. There are chances of not reaching replica storage IP assignment. In this case, other controllers will get blocked by the `checkReplica` during the ownership change.

https://github.com/longhorn/longhorn/issues/4213#issuecomment-1184955056