### PR TITLE
fix(recurring job): add an eventRecorder and a new job type

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -360,6 +360,12 @@ func (job *Job) run() (err error) {
 		job.logger.Infof("Volume %v is in state %v", volumeName, volume.State)
 	}
 
+	if job.task == longhorn.RecurringJobTypeSnapshot || job.task == longhorn.RecurringJobTypeBackup {
+		if err := job.doSnapshotCleanup(false); err != nil {
+			return err
+		}
+	}
+
 	if job.task == longhorn.RecurringJobTypeBackup {
 		job.logger.Infof("Running recurring backup for volume %v", volumeName)
 		return job.doRecurringBackup()

--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -367,7 +367,7 @@ func (job *Job) run() (err error) {
 		}
 	}
 
-	if job.task == longhorn.RecurringJobTypeBackup {
+	if job.task == longhorn.RecurringJobTypeBackup || job.task == longhorn.RecurringJobTypeBackupForceCreate {
 		job.logger.Infof("Running recurring backup for volume %v", volumeName)
 		return job.doRecurringBackup()
 	}
@@ -571,10 +571,6 @@ func (job *Job) doRecurringBackup() (err error) {
 	}
 
 	if err := job.doSnapshot(); err != nil {
-		return err
-	}
-
-	if err := job.doSnapshotCleanup(false); err != nil {
 		return err
 	}
 

--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -360,6 +360,7 @@ func (job *Job) run() (err error) {
 		job.logger.Infof("Volume %v is in state %v", volumeName, volume.State)
 	}
 
+	// only recurring job types `snapshot` and `backup` need to check if old snapshots can be deleted or not before creating
 	if job.task == longhorn.RecurringJobTypeSnapshot || job.task == longhorn.RecurringJobTypeBackup {
 		if err := job.doSnapshotCleanup(false); err != nil {
 			return err
@@ -383,7 +384,7 @@ func (job *Job) doRecurringSnapshot() (err error) {
 	}()
 
 	switch job.task {
-	case longhorn.RecurringJobTypeSnapshot:
+	case longhorn.RecurringJobTypeSnapshot, longhorn.RecurringJobTypeSnapshotForceCreate:
 		if err = job.doSnapshot(); err != nil {
 			return err
 		}
@@ -530,7 +531,7 @@ func (job *Job) filterExpiredSnapshotsOfCurrentRecurringJob(snapshots []longhorn
 	// Only consider deleting the snapshots that were created by our current job
 	snapshots = filterSnapshotsWithLabel(snapshots, types.RecurringJobLabel, jobLabel)
 
-	if job.task == longhorn.RecurringJobTypeSnapshot {
+	if job.task == longhorn.RecurringJobTypeSnapshot || job.task == longhorn.RecurringJobTypeSnapshotForceCreate {
 		return filterExpiredItems(snapshotsToNameWithTimestamps(snapshots), job.retain)
 	}
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3778,6 +3778,7 @@ func ValidateRecurringJob(job longhorn.RecurringJobSpec) error {
 
 func isValidRecurringJobTask(task longhorn.RecurringJobType) bool {
 	return task == longhorn.RecurringJobTypeBackup ||
+		task == longhorn.RecurringJobTypeBackupForceCreate ||
 		task == longhorn.RecurringJobTypeSnapshot ||
 		task == longhorn.RecurringJobTypeSnapshotForceCreate ||
 		task == longhorn.RecurringJobTypeSnapshotCleanup ||

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3779,6 +3779,7 @@ func ValidateRecurringJob(job longhorn.RecurringJobSpec) error {
 func isValidRecurringJobTask(task longhorn.RecurringJobType) bool {
 	return task == longhorn.RecurringJobTypeBackup ||
 		task == longhorn.RecurringJobTypeSnapshot ||
+		task == longhorn.RecurringJobTypeSnapshotForceCreate ||
 		task == longhorn.RecurringJobTypeSnapshotCleanup ||
 		task == longhorn.RecurringJobTypeSnapshotDelete
 }

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2151,7 +2151,7 @@ spec:
       jsonPath: .spec.groups
       name: Groups
       type: string
-    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup"
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create".
       jsonPath: .spec.task
       name: Task
       type: string
@@ -2213,13 +2213,14 @@ spec:
                 description: The retain count of the snapshot/backup.
                 type: integer
               task:
-                description: The recurring job task. Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup".
+                description: The recurring job task. Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create".
                 enum:
                 - snapshot
                 - snapshot-force-create
                 - snapshot-cleanup
                 - snapshot-delete
                 - backup
+                - backup-force-create
                 type: string
             type: object
           status:
@@ -3316,6 +3317,7 @@ spec:
                       - snapshot-cleanup
                       - snapshot-delete
                       - backup
+                      - backup-force-create
                       type: string
                   type: object
                 type: array

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2151,7 +2151,7 @@ spec:
       jsonPath: .spec.groups
       name: Groups
       type: string
-    - description: Should be one of "snapshot", "snapshot-cleanup", "snapshot-delete" or "backup"
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup"
       jsonPath: .spec.task
       name: Task
       type: string
@@ -2213,9 +2213,10 @@ spec:
                 description: The retain count of the snapshot/backup.
                 type: integer
               task:
-                description: The recurring job task. Can be "snapshot", "snapshot-cleanup", "snapshot-delete" or "backup".
+                description: The recurring job task. Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup".
                 enum:
                 - snapshot
+                - snapshot-force-create
                 - snapshot-cleanup
                 - snapshot-delete
                 - backup
@@ -3311,6 +3312,7 @@ spec:
                     task:
                       enum:
                       - snapshot
+                      - snapshot-force-create
                       - snapshot-cleanup
                       - snapshot-delete
                       - backup

--- a/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
@@ -2,7 +2,7 @@ package v1beta2
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +kubebuilder:validation:Enum=snapshot;snapshot-force-create;snapshot-cleanup;snapshot-delete;backup
+// +kubebuilder:validation:Enum=snapshot;snapshot-force-create;snapshot-cleanup;snapshot-delete;backup;backup-force-create
 type RecurringJobType string
 
 const (
@@ -11,6 +11,7 @@ const (
 	RecurringJobTypeSnapshotCleanup     = RecurringJobType("snapshot-cleanup")      // periodically purge removable snapshots and system snapshots
 	RecurringJobTypeSnapshotDelete      = RecurringJobType("snapshot-delete")       // periodically remove and purge all kinds of snapshots that exceed the retention count
 	RecurringJobTypeBackup              = RecurringJobType("backup")                // periodically create snapshots then do backups
+	RecurringJobTypeBackupForceCreate   = RecurringJobType("backup-force-create")   // periodically create snapshots then do backups even if old snapshots cleanup failed
 
 	RecurringJobGroupDefault = "default"
 )
@@ -36,7 +37,7 @@ type RecurringJobSpec struct {
 	// +optional
 	Groups []string `json:"groups,omitempty"`
 	// The recurring job task.
-	// Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup".
+	// Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup" or "backup-force-create".
 	// +optional
 	Task RecurringJobType `json:"task"`
 	// The cron setting.
@@ -66,7 +67,7 @@ type RecurringJobStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Groups",type=string,JSONPath=`.spec.groups`,description="Sets groupings to the jobs. When set to \"default\" group will be added to the volume label when no other job label exist in volume"
-// +kubebuilder:printcolumn:name="Task",type=string,JSONPath=`.spec.task`,description="Should be one of \"snapshot\", \"snapshot-force-create\", \"snapshot-cleanup\", \"snapshot-delete\" or \"backup\""
+// +kubebuilder:printcolumn:name="Task",type=string,JSONPath=`.spec.task`,description="Should be one of \"snapshot\", \"snapshot-force-create\", \"snapshot-cleanup\", \"snapshot-delete\", \"backup\" or \"backup-force-create\""
 // +kubebuilder:printcolumn:name="Cron",type=string,JSONPath=`.spec.cron`,description="The cron expression represents recurring job scheduling"
 // +kubebuilder:printcolumn:name="Retain",type=integer,JSONPath=`.spec.retain`,description="The number of snapshots/backups to keep for the volume"
 // +kubebuilder:printcolumn:name="Concurrency",type=integer,JSONPath=`.spec.concurrency`,description="The concurrent job to run by each cron job"

--- a/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
@@ -2,14 +2,15 @@ package v1beta2
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +kubebuilder:validation:Enum=snapshot;snapshot-cleanup;snapshot-delete;backup
+// +kubebuilder:validation:Enum=snapshot;snapshot-force-create;snapshot-cleanup;snapshot-delete;backup
 type RecurringJobType string
 
 const (
-	RecurringJobTypeSnapshot        = RecurringJobType("snapshot")         // periodically create snapshots
-	RecurringJobTypeSnapshotCleanup = RecurringJobType("snapshot-cleanup") // periodically purge removable snapshots and system snapshots
-	RecurringJobTypeSnapshotDelete  = RecurringJobType("snapshot-delete")  // periodically remove and purge all kinds of snapshots that exceed the retention count
-	RecurringJobTypeBackup          = RecurringJobType("backup")           // periodically create snapshots then do backups
+	RecurringJobTypeSnapshot            = RecurringJobType("snapshot")              // periodically create snapshots except for old snapshots cleanup failed before creating new snapshots
+	RecurringJobTypeSnapshotForceCreate = RecurringJobType("snapshot-force-create") // periodically create snapshots even if old snapshots cleanup failed
+	RecurringJobTypeSnapshotCleanup     = RecurringJobType("snapshot-cleanup")      // periodically purge removable snapshots and system snapshots
+	RecurringJobTypeSnapshotDelete      = RecurringJobType("snapshot-delete")       // periodically remove and purge all kinds of snapshots that exceed the retention count
+	RecurringJobTypeBackup              = RecurringJobType("backup")                // periodically create snapshots then do backups
 
 	RecurringJobGroupDefault = "default"
 )
@@ -35,7 +36,7 @@ type RecurringJobSpec struct {
 	// +optional
 	Groups []string `json:"groups,omitempty"`
 	// The recurring job task.
-	// Can be "snapshot", "snapshot-cleanup", "snapshot-delete" or "backup".
+	// Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete" or "backup".
 	// +optional
 	Task RecurringJobType `json:"task"`
 	// The cron setting.
@@ -65,7 +66,7 @@ type RecurringJobStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Groups",type=string,JSONPath=`.spec.groups`,description="Sets groupings to the jobs. When set to \"default\" group will be added to the volume label when no other job label exist in volume"
-// +kubebuilder:printcolumn:name="Task",type=string,JSONPath=`.spec.task`,description="Should be one of \"snapshot\", \"snapshot-cleanup\", \"snapshot-delete\" or \"backup\""
+// +kubebuilder:printcolumn:name="Task",type=string,JSONPath=`.spec.task`,description="Should be one of \"snapshot\", \"snapshot-force-create\", \"snapshot-cleanup\", \"snapshot-delete\" or \"backup\""
 // +kubebuilder:printcolumn:name="Cron",type=string,JSONPath=`.spec.cron`,description="The cron expression represents recurring job scheduling"
 // +kubebuilder:printcolumn:name="Retain",type=integer,JSONPath=`.spec.retain`,description="The number of snapshots/backups to keep for the volume"
 // +kubebuilder:printcolumn:name="Concurrency",type=integer,JSONPath=`.spec.concurrency`,description="The concurrent job to run by each cron job"


### PR DESCRIPTION
Create an event to inform the users if it failed to clean up old snapshots.

~Add a new filed `DeleteSnapshotMode`, default is `create-first`, 
to force the recurring job to delete old snapshots before creating a new snapshot.~

Forcibly do deletion first when the snapshot count exceeds retain count.

Introduce a new recurring job type `snapshot-force-create` to take a new snapshot forcibly when cleaning up old snapshots failed and a new recurring job type `backup-force-create` to to take a new snapshot and do the backup forcibly when cleaning up old snapshots failed.


longhorn/longhorn#4898

Regression test: 
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/3223/