### PR TITLE
[v1.3.3] Mark the setting allow-node-drain-with-last-healthy-replica as deprecated

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -593,7 +593,7 @@ var (
 	}
 
 	SettingDefinitionAllowNodeDrainWithLastHealthyReplica = SettingDefinition{
-		DisplayName: "Allow Node Drain with the Last Healthy Replica",
+		DisplayName: "Allow Node Drain with the Last Healthy Replica (Deprecated)",
 		Description: "By default, Longhorn will block `kubectl drain` action on a node if the node contains the last healthy replica of a volume.\n\n" +
 			"If this setting is enabled, Longhorn will **not** block `kubectl drain` action on a node even if the node contains the last healthy replica of a volume.",
 		Category: SettingCategoryGeneral,


### PR DESCRIPTION
longhorn/longhorn#5585
longhorn/longhorn#5768