### PR TITLE
fix(dr-volume): activating volume failed

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2863,22 +2863,12 @@ func (vc *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *l
 		!v.Spec.Standby) {
 		return nil
 	}
-	allScheduledReplicasIncluded := true
-	for _, r := range rs {
-		// skip unscheduled replicas
-		if r.Spec.NodeID == "" {
-			continue
-		}
-		if isDownOrDeleted, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID); err != nil {
-			return err
-		} else if isDownOrDeleted {
-			continue
-		}
-		if mode := e.Status.ReplicaModeMap[r.Name]; mode != longhorn.ReplicaModeRW {
-			allScheduledReplicasIncluded = false
-			break
-		}
+
+	allScheduledReplicasIncluded, err := vc.checkAllScheduledReplicasIncluded(v, e, rs)
+	if err != nil {
+		return err
 	}
+
 	if !isPurging && (v.Status.Robustness == longhorn.VolumeRobustnessHealthy || v.Status.Robustness == longhorn.VolumeRobustnessDegraded) && allScheduledReplicasIncluded {
 		log.Info("Restore/DR volume finished")
 		v.Status.IsStandby = false
@@ -2886,6 +2876,30 @@ func (vc *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *l
 	}
 
 	return nil
+}
+
+func (vc *VolumeController) checkAllScheduledReplicasIncluded(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (bool, error) {
+	healthReplicaCount := 0
+	hasReplicaNotIncluded := false
+
+	for _, r := range rs {
+		// skip unscheduled replicas
+		if r.Spec.NodeID == "" {
+			continue
+		}
+		if isDownOrDeleted, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID); err != nil {
+			return false, err
+		} else if isDownOrDeleted {
+			continue
+		}
+		if mode := e.Status.ReplicaModeMap[r.Name]; mode == longhorn.ReplicaModeRW {
+			healthReplicaCount++
+		} else {
+			hasReplicaNotIncluded = true
+		}
+	}
+
+	return healthReplicaCount != 0 && (healthReplicaCount >= v.Spec.NumberOfReplicas || !hasReplicaNotIncluded), nil
 }
 
 func (vc *VolumeController) updateRequestedDataSourceForVolumeCloning(v *longhorn.Volume, e *longhorn.Engine) (err error) {
@@ -3102,22 +3116,12 @@ func (vc *VolumeController) checkForAutoDetachment(v *longhorn.Volume, e *longho
 		!v.Spec.Standby) {
 		return nil
 	}
-	allScheduledReplicasIncluded := true
-	for _, r := range rs {
-		// skip unscheduled replicas
-		if r.Spec.NodeID == "" {
-			continue
-		}
-		if isDownOrDeleted, err := vc.ds.IsNodeDownOrDeleted(r.Spec.NodeID); err != nil {
-			return err
-		} else if isDownOrDeleted {
-			continue
-		}
-		if mode := e.Status.ReplicaModeMap[r.Name]; mode != longhorn.ReplicaModeRW {
-			allScheduledReplicasIncluded = false
-			break
-		}
+
+	allScheduledReplicasIncluded, err := vc.checkAllScheduledReplicasIncluded(v, e, rs)
+	if err != nil {
+		return err
 	}
+
 	if (cliAPIVersion >= engineapi.CLIVersionFour && !isPurging && (v.Status.Robustness == longhorn.VolumeRobustnessHealthy || v.Status.Robustness == longhorn.VolumeRobustnessDegraded) && allScheduledReplicasIncluded) ||
 		(cliAPIVersion < engineapi.CLIVersionFour && (v.Status.Robustness == longhorn.VolumeRobustnessHealthy || v.Status.Robustness == longhorn.VolumeRobustnessDegraded)) {
 		log.Info("Preparing to do auto detachment for restore/DR volume")


### PR DESCRIPTION
Counting the all healthy replicas and activated the DR volume if healthy replicas count is equal to or bigger than the number of default replica of the volume or all replicas scheduled are healthy

Ref: longhorn/longhorn#3069