### PR TITLE
feat: add settings to get supported k8s versions

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -53,8 +53,11 @@ const (
 	SettingNameStorageReservedPercentageForDefaultDisk                  = SettingName("storage-reserved-percentage-for-default-disk")
 	SettingNameUpgradeChecker                                           = SettingName("upgrade-checker")
 	SettingNameCurrentLonghornVersion                                   = SettingName("current-longhorn-version")
+	SettingNameCurrentLonghornSupportedK8sVersions                      = SettingName("current-longhorn-supported-k8s-versions")
 	SettingNameLatestLonghornVersion                                    = SettingName("latest-longhorn-version")
+	SettingNameLatestLonghornSupportedK8sVersions                       = SettingName("latest-longhorn-supported-k8s-versions")
 	SettingNameStableLonghornVersions                                   = SettingName("stable-longhorn-versions")
+	SettingNameStableLonghornSupportedK8sVersions                       = SettingName("stable-longhorn-supported-k8s-versions")
 	SettingNameDefaultReplicaCount                                      = SettingName("default-replica-count")
 	SettingNameDefaultDataLocality                                      = SettingName("default-data-locality")
 	SettingNameGuaranteedEngineCPU                                      = SettingName("guaranteed-engine-cpu")
@@ -126,8 +129,11 @@ var (
 		SettingNameStorageReservedPercentageForDefaultDisk,
 		SettingNameUpgradeChecker,
 		SettingNameCurrentLonghornVersion,
+		SettingNameCurrentLonghornSupportedK8sVersions,
 		SettingNameLatestLonghornVersion,
+		SettingNameLatestLonghornSupportedK8sVersions,
 		SettingNameStableLonghornVersions,
+		SettingNameStableLonghornSupportedK8sVersions,
 		SettingNameDefaultReplicaCount,
 		SettingNameDefaultDataLocality,
 		SettingNameGuaranteedEngineCPU,
@@ -224,8 +230,11 @@ var (
 		SettingNameStorageReservedPercentageForDefaultDisk:                  SettingDefinitionStorageReservedPercentageForDefaultDisk,
 		SettingNameUpgradeChecker:                                           SettingDefinitionUpgradeChecker,
 		SettingNameCurrentLonghornVersion:                                   SettingDefinitionCurrentLonghornVersion,
+		SettingNameCurrentLonghornSupportedK8sVersions:                      SettingDefinitionCurrentLonghornSupportedK8sVersions,
 		SettingNameLatestLonghornVersion:                                    SettingDefinitionLatestLonghornVersion,
+		SettingNameLatestLonghornSupportedK8sVersions:                       SettingDefinitionLatestLonghornSupportedK8sVersions,
 		SettingNameStableLonghornVersions:                                   SettingDefinitionStableLonghornVersions,
+		SettingNameStableLonghornSupportedK8sVersions:                       SettingDefinitionStableLonghornSupportedK8sVersions,
 		SettingNameDefaultReplicaCount:                                      SettingDefinitionDefaultReplicaCount,
 		SettingNameDefaultDataLocality:                                      SettingDefinitionDefaultDataLocality,
 		SettingNameGuaranteedEngineCPU:                                      SettingDefinitionGuaranteedEngineCPU,
@@ -498,6 +507,15 @@ var (
 		Default:     meta.Version,
 	}
 
+	SettingDefinitionCurrentLonghornSupportedK8sVersions = SettingDefinition{
+		DisplayName: "Kubernetes Versions Supported By Current Longhorn Version",
+		Description: "The Kubernetes versions supported by current Longhorn version.",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeString,
+		Required:    false,
+		ReadOnly:    true,
+	}
+
 	SettingDefinitionLatestLonghornVersion = SettingDefinition{
 		DisplayName: "Latest Longhorn Version",
 		Description: "The latest version of Longhorn available. Updated by Upgrade Checker automatically",
@@ -507,9 +525,27 @@ var (
 		ReadOnly:    true,
 	}
 
+	SettingDefinitionLatestLonghornSupportedK8sVersions = SettingDefinition{
+		DisplayName: "Kubernetes Versions Supported By Latest Longhorn Version",
+		Description: "The Kubernetes versions supported by latest Longhorn version.",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeString,
+		Required:    false,
+		ReadOnly:    true,
+	}
+
 	SettingDefinitionStableLonghornVersions = SettingDefinition{
 		DisplayName: "Stable Longhorn Versions",
 		Description: "The latest stable version of every minor release line. Updated by Upgrade Checker automatically",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeString,
+		Required:    false,
+		ReadOnly:    true,
+	}
+
+	SettingDefinitionStableLonghornSupportedK8sVersions = SettingDefinition{
+		DisplayName: "Kubernetes Versions Supported By Stable Longhorn Version",
+		Description: "The Kubernetes versions supported by stable Longhorn version in <kubernetes versions> (<Longhorn version>) format.",
 		Category:    SettingCategoryGeneral,
 		Type:        SettingTypeString,
 		Required:    false,


### PR DESCRIPTION
[Longhorn 4813](https://github.com/longhorn/longhorn/issues/4813)

Signed-off-by: Ray Chang <ray.chang@suse.com>

Just add a new parameter: `SupportedK8sVersions` to the `ExtraInfo` field of `response.json` to respond without modifying the `Upgrade Responder`. The `SupportedK8sVersions` field should be filled with K8S information supported by the current version and the latest version of Longhorn.
![image](https://user-images.githubusercontent.com/17548901/223150373-96ddbca7-c43e-4f19-a6df-460aab032215.png)


self-test:
 - Update and add new latest version: v1.4.1
```json
{
    "Versions": [
        {
            "Name": "v1.1.3",
            "ReleaseDate": "2021-12-17T00:00:00Z",
            "Tags": [
                "stable"
            ],
            "ExtraInfo": {
                "SupportedK8sVersions": ">=v1.16.0-0 <v1.22.0-0"
            }
        },
        {
            "Name": "v1.2.4",
            "ReleaseDate": "2022-03-17T00:00:00Z",
            "Tags": [
                "stable"
            ],
            "ExtraInfo": {
                "SupportedK8sVersions": ">=1.18.0-0"
            }
        },
        {
            "Name": "v1.4.0",
            "ReleaseDate": "2022-12-30T00:00:00Z",
            "Tags": [
                "stable"
            ],
            "ExtraInfo": {
                "SupportedK8sVersions": ">=1.21.0-0"
            }
        },
        {
            "Name": "v1.4.1",
            "ReleaseDate": "2023-03-01T00:00:00Z",
            "Tags": [
                "latest"
            ],
            "ExtraInfo": {
                "SupportedK8sVersions": ">=1.21.0-0"
            }
        },
        {
            "Name": "v1.3.2",
            "ReleaseDate": "2022-10-14T00:00:00Z",
            "Tags": [
                "stable"
            ],
            "ExtraInfo": {
                    "SupportedK8sVersions": ">=1.18.0-0 <1.25.0-0"
            }
        }
    ]
}
```
![image](https://user-images.githubusercontent.com/17548901/223150081-a416e7ed-ef9d-47c2-9cc2-1d341de39b4b.png)

