### PR TITLE
fix: Check if backup exists before performing backup deletion

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -15,7 +15,7 @@ func (s *Server) BackupTargetList(w http.ResponseWriter, req *http.Request) erro
 
 	backupTargets, err := s.m.ListBackupTargetsSorted()
 	if err != nil {
-		return errors.Wrapf(err, "error listing backup targets")
+		return errors.Wrap(err, "failed to list backup targets")
 	}
 	apiContext.Write(toBackupTargetCollection(backupTargets))
 	return nil
@@ -35,7 +35,7 @@ func (s *Server) BackupVolumeList(w http.ResponseWriter, req *http.Request) erro
 func (s *Server) backupVolumeList(apiContext *api.ApiContext) (*client.GenericCollection, error) {
 	bvs, err := s.m.ListBackupVolumesSorted()
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing backup volume")
+		return nil, errors.Wrap(err, "failed to list backup volume")
 	}
 	return toBackupVolumeCollection(bvs, apiContext), nil
 }
@@ -47,7 +47,7 @@ func (s *Server) BackupVolumeGet(w http.ResponseWriter, req *http.Request) error
 
 	bv, err := s.m.GetBackupVolume(volName)
 	if err != nil {
-		return errors.Wrapf(err, "error get backup volume '%s'", volName)
+		return errors.Wrapf(err, "failed to get backup volume '%s'", volName)
 	}
 	apiContext.Write(toBackupVolumeResource(bv, apiContext))
 	return nil
@@ -56,7 +56,7 @@ func (s *Server) BackupVolumeGet(w http.ResponseWriter, req *http.Request) error
 func (s *Server) BackupVolumeDelete(w http.ResponseWriter, req *http.Request) error {
 	volName := mux.Vars(req)["volName"]
 	if err := s.m.DeleteBackupVolume(volName); err != nil {
-		return errors.Wrapf(err, "error deleting backup volume %s", volName)
+		return errors.Wrapf(err, "failed to delet backup volume '%s'", volName)
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func (s *Server) BackupList(w http.ResponseWriter, req *http.Request) error {
 
 	bs, err := s.m.ListBackupsForVolumeSorted(volName)
 	if err != nil {
-		return errors.Wrapf(err, "error listing backups for volume '%s'", volName)
+		return errors.Wrapf(err, "failed to list backups for volume '%s'", volName)
 	}
 	apiContext.Write(toBackupCollection(bs))
 	return nil
@@ -77,7 +77,7 @@ func (s *Server) BackupList(w http.ResponseWriter, req *http.Request) error {
 func (s *Server) backupListAll(apiContext *api.ApiContext) (*client.GenericCollection, error) {
 	bs, err := s.m.ListAllBackupsSorted()
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing all backups")
+		return nil, errors.Wrap(err, "failed to list all backups")
 	}
 	return toBackupCollection(bs), nil
 }
@@ -91,16 +91,16 @@ func (s *Server) BackupGet(w http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 	if input.Name == "" {
-		return errors.Errorf("empty backup name is not allowed")
+		return errors.New("empty backup name is not allowed")
 	}
 	volName := mux.Vars(req)["volName"]
 
 	backup, err := s.m.GetBackup(input.Name, volName)
 	if err != nil {
-		return errors.Wrapf(err, "error getting backup %v of volume %v", input.Name, volName)
+		return errors.Wrapf(err, "failed to get backup '%v' of volume '%v'", input.Name, volName)
 	}
 	if backup == nil {
-		logrus.Warnf("cannot find backup %v of volume %v", input.Name, volName)
+		logrus.Warnf("cannot find backup '%v' of volume '%v'", input.Name, volName)
 		w.WriteHeader(http.StatusNotFound)
 		return nil
 	}
@@ -117,25 +117,25 @@ func (s *Server) BackupDelete(w http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 	if input.Name == "" {
-		return errors.Errorf("empty backup name is not allowed")
+		return errors.New("empty backup name is not allowed")
 	}
 
 	volName := mux.Vars(req)["volName"]
 
 	backup, err := s.m.GetBackup(input.Name, volName)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to get backup %v of volume %v", input.Name, volName)
+		logrus.WithError(err).Warnf("failed to get backup '%v' of volume '%v'", input.Name, volName)
 	}
 
 	if backup != nil {
 		if err := s.m.DeleteBackup(input.Name, volName); err != nil {
-			return errors.Wrapf(err, "error deleting backup %v of volume %v", input.Name, volName)
+			return errors.Wrapf(err, "failed to delete backup '%v' of volume '%v'", input.Name, volName)
 		}
 	}
 
 	bv, err := s.m.GetBackupVolume(volName)
 	if err != nil {
-		return errors.Wrapf(err, "error get backup volume '%s'", volName)
+		return errors.Wrapf(err, "failed to get backup volume '%s'", volName)
 	}
 	apiContext.Write(toBackupVolumeResource(bv, apiContext))
 	return nil

--- a/api/backup.go
+++ b/api/backup.go
@@ -122,8 +122,15 @@ func (s *Server) BackupDelete(w http.ResponseWriter, req *http.Request) error {
 
 	volName := mux.Vars(req)["volName"]
 
-	if err := s.m.DeleteBackup(input.Name, volName); err != nil {
-		return errors.Wrapf(err, "error deleting backup %v of volume %v", input.Name, volName)
+	backup, err := s.m.GetBackup(input.Name, volName)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to get backup %v of volume %v", input.Name, volName)
+	}
+
+	if backup != nil {
+		if err := s.m.DeleteBackup(input.Name, volName); err != nil {
+			return errors.Wrapf(err, "error deleting backup %v of volume %v", input.Name, volName)
+		}
 	}
 
 	bv, err := s.m.GetBackupVolume(volName)


### PR DESCRIPTION
[Longhorn 4107](https://github.com/longhorn/longhorn/issues/4107)

If the backup not exists but performing backup deletion, then it will return error.  In the [Longhorn 4107](https://github.com/longhorn/longhorn/issues/4107) scenario, the `volumesnapshot` cannot be deleted normally.  

Test result
 - the `volumesnapshot` can be delete normally even if the backup was removed first
     ![image](https://user-images.githubusercontent.com/17548901/203973070-fa87b728-72ba-4d25-96dc-2d33e6418e3a.png)


Signed-off-by: Ray Chang <ray.chang@suse.com>