### PR TITLE
Only active replica if it doesn't have deletion timestamp

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2579,7 +2579,7 @@ func (vc *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[st
 	}
 
 	if err := vc.switchActiveReplicas(rs, func(r *longhorn.Replica, engineImage string) bool {
-		return r.Spec.EngineImage == engineImage
+		return r.Spec.EngineImage == engineImage && !r.DeletionTimestamp.IsZero()
 	}, v.Spec.EngineImage); err != nil {
 		return err
 	}


### PR DESCRIPTION
I am worrying about this case:
1. volume.Spec.EngineImage change to new one (EI-2) -> upgrading process start
1. [Longhorn create new migrating replicas and set them to inactive](https://github.com/longhorn/longhorn-manager/blob/0fad975f5ec4d4ccc98ecab7a9b8c5e176e520f4/controller/volume_controller.go#L2534)
1. Assume that all inactive replicas failed for some reason
[Volume controller set deletion timestamp for them](https://github.com/longhorn/longhorn-manager/blob/0fad975f5ec4d4ccc98ecab7a9b8c5e176e520f4/controller/volume_controller.go#L860-L867)
1. Then Volume controller [active these replicas](https://github.com/longhorn/longhorn-manager/blob/0fad975f5ec4d4ccc98ecab7a9b8c5e176e520f4/controller/volume_controller.go#L2581)
1. Replica controller delete all the replica folders [because they are active replica](https://github.com/longhorn/longhorn-manager/blob/0fad975f5ec4d4ccc98ecab7a9b8c5e176e520f4/controller/replica_controller.go#L312)

Which is a very tricky case. I am not 100% sure if it can happen but this modification will avoid that theoretical case.