### PR TITLE
Save the access mode when creating backup, for restoring from the backup

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -102,6 +102,7 @@ const (
 	LonghornLabelOrphan                   = "orphan"
 	LonghornLabelOrphanType               = "orphan-type"
 	LonghornLabelCRDAPIVersion            = "crd-api-version"
+	LonghornLabelVolumeAccessMode         = "volume-access-mode"
 
 	LonghornLabelValueEnabled = "enabled"
 


### PR DESCRIPTION
[Issue #3444](https://github.com/longhorn/longhorn/issues/3444)
Signed-off-by: Ray Chang <ray.chang@suse.com>
## Enhancement
  1. When create backup, save the access mode into backup label
  2. When restore backup, if the access mode is empty then use the backup label to create new volume.

## Self-testing
  1. Create two volumes: ReadWriteOnce (RWO) * 1 + ReadWriteMany (RWX) * 1, and both are attached to one node.
      ![image](https1. Create two volumes: ReadWriteOnce (RWO) * 1 + ReadWriteMany (RWX) * 1, and both are attached to one node.
      ![image](https://user-images.githubusercontent.com/17548901/187202524-568df547-f571-46d7-be32-3a58ed8dc32f.png)
  3. Create backups for each volumes.
      ![image](https://user-images.githubusercontent.com/17548901/187203270-4d3191b6-5c9f-460e-9900-0add8c5c7313.png)
  4. Wait all backups are complete, then delete all volumes.
  5. Switch to `Backup' page, and click the backup name and the tags filed. 
  6. **CHECK: The `LonghornVolumeAccessMode` of backup labels should be equal as the access mode.**
      ![image](https://user-images.githubusercontent.com/17548901/188392781-357d5a30-0fca-4f0a-91dc-3c68f24721be.png)
  7. Select all backups and click `Restore Latest Backup` button
      ![Screenshot from 2022-08-29 20-53-17](https://user-images.githubusercontent.com/17548901/187205628-bba8336a-f2bf-4ed3-8f06-f0f588f46020.png)
  8. DON'T fill in any filed and click `OK` button.
  9. Switch back to `Volume` page and click the name filed.
  10. CHECK: The access mode should be same as the volume's backup.
       - ReadWriteOnece
         ![image](https://user-images.githubusercontent.com/17548901/187209956-88d7ef4f-b140-4538-9fdf-c8e0d34ae83f.png)
       - ReadWriteMany
          ![image](https://user-images.githubusercontent.com/17548901/187210220-52f867a7-eaf3-4b26-8e41-c9110f5ae9e7.png)://user-images.githubusercontent.com/17548901/187202524-568df547-f571-46d7-be32-3a58ed8dc32f.png)
  3. Create backups for each volumes.
      ![image](https://user-images.githubusercontent.com/17548901/187203270-4d3191b6-5c9f-460e-9900-0add8c5c7313.png)
  4. Wait all backups are complete, then delete all volumes.
  5. Switch to `Backup' page, and click the backup name and the tags filed. 
  6. **CHECK: The `LonghornVolumeAccessMode` of backup labels should be equal as the access mode.**
      ![image](https://user-images.githubusercontent.com/17548901/188393449-25616016-4fbe-4349-bdae-69a5cb185923.png)
  8. Select all backups and click `Restore Latest Backup` button
      ![Screenshot from 2022-08-29 20-53-17](https://user-images.githubusercontent.com/17548901/187205628-bba8336a-f2bf-4ed3-8f06-f0f588f46020.png)
  9. DON'T fill in any filed and click `OK` button.
  10. Switch back to `Volume` page and click the name filed.
  11. CHECK: The access mode should be same as the volume's backup.
       - ReadWriteOnece
         ![image](https://user-images.githubusercontent.com/17548901/187209956-88d7ef4f-b140-4538-9fdf-c8e0d34ae83f.png)      
       - ReadWriteMany
          ![image](https://user-images.githubusercontent.com/17548901/187210220-52f867a7-eaf3-4b26-8e41-c9110f5ae9e7.png)

