### PR TITLE
Bump CSI sidecars v1.4

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -20,12 +20,12 @@ import (
 )
 
 const (
-	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v3.4.0"
+	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v4.2.0"
 	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v2.1.2"
-	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.3.0"
+	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.7.0"
 	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v5.0.1"
-	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.5.0"
-	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.8.0"
+	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.7.0"
+	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.9.0"
 
 	DefaultCSIAttacherReplicaCount    = 3
 	DefaultCSIProvisionerReplicaCount = 3

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v4.2.0"
-	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v2.1.2"
+	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v2.2.2"
 	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.7.0"
 	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v5.0.1"
 	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.7.0"


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5672

Mostly the same as #1839 except it doesn't bump external-provisioner and external-snapshotter beyond the v1beta1 VolumeSnapshot API.