### PR TITLE
fix: Check if the channel has been closed before closing

### DIFF
--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -927,10 +927,10 @@ func (c *BackingImageDataSourceController) stopMonitoring(bidsName string) {
 		log.Warn("No monitor goroutine for stopping")
 		return
 	}
-	log.Infof("Stopping monitoring")
+	log.Info("Stopping monitoring")
 	close(stopCh)
 	delete(c.monitorMap, bidsName)
-	log.Infof("Stopped monitoring")
+	log.Info("Stopped monitoring")
 
 }
 
@@ -978,7 +978,7 @@ func (m *BackingImageDataSourceMonitor) sync() {
 		if syncErr != nil {
 			m.retryCount++
 			if m.retryCount == engineapi.MaxMonitorRetryCount {
-				close(m.stopCh)
+				m.stopCh <- struct{}{}
 				m.log.Warnf("Stop monitoring since monitor %v sync reaches the max retry count %v", m.Name, engineapi.MaxMonitorRetryCount)
 				return
 			}
@@ -991,7 +991,7 @@ func (m *BackingImageDataSourceMonitor) sync() {
 	bids, err := m.ds.GetBackingImageDataSource(m.Name)
 	if err != nil {
 		if datastore.ErrorIsNotFound(err) {
-			close(m.stopCh)
+			m.stopCh <- struct{}{}
 			m.log.Warnf("Stop monitoring since backing image data source %v is not found", m.Name)
 			return
 		}
@@ -1000,7 +1000,7 @@ func (m *BackingImageDataSourceMonitor) sync() {
 		return
 	}
 	if bids.Status.OwnerID != m.controllerID {
-		close(m.stopCh)
+		m.stopCh <- struct{}{}
 		m.log.Warnf("Stop monitoring since backing image data source %v owner %v is not the same as monitor current controller %v", m.Name, bids.Status.OwnerID, m.controllerID)
 		return
 	}


### PR DESCRIPTION
[Longhorn 4865](https://github.com/longhorn/longhorn/issues/4865)

- When the `backingImageDataSource` POD fails to respond, the monitor thread in the LH manager will consider the `backingImageDataSource` pod as invalid. Then it tries to stop and close its own channel but it has already been closed. So check to see if the channel is closed before closing it to avoid panic.

- Self test results:
  - After monitoring is stopped due to failure to connect to the data source POD, the next round of monitoring will continue.
    ![image](https://user-images.githubusercontent.com/17548901/206142399-f433d370-77e5-4944-8e1d-49557f2e75ab.png)

Signed-off-by: Ray Chang <ray.chang@suse.com>