### PR TITLE
fix(restore): sync backup target when activate DR volume

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2916,7 +2916,23 @@ func (vc *VolumeController) checkForAutoDetachment(v *longhorn.Volume, e *longho
 			break
 		}
 	}
-	if !(e.Spec.RequestedBackupRestore != "" && e.Spec.RequestedBackupRestore == e.Status.LastRestoredBackup &&
+
+	// After the volume is detached, the engine stops and does not perform recovery,
+	// so it should ensure that the backup volume is synced and updated at least once
+	// so that the engine restores with the latest backup before the volume is detached
+	if backupVolumeName, isExist := v.Labels[types.LonghornLabelBackupVolume]; isExist && backupVolumeName != "" {
+		backupVolume, err := vc.ds.GetBackupVolumeRO(backupVolumeName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get backup volume: %v", v.Name)
+		}
+		if backupVolume.Status.LastSyncedAt.Before(&backupVolume.Spec.SyncRequestedAt) {
+			return nil
+		}
+	}
+
+	// make sure engine finish restoring with the latest backup and no longer a DR volume
+	if !(e.Spec.RequestedBackupRestore != "" &&
+		e.Spec.RequestedBackupRestore == e.Status.LastRestoredBackup &&
 		!v.Spec.Standby) {
 		return nil
 	}


### PR DESCRIPTION
[Longhorn 5292](https://github.com/longhorn/longhorn/issues/5292)

Signed-off-by: Ray Chang <ray.chang@suse.com>

 - the explanation for the fix 
   - When activate the DR volume, it will trigger to synchronize the backup volume and backups. Then trigger the replicas of engine to restore from the latest backup.
- test steps
    1. with 2 clusters w/ same backup target: cluster_a & cluster_b
    2. deploy a volume w/ 5G data in cluster_a
    3. create a backup for the volume in cluster_a
    4. create a DR volume from the backup volume in cluster_b
    5. extend `Backupstore Poll Interval` setting value, e.g., 1000 in cluster_b
    6. write more data into the volume in cluster_a
    7. activate the DR volume in cluster_b
    8. show `restoring with latest backup in progress` if it is restoring w/ last backup
    9. check the activated DR volume should be with the latest data
 - e2e
   - test_basic
     ![image](https://user-images.githubusercontent.com/17548901/220122559-a38c7c58-c5b4-4f1a-8c55-f59c0091869a.png)
   - test_csi
     ![image](https://user-images.githubusercontent.com/17548901/220135970-dd6afff0-efb3-4ae1-908a-ff1b4494bf14.png)
