### PR TITLE
Remove unused InstanceManagerProxyAPIVersion

### DIFF
--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -546,7 +546,7 @@ func (c *BackingImageManagerController) handleBackingImageFiles(bim *longhorn.Ba
 		return nil
 	}
 
-	if err := engineapi.CheckBackingImageManagerCompatibilty(bim.Status.APIMinVersion, bim.Status.APIVersion); err != nil {
+	if err := engineapi.CheckBackingImageManagerCompatibility(bim.Status.APIMinVersion, bim.Status.APIVersion); err != nil {
 		log.Debug("BackingImageManagerController will skip handling files for incompatible backing image manager")
 		return nil
 	}

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -325,7 +325,7 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 		return err
 	}
 
-	if err := engineapi.CheckCLICompatibilty(engineImage.Status.CLIAPIVersion, engineImage.Status.CLIAPIMinVersion); err != nil {
+	if err := engineapi.CheckCLICompatibility(engineImage.Status.CLIAPIVersion, engineImage.Status.CLIAPIMinVersion); err != nil {
 		engineImage.Status.Conditions = types.SetCondition(engineImage.Status.Conditions, longhorn.EngineImageConditionTypeReady, longhorn.ConditionStatusFalse, longhorn.EngineImageConditionTypeReadyReasonBinary, "incompatible")
 		engineImage.Status.State = longhorn.EngineImageStateIncompatible
 		return nil

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -506,7 +506,7 @@ func (imc *InstanceManagerController) syncMonitor(im *longhorn.InstanceManager) 
 	}
 
 	isMonitorRequired := im.Status.CurrentState == longhorn.InstanceManagerStateRunning &&
-		engineapi.CheckInstanceManagerCompatibilty(im.Status.APIMinVersion, im.Status.APIVersion) == nil
+		engineapi.CheckInstanceManagerCompatibility(im.Status.APIMinVersion, im.Status.APIVersion) == nil
 
 	if isMonitorRequired {
 		imc.startMonitoring(im)

--- a/engineapi/backing_image_manager.go
+++ b/engineapi/backing_image_manager.go
@@ -23,7 +23,7 @@ type BackingImageManagerClient struct {
 	grpcClient *bimclient.BackingImageManagerClient
 }
 
-func CheckBackingImageManagerCompatibilty(bimMinVersion, bimVersion int) error {
+func CheckBackingImageManagerCompatibility(bimMinVersion, bimVersion int) error {
 	if MinBackingImageManagerAPIVersion > bimVersion || CurrentBackingImageManagerAPIVersion < bimMinVersion {
 		return fmt.Errorf("current-min API version used by longhorn manager %v-%v is not compatible with BackingImageManager current-min APIVersion %v-%v",
 			CurrentBackingImageManagerAPIVersion, MinBackingImageManagerAPIVersion, bimVersion, bimMinVersion)
@@ -36,7 +36,7 @@ func NewBackingImageManagerClient(bim *longhorn.BackingImageManager) (*BackingIm
 		return nil, fmt.Errorf("invalid Backing Image Manager %v, state: %v, IP: %v", bim.Name, bim.Status.CurrentState, bim.Status.IP)
 	}
 	if bim.Status.APIMinVersion != UnknownBackingImageManagerAPIVersion {
-		if err := CheckBackingImageManagerCompatibilty(bim.Status.APIMinVersion, bim.Status.APIVersion); err != nil {
+		if err := CheckBackingImageManagerCompatibility(bim.Status.APIMinVersion, bim.Status.APIVersion); err != nil {
 			return nil, fmt.Errorf("cannot launch a client for incompatible backing image manager %v", bim.Name)
 		}
 	}
@@ -68,7 +68,7 @@ func (c *BackingImageManagerClient) parseBackingImageFileInfo(bi *bimapi.Backing
 }
 
 func (c *BackingImageManagerClient) Fetch(name, uuid, checksum, dataSourceAddress string, size int64) (*longhorn.BackingImageFileInfo, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	resp, err := c.grpcClient.Fetch(name, uuid, checksum, dataSourceAddress, size)
@@ -79,7 +79,7 @@ func (c *BackingImageManagerClient) Fetch(name, uuid, checksum, dataSourceAddres
 }
 
 func (c *BackingImageManagerClient) Sync(name, uuid, checksum, fromHost string, size int64) (*longhorn.BackingImageFileInfo, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	resp, err := c.grpcClient.Sync(name, uuid, checksum, fmt.Sprintf("%s:%d", fromHost, BackingImageManagerDefaultPort), size)
@@ -90,21 +90,21 @@ func (c *BackingImageManagerClient) Sync(name, uuid, checksum, fromHost string, 
 }
 
 func (c *BackingImageManagerClient) PrepareDownload(name, uuid string) (string, string, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return "", "", err
 	}
 	return c.grpcClient.PrepareDownload(name, uuid)
 }
 
 func (c *BackingImageManagerClient) Delete(name, uuid string) error {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return err
 	}
 	return c.grpcClient.Delete(name, uuid)
 }
 
 func (c *BackingImageManagerClient) Get(name, uuid string) (*longhorn.BackingImageFileInfo, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	backingImage, err := c.grpcClient.Get(name, uuid)
@@ -115,7 +115,7 @@ func (c *BackingImageManagerClient) Get(name, uuid string) (*longhorn.BackingIma
 }
 
 func (c *BackingImageManagerClient) List() (map[string]longhorn.BackingImageFileInfo, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	backingImages, err := c.grpcClient.List()
@@ -130,7 +130,7 @@ func (c *BackingImageManagerClient) List() (map[string]longhorn.BackingImageFile
 }
 
 func (c *BackingImageManagerClient) Watch() (*bimapi.BackingImageStream, error) {
-	if err := CheckBackingImageManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	return c.grpcClient.Watch()

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -10,9 +10,8 @@ import (
 	imclient "github.com/longhorn/longhorn-instance-manager/pkg/client"
 	imutil "github.com/longhorn/longhorn-instance-manager/pkg/util"
 
-	"github.com/longhorn/longhorn-manager/types"
-
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
 )
 
 const (
@@ -20,11 +19,9 @@ const (
 	MinInstanceManagerAPIVersion     = 1
 	UnknownInstanceManagerAPIVersion = 0
 
-	CurrentInstanceManagerProxyAPIVersion = 2
-	MinInstanceManagerProxyAPIVersion     = 1
 	UnknownInstanceManagerProxyAPIVersion = 0
-	// UnsupportInstanceManagerProxyAPIVersion means the instance manager without the proxy client (Longhorn release before v1.3.0)
-	UnsupportInstanceManagerProxyAPIVersion = 0
+	// UnsupportedInstanceManagerProxyAPIVersion means the instance manager without the proxy client (Longhorn release before v1.3.0)
+	UnsupportedInstanceManagerProxyAPIVersion = 0
 
 	DefaultEnginePortCount  = 1
 	DefaultReplicaPortCount = 15
@@ -67,17 +64,8 @@ func CheckInstanceManagerCompatibility(imMinVersion, imVersion int) error {
 	return nil
 }
 
-func CheckInstanceManagerProxyCompatibility(im *longhorn.InstanceManager) error {
-	if MinInstanceManagerProxyAPIVersion > im.Status.ProxyAPIVersion ||
-		CurrentInstanceManagerProxyAPIVersion < im.Status.ProxyAPIMinVersion {
-		return fmt.Errorf("current InstanceManager proxy version %v-%v is not compatible with InstanceManagerProxyAPIVersion %v and InstanceManagerProxyAPIMinVersion %v",
-			CurrentInstanceManagerProxyAPIVersion, MinInstanceManagerProxyAPIVersion, im.Status.ProxyAPIVersion, im.Status.ProxyAPIMinVersion)
-	}
-	return nil
-}
-
 func CheckInstanceManagerProxySupport(im *longhorn.InstanceManager) error {
-	if UnsupportInstanceManagerProxyAPIVersion == im.Status.ProxyAPIVersion {
+	if UnsupportedInstanceManagerProxyAPIVersion == im.Status.ProxyAPIVersion {
 		return fmt.Errorf("%v does not support proxy", im.Name)
 	}
 	return nil

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -59,7 +59,7 @@ func GetDeprecatedInstanceManagerBinary(image string) string {
 	return filepath.Join(types.EngineBinaryDirectoryOnHost, cname, DeprecatedInstanceManagerBinaryName)
 }
 
-func CheckInstanceManagerCompatibilty(imMinVersion, imVersion int) error {
+func CheckInstanceManagerCompatibility(imMinVersion, imVersion int) error {
 	if MinInstanceManagerAPIVersion > imVersion || CurrentInstanceManagerAPIVersion < imMinVersion {
 		return fmt.Errorf("current InstanceManager version %v-%v is not compatible with InstanceManagerAPIVersion %v and InstanceManagerAPIMinVersion %v",
 			CurrentInstanceManagerAPIVersion, MinInstanceManagerAPIVersion, imVersion, imMinVersion)
@@ -127,7 +127,7 @@ func NewInstanceManagerClient(im *longhorn.InstanceManager) (*InstanceManagerCli
 	}
 
 	// TODO: consider evaluating im client version since we do the call anyway to validate the connection, i.e. fallback to non tls
-	//  This way we don't need the per call compatibility check, ref: `CheckInstanceManagerCompatibilty`
+	//  This way we don't need the per call compatibility check, ref: `CheckInstanceManagerCompatibility`
 
 	return &InstanceManagerClient{
 		ip:            im.Status.IP,
@@ -162,7 +162,7 @@ func (c *InstanceManagerClient) parseProcess(p *imapi.Process) *longhorn.Instanc
 }
 
 func (c *InstanceManagerClient) EngineProcessCreate(e *longhorn.Engine, volumeFrontend longhorn.VolumeFrontend, engineReplicaTimeout int64, engineCLIAPIVersion int) (*longhorn.InstanceProcess, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	frontend, err := GetEngineProcessFrontend(volumeFrontend)
@@ -206,7 +206,7 @@ func (c *InstanceManagerClient) EngineProcessCreate(e *longhorn.Engine, volumeFr
 }
 
 func (c *InstanceManagerClient) ReplicaProcessCreate(replicaName, engineImage, dataPath, backingImagePath string, size int64, revCounterDisabled bool) (*longhorn.InstanceProcess, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	args := []string{
@@ -238,7 +238,7 @@ func (c *InstanceManagerClient) ProcessDelete(name string) error {
 }
 
 func (c *InstanceManagerClient) ProcessGet(name string) (*longhorn.InstanceProcess, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	process, err := c.grpcClient.ProcessGet(name)
@@ -250,7 +250,7 @@ func (c *InstanceManagerClient) ProcessGet(name string) (*longhorn.InstanceProce
 
 // ProcessLog returns a grpc stream that will be closed when the passed context is cancelled or the underlying grpc client is closed
 func (c *InstanceManagerClient) ProcessLog(ctx context.Context, name string) (*imapi.LogStream, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	return c.grpcClient.ProcessLog(ctx, name)
@@ -258,14 +258,14 @@ func (c *InstanceManagerClient) ProcessLog(ctx context.Context, name string) (*i
 
 // ProcessWatch returns a grpc stream that will be closed when the passed context is cancelled or the underlying grpc client is closed
 func (c *InstanceManagerClient) ProcessWatch(ctx context.Context) (*imapi.ProcessStream, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	return c.grpcClient.ProcessWatch(ctx)
 }
 
 func (c *InstanceManagerClient) ProcessList() (map[string]longhorn.InstanceProcess, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	processes, err := c.grpcClient.ProcessList()
@@ -280,7 +280,7 @@ func (c *InstanceManagerClient) ProcessList() (map[string]longhorn.InstanceProce
 }
 
 func (c *InstanceManagerClient) EngineProcessUpgrade(e *longhorn.Engine, volumeFrontend longhorn.VolumeFrontend, engineReplicaTimeout int64, engineCLIAPIVersion int) (*longhorn.InstanceProcess, error) {
-	if err := CheckInstanceManagerCompatibilty(c.apiMinVersion, c.apiVersion); err != nil {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return nil, err
 	}
 	frontend, err := GetEngineProcessFrontend(volumeFrontend)

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -213,7 +213,7 @@ func ValidateReplicaURL(url string) error {
 	return nil
 }
 
-func CheckCLICompatibilty(cliVersion, cliMinVersion int) error {
+func CheckCLICompatibility(cliVersion, cliMinVersion int) error {
 	if MinCLIVersion > cliVersion || CurrentCLIVersion < cliMinVersion {
 		return fmt.Errorf("manager current CLI version %v and min CLI version %v is not compatible with CLIVersion %v and CLIMinVersion %v", CurrentCLIVersion, MinCLIVersion, cliVersion, cliMinVersion)
 	}


### PR DESCRIPTION
CurrentInstanceManagerProxyAPIVersion and its check function are unused for now.
Remove it for avoiding the confusion.

https://github.com/longhorn/longhorn/issues/4210
https://github.com/longhorn/longhorn/issues/3198

Signed-off-by: Derek Su <derek.su@suse.com>