### PR TITLE
Add log message for failing replica when the node is down and volume is at non-attached state

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1589,6 +1589,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 				// In the attached mode, we can determine whether the replica can fail by relying on the data plane's
 				// connectivity status.
 				if v.Status.State != longhorn.VolumeStateAttached {
+					log.WithField("replica", r.Name).Warnf("Replica %v is marked as failed since the volume %v is not attached because the instance manager is unable to launch the replica", r.Name, v.Name)
 					if r.Spec.FailedAt == "" {
 						r.Spec.FailedAt = vc.nowHandler()
 					}


### PR DESCRIPTION
Longhorn/longhorn#5464
Longhorn/longhorn#5477