### PR TITLE
Eliminate race between replica and instance manager controllers follow-up (backport #1887)

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -58,6 +58,7 @@ const (
 	TestVolumeSize         = 1073741824
 	TestVolumeStaleTimeout = 60
 	TestEngineName         = "test-volume-engine"
+	TestReplicaName        = "test-volume-replica"
 
 	TestPVName  = "test-pv"
 	TestPVCName = "test-pvc"

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1774,6 +1774,7 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 
 		// It has been at least 10 seconds (2 * EnginePollInterval) since we were asked to rebuild.
 		// Should we still communicate with addr?
+		// TODO: Remove this check in versions that include a completed longhorn/longhorn#5845.
 		updatedEngine, err := ec.ds.GetEngineRO(e.Name)
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -418,15 +418,13 @@ func (imc *InstanceManagerController) syncStatusWithPod(im *longhorn.InstanceMan
 // syncInstanceStatus sets the status of instances in special cases independent of InstanceManagerMonitor (e.g. when
 // InstanceManagerMonitor isn't running yet).
 func (imc *InstanceManagerController) syncInstanceStatus(im *longhorn.InstanceManager) error {
-	if im.Status.CurrentState == longhorn.InstanceManagerStateStarting {
-		// In this state, we can be sure instance processes are not running.
+	if im.Status.CurrentState == longhorn.InstanceManagerStateStopped ||
+		im.Status.CurrentState == longhorn.InstanceManagerStateError ||
+		im.Status.CurrentState == longhorn.InstanceManagerStateStarting {
+		// In these states, instance processes either are not running or will soon not be running.
 		// This step prevents other controllers from being confused by stale information.
-		// InstanceManagerMonitor will change this when it polls for the first time.
-		for k, v := range im.Status.Instances {
-			// Retain historical information (e.g. ErrorMsg).
-			v.Status.State = longhorn.InstanceStateStopped
-			im.Status.Instances[k] = v
-		}
+		// InstanceManagerMonitor will change this when/if it polls.
+		im.Status.Instances = nil
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5867

This is the backport to https://github.com/longhorn/longhorn-manager/pull/1887. Those commits could not be directly backported because of changes to instance manager in Longhorn v1.5.x.

Integration tested against v1.4.2-rc1 (w/ modified longhorn-manager) using v1.4.x-head tests. All test cases passed.