### PR TITLE
feat: introduce failed-and-cleanup state to backingimage to handle data source tmp files

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -212,6 +212,14 @@ func (bic *BackingImageController) syncBackingImage(key string) (err error) {
 			log.Info("Need to wait for all replicas stopping using this backing image before removing the finalizer")
 			return nil
 		}
+		log.Info("Try to clean up backing image data source tmp file before cleaning up backing image manager")
+		cleanUpTmpFileFinished, err := bic.cleanupBackingImageDataSourceTmpFile(backingImage)
+		if err != nil {
+			return err
+		}
+		if !cleanUpTmpFileFinished {
+			return nil
+		}
 		log.Info("No replica is using this backing image, will clean up the record for backing image managers and remove the finalizer then")
 		if err := bic.cleanupBackingImageManagers(backingImage); err != nil {
 			return err
@@ -277,6 +285,32 @@ func (bic *BackingImageController) syncBackingImage(key string) (err error) {
 	}
 
 	return nil
+}
+
+func (bic *BackingImageController) cleanupBackingImageDataSourceTmpFile(bi *longhorn.BackingImage) (finished bool, err error) {
+	bids, err := bic.ds.GetBackingImageDataSource(bi.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	// if bids is transferred or it is not in progress, there is no tmp file left on the host.
+	fileProcessingStarted :=
+		bids.Status.CurrentState == longhorn.BackingImageStateStarting ||
+			bids.Status.CurrentState == longhorn.BackingImageStateInProgress
+
+	if bids.Spec.FileTransferred || !fileProcessingStarted ||
+		bids.Status.CurrentState == longhorn.BackingImageStateFailedAndCleanUp ||
+		bids.Status.CurrentState == longhorn.BackingImageStateUnknown {
+		return true, nil
+	}
+
+	// mark the status to failed so manager can clean up the orphan tmp file
+	bids.Status.Message = "backing image is deleted, try to cleaning up the tmp file of data source"
+	bids.Status.CurrentState = longhorn.BackingImageStateFailed
+	if _, err = bic.ds.UpdateBackingImageDataSourceStatus(bids); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func (bic *BackingImageController) cleanupBackingImageManagers(bi *longhorn.BackingImage) (err error) {

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -437,7 +437,8 @@ func (c *BackingImageDataSourceController) syncBackingImageDataSourcePod(bids *l
 	} else {
 		bids.Status.StorageIP = ""
 		bids.Status.IP = ""
-		if bids.Status.CurrentState != longhorn.BackingImageStateFailed {
+		if bids.Status.CurrentState != longhorn.BackingImageStateFailed &&
+			bids.Status.CurrentState != longhorn.BackingImageStateFailedAndCleanUp {
 			if podFailed {
 				podLog := ""
 				podLogBytes, err := c.ds.GetPodContainerLog(podName, BackingImageDataSourcePodContainerName)
@@ -471,7 +472,8 @@ func (c *BackingImageDataSourceController) syncBackingImageDataSourcePod(bids *l
 		}
 	}
 
-	if bids.Status.CurrentState == longhorn.BackingImageStateFailed {
+	if bids.Status.CurrentState == longhorn.BackingImageStateFailed ||
+		bids.Status.CurrentState == longhorn.BackingImageStateFailedAndCleanUp {
 		if err := c.cleanup(bids); err != nil {
 			return err
 		}

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -23,7 +23,6 @@ const (
 	BackingImageStateReady            = BackingImageState("ready")
 	BackingImageStateInProgress       = BackingImageState("in-progress")
 	BackingImageStateFailed           = BackingImageState("failed")
-	BackingImageStateFailedAndCleanUp = BackingImageState("failed-and-cleanup")
 	BackingImageStateUnknown          = BackingImageState("unknown")
 )
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -23,6 +23,7 @@ const (
 	BackingImageStateReady            = BackingImageState("ready")
 	BackingImageStateInProgress       = BackingImageState("in-progress")
 	BackingImageStateFailed           = BackingImageState("failed")
+	BackingImageStateFailedAndCleanUp = BackingImageState("failed-and-cleanup")
 	BackingImageStateUnknown          = BackingImageState("unknown")
 )
 

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
@@ -14,6 +14,7 @@ const (
 	BackingImageStateReady            = BackingImageState("ready")
 	BackingImageStateInProgress       = BackingImageState("in-progress")
 	BackingImageStateFailed           = BackingImageState("failed")
+	BackingImageStateFailedAndCleanUp = BackingImageState("failed-and-cleanup")
 	BackingImageStateUnknown          = BackingImageState("unknown")
 )
 


### PR DESCRIPTION
[longhorn/longhorn#3682](https://github.com/longhorn/longhorn/issues/3682)

Depends on: backing-image-manager [PR#101](https://github.com/longhorn/backing-image-manager/pull/101)

Implementation
- Add remove data source tmp file in `Delete api` in backing-image-manager
- Introduce a new state for BackingImageDataSource: `FailedAndCleanUp`

For Case: data source Pod is deleted in the progress
- invoke `Delete` when BackingImageManager Controller finds that
    - BackingImageDataSource CurrentState is failed and Transferred is false ([ref](https://github.com/longhorn/longhorn-manager/blob/master/controller/backing_image_manager_controller.go#L678))
    - then change the BackingImageDataSource state to `FailedAndCleanUp`

For Case: BackingImage CR is deleted in the progress
In BackingImageController
- before removing the finalizer
    - if BackingImageDataSource CR is in-progress status and not transferred, update BackingImageDataSource status to `Failed`, this will trigger the above behavior to clean up the tmp files
- can remove the finalizer when BackingImageDataSource's status is changed to `FailedAndCleanUp` by BackingImageManager Controller