### PR TITLE
fix: incorrect router retry mechanism

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -2,38 +2,20 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/sirupsen/logrus"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/longhorn/longhorn-manager/metrics_collector/registry"
-)
-
-var (
-	RetryCounts   = 5
-	RetryInterval = 100 * time.Millisecond
 )
 
 type HandleFuncWithError func(http.ResponseWriter, *http.Request) error
 
 func HandleError(s *client.Schemas, t HandleFuncWithError) http.Handler {
 	return api.ApiHandler(s, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		var err error
-		for i := 0; i < RetryCounts; i++ {
-			err = t(rw, req)
-			if !apierrors.IsConflict(errors.Cause(err)) {
-				break
-			}
-			logrus.WithError(err).Warn("Retry API call due to conflict")
-			time.Sleep(RetryInterval)
-		}
-		if err != nil {
+		if err := t(rw, req); err != nil {
 			logrus.Warnf("HTTP handling error %v", err)
 			apiContext := api.GetApiContext(req)
 			apiContext.WriteErr(err)


### PR DESCRIPTION
Keep the http request body and copy to the request body again when the retry occurred.

Handling in HandleError function is not correct when the request body was already read before, and the next retry always hit the EOF error.

longhorn/longhorn#5259
