### PR TITLE
[BACKPORT][v1.2.x] fix(replica-schedule): unused replica failed.

### DIFF
--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -52,6 +52,12 @@ func (rcs *ReplicaScheduler) ScheduleReplica(replica *longhorn.Replica, replicas
 		return nil, nil, fmt.Errorf("BUG: Replica %v has been scheduled to node %v", replica.Name, replica.Spec.NodeID)
 	}
 
+	// not to schedule a replica failed and unused before.
+	if replica.Spec.HealthyAt == "" && replica.Spec.FailedAt != "" {
+		logrus.WithField("replica", replica.Name).Warn("Failed replica is not scheduled")
+		return nil, nil, nil
+	}
+
 	// get all hosts
 	nodesInfo, err := rcs.getNodeInfo()
 	if err != nil {


### PR DESCRIPTION
Not to schedule unused replicas that marked as failed when the node with engine and instance-manager rebooted.

longhorn/longhorn#4696

Signed-off-by: James Lu <james.lu@suse.com>