### PR TITLE
Fix bug: volume is stuck in live engine upgrading

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1997,7 +1997,7 @@ func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine, log *logrus
 
 	processBinary, err := c.ProcessGetBinary(e.Name)
 	if err != nil {
-		return errors.Wrapf(err, "fail to get the binary of the current engine process")
+		return errors.Wrapf(err, "failed to get the binary of the current engine process")
 	}
 	if strings.Contains(processBinary, types.GetImageCanonicalName(e.Spec.EngineImage)) {
 		log.Infof("The existing engine process already has the new engine image %v", e.Spec.EngineImage)

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -316,7 +316,7 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 
 	syncReplicaAddressMap := false
 	if len(engine.Spec.UpgradedReplicaAddressMap) != 0 && engine.Status.CurrentImage != engine.Spec.EngineImage {
-		if err := ec.Upgrade(engine); err != nil {
+		if err := ec.Upgrade(engine, log); err != nil {
 			// Engine live upgrade failure shouldn't block the following engine state update.
 			log.WithError(err).Error("failed to run engine live upgrade")
 			// Sync replica address map as usual when the upgrade fails.
@@ -1924,12 +1924,10 @@ func getReplicaRebuildFailedReasonFromError(errMsg string) (string, longhorn.Con
 	}
 }
 
-func (ec *EngineController) Upgrade(e *longhorn.Engine) (err error) {
+func (ec *EngineController) Upgrade(e *longhorn.Engine, log *logrus.Entry) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "cannot live upgrade image for %v", e.Name)
 	}()
-
-	log := ec.logger.WithField("volume", e.Spec.VolumeName)
 
 	engineClientProxy, err := ec.getEngineClientProxy(e, e.Spec.EngineImage)
 	if err != nil {
@@ -1947,7 +1945,7 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine) (err error) {
 	if version.ClientVersion.GitCommit != version.ServerVersion.GitCommit {
 		log.Debugf("Trying to upgrade engine from %v to %v",
 			e.Status.CurrentImage, e.Spec.EngineImage)
-		if err := ec.UpgradeEngineProcess(e); err != nil {
+		if err := ec.UpgradeEngineProcess(e, log); err != nil {
 			return err
 		}
 	}
@@ -1961,7 +1959,7 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine) (err error) {
 	return nil
 }
 
-func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine) error {
+func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine, log *logrus.Entry) error {
 	frontend := e.Spec.Frontend
 	if e.Spec.DisableFrontend {
 		frontend = longhorn.VolumeFrontendEmpty
@@ -1995,6 +1993,15 @@ func (ec *EngineController) UpgradeEngineProcess(e *longhorn.Engine) error {
 	engineCLIAPIVersion, err := ec.ds.GetEngineImageCLIAPIVersion(e.Spec.EngineImage)
 	if err != nil {
 		return err
+	}
+
+	processBinary, err := c.ProcessGetBinary(e.Name)
+	if err != nil {
+		return errors.Wrapf(err, "fail to get the binary of the current engine process")
+	}
+	if strings.Contains(processBinary, types.GetImageCanonicalName(e.Spec.EngineImage)) {
+		log.Infof("The existing engine process already has the new engine image %v", e.Spec.EngineImage)
+		return nil
 	}
 
 	engineProcess, err := c.EngineProcessUpgrade(e, frontend, engineReplicaTimeout, fileSyncHTTPClientTimeout, v.Spec.DataLocality, engineCLIAPIVersion)

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1829,7 +1829,6 @@ func (vc *VolumeController) replenishReplicas(v *longhorn.Volume, e *longhorn.En
 	if (!newVolume && replenishCount > 0) || hardNodeAffinity != "" {
 		replenishCount = 1
 	}
-
 	for i := 0; i < replenishCount; i++ {
 		reusableFailedReplica, err := vc.scheduler.CheckAndReuseFailedReplica(rs, v, hardNodeAffinity)
 		if err != nil {
@@ -2220,7 +2219,7 @@ func (vc *VolumeController) getReplenishReplicasCount(v *longhorn.Volume, rs map
 			continue
 		}
 		// Skip the replica has been requested eviction.
-		if r.Spec.FailedAt == "" && (!r.Status.EvictionRequested) {
+		if r.Spec.FailedAt == "" && (!r.Status.EvictionRequested) && r.Spec.Active {
 			usableCount++
 		}
 	}
@@ -2391,7 +2390,7 @@ func (vc *VolumeController) getNodeCandidatesForAutoBalanceZone(v *longhorn.Volu
 func (vc *VolumeController) hasEngineStatusSynced(e *longhorn.Engine, rs map[string]*longhorn.Replica) bool {
 	connectedReplicaCount := 0
 	for _, r := range rs {
-		if r.Spec.FailedAt == "" && r.Spec.NodeID != "" {
+		if r.Spec.FailedAt == "" && r.Spec.NodeID != "" && r.Spec.Active {
 			connectedReplicaCount++
 		}
 	}

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -258,6 +258,17 @@ func (c *InstanceManagerClient) ProcessGet(name string) (*longhorn.InstanceProce
 	return c.parseProcess(process), nil
 }
 
+func (c *InstanceManagerClient) ProcessGetBinary(name string) (string, error) {
+	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
+		return "", err
+	}
+	process, err := c.grpcClient.ProcessGet(name)
+	if err != nil {
+		return "", err
+	}
+	return process.Binary, nil
+}
+
 // ProcessLog returns a grpc stream that will be closed when the passed context is cancelled or the underlying grpc client is closed
 func (c *InstanceManagerClient) ProcessLog(ctx context.Context, name string) (*imapi.LogStream, error) {
 	if err := CheckInstanceManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -425,8 +425,19 @@ func (rcs *ReplicaScheduler) getDiskWithMostUsableStorage(disks map[string]*Disk
 
 	return diskWithMostUsableStorage
 }
+func filterActiveReplicas(replicas map[string]*longhorn.Replica) map[string]*longhorn.Replica {
+	result := map[string]*longhorn.Replica{}
+	for _, r := range replicas {
+		if r.Spec.Active {
+			result[r.Name] = r
+		}
+	}
+	return result
+}
 
 func (rcs *ReplicaScheduler) CheckAndReuseFailedReplica(replicas map[string]*longhorn.Replica, volume *longhorn.Volume, hardNodeAffinity string) (*longhorn.Replica, error) {
+	replicas = filterActiveReplicas(replicas)
+
 	allNodesInfo, err := rcs.getNodeInfo()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1. During the live engine upgrade, if the volume becomes degraded before the engine.Spec.EngineImage is set to new engine image, Longhorn doesn't try to rebuild the volume. Volume never becomes healthy which block the engine live upgrade process
2. Due to ETCD update conflict, sometime the UpgradeEngineProcess() is called multiple times. However, if the first call already succeeded, the subsequent calls will always fail. We shouldn't call the function UpgradeEngineProcess() if the existing process already has the newer engine image

More details are at https://github.com/longhorn/longhorn/issues/5684#issuecomment-1496777410

longhorn/longhorn#5684