### PR TITLE
[BACKPORT][v1.2.6] Relieve the constraints of cleanupFailedToScheduledReplicas()

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -829,7 +829,7 @@ func (vc *VolumeController) cleanupFailedToScheduledReplicas(v *longhorn.Volume,
 	if healthyCount >= v.Spec.NumberOfReplicas {
 		for _, r := range rs {
 			if !hasEvictionRequestedReplicas {
-				if r.Spec.HealthyAt == "" && r.Spec.FailedAt == "" && r.Spec.NodeID == "" &&
+				if r.Spec.HealthyAt == "" && r.Spec.NodeID == "" &&
 					(isDataLocalityDisabled(v) || r.Spec.HardNodeAffinity != v.Status.CurrentNodeID) {
 					logrus.Infof("Cleaning up failed to scheduled replica %v", r.Name)
 					if err := vc.deleteReplica(r, rs); err != nil {


### PR DESCRIPTION
In the test case https://github.com/longhorn/longhorn/issues/3220#issuecomment-1149558769, a replica cannot be scheduled to a node, but it's spec.failedAt is set in https://github.com/longhorn/longhorn-manager/blob/master/controller/volume_controller.go#L1317. The strict constraints of cleanupFailedToScheduledReplicas() results in that the failed replica cannot be cleanup up.

https://github.com/longhorn/longhorn/issues/3220
https://github.com/longhorn/longhorn/issues/4732

Signed-off-by: Derek Su <derek.su@suse.com>
(cherry picked from commit fedb7eb0303bbc509b995916b3f5460e519c4e2b)