### PR TITLE
Fail replica if volume is not attached and node is down

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1584,6 +1584,16 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 				if vc.isVolumeUpgrading(v) {
 					continue
 				}
+
+				// Whenever the engine isn't attached, if the node goes down, the replica can be marked as failed.
+				// In the attached mode, we can determine whether the replica can fail by relying on the data plane's
+				// connectivity status.
+				if v.Status.State != longhorn.VolumeStateAttached {
+					if r.Spec.FailedAt == "" {
+						r.Spec.FailedAt = vc.nowHandler()
+					}
+					r.Spec.DesireState = longhorn.InstanceStateStopped
+				}
 			}
 			rs[r.Name] = r
 		}

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -807,6 +807,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for _, r := range tc.expectReplicas {
 		if r.Spec.NodeID == TestNode2 {
 			r.Spec.DesireState = longhorn.InstanceStateStopped
+			r.Spec.FailedAt = getTestNow()
 		} else {
 			r.Spec.DesireState = longhorn.InstanceStateRunning
 		}


### PR DESCRIPTION
Whenever the engine isn't attached, if the node goes down, the replica can be marked as failed. In the attached mode, we can determine whether the replica can fail by relying on the data plane's connectivity status.

Longhorn/longhorn#5464
Longhorn/longhorn#5477