### PR TITLE
chore: run k8s/generate_code.sh

### DIFF
--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimage.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimagedatasource.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backingimagemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backup.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backuptarget.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/backupvolume.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/engine.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/engineimage.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimage.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimagedatasource.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimagedatasource.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimagemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backingimagemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backup.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backup.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backuptarget.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backuptarget.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backupvolume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_backupvolume.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_engine.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_engine.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_engineimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_engineimage.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_instancemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_instancemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_node.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_node.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_recurringjob.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_recurringjob.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_replica.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_replica.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_setting.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_setting.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_sharemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_sharemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_volume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/fake/fake_volume.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/instancemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/node.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/node.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/recurringjob.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/recurringjob.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/replica.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/replica.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/setting.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/setting.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/sharemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/sharemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta1/volume.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimage.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimagedatasource.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimagedatasource.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimagemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backingimagemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backup.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backuptarget.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backuptarget.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backupvolume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/backupvolume.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/engine.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/engineimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/engineimage.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimage.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimagedatasource.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimagedatasource.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimagemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backingimagemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backup.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backup.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backuptarget.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backuptarget.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backupvolume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_backupvolume.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_engine.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_engine.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_engineimage.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_engineimage.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_instancemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_instancemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_node.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_node.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_orphan.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_orphan.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_recurringjob.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_recurringjob.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_replica.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_replica.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_setting.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_setting.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_sharemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_sharemanager.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_snapshot.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_snapshot.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_supportbundle.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_supportbundle.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_volume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/fake/fake_volume.go
@@ -19,8 +19,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/instancemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/instancemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/node.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/node.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/orphan.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/orphan.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/recurringjob.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/replica.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/replica.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/setting.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/setting.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/sharemanager.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/sharemanager.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/snapshot.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/snapshot.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/supportbundle.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/supportbundle.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2/volume.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	scheme "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/scheme"
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"


### PR DESCRIPTION
Ref: https://golang.org/pkg/context, this is available in the standard library `context`.

Reverting the updated change in [here](https://github.com/longhorn/longhorn-manager/pull/1582/commits/e6c5f0716ac2f1efcc8f1ff88830278eea9218c8).