### PR TITLE
fix: Custom default settings and values ​​will not be updated if they exist

### DIFF
--- a/controller/kubernetes_configmap_controller.go
+++ b/controller/kubernetes_configmap_controller.go
@@ -68,11 +68,12 @@ func NewKubernetesConfigMapController(
 		eventRecorder: eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "longhorn-kubernetes-configmap-controller"}),
 	}
 
-	ds.ConfigMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    kc.enqueueConfigMapChange,
-		UpdateFunc: func(old, cur interface{}) { kc.enqueueConfigMapChange(cur) },
-		DeleteFunc: kc.enqueueConfigMapChange,
-	})
+	ds.ConfigMapInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    kc.enqueueConfigMapChange,
+			UpdateFunc: func(old, cur interface{}) { kc.enqueueConfigMapChange(cur) },
+			DeleteFunc: kc.enqueueConfigMapChange,
+		}, 0)
 
 	ds.StorageClassInformer.AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{


### PR DESCRIPTION
[Longhorn 4554](https://github.com/longhorn/longhorn/issues/4554)

Singed-off-by: Ray Chang <ray.chang@suse.com>

### task items
 1. Customized default settings won't be update if setting and value exist
 2. Change the Customized default settings error message to warn instead, because it's not thrown out but just recognized 
 3. Disable ConfigMap re-synchronize periodically

### self test
Step 1. Install Longhorn, e.g, via Helm
 - 1.1 Clone Helm chart to local
 - 1.2 Add tolerance value in `values.yaml` like below:
    ```yaml
    defaultSettings:
      taintToleration: "kubevirt.io/drain:NoSchedule"
    longhornManager:
      tolerations:
      - key: "kubevirt.io/drain"
        operator: "Equal"
        value: ""
        effect: "NoSchedule"
    longhornDriver:
      tolerations:
      - key: "kubevirt.io/drain"
        operator: "Equal"
        value: ""
        effect: "NoSchedule"
    longhornUI:
      tolerations:
      - key: "kubevirt.io/drain"
        operator: "Equal"
        value: ""
        effect: "NoSchedule"
     ```
 - 1.3 Start the installation: `helm install longhorn . --namespace longhorn-system --create-space`

Step 2. Check if the setting was applied success
   - setting CR: `kubectl get settings.longhorn.io taint-toleration -n longhorn-system`
   - Instance-manager: `kubectl get pod instance-manager-r-047a4c1a -n longhorn-system -o yaml` -> `spec/tolerations`

Step 3. Create a volume and attach to a node

Step 4. Validate `Item 2`
   1. type `kubectl logs longhorn-manager-wzxt6 -n longhorn-system | grep "invalid customized default setting "`
   2. The output reveals warning message like below:  
    ![image](https://user-images.githubusercontent.com/17548901/197694966-039c5103-08f7-4280-8e3b-040e1a769433.png)

Step 5. Detach all volumes

Step 6. Update the tolerations value
   - Export current value: `kubectl get cm longhorn-default-setting -n longhorn-system -o yaml > default-setting-cm.yaml`
   - Modify the value and apply it: `kubectl apply -f default-setting-cm.yaml`

Step 7. Validate `Item 1` and `Item 3`
   - type `kubectl logs longhorn-manager-wzxt6 -n longhorn-system | grep "invalid customized default setting "`
   - check the message doesn't keep appearing every 30 seconds