### PR TITLE
chore: the io/ioutil package is deprecated from Go 1.16

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -57,7 +56,7 @@ func IsNotFound(err error) bool {
 }
 
 func newApiError(resp *http.Response, url string) *ApiError {
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	var body string
 	if err != nil {
 		body = "Unreadable body."
@@ -197,7 +196,7 @@ func setupRancherBaseClient(rancherClient *RancherBaseClientImpl, opts *ClientOp
 	}
 
 	var schemas Schemas
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -249,7 +248,7 @@ func (rancherClient *RancherBaseClientImpl) doDelete(url string) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return err
 	}
@@ -306,7 +305,7 @@ func (rancherClient *RancherBaseClientImpl) doGet(url string, opts *ListOpts, re
 		return newApiError(resp, url)
 	}
 
-	byteContent, err := ioutil.ReadAll(resp.Body)
+	byteContent, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -392,7 +391,7 @@ func (rancherClient *RancherBaseClientImpl) doModify(method string, url string, 
 		return newApiError(resp, url)
 	}
 
-	byteContent, err := ioutil.ReadAll(resp.Body)
+	byteContent, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -587,7 +586,7 @@ func (rancherClient *RancherBaseClientImpl) doAction(schemaType string, action s
 		return newApiError(resp, actionUrl)
 	}
 
-	byteContent, err := ioutil.ReadAll(resp.Body)
+	byteContent, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -905,7 +905,7 @@ func (sc *SettingController) CheckLatestAndStableLonghornVersions() (string, str
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
 		message := ""
-		messageBytes, err := ioutil.ReadAll(r.Body)
+		messageBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			message = err.Error()
 		} else {

--- a/controller/support_bundle_controller_test.go
+++ b/controller/support_bundle_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -337,7 +337,7 @@ func (m *fakeSupportBundleHTTPClient) Do(req *http.Request) (*http.Response, err
 		return nil, errors.Wrapf(err, "failed to marshal from mocked client")
 	}
 	if req.URL.Path == "/status" {
-		responseBody := ioutil.NopCloser(bytes.NewBuffer(statusByte))
+		responseBody := io.NopCloser(bytes.NewBuffer(statusByte))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       responseBody,

--- a/controller/system_rollout_controller.go
+++ b/controller/system_rollout_controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -620,7 +619,7 @@ func (c *SystemRolloutController) cacheLonghornResources() error {
 func (c *SystemRolloutController) cacheResourcesFromDirectory(name string, scheme *runtime.Scheme) error {
 	codecs := serializer.NewCodecFactory(scheme)
 
-	files, err := ioutil.ReadDir(name)
+	files, err := os.ReadDir(name)
 	if err != nil {
 		if errors.Is(err, unix.ENOENT) {
 			return nil

--- a/util/http.go
+++ b/util/http.go
@@ -2,14 +2,14 @@ package util
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
 func CopyReq(req *http.Request) *http.Request {
 	r := *req
-	buf, _ := ioutil.ReadAll(r.Body)
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+	buf, _ := io.ReadAll(r.Body)
+	req.Body = io.NopCloser(bytes.NewBuffer(buf))
+	r.Body = io.NopCloser(bytes.NewBuffer(buf))
 	return &r
 }

--- a/webhook/conversion/conversion.go
+++ b/webhook/conversion/conversion.go
@@ -3,7 +3,7 @@ package conversion
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -42,7 +42,7 @@ func NewHandler() (*Handler, error) {
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var body []byte
 	if req.Body != nil {
-		if data, err := ioutil.ReadAll(req.Body); err == nil {
+		if data, err := io.ReadAll(req.Body); err == nil {
 			body = data
 		}
 	}


### PR DESCRIPTION
[The `io/ioutil` package is deprecated from Go 1.16](https://pkg.go.dev/io/ioutil#:~:text=Deprecated%3A%20As%20of%20Go%201.16%2C%20the%20same%20functionality%20is%20now%20provided%20by%20package%20io%20or%20package%20os).