### PR TITLE
[Backport][v1.3.x]Failed backups cleanup

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -299,6 +299,10 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		// Disable monitor regardless of backup state
 		bc.disableBackupMonitor(backup.Name)
 
+		if backup.Status.State == longhorn.BackupStateError || backup.Status.State == longhorn.BackupStateUnknown {
+			bc.eventRecorder.Eventf(backup, corev1.EventTypeWarning, string(backup.Status.State), "Failed backup %s has been deleted: %s", backup.Name, backup.Status.Error)
+		}
+
 		return bc.ds.RemoveFinalizerForBackup(backup)
 	}
 

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -284,11 +284,24 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		return err
 	}
 
+	// Get `Time to live` after failed backup was marked as `Error` or `Unknown`,
+	failedBackupTTL, err := bvc.ds.GetSettingAsInt(types.SettingNameFailedBackupTTL)
+	if err != nil {
+		log.WithError(err).Warnf("Failed to get %v setting, and it will skip the auto-deletion for the failed backups", types.SettingNameFailedBackupTTL)
+	}
 	clustersSet := sets.NewString()
 	for _, b := range clusterBackups {
 		// Skip the Backup CR which is created from the local cluster and
 		// the snapshot backup hasn't be completed or pulled from the remote backup target yet
 		if b.Spec.SnapshotName != "" && b.Status.State != longhorn.BackupStateCompleted {
+			if b.Status.State == longhorn.BackupStateError || b.Status.State == longhorn.BackupStateUnknown {
+				// Failed backup `LastSyncedAt` should not be updated after it was marked as `Error` or `Unknown`
+				if failedBackupTTL > 0 && time.Now().After(b.Status.LastSyncedAt.Add(time.Duration(failedBackupTTL)*time.Minute)) {
+					if err = bvc.ds.DeleteBackup(b.Name); err != nil {
+						log.WithError(err).Errorf("failed to delete failed backup %s", b.Name)
+					}
+				}
+			}
 			continue
 		}
 		clustersSet.Insert(b.Name)

--- a/deploy/install/01-prerequisite/04-default-setting.yaml
+++ b/deploy/install/01-prerequisite/04-default-setting.yaml
@@ -44,3 +44,4 @@ data:
     #kubernetes-cluster-autoscaler-enabled:
     #orphan-auto-deletion:
     #storage-network:
+    #failed-backup-ttl:


### PR DESCRIPTION
Clean up failed backups when there is a backup in state `Error` or `Unknown`.

longhorn/longhorn#4455

Signed-off-by: James Lu <james.lu@suse.com>