### PR TITLE
Exclude empty node ID when checking engine image readiness

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2474,6 +2474,9 @@ func (vc *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[st
 
 	volumeAndReplicaNodes := []string{v.Status.CurrentNodeID}
 	for _, r := range rs {
+		if r.Spec.NodeID == "" {
+			continue
+		}
 		volumeAndReplicaNodes = append(volumeAndReplicaNodes, r.Spec.NodeID)
 	}
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1463,6 +1463,9 @@ func (s *DataStore) CheckEngineImageReadiness(image string, nodes ...string) (is
 	}
 	undeployedNodes := []string{}
 	for _, node := range nodes {
+		if node == "" {
+			continue
+		}
 		if _, ok := nodesHaveEngineImage[node]; !ok {
 			undeployedNodes = append(undeployedNodes, node)
 		}


### PR DESCRIPTION
Longhorn/longhorn#5740