### PR TITLE
Fix don't set volume to faulted if it is attaching the first time and one of the replica failed during attaching process

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -701,6 +701,33 @@ func (vc *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es m
 	return nil
 }
 
+func isAutoSalvageNeeded(rs map[string]*longhorn.Replica) bool {
+	if isFirstAttachment(rs) {
+		return areAllReplicasFailed(rs)
+	}
+	return getHealthyAndActiveReplicaCount(rs) == 0 && getFailedReplicaCount(rs) > 0
+}
+
+func areAllReplicasFailed(rs map[string]*longhorn.Replica) bool {
+	for _, r := range rs {
+		if r.Spec.FailedAt == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// isFirstAttachment returns true if this is the first time the volume is attached.
+// I.e., all replicas have empty Spec.HealthyAt
+func isFirstAttachment(rs map[string]*longhorn.Replica) bool {
+	for _, r := range rs {
+		if r.Spec.HealthyAt != "" {
+			return false
+		}
+	}
+	return true
+}
+
 func getHealthyAndActiveReplicaCount(rs map[string]*longhorn.Replica) int {
 	count := 0
 	for _, r := range rs {
@@ -1196,8 +1223,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 		e.Spec.SalvageRequested = false
 	}
 
-	isAutoSalvageNeeded := getHealthyAndActiveReplicaCount(rs) == 0 && getFailedReplicaCount(rs) > 0
-	if isAutoSalvageNeeded {
+	if isAutoSalvageNeeded(rs) {
 		v.Status.Robustness = longhorn.VolumeRobustnessFaulted
 		v.Status.CurrentNodeID = ""
 


### PR DESCRIPTION
In this case, there are still other replicas that can be started
so we don't set the volume to faulted here

longhorn/longhorn#4386
