### PR TITLE
Skip updating the trim related field for old engines or engines in old engine instance managers

### DIFF
--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -13,7 +13,7 @@ import (
 const (
 	// CurrentCLIVersion indicates the default API version manager used to talk with the
 	// engine, including `longhorn-engine` and `longhorn-instance-manager`
-	CurrentCLIVersion = 6
+	CurrentCLIVersion = 7
 	// MinCLIVersion indicates the Min API version manager used to talk with the
 	// engine.
 	MinCLIVersion = 3


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5218