### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @longhorn/dev-control-plane


### PR DESCRIPTION
Support automatically requested for review when someone opens a pull request.
Note that:
- code owners are not automatically requested to review draft pull requests.
- when you mark a draft pull request as ready for review, code owners are automatically notified.

More information on https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

https://github.com/longhorn/longhorn/issues/2382