### PR TITLE
[Backport][v1.2.x] Failed backups cleanup

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -268,6 +268,11 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 				// to update it's BackupVolume CR status
 			}
 		}
+
+		if backup.Status.State == longhorn.BackupStateError || backup.Status.State == longhorn.BackupStateUnknown {
+			bc.eventRecorder.Eventf(backup, corev1.EventTypeWarning, string(backup.Status.State), "Failed backup %s has been deleted: %s", backup.Name, backup.Status.Error)
+		}
+
 		return bc.ds.RemoveFinalizerForBackup(backup)
 	}
 

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -41,3 +41,4 @@ data:
     #backing-image-recovery-wait-interval:
     #guaranteed-engine-manager-cpu:
     #guaranteed-replica-manager-cpu:
+    #failed-backup-ttl:


### PR DESCRIPTION
Clean up failed backups when there is a backup in state `Error` or `Unknown`.

longhorn/longhorn#4456

Signed-off-by: James Lu <james.lu@suse.com>