### PR TITLE
Allow trimming encrypted devices via UI

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -669,7 +669,7 @@ func (m *VolumeManager) TrimFilesystem(name string) (v *longhorn.Volume, err err
 		return nil, fmt.Errorf("volume frontend is disabled")
 	}
 
-	return v, util.TrimFilesystem(name)
+	return v, util.TrimFilesystem(name, v.Spec.Encrypted)
 }
 
 func (m *VolumeManager) AddVolumeRecurringJob(volumeName string, name string, isGroup bool) (volumeRecurringJob map[string]*longhorn.VolumeRecurringJob, err error) {


### PR DESCRIPTION
Users need to enable flag `discards` for the encrypted devices manually first:
https://wiki.archlinux.org/title/Dm-crypt/Specialties#Discard/TRIM_support_for_solid_state_drives_(SSD)

Longhorn/longhorn#836