### PR TITLE
types: setting 'Support Bundle Manager Image' should be read-only

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -365,7 +365,7 @@ var (
 		Category:    SettingCategoryGeneral,
 		Type:        SettingTypeString,
 		Required:    true,
-		ReadOnly:    false,
+		ReadOnly:    true,
 	}
 
 	SettingDefinitionReplicaSoftAntiAffinity = SettingDefinition{


### PR DESCRIPTION
Otherwise, the setting reset function at the beginning of each integration test will error out