### PR TITLE
fix: remove default image settings

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -154,7 +154,7 @@ func startManager(c *cli.Context) error {
 
 	proxyConnCounter := util.NewAtomicCounter()
 
-	ds, wsc, err := controller.StartControllers(logger, ctx.Done(), currentNodeID, serviceAccount, managerImage, backingImageManagerImage, kubeconfigPath, meta.Version, proxyConnCounter)
+	ds, wsc, err := controller.StartControllers(logger, ctx.Done(), currentNodeID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage, kubeconfigPath, meta.Version, proxyConnCounter)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,6 @@ func startManager(c *cli.Context) error {
 	defaultImageSettings := map[types.SettingName]string{
 		types.SettingNameDefaultEngineImage:              engineImage,
 		types.SettingNameDefaultInstanceManagerImage:     instanceManagerImage,
-		types.SettingNameDefaultShareManagerImage:        shareManagerImage,
 		types.SettingNameDefaultBackingImageManagerImage: backingImageManagerImage,
 		types.SettingNameSupportBundleManagerImage:       supportBundleManagerImage,
 	}

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -154,7 +154,9 @@ func startManager(c *cli.Context) error {
 
 	proxyConnCounter := util.NewAtomicCounter()
 
-	ds, wsc, err := controller.StartControllers(logger, ctx.Done(), currentNodeID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage, kubeconfigPath, meta.Version, proxyConnCounter)
+	ds, wsc, err := controller.StartControllers(logger, ctx.Done(),
+		currentNodeID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage,
+		kubeconfigPath, meta.Version, proxyConnCounter)
 	if err != nil {
 		return err
 	}

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -154,7 +154,7 @@ func startManager(c *cli.Context) error {
 
 	proxyConnCounter := util.NewAtomicCounter()
 
-	ds, wsc, err := controller.StartControllers(logger, ctx.Done(), currentNodeID, serviceAccount, managerImage, kubeconfigPath, meta.Version, proxyConnCounter)
+	ds, wsc, err := controller.StartControllers(logger, ctx.Done(), currentNodeID, serviceAccount, managerImage, backingImageManagerImage, kubeconfigPath, meta.Version, proxyConnCounter)
 	if err != nil {
 		return err
 	}

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -51,6 +51,7 @@ type BackingImageDataSourceController struct {
 	namespace      string
 	controllerID   string
 	serviceAccount string
+	bimImageName   string
 
 	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
@@ -84,7 +85,7 @@ func NewBackingImageDataSourceController(
 	ds *datastore.DataStore,
 	scheme *runtime.Scheme,
 	kubeClient clientset.Interface,
-	namespace, controllerID, serviceAccount string,
+	namespace, controllerID, serviceAccount, imageManagerImage string,
 	proxyConnCounter util.Counter,
 ) *BackingImageDataSourceController {
 
@@ -98,6 +99,7 @@ func NewBackingImageDataSourceController(
 		namespace:      namespace,
 		controllerID:   controllerID,
 		serviceAccount: serviceAccount,
+		bimImageName:   imageManagerImage,
 
 		kubeClient:    kubeClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "longhorn-backing-image-data-source-controller"}),
@@ -406,11 +408,6 @@ func (c *BackingImageDataSourceController) syncBackingImageDataSourcePod(bids *l
 	}()
 	log := getLoggerForBackingImageDataSource(c.logger, bids)
 
-	defaultImage, err := c.ds.GetSettingValueExisted(types.SettingNameDefaultBackingImageManagerImage)
-	if err != nil {
-		return err
-	}
-
 	newBackingImageDataSource := bids.Status.CurrentState == ""
 
 	podName := types.GetBackingImageDataSourcePodName(bids.Name)
@@ -427,7 +424,7 @@ func (c *BackingImageDataSourceController) syncBackingImageDataSourcePod(bids *l
 		podNotReadyMessage = fmt.Sprintf("pod spec node ID %v doesn't match the desired node ID %v", pod.Spec.NodeName, bids.Spec.NodeID)
 	} else if pod.DeletionTimestamp != nil {
 		podNotReadyMessage = "the pod dedicated to prepare the first backing image file is being deleted"
-	} else if pod.Spec.Containers[0].Image != defaultImage {
+	} else if pod.Spec.Containers[0].Image != c.bimImageName {
 		podNotReadyMessage = "the pod image is not the default one"
 	} else {
 		switch pod.Status.Phase {
@@ -666,11 +663,6 @@ func (c *BackingImageDataSourceController) generateBackingImageDataSourcePodMani
 		return nil, err
 	}
 
-	bimImage, err := c.ds.GetSettingValueExisted(types.SettingNameDefaultBackingImageManagerImage)
-	if err != nil {
-		return nil, err
-	}
-
 	bi, err := c.ds.GetBackingImage(bids.Name)
 	if err != nil {
 		return nil, err
@@ -715,7 +707,7 @@ func (c *BackingImageDataSourceController) generateBackingImageDataSourcePodMani
 			Containers: []v1.Container{
 				{
 					Name:            BackingImageDataSourcePodContainerName,
-					Image:           bimImage,
+					Image:           c.bimImageName,
 					ImagePullPolicy: imagePullPolicy,
 					Command:         cmd,
 					ReadinessProbe: &v1.Probe{

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -35,7 +35,7 @@ var (
 	longhornFinalizerKey = longhorn.SchemeGroupVersion.Group
 )
 
-func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, controllerID, serviceAccount, managerImage, kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
+func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, controllerID, serviceAccount, managerImage, backingImageManagerImage, kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
 	namespace := os.Getenv(types.EnvPodNamespace)
 	if namespace == "" {
 		logrus.Warnf("Cannot detect pod namespace, environment variable %v is missing, "+
@@ -94,9 +94,9 @@ func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, control
 	bc := NewBackupController(logger, ds, scheme, kubeClient, controllerID, namespace, proxyConnCounter)
 	imc := NewInstanceManagerController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount)
 	smc := NewShareManagerController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount)
-	bic := NewBackingImageController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount)
-	bimc := NewBackingImageManagerController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount)
-	bidsc := NewBackingImageDataSourceController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount, proxyConnCounter)
+	bic := NewBackingImageController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount, backingImageManagerImage)
+	bimc := NewBackingImageManagerController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount, backingImageManagerImage)
+	bidsc := NewBackingImageDataSourceController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount, backingImageManagerImage, proxyConnCounter)
 	rjc := NewRecurringJobController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount, managerImage)
 	oc := NewOrphanController(logger, ds, scheme, kubeClient, controllerID, namespace)
 	snapc := NewSnapshotController(logger, ds, scheme, kubeClient, namespace, controllerID, &engineapi.EngineCollection{}, proxyConnCounter)

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -35,7 +35,7 @@ var (
 	longhornFinalizerKey = longhorn.SchemeGroupVersion.Group
 )
 
-func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, controllerID, serviceAccount, managerImage, backingImageManagerImage, kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
+func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, controllerID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage, kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
 	namespace := os.Getenv(types.EnvPodNamespace)
 	if namespace == "" {
 		logrus.Warnf("Cannot detect pod namespace, environment variable %v is missing, "+
@@ -84,7 +84,7 @@ func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, control
 
 	rc := NewReplicaController(logger, ds, scheme, kubeClient, namespace, controllerID)
 	ec := NewEngineController(logger, ds, scheme, kubeClient, &engineapi.EngineCollection{}, namespace, controllerID, proxyConnCounter)
-	vc := NewVolumeController(logger, ds, scheme, kubeClient, namespace, controllerID, proxyConnCounter)
+	vc := NewVolumeController(logger, ds, scheme, kubeClient, namespace, controllerID, shareManagerImage, proxyConnCounter)
 	ic := NewEngineImageController(logger, ds, scheme, kubeClient, namespace, controllerID, serviceAccount)
 	nc := NewNodeController(logger, ds, scheme, kubeClient, namespace, controllerID)
 	ws := NewWebsocketController(logger, ds)

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -35,7 +35,10 @@ var (
 	longhornFinalizerKey = longhorn.SchemeGroupVersion.Group
 )
 
-func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{}, controllerID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage, kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
+// StartControllers initiates all Longhorn component controllers and monitors to manage the creating, updating, and deletion of Longhorn resources
+func StartControllers(logger logrus.FieldLogger, stopCh <-chan struct{},
+	controllerID, serviceAccount, managerImage, backingImageManagerImage, shareManagerImage,
+	kubeconfigPath, version string, proxyConnCounter util.Counter) (*datastore.DataStore, *WebsocketController, error) {
 	namespace := os.Getenv(types.EnvPodNamespace)
 	if namespace == "" {
 		logrus.Warnf("Cannot detect pod namespace, environment variable %v is missing, "+

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -43,6 +43,7 @@ const (
 	TestInstanceManagerImage      = "longhorn-instance-manager:latest"
 	TestExtraInstanceManagerImage = "longhorn-instance-manager:upgraded"
 	TestManagerImage              = "longhorn-manager:latest"
+	TestShareManagerImage         = "longhorn-share-manager:latest"
 	TestServiceAccount            = "longhorn-service-account"
 
 	TestBackingImage = "test-backing-image"

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -59,7 +59,7 @@ func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerF
 
 	logger := logrus.StandardLogger()
 
-	vc := NewVolumeController(logger, ds, scheme.Scheme, kubeClient, TestNamespace, controllerID, proxyConnCounter)
+	vc := NewVolumeController(logger, ds, scheme.Scheme, kubeClient, TestNamespace, controllerID, TestShareManagerImage, proxyConnCounter)
 
 	fakeRecorder := record.NewFakeRecorder(100)
 	vc.eventRecorder = fakeRecorder

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1811,29 +1811,6 @@ func (s *DataStore) ListBackingImageManagersByDiskUUID(diskUUID string) (map[str
 	return s.listBackingImageManagers(diskSelector)
 }
 
-// ListDefaultBackingImageManagers gets a list of BackingImageManager
-// using default image with the given namespace.
-func (s *DataStore) ListDefaultBackingImageManagers() (map[string]*longhorn.BackingImageManager, error) {
-	defaultImage, err := s.GetSettingValueExisted(types.SettingNameDefaultBackingImageManagerImage)
-	if err != nil {
-		return nil, err
-	}
-
-	itemMap := map[string]*longhorn.BackingImageManager{}
-	list, err := s.bimLister.BackingImageManagers(s.namespace).List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-	for _, itemRO := range list {
-		if itemRO.Spec.Image != defaultImage {
-			continue
-		}
-		// Cannot use cached object from lister
-		itemMap[itemRO.Name] = itemRO.DeepCopy()
-	}
-	return itemMap, nil
-}
-
 // GetOwnerReferencesForBackingImageManager returns OwnerReference for the given
 // // backing image manager name and UID
 func GetOwnerReferencesForBackingImageManager(backingImageManager *longhorn.BackingImageManager) []metav1.OwnerReference {

--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -67,6 +67,7 @@ func (m *VolumeManager) GetBackingImageDataSourcePod(name string) (*v1.Pod, erro
 	return pod, nil
 }
 
+// GetDefaultBackingImageManagersByDiskUUID returns a default backing image manager resource object searched by the disk UUID
 func (m *VolumeManager) GetDefaultBackingImageManagersByDiskUUID(diskUUID string) (*longhorn.BackingImageManager, error) {
 	defaultImage, err := m.ds.GetSettingValueExisted(types.SettingNameDefaultBackingImageManagerImage)
 	if err != nil {

--- a/types/setting.go
+++ b/types/setting.go
@@ -369,7 +369,7 @@ var (
 		DisplayName: "Default Instance Manager Image",
 		Description: "The default instance manager image used by the manager. Can be changed on the manager starting command line only",
 		Category:    SettingCategoryGeneral,
-		Type:        SettingTypeString,
+		Type:        SettingTypeDeprecated,
 		Required:    true,
 		ReadOnly:    true,
 	}

--- a/types/setting.go
+++ b/types/setting.go
@@ -390,7 +390,7 @@ var (
 		DisplayName: "Default Backing Image Manager Image",
 		Description: "The default backing image manager image used by the manager. Can be changed on the manager starting command line only",
 		Category:    SettingCategoryGeneral,
-		Type:        SettingTypeString,
+		Type:        SettingTypeDeprecated,
 		Required:    true,
 		ReadOnly:    true,
 	}

--- a/types/setting.go
+++ b/types/setting.go
@@ -43,7 +43,6 @@ const (
 	SettingNameDefaultDataPath                                          = SettingName("default-data-path")
 	SettingNameDefaultEngineImage                                       = SettingName("default-engine-image")
 	SettingNameDefaultInstanceManagerImage                              = SettingName("default-instance-manager-image")
-	SettingNameDefaultShareManagerImage                                 = SettingName("default-share-manager-image")
 	SettingNameDefaultBackingImageManagerImage                          = SettingName("default-backing-image-manager-image")
 	SettingNameSupportBundleManagerImage                                = SettingName("support-bundle-manager-image")
 	SettingNameReplicaSoftAntiAffinity                                  = SettingName("replica-soft-anti-affinity")
@@ -113,7 +112,6 @@ var (
 		SettingNameDefaultDataPath,
 		SettingNameDefaultEngineImage,
 		SettingNameDefaultInstanceManagerImage,
-		SettingNameDefaultShareManagerImage,
 		SettingNameDefaultBackingImageManagerImage,
 		SettingNameSupportBundleManagerImage,
 		SettingNameReplicaSoftAntiAffinity,
@@ -208,7 +206,6 @@ var (
 		SettingNameDefaultDataPath:                                          SettingDefinitionDefaultDataPath,
 		SettingNameDefaultEngineImage:                                       SettingDefinitionDefaultEngineImage,
 		SettingNameDefaultInstanceManagerImage:                              SettingDefinitionDefaultInstanceManagerImage,
-		SettingNameDefaultShareManagerImage:                                 SettingDefinitionDefaultShareManagerImage,
 		SettingNameDefaultBackingImageManagerImage:                          SettingDefinitionDefaultBackingImageManagerImage,
 		SettingNameSupportBundleManagerImage:                                SettingDefinitionSupportBundleManagerImage,
 		SettingNameReplicaSoftAntiAffinity:                                  SettingDefinitionReplicaSoftAntiAffinity,
@@ -371,15 +368,6 @@ var (
 	SettingDefinitionDefaultInstanceManagerImage = SettingDefinition{
 		DisplayName: "Default Instance Manager Image",
 		Description: "The default instance manager image used by the manager. Can be changed on the manager starting command line only",
-		Category:    SettingCategoryGeneral,
-		Type:        SettingTypeString,
-		Required:    true,
-		ReadOnly:    true,
-	}
-
-	SettingDefinitionDefaultShareManagerImage = SettingDefinition{
-		DisplayName: "Default Share Manager Image",
-		Description: "The default share manager image used by the manager. Can be changed on the manager starting command line only",
 		Category:    SettingCategoryGeneral,
 		Type:        SettingTypeString,
 		Required:    true,


### PR DESCRIPTION
Remove the global default image settings during upgrade to v1.5.0 including `default-instance-manager-image`, `default-share-manager-image` and `default-backing-image-manager-image`.

Ref: longhorn/longhorn#5028

Regression Test:
- RWX: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/3873
- Backing image: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/3872

- Full run: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/3875