### PR TITLE
[Backport][v1.2.x] datasource: Stop using cascading deletion for backing image manager

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1601,8 +1601,7 @@ func (s *DataStore) UpdateBackingImageManagerStatus(backingImageManager *longhor
 // DeleteBackingImageManager won't result in immediately deletion since finalizer was
 // set by default
 func (s *DataStore) DeleteBackingImageManager(name string) error {
-	propagation := metav1.DeletePropagationForeground
-	return s.lhClient.LonghornV1beta1().BackingImageManagers(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+	return s.lhClient.LonghornV1beta1().BackingImageManagers(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
 // RemoveFinalizerForBackingImageManager will result in deletion if DeletionTimestamp was set


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/4308
https://github.com/longhorn/longhorn/issues/4344