### PR TITLE
Allow customization of the cipher

### DIFF
--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -10,7 +10,53 @@ import (
 
 const (
 	mapperFilePathPrefix = "/dev/mapper"
+
+	CryptoKeyDefaultCipher = "aes-xts-plain64"
+	CryptoKeyDefaultHash   = "sha256"
+	CryptoKeyDefaultSize   = "256"
+	CryptoDefaultPBKDF     = "argon2i"
 )
+
+// EncryptParams keeps the customized cipher options from the secret CR
+type EncryptParams struct {
+	KeyProvider string
+	KeyCipher   string
+	KeyHash     string
+	KeySize     string
+	PBKDF       string
+}
+
+func NewEncryptParams(keyProvider, keyCipher, keyHash, keySize, pbkdf string) *EncryptParams {
+	return &EncryptParams{KeyProvider: keyProvider, KeyCipher: keyCipher, KeyHash: keyHash, KeySize: keySize, PBKDF: pbkdf}
+}
+
+func (cp *EncryptParams) GetKeyCipher() string {
+	if cp.KeyCipher == "" {
+		return CryptoKeyDefaultCipher
+	}
+	return cp.KeyCipher
+}
+
+func (cp *EncryptParams) GetKeyHash() string {
+	if cp.KeyHash == "" {
+		return CryptoKeyDefaultHash
+	}
+	return cp.KeyHash
+}
+
+func (cp *EncryptParams) GetKeySize() string {
+	if cp.KeySize == "" {
+		return CryptoKeyDefaultSize
+	}
+	return cp.KeySize
+}
+
+func (cp *EncryptParams) GetPBKDF() string {
+	if cp.PBKDF == "" {
+		return CryptoDefaultPBKDF
+	}
+	return cp.PBKDF
+}
 
 // VolumeMapper returns the path for mapped encrypted device.
 func VolumeMapper(volume string) string {
@@ -18,9 +64,9 @@ func VolumeMapper(volume string) string {
 }
 
 // EncryptVolume encrypts provided device with LUKS.
-func EncryptVolume(devicePath, passphrase string) error {
+func EncryptVolume(devicePath, passphrase string, cryptoParams *EncryptParams) error {
 	logrus.Debugf("Encrypting device %s with LUKS", devicePath)
-	if _, err := luksFormat(devicePath, passphrase); err != nil {
+	if _, err := luksFormat(devicePath, passphrase, cryptoParams); err != nil {
 		return fmt.Errorf("failed to encrypt device %s with LUKS: %w", devicePath, err)
 	}
 	return nil

--- a/csi/crypto/luks.go
+++ b/csi/crypto/luks.go
@@ -24,9 +24,9 @@ func luksClose(volume string) (stdout string, err error) {
 	return cryptSetup("luksClose", volume)
 }
 
-func luksFormat(devicePath, passphrase string) (stdout string, err error) {
+func luksFormat(devicePath, passphrase string, cryptoParams *EncryptParams) (stdout string, err error) {
 	return cryptSetupWithPassphrase(passphrase,
-		"-q", "luksFormat", "--type", "luks2", "--hash", "sha256",
+		"-q", "luksFormat", "--type", "luks2", "--cipher", cryptoParams.GetKeyCipher(), "--hash", cryptoParams.GetKeyHash(), "--key-size", cryptoParams.GetKeySize(), "--pbkdf", cryptoParams.GetPBKDF(),
 		devicePath, "-d", "/dev/stdin")
 }
 

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -32,6 +32,10 @@ const (
 	// We currently only support passphrase retrieval via direct secret values
 	CryptoKeyProvider = "CRYPTO_KEY_PROVIDER"
 	CryptoKeyValue    = "CRYPTO_KEY_VALUE"
+	CryptoKeyCipher   = "CRYPTO_KEY_CIPHER"
+	CryptoKeyHash     = "CRYPTO_KEY_HASH"
+	CryptoKeySize     = "CRYPTO_KEY_SIZE"
+	CryptoPBKDF       = "CRYPTO_PBKDF"
 
 	defaultFsType = "ext4"
 )
@@ -412,9 +416,11 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported disk encryption format %v", diskFormat)
 		}
 
+		cryptoParams := crypto.NewEncryptParams(keyProvider, secrets[CryptoKeyCipher], secrets[CryptoKeyHash], secrets[CryptoKeySize], secrets[CryptoPBKDF])
+
 		// initial setup of longhorn device for crypto
 		if diskFormat == "" {
-			if err := crypto.EncryptVolume(devicePath, passphrase); err != nil {
+			if err := crypto.EncryptVolume(devicePath, passphrase, cryptoParams); err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 		}

--- a/examples/crypto/secret-crypto-customized-rhel-FIPS-enabled.yaml
+++ b/examples/crypto/secret-crypto-customized-rhel-FIPS-enabled.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: longhorn-system
+stringData:
+  CRYPTO_KEY_VALUE: "Simple passphrase"
+  CRYPTO_KEY_PROVIDER: "secret" # this is optional we currently only support direct keys via secrets
+  CRYPTO_KEY_CIPHER: "aes-cbc-essiv:sha256" # this is optional, default value for RHEL
+  CRYPTO_KEY_HASH: "sha256" # this is optional, default value
+  CRYPTO_KEY_SIZE: "256" # this is optional, default value
+  CRYPTO_PBKDF: "pbkdf2" # Only PBKDF2 is supported in FIPS mode, needs to be set on RHEL7

--- a/examples/crypto/secret-crypto-customized.yaml
+++ b/examples/crypto/secret-crypto-customized.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: longhorn-system
+stringData:
+  CRYPTO_KEY_VALUE: "Simple passphrase"
+  CRYPTO_KEY_PROVIDER: "secret" # this is optional we currently only support direct keys via secrets
+  CRYPTO_KEY_CIPHER: "aes-xts-plain64" # this is optional, default value
+  CRYPTO_KEY_HASH: "sha256" # this is optional, default value
+  CRYPTO_KEY_SIZE: "256" # this is optional, default value
+  CRYPTO_PBKDF: "argon2i" # this is optional, default value


### PR DESCRIPTION
Allow customization of the cipher used by cryptsetup in volume encryption.
Now the parameters allowing for customization are `cipher`, `hash`, and `key-size`.

longhorn/longhorn#3353