### PR TITLE
volume mutator: update restoreVolumeRecurringJob and snapshotDataIntegrity

### DIFF
--- a/webhook/resources/volume/mutator.go
+++ b/webhook/resources/volume/mutator.go
@@ -259,6 +259,12 @@ func (v *volumeMutator) Update(request *admission.Request, oldObj runtime.Object
 	if volume.Spec.UnmapMarkSnapChainRemoved == "" {
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/unmapMarkSnapChainRemoved", "value": "%s"}`, longhorn.UnmapMarkSnapChainRemovedIgnored))
 	}
+	if string(volume.Spec.SnapshotDataIntegrity) == "" {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/snapshotDataIntegrity", "value": "%s"}`, longhorn.SnapshotDataIntegrityIgnored))
+	}
+	if string(volume.Spec.RestoreVolumeRecurringJob) == "" {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/restoreVolumeRecurringJob", "value": "%s"}`, longhorn.RestoreVolumeRecurringJobDefault))
+	}
 
 	size := util.RoundUpSize(volume.Spec.Size)
 	if size != volume.Spec.Size {


### PR DESCRIPTION
The upgrade path can patch the values and directly update to the API server. However, vefore the volume lister is updated, volume.spec will be upated with outdated values. To mitigate the issue, we need to patch the empty values in the update as well.

Longhorn/longhorn#5485