### PR TITLE
Allow update node resources if kubernetes node is already gone

### DIFF
--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -85,27 +85,33 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 	if newNode.Spec.EngineManagerCPURequest != 0 || newNode.Spec.ReplicaManagerCPURequest != 0 {
 		kubeNode, err := n.ds.GetKubernetesNode(oldNode.Name)
 		if err != nil {
-			return werror.NewInvalidError(err.Error(), "")
+			if !datastore.ErrorIsNotFound(err) {
+				return werror.NewInvalidError(err.Error(), "")
+			}
+			logrus.Warnf("Kubernetes node %v has been deleted", oldNode.Name)
 		}
-		allocatableCPU := float64(kubeNode.Status.Allocatable.Cpu().MilliValue())
-		engineManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedEngineManagerCPU)
-		if err != nil {
-			return werror.NewInvalidError(err.Error(), "")
-		}
-		engineManagerCPUInPercentage := engineManagerCPUSetting.Value
-		if newNode.Spec.EngineManagerCPURequest > 0 {
-			engineManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.EngineManagerCPURequest)/allocatableCPU*100.0))
-		}
-		replicaManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedReplicaManagerCPU)
-		if err != nil {
-			return werror.NewInvalidError(err.Error(), "")
-		}
-		replicaManagerCPUInPercentage := replicaManagerCPUSetting.Value
-		if newNode.Spec.ReplicaManagerCPURequest > 0 {
-			replicaManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.ReplicaManagerCPURequest)/allocatableCPU*100.0))
-		}
-		if err := types.ValidateCPUReservationValues(engineManagerCPUInPercentage, replicaManagerCPUInPercentage); err != nil {
-			return werror.NewInvalidError(err.Error(), "")
+
+		if err == nil {
+			allocatableCPU := float64(kubeNode.Status.Allocatable.Cpu().MilliValue())
+			engineManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedEngineManagerCPU)
+			if err != nil {
+				return werror.NewInvalidError(err.Error(), "")
+			}
+			engineManagerCPUInPercentage := engineManagerCPUSetting.Value
+			if newNode.Spec.EngineManagerCPURequest > 0 {
+				engineManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.EngineManagerCPURequest)/allocatableCPU*100.0))
+			}
+			replicaManagerCPUSetting, err := n.ds.GetSetting(types.SettingNameGuaranteedReplicaManagerCPU)
+			if err != nil {
+				return werror.NewInvalidError(err.Error(), "")
+			}
+			replicaManagerCPUInPercentage := replicaManagerCPUSetting.Value
+			if newNode.Spec.ReplicaManagerCPURequest > 0 {
+				replicaManagerCPUInPercentage = fmt.Sprintf("%.0f", math.Round(float64(newNode.Spec.ReplicaManagerCPURequest)/allocatableCPU*100.0))
+			}
+			if err := types.ValidateCPUReservationValues(engineManagerCPUInPercentage, replicaManagerCPUInPercentage); err != nil {
+				return werror.NewInvalidError(err.Error(), "")
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, if the kubernetes node is gone, the node validating webhook did
not allow the modification of the node resource. It hindered the remove of the
finalizers and resulted in the deletion failure of the node resource.

https://github.com/longhorn/longhorn/issues/4245
https://github.com/longhorn/longhorn/issues/4213

Signed-off-by: Derek Su <derek.su@suse.com>