### PR TITLE
feat: marked replica failed if the node is deleted

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -2415,6 +2415,25 @@ func (s *DataStore) IsNodeDownOrDeleted(name string) (bool, error) {
 	return false, nil
 }
 
+// IsNodeDeleted checks whether the node does not exist by passing in the node name
+func (s *DataStore) IsNodeDeleted(name string) (bool, error) {
+	if name == "" {
+		return false, errors.New("no node name provided to check node down or deleted")
+	}
+
+	node, err := s.GetNodeRO(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	cond := types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady)
+
+	return cond.Status == longhorn.ConditionStatusFalse && cond.Reason == longhorn.NodeConditionReasonKubernetesNodeGone, nil
+}
+
 func (s *DataStore) IsNodeSchedulable(name string) bool {
 	node, err := s.GetNodeRO(name)
 	if err != nil {


### PR DESCRIPTION
[Longhorn 5542](https://github.com/longhorn/longhorn/issues/5542)

Signed-off-by: Ray Chang <ray.chang@suse.com>

In `ReconcileVolumeState()`, check if the node where the replica is located is deleted, and if so, directly mark the replica as failed.

Below are the test results:
 - Having a volume with one replica, then delete the VM that volume attached
   - Both the Volume and replica become `Faulted`
     ![volume_faulted](https://user-images.githubusercontent.com/17548901/225528312-977a9eb6-14e5-44cb-8e91-b281ee251317.png)
     ![replica_failedAt](https://user-images.githubusercontent.com/17548901/225528265-eed69f86-8ff8-48a6-9234-39620b68d8aa.png)
     ![UI](https://user-images.githubusercontent.com/17548901/225528364-07597337-bce0-44b3-b010-b15551619bc8.png)

 - Having a volume with two replicas
   - delete the VM that volume attached
     - The volume becomes `unknown` and the copy becomes `failed`. The volume is then reattached to another schedulable node and the failed replica is removed, and the volume returns to a `healthy` state.
       ![1](https://user-images.githubusercontent.com/17548901/225530866-8b880837-aac9-4b3f-bb5b-14a4e4c0c922.png)
       ![2](https://user-images.githubusercontent.com/17548901/225530772-b67e6cc0-a22f-4cfc-abdb-9dfa084037e3.png)
   - delete the VM that volume doesn't attached
     - The volume becomes `Degraded` and the replica becomes `Failed`. After delete the failed replica, the volume back to `Healthy` state. 
     ![replica_failedAt_2](https://user-images.githubusercontent.com/17548901/225528520-de22d791-2f95-4175-af5b-ce1160d379be.png)
