### PR TITLE
datasource: Stop using cascading deletion for backing image manager

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1635,8 +1635,7 @@ func (s *DataStore) UpdateBackingImageManagerStatus(backingImageManager *longhor
 // DeleteBackingImageManager won't result in immediately deletion since finalizer was
 // set by default
 func (s *DataStore) DeleteBackingImageManager(name string) error {
-	propagation := metav1.DeletePropagationForeground
-	return s.lhClient.LonghornV1beta2().BackingImageManagers(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+	return s.lhClient.LonghornV1beta2().BackingImageManagers(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
 // RemoveFinalizerForBackingImageManager will result in deletion if DeletionTimestamp was set


### PR DESCRIPTION
The cascading deletion of the backing image manager would lead to
the pod being deleted before the file cleanup complete.
In other words, the pod should be deleted manually by the
controller after the file cleanup complete.

Longhorn/longhorn#4308