### PR TITLE
Make sure pod.Spec.NodeName is assigned before check the node status

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -597,6 +597,11 @@ func (c *ShareManagerController) syncShareManagerPod(sm *longhorn.ShareManager) 
 		}
 	}
 
+	if pod.Spec.NodeName == "" {
+		log.Debugf("Pod %v spec.nodeName is not assigned", pod.Name)
+		return nil
+	}
+
 	// If the node where the pod is running on become defective, we clean up the pod by setting sm.Status.State to STOPPED or ERROR
 	// A new pod will be recreated by the share manager controller.
 	isDown, err := c.ds.IsNodeDownOrDeleted(pod.Spec.NodeName)


### PR DESCRIPTION
Previously, the immediate IsNodeDownOrDeleted check could fail if the share manager pod's spec.nodeName was not set, which could lead to the detachment of the volume and the transfer of ownership.
A race condition between the deletion of old volume replicas and the attachment of new volume could lead to a faulty volumes.

Longhorn/longhorn#5537