### PR TITLE
fix(upgrade): missing command `pre-upgrade`

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 		app.RecurringJobCmd(),
 		app.DeployDriverCmd(),
 		app.CSICommand(),
+		app.PreUpgradeCmd(),
 		app.PostUpgradeCmd(),
 		app.UninstallCmd(),
 		app.SystemRolloutCmd(),


### PR DESCRIPTION
Add `pre-upgrade` command in main.go

Ref: longhorn/longhorn#5131, longhorn/longhorn#5862