### PR TITLE
Fix expanding volume detachment failure when node is gone

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2853,6 +2853,13 @@ func (vc *VolumeController) checkForAutoDetachment(v *longhorn.Volume, e *longho
 	}
 
 	if v.Status.ExpansionRequired {
+		_, err := vc.ds.GetNodeRO(v.Status.CurrentNodeID)
+		if err == nil || (err != nil && !datastore.ErrorIsNotFound(err)) {
+			return nil
+		}
+
+		log.Infof("Preparing to do auto-detachment of expanding volume %v, because the node %v is unavailable", v.Name, v.Status.CurrentNodeID)
+		v.Status.CurrentNodeID = ""
 		return nil
 	}
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1674

Fix the [node deletion - volume attached to down node, so the expansion stuck](https://github.com/longhorn/longhorn/issues/1674#issuecomment-1367068900)

Signed-off-by: Derek Su <derek.su@suse.com>