### PR TITLE
fix(replica-auto-balance): data locality rebuild loop

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -866,11 +866,17 @@ func (vc *VolumeController) cleanupExtraHealthyReplicas(v *longhorn.Volume, e *l
 		return err
 	}
 
-	if cleaned, err = vc.cleanupAutoBalancedReplicas(v, e, rs); err != nil || cleaned {
+	if cleaned, err = vc.cleanupDataLocalityReplicas(v, e, rs); err != nil || cleaned {
 		return err
 	}
 
-	if cleaned, err = vc.cleanupDataLocalityReplicas(v, e, rs); err != nil || cleaned {
+	// Auto-balanced replicas get cleaned based on the sorted order. Hence,
+	// cleaning up for data locality replica needs to go first. Or else, a
+	// new replica could have a name alphabetically smaller than all the
+	// existing replicas. And this causes a rebuilding loop if this new
+	// replica is for data locality.
+	// Ref: https://github.com/longhorn/longhorn/issues/4761
+	if cleaned, err = vc.cleanupAutoBalancedReplicas(v, e, rs); err != nil || cleaned {
 		return err
 	}
 


### PR DESCRIPTION
The rebuild loop happens when the data locality is trying to rebuild a new replica, and it got cleaned up by the auto-balance because of the sorted order.

Exchanging the order will let the data locality clean up its own redundant replica first.

https://github.com/longhorn/longhorn/issues/4761