### PR TITLE
fix(backupvolume): Ignore BackupVolume not found error in autodetachment

### DIFF
--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -220,11 +220,6 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	// Examine DeletionTimestamp to determine if object is under deletion
 	if !backupVolume.DeletionTimestamp.IsZero() {
 
-		if unused, err := bvc.isBackupNotBeingUsedForVolumeRestore(backupVolumeName); !unused {
-			log.WithError(err).Warnf("Unable to delete backups of the backup volume")
-			return nil
-		}
-
 		if err := bvc.ds.DeleteAllBackupsForBackupVolume(backupVolumeName); err != nil {
 			log.WithError(err).Error("Error deleting backups")
 			return err
@@ -437,17 +432,4 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 	requiresNewOwner := currentNodeEngineAvailable && !currentOwnerEngineAvailable
 
 	return isPreferredOwner || continueToBeOwner || requiresNewOwner, nil
-}
-
-func (bvc *BackupVolumeController) isBackupNotBeingUsedForVolumeRestore(backupVolumeName string) (bool, error) {
-	volumes, err := bvc.ds.ListVolumesByBackupVolumeRO(backupVolumeName)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to list volumes for backup volume %v for checking restore status", backupVolumeName)
-	}
-	for _, v := range volumes {
-		if types.GetCondition(v.Status.Conditions, longhorn.VolumeConditionTypeRestore).Status == longhorn.ConditionStatusTrue {
-			return false, fmt.Errorf("backups cannot be deleted due to the ongoing volume %v restoration", v.Name)
-		}
-	}
-	return true, nil
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2947,10 +2947,10 @@ func (vc *VolumeController) checkForAutoDetachment(v *longhorn.Volume, e *longho
 	// so that the engine restores with the latest backup before the volume is detached
 	if backupVolumeName, isExist := v.Labels[types.LonghornLabelBackupVolume]; isExist && backupVolumeName != "" {
 		backupVolume, err := vc.ds.GetBackupVolumeRO(backupVolumeName)
-		if err != nil {
+		if err != nil && !datastore.ErrorIsNotFound(err) {
 			return errors.Wrapf(err, "failed to get backup volume: %v", v.Name)
 		}
-		if backupVolume.Status.LastSyncedAt.Before(&backupVolume.Spec.SyncRequestedAt) {
+		if backupVolume != nil && backupVolume.Status.LastSyncedAt.Before(&backupVolume.Spec.SyncRequestedAt) {
 			return nil
 		}
 	}


### PR DESCRIPTION
ref: [longhorn/longhorn#5506](https://github.com/longhorn/longhorn/issues/5506)

There is a timing issue

- when user click Delete all Backups right before volume is attached and start restoration, the condition of volume restore is still false, and the BackupVolume can be deleted. In this case, we should block the situation by checking engine status instead, because its `isRestoring` will be **true** at the moment
- But if we only check engine status, then when engine restore progress 100%, it then turns into `isRestoring=False`. But the volume condition restore will still be true until it is **autodetached**. We should wait until condition `restore=False` then we can delete BackupVolume