### PR TITLE
Bump CSI sidecars v1.5

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -20,12 +20,12 @@ import (
 )
 
 const (
-	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v3.4.0"
+	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v4.2.0"
 	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v2.1.2"
-	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.3.0"
+	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.7.0"
 	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v5.0.1"
-	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.5.0"
-	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.8.0"
+	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.7.0"
+	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.9.0"
 
 	DefaultCSIAttacherReplicaCount    = 3
 	DefaultCSIProvisionerReplicaCount = 3

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v4.2.0"
-	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v2.1.2"
+	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v3.4.1"
 	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.7.0"
-	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v5.0.1"
+	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v6.2.1"
 	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.7.0"
 	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.9.0"
 


### PR DESCRIPTION
[longhorn/longhorn#5672](https://github.com/longhorn/longhorn/issues/5672)

We can't move to these versions of external-provisioner and external-snapshotter in Longhorn < v1.5, as they no longer support the v1beta1 VolumeSnapshot API. We deprecated its use in Longhorn v1.4 (https://github.com/longhorn/longhorn/blob/master/CHANGELOG/CHANGELOG-1.4.0.md#deprecation--incompatibilities). I will create separate PRs to bump sidecar versions in the v1.4.x and v1.3.x branches without these components.

EDIT: This comment was previously (incorrectly) missing the "<" sign.
