### PR TITLE
feat: enforce the upgrade path

### DIFF
--- a/app/pre_uppgrade.go
+++ b/app/pre_uppgrade.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"k8s.io/client-go/tools/clientcmd"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	"github.com/longhorn/longhorn-manager/types"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+func PreUpgradeCmd() cli.Command {
+	return cli.Command{
+		Name: "pre-upgrade",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  FlagKubeConfig,
+				Usage: "Specify path to kube config (optional)",
+			},
+			cli.StringFlag{
+				Name:     FlagNamespace,
+				EnvVar:   types.EnvPodNamespace,
+				Required: true,
+				Usage:    "Specify Longhorn namespace",
+			},
+		},
+		Action: func(c *cli.Context) {
+			logrus.Infof("Running pre-upgrade...")
+			defer logrus.Infof("Completed pre-upgrade.")
+
+			if err := preUpgrade(c); err != nil {
+				logrus.WithError(err).Fatalf("Failed to run pre-upgrade")
+			}
+		},
+	}
+}
+
+func preUpgrade(c *cli.Context) error {
+	namespace := c.String(FlagNamespace)
+
+	config, err := clientcmd.BuildConfigFromFlags("", c.String(FlagKubeConfig))
+	if err != nil {
+		return errors.Wrap(err, "unable to get client config")
+	}
+
+	lhClient, err := lhclientset.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "unable to get clientset")
+	}
+
+	if err := upgradeutil.CheckUpgradePathSupported(namespace, lhClient); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -76,7 +76,7 @@ func Upgrade(kubeconfigPath, currentNodeID string) error {
 		return errors.Wrap(err, "unable to create scheme")
 	}
 
-	if err := upgradeLocalNode(); err != nil {
+	if err := upgradeutil.CheckUpgradePathSupported(namespace, lhClient); err != nil {
 		return err
 	}
 
@@ -216,16 +216,6 @@ func doAPIVersionUpgrade(namespace string, config *restclient.Config, lhClient *
 		return fmt.Errorf("don't support upgrade from %v to %v", crdAPIVersion, types.CurrentCRDAPIVersion)
 	}
 
-	return nil
-}
-
-func upgradeLocalNode() (err error) {
-	defer func() {
-		err = errors.Wrap(err, "upgrade local node failed")
-	}()
-	if err := v070to080.UpgradeLocalNode(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/upgrade/util/util_test.go
+++ b/upgrade/util/util_test.go
@@ -1,8 +1,25 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	"github.com/longhorn/longhorn-manager/meta"
+	"github.com/longhorn/longhorn-manager/types"
+
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	TestNamespace = "longhorn-system"
 )
 
 func TestProgressMonitorInc(t *testing.T) {
@@ -45,4 +62,121 @@ func TestProgressMonitorInc(t *testing.T) {
 	if targetValue != expectedTargetValue {
 		t.Fatalf(`targetValue = %v, expectedTargetValue = %v`, targetValue, expectedTargetValue)
 	}
+}
+
+func TestCheckUpgradePathSupported(t *testing.T) {
+	testCases := []struct {
+		name           string
+		currentVersion string
+		upgradeVersion string
+		expectError    bool
+	}{
+		{
+			name:           "new install",
+			currentVersion: "",
+			upgradeVersion: "v1.5.0",
+			expectError:    false,
+		},
+		{
+			name:           "major version downgrade",
+			currentVersion: "v2.0.0",
+			upgradeVersion: "v1.5.0",
+			expectError:    true,
+		},
+		{
+			name:           "upgrade across two major versions",
+			currentVersion: "v1.5.0",
+			upgradeVersion: "v3.0.0",
+			expectError:    true,
+		},
+		{
+			name:           "major version upgrade with lower minor version",
+			currentVersion: "v1.5.0",
+			upgradeVersion: "v2.0.0",
+			expectError:    true,
+		},
+		{
+			name:           "major version upgrade with upgradable minor version",
+			currentVersion: "v1.30.0",
+			upgradeVersion: "v2.0.0",
+			expectError:    false,
+		},
+		{
+			name:           "upgrade across two minor versions",
+			currentVersion: "v1.3.0-dev",
+			upgradeVersion: "v1.5.0",
+			expectError:    true,
+		},
+		{
+			name:           "upgradable minor version",
+			currentVersion: "v1.4.1",
+			upgradeVersion: "v1.5.0",
+			expectError:    false,
+		},
+		{
+			name:           "minor version downgrade",
+			currentVersion: "v1.5.0-dev",
+			upgradeVersion: "v1.4.0",
+			expectError:    true,
+		},
+		{
+			name:           "patch version upgrade across one patch version 1",
+			currentVersion: "v1.5.0",
+			upgradeVersion: "v1.5.1",
+			expectError:    false,
+		},
+		{
+			name:           "patch version upgrade across one patch version 2",
+			currentVersion: "v1.5.2",
+			upgradeVersion: "v1.5.3",
+			expectError:    false,
+		},
+		{
+			name:           "patch version upgrade across patch versions",
+			currentVersion: "v1.5.0",
+			upgradeVersion: "v1.5.9",
+			expectError:    false,
+		},
+		{
+			name:           "patch version downgrade",
+			currentVersion: "v1.5.1-dev",
+			upgradeVersion: "v1.5.0",
+			expectError:    true,
+		},
+		{
+			name:           "upgradable pre-release version",
+			currentVersion: "v1.5.0-rc1",
+			upgradeVersion: "v1.5.0-rc3",
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range testCases {
+		lhClient := lhfake.NewSimpleClientset()
+		setting := &longhorn.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: string(types.SettingNameCurrentLonghornVersion),
+			},
+			Value: tt.currentVersion,
+		}
+		lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			meta.Version = tt.upgradeVersion
+			err := newCheckUpgradePathSupported(lhClient)
+			if tt.expectError {
+				fmt.Println(err)
+				assert.NotNil(err)
+			} else {
+				fmt.Println(err)
+				assert.Nil(err)
+			}
+		})
+	}
+}
+
+func newCheckUpgradePathSupported(lhClient lhclientset.Interface) error {
+	return CheckUpgradePathSupported(TestNamespace, lhClient)
 }


### PR DESCRIPTION
Only allow upgrading from previous minor version. ex. v1.4.x to v1.5.0

Now it returns error only when new apps/pods are created by kubernetes for upgrading and old pods will be killed.
User could only apply the old manifest to roll back the longhorn system.

longhorn/longhorn#5131