### PR TITLE
[BACKPORT][v1.3.3] Prevent creating multiple default instance managers

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -860,7 +860,7 @@ func (nc *NodeController) syncInstanceManagers(node *longhorn.Node) error {
 			}
 		}
 		if !defaultInstanceManagerCreated {
-			imName, err := types.GetInstanceManagerName(imType)
+			imName, err := types.GetInstanceManagerName(imType, node.Name, defaultInstanceManagerImage)
 			if err != nil {
 				return err
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -171,7 +171,8 @@ const (
 	// DefaultStaleReplicaTimeout in minutes. 48h by default
 	DefaultStaleReplicaTimeout = "2880"
 
-	ImageChecksumNameLength = 8
+	ImageChecksumNameLength             = 8
+	InstanceManagerSuffixChecksumLength = 32
 )
 
 type NotFoundError struct {
@@ -467,12 +468,13 @@ func ValidateEngineImageChecksumName(name string) bool {
 	return matched
 }
 
-func GetInstanceManagerName(imType longhorn.InstanceManagerType) (string, error) {
+func GetInstanceManagerName(imType longhorn.InstanceManagerType, nodeName, image string) (string, error) {
+	hashedSuffix := util.GetStringChecksum(nodeName + image)[:InstanceManagerSuffixChecksumLength]
 	switch imType {
 	case longhorn.InstanceManagerTypeEngine:
-		return engineManagerPrefix + util.RandomID(), nil
+		return engineManagerPrefix + hashedSuffix, nil
 	case longhorn.InstanceManagerTypeReplica:
-		return replicaManagerPrefix + util.RandomID(), nil
+		return replicaManagerPrefix + hashedSuffix, nil
 	}
 	return "", fmt.Errorf("cannot generate name for unknown instance manager type %v", imType)
 }


### PR DESCRIPTION
Prevent creating multiple default instance managers by hashing (node name + image name) to create instance manager name

https://github.com/longhorn/longhorn/issues/5027