### PR TITLE
[PART-2] Attachment/Detachment Controller and Volume Controller Refactoring

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -249,6 +249,7 @@ type AttachInput struct {
 
 type DetachInput struct {
 	AttachmentID string `json:"attachmentID"`
+	HostID       string `json:"hostId"`
 	ForceDetach  bool   `json:"forceDetach"`
 }
 

--- a/api/volume.go
+++ b/api/volume.go
@@ -236,11 +236,12 @@ func (s *Server) VolumeDetach(rw http.ResponseWriter, req *http.Request) error {
 	if err := apiContext.Read(&input); err != nil {
 		// HACK: for ui detach requests that don't send a body
 		input.AttachmentID = ""
+		input.HostID = ""
 	}
 	id := mux.Vars(req)["name"]
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
-		return s.m.Detach(id, input.AttachmentID, input.ForceDetach)
+		return s.m.Detach(id, input.AttachmentID, input.HostID, input.ForceDetach)
 	})
 	if err != nil {
 		return err

--- a/client/generated_detach_input.go
+++ b/client/generated_detach_input.go
@@ -10,6 +10,8 @@ type DetachInput struct {
 	AttachmentID string `json:"attachmentID,omitempty" yaml:"attachment_id,omitempty"`
 
 	ForceDetach bool `json:"forceDetach,omitempty" yaml:"force_detach,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
 }
 
 type DetachInputCollection struct {

--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -421,7 +421,7 @@ func (bic *BackingImageController) handleBackingImageDataSource(bi *longhorn.Bac
 			bids.Spec.Parameters = map[string]string{}
 		}
 		if bids.Spec.SourceType == longhorn.BackingImageDataSourceTypeExportFromVolume {
-			bids.Labels = map[string]string{types.GetLonghornLabelKey(types.LonghornLabelExportFromVolume): bids.Spec.Parameters[DataSourceTypeExportFromVolumeParameterVolumeName]}
+			bids.Labels = map[string]string{types.GetLonghornLabelKey(types.LonghornLabelExportFromVolume): bids.Spec.Parameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeName]}
 		}
 		if bids, err = bic.ds.CreateBackingImageDataSource(bids); err != nil {
 			return err

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -588,23 +588,7 @@ func (c *BackingImageDataSourceController) handleAttachmentTicketCreation(bids *
 	}()
 
 	attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeBackingImageDataSourceController, bids.Name)
-
-	attachmentTicket, ok := va.Spec.AttachmentTickets[attachmentTicketID]
-	if !ok {
-		//create new one
-		attachmentTicket = &longhorn.AttachmentTicket{
-			ID:     attachmentTicketID,
-			Type:   longhorn.AttacherTypeBackingImageDataSourceController,
-			NodeID: vol.Status.OwnerID,
-			Parameters: map[string]string{
-				longhorn.AttachmentParameterDisableFrontend: longhorn.AnyValue,
-			},
-		}
-	}
-	if attachmentTicket.NodeID != vol.Status.OwnerID {
-		attachmentTicket.NodeID = vol.Status.OwnerID
-	}
-	va.Spec.AttachmentTickets[attachmentTicket.ID] = attachmentTicket
+	createOrUpdateAttachmentTicket(va, attachmentTicketID, vol.Status.OwnerID, longhorn.AnyValue, longhorn.AttacherTypeBackingImageDataSourceController)
 
 	return nil
 }

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -38,11 +38,6 @@ import (
 
 const (
 	BackingImageDataSourcePodContainerName = "backing-image-data-source"
-
-	DataSourceTypeExportFromVolumeParameterVolumeName    = "volume-name"
-	DataSourceTypeExportFromVolumeParameterVolumeSize    = "volume-size"
-	DataSourceTypeExportFromVolumeParameterSnapshotName  = "snapshot-name"
-	DataSourceTypeExportFromVolumeParameterSenderAddress = "sender-address"
 )
 
 type BackingImageDataSourceController struct {
@@ -540,7 +535,7 @@ func (c *BackingImageDataSourceController) handleAttachmentTicketDeletion(bids *
 		return nil
 	}
 
-	volumeName := bids.Spec.Parameters[DataSourceTypeExportFromVolumeParameterVolumeName]
+	volumeName := bids.Spec.Parameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeName]
 	va, err := c.ds.GetLHVolumeAttachmentByVolumeName(volumeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -567,7 +562,7 @@ func (c *BackingImageDataSourceController) handleAttachmentTicketCreation(bids *
 		return nil
 	}
 
-	volumeName := bids.Spec.Parameters[DataSourceTypeExportFromVolumeParameterVolumeName]
+	volumeName := bids.Spec.Parameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeName]
 	vol, err := c.ds.GetVolume(volumeName)
 	if err != nil {
 		return err
@@ -781,7 +776,7 @@ func (c *BackingImageDataSourceController) prepareRunningParameters(bids *longho
 		return nil
 	}
 
-	volumeName := bids.Spec.Parameters[DataSourceTypeExportFromVolumeParameterVolumeName]
+	volumeName := bids.Spec.Parameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeName]
 	v, err := c.ds.GetVolume(volumeName)
 	if err != nil {
 		return err
@@ -789,7 +784,7 @@ func (c *BackingImageDataSourceController) prepareRunningParameters(bids *longho
 	if v.Status.State != longhorn.VolumeStateAttached {
 		return fmt.Errorf("need to wait for volume %v attached before preparing parameters", volumeName)
 	}
-	bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterVolumeSize] = strconv.FormatInt(v.Spec.Size, 10)
+	bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeSize] = strconv.FormatInt(v.Spec.Size, 10)
 
 	e, err := c.ds.GetVolumeCurrentEngine(volumeName)
 	if err != nil {
@@ -803,8 +798,8 @@ func (c *BackingImageDataSourceController) prepareRunningParameters(bids *longho
 	}
 
 	newSnapshotRequired := true
-	if bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterSnapshotName] != "" {
-		if _, ok := e.Status.Snapshots[bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterSnapshotName]]; ok {
+	if bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterSnapshotName] != "" {
+		if _, ok := e.Status.Snapshots[bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterSnapshotName]]; ok {
 			newSnapshotRequired = false
 		}
 	}
@@ -820,7 +815,7 @@ func (c *BackingImageDataSourceController) prepareRunningParameters(bids *longho
 		if err != nil {
 			return err
 		}
-		bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterSnapshotName] = snapshotName
+		bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterSnapshotName] = snapshotName
 	}
 
 	for rName, mode := range e.Status.ReplicaModeMap {
@@ -838,9 +833,9 @@ func (c *BackingImageDataSourceController) prepareRunningParameters(bids *longho
 		if rAddress == "" || rAddress != fmt.Sprintf("%s:%d", r.Status.StorageIP, r.Status.Port) {
 			continue
 		}
-		bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterSenderAddress] = rAddress
+		bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterSenderAddress] = rAddress
 	}
-	if bids.Status.RunningParameters[DataSourceTypeExportFromVolumeParameterSenderAddress] == "" {
+	if bids.Status.RunningParameters[longhorn.DataSourceTypeExportFromVolumeParameterSenderAddress] == "" {
 		return fmt.Errorf("failed to get an available replica from volume %v during backing image %v exporting", v.Name, bids.Name)
 	}
 

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -492,23 +492,7 @@ func (bc *BackupController) handleAttachmentTicketCreation(backup *longhorn.Back
 	}()
 
 	attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeBackupController, backup.Name)
-
-	attachmentTicket, ok := va.Spec.AttachmentTickets[attachmentTicketID]
-	if !ok {
-		//create new one
-		attachmentTicket = &longhorn.AttachmentTicket{
-			ID:     attachmentTicketID,
-			Type:   longhorn.AttacherTypeBackupController,
-			NodeID: vol.Status.OwnerID,
-			Parameters: map[string]string{
-				"disableFrontend": longhorn.AnyValue,
-			},
-		}
-	}
-	if attachmentTicket.NodeID != vol.Status.OwnerID {
-		attachmentTicket.NodeID = vol.Status.OwnerID
-	}
-	va.Spec.AttachmentTickets[attachmentTicket.ID] = attachmentTicket
+	createOrUpdateAttachmentTicket(va, attachmentTicketID, vol.Status.OwnerID, longhorn.AnyValue, longhorn.AttacherTypeBackupController)
 
 	return nil
 }

--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -483,23 +483,7 @@ func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snap
 	}()
 
 	attachmentID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeSnapshotController, snap.Name)
-
-	attachment, ok := va.Spec.AttachmentTickets[attachmentID]
-	if !ok {
-		//create new one
-		attachment = &longhorn.AttachmentTicket{
-			ID:     attachmentID,
-			Type:   longhorn.AttacherTypeSnapshotController,
-			NodeID: vol.Status.OwnerID,
-			Parameters: map[string]string{
-				longhorn.AttachmentParameterDisableFrontend: longhorn.AnyValue,
-			},
-		}
-	}
-	if attachment.NodeID != vol.Status.OwnerID {
-		attachment.NodeID = vol.Status.OwnerID
-	}
-	va.Spec.AttachmentTickets[attachment.ID] = attachment
+	createOrUpdateAttachmentTicket(va, attachmentID, vol.Status.OwnerID, longhorn.AnyValue, longhorn.AttacherTypeSnapshotController)
 
 	return nil
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -31,20 +31,6 @@ func isTargetVolumeOfCloning(v *longhorn.Volume) bool {
 	return isCloningDesired && !isCloningDone
 }
 
-// isSourceVolumeOfCloning checks if the input volume is the source volume of an on-going cloning process
-func (vc *VolumeController) isSourceVolumeOfCloning(v *longhorn.Volume) (bool, error) {
-	vols, err := vc.ds.ListVolumes()
-	if err != nil {
-		return false, err
-	}
-	for _, vol := range vols {
-		if isTargetVolumeOfCloning(vol) && types.GetVolumeName(vol.Spec.DataSource) == v.Name {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func isVolumeFullyDetached(vol *longhorn.Volume) bool {
 	return vol.Spec.NodeID == "" &&
 		vol.Spec.MigrationNodeID == "" &&

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -37,3 +37,22 @@ func isVolumeFullyDetached(vol *longhorn.Volume) bool {
 		vol.Status.PendingNodeID == "" &&
 		vol.Status.State == longhorn.VolumeStateDetached
 }
+
+func createOrUpdateAttachmentTicket(va *longhorn.VolumeAttachment, ticketID, nodeID, disableFrontend string, attacherType longhorn.AttacherType) {
+	attachmentTicket, ok := va.Spec.AttachmentTickets[ticketID]
+	if !ok {
+		// Create new one
+		attachmentTicket = &longhorn.AttachmentTicket{
+			ID:     ticketID,
+			Type:   attacherType,
+			NodeID: nodeID,
+			Parameters: map[string]string{
+				longhorn.AttachmentParameterDisableFrontend: disableFrontend,
+			},
+		}
+	}
+	if attachmentTicket.NodeID != nodeID {
+		attachmentTicket.NodeID = nodeID
+	}
+	va.Spec.AttachmentTickets[attachmentTicket.ID] = attachmentTicket
+}

--- a/controller/volume_attachment_controller.go
+++ b/controller/volume_attachment_controller.go
@@ -310,7 +310,7 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationStart(va *longhorn.V
 
 	hasCSIAttachmentTicket := false
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
-		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher {
+		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher && attachmentTicket.Type != longhorn.AttacherTypeLonghornUpgrader {
 			continue
 		}
 		// Found one csi attachmentTicket that is requesting volume to attach to the current node
@@ -324,7 +324,7 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationStart(va *longhorn.V
 	}
 
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
-		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher {
+		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher && attachmentTicket.Type != longhorn.AttacherTypeLonghornUpgrader {
 			continue
 		}
 		// Found one csi attachmentTicket that is requesting volume to attach to a different node
@@ -343,7 +343,7 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationConfirmation(va *lon
 
 	hasCSIAttachmentTicketRequestingPrevNode := false
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
-		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher {
+		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher && attachmentTicket.Type != longhorn.AttacherTypeLonghornUpgrader {
 			continue
 		}
 		// Found one csi attachmentTicket that is requesting volume to attach to the current node
@@ -418,7 +418,7 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationRollback(va *longhor
 
 	hasCSIAttachmentTicketRequestingMigratingNode := false
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
-		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher {
+		if attachmentTicket.Type != longhorn.AttacherTypeCSIAttacher && attachmentTicket.Type != longhorn.AttacherTypeLonghornUpgrader {
 			continue
 		}
 		// Found one csi attachmentTicket that is requesting volume to attach to the current node

--- a/controller/volume_attachment_controller.go
+++ b/controller/volume_attachment_controller.go
@@ -432,14 +432,12 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationRollback(va *longhor
 }
 
 func (vac *VolumeAttachmentController) handleVolumeDetachment(va *longhorn.VolumeAttachment, vol *longhorn.Volume) {
-	// handle volume migration confirmation/rollback
-
 	// Volume is already trying to detach
 	if vol.Spec.NodeID == "" {
 		return
 	}
 
-	if !shouldDoDetach(va, vol) {
+	if !vac.shouldDoDetach(va, vol) {
 		return
 	}
 
@@ -450,7 +448,8 @@ func (vac *VolumeAttachmentController) handleVolumeDetachment(va *longhorn.Volum
 	setAttachmentParameter(map[string]string{}, vol)
 }
 
-func shouldDoDetach(va *longhorn.VolumeAttachment, vol *longhorn.Volume) bool {
+func (vac *VolumeAttachmentController) shouldDoDetach(va *longhorn.VolumeAttachment, vol *longhorn.Volume) bool {
+	log := getLoggerForLHVolumeAttachment(vac.logger, va)
 	// For auto salvage logic
 	// TODO: create Auto Salvage controller to handle this logic instead of AD controller
 	if vol.Status.Robustness == longhorn.VolumeRobustnessFaulted {
@@ -460,6 +459,9 @@ func shouldDoDetach(va *longhorn.VolumeAttachment, vol *longhorn.Volume) bool {
 		// if the volume is migrating, the detachment will be handled by handleVolumeMigration()
 		return false
 	}
+
+	currentAttachmentTickets := map[string]*longhorn.AttachmentTicket{}
+	attachmentTicketsOnOtherNodes := map[string]*longhorn.AttachmentTicket{}
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
 		// For the RWX volume attachment, VolumeAttachment controller will not directly handle
 		// the tickets from the CSI plugin. Instead, ShareManager controller will add a
@@ -469,12 +471,44 @@ func shouldDoDetach(va *longhorn.VolumeAttachment, vol *longhorn.Volume) bool {
 		if isCSIAttacherTicketOfRegularRWXVolume(attachmentTicket, vol) {
 			continue
 		}
-		// Found one attachmentTicket that is still requesting volume to attach to the current node
 		if attachmentTicket.NodeID == vol.Spec.NodeID && verifyAttachmentParameters(attachmentTicket.Parameters, vol) {
-			return false
+			currentAttachmentTickets[attachmentTicket.ID] = attachmentTicket
+		}
+		if attachmentTicket.NodeID != vol.Spec.NodeID {
+			attachmentTicketsOnOtherNodes[attachmentTicket.ID] = attachmentTicket
 		}
 	}
-	return true
+
+	if len(currentAttachmentTickets) == 0 {
+		return true
+	}
+	if !hasUninterruptibleTicket(currentAttachmentTickets) && hasWorkloadTicket(attachmentTicketsOnOtherNodes) {
+		log.Debugf("Workload attachment ticket interrupted snapshot-controller/backup-controller attachment tickets")
+		return true
+	}
+
+	return false
+}
+
+func hasUninterruptibleTicket(attachmentTickets map[string]*longhorn.AttachmentTicket) bool {
+	for _, ticket := range attachmentTickets {
+		if ticket.Type != longhorn.AttacherTypeSnapshotController &&
+			ticket.Type != longhorn.AttacherTypeBackupController {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWorkloadTicket(attachmentTickets map[string]*longhorn.AttachmentTicket) bool {
+	for _, ticket := range attachmentTickets {
+		if ticket.Type == longhorn.AttacherTypeCSIAttacher ||
+			ticket.Type == longhorn.AttacherTypeLonghornAPI ||
+			ticket.Type == longhorn.AttacherTypeShareManagerController {
+			return true
+		}
+	}
+	return false
 }
 
 func (vac *VolumeAttachmentController) handleVolumeAttachment(va *longhorn.VolumeAttachment, vol *longhorn.Volume) {

--- a/controller/volume_eviction_controller.go
+++ b/controller/volume_eviction_controller.go
@@ -195,22 +195,7 @@ func (vec *VolumeEvictionController) reconcile(volName string) (err error) {
 	evictingAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeEvictionController, volName)
 
 	if hasReplicaEvictionRequested(replicas) {
-		evictingAttachmentTicket, ok := va.Spec.AttachmentTickets[evictingAttachmentTicketID]
-		if !ok {
-			//create new one
-			evictingAttachmentTicket = &longhorn.AttachmentTicket{
-				ID:     evictingAttachmentTicketID,
-				Type:   longhorn.AttacherTypeVolumeEvictionController,
-				NodeID: vol.Status.OwnerID,
-				Parameters: map[string]string{
-					longhorn.AttachmentParameterDisableFrontend: longhorn.AnyValue,
-				},
-			}
-		}
-		if evictingAttachmentTicket.NodeID != vol.Status.OwnerID {
-			evictingAttachmentTicket.NodeID = vol.Status.OwnerID
-		}
-		va.Spec.AttachmentTickets[evictingAttachmentTicket.ID] = evictingAttachmentTicket
+		createOrUpdateAttachmentTicket(va, evictingAttachmentTicketID, vol.Status.OwnerID, longhorn.AnyValue, longhorn.AttacherTypeVolumeEvictionController)
 	} else {
 		delete(va.Spec.AttachmentTickets, evictingAttachmentTicketID)
 	}

--- a/controller/volume_expansion_controller.go
+++ b/controller/volume_expansion_controller.go
@@ -196,7 +196,7 @@ func (vec *VolumeExpansionController) reconcile(volName string) (err error) {
 				Type:   longhorn.AttacherTypeVolumeExpansionController,
 				NodeID: vol.Status.OwnerID,
 				Parameters: map[string]string{
-					longhorn.AttachmentParameterDisableFrontend: longhorn.AnyValue,
+					longhorn.AttachmentParameterDisableFrontend: longhorn.FalseValue,
 				},
 			}
 		}

--- a/controller/volume_expansion_controller.go
+++ b/controller/volume_expansion_controller.go
@@ -188,22 +188,7 @@ func (vec *VolumeExpansionController) reconcile(volName string) (err error) {
 	expandingAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeExpansionController, volName)
 
 	if vol.Status.ExpansionRequired {
-		expandingAttachmentTicket, ok := va.Spec.AttachmentTickets[expandingAttachmentTicketID]
-		if !ok {
-			//create new one
-			expandingAttachmentTicket = &longhorn.AttachmentTicket{
-				ID:     expandingAttachmentTicketID,
-				Type:   longhorn.AttacherTypeVolumeExpansionController,
-				NodeID: vol.Status.OwnerID,
-				Parameters: map[string]string{
-					longhorn.AttachmentParameterDisableFrontend: longhorn.FalseValue,
-				},
-			}
-		}
-		if expandingAttachmentTicket.NodeID != vol.Status.OwnerID {
-			expandingAttachmentTicket.NodeID = vol.Status.OwnerID
-		}
-		va.Spec.AttachmentTickets[expandingAttachmentTicket.ID] = expandingAttachmentTicket
+		createOrUpdateAttachmentTicket(va, expandingAttachmentTicketID, vol.Status.OwnerID, longhorn.FalseValue, longhorn.AttacherTypeVolumeExpansionController)
 	} else {
 		delete(va.Spec.AttachmentTickets, expandingAttachmentTicketID)
 	}

--- a/controller/volume_restore_controller.go
+++ b/controller/volume_restore_controller.go
@@ -188,22 +188,7 @@ func (vrsc *VolumeRestoreController) reconcile(volName string) (err error) {
 	restoringAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeRestoreController, volName)
 
 	if vol.Status.RestoreRequired {
-		restoringAttachmentTicket, ok := va.Spec.AttachmentTickets[restoringAttachmentTicketID]
-		if !ok {
-			//create new one
-			restoringAttachmentTicket = &longhorn.AttachmentTicket{
-				ID:     restoringAttachmentTicketID,
-				Type:   longhorn.AttacherTypeVolumeRestoreController,
-				NodeID: vol.Status.OwnerID,
-				Parameters: map[string]string{
-					longhorn.AttachmentParameterDisableFrontend: longhorn.TrueValue,
-				},
-			}
-		}
-		if restoringAttachmentTicket.NodeID != vol.Status.OwnerID {
-			restoringAttachmentTicket.NodeID = vol.Status.OwnerID
-		}
-		va.Spec.AttachmentTickets[restoringAttachmentTicket.ID] = restoringAttachmentTicket
+		createOrUpdateAttachmentTicket(va, restoringAttachmentTicketID, vol.Status.OwnerID, longhorn.TrueValue, longhorn.AttacherTypeVolumeRestoreController)
 	} else {
 		delete(va.Spec.AttachmentTickets, restoringAttachmentTicketID)
 	}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -538,6 +538,7 @@ func (cs *ControllerServer) unpublishVolume(volume *longhornclient.Volume, nodeI
 	logrus.Debugf("requesting Volume %v detachment for %v with attachmentID %v ", volume.Name, nodeID, attachmentID)
 	detachInput := &longhornclient.DetachInput{
 		AttachmentID: attachmentID,
+		HostId:       nodeID,
 		// if nodeID == "" means to detach from all nodes
 		ForceDetach: nodeID == "",
 	}

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
@@ -15,6 +15,11 @@ const (
 	BackingImageDataSourceTypeDownload         = BackingImageDataSourceType("download")
 	BackingImageDataSourceTypeUpload           = BackingImageDataSourceType("upload")
 	BackingImageDataSourceTypeExportFromVolume = BackingImageDataSourceType("export-from-volume")
+
+	DataSourceTypeExportFromVolumeParameterVolumeName    = "volume-name"
+	DataSourceTypeExportFromVolumeParameterVolumeSize    = "volume-size"
+	DataSourceTypeExportFromVolumeParameterSnapshotName  = "snapshot-name"
+	DataSourceTypeExportFromVolumeParameterSenderAddress = "sender-address"
 )
 
 // BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source

--- a/manager/snapshot.go
+++ b/manager/snapshot.go
@@ -9,7 +9,6 @@ import (
 
 	bsutil "github.com/longhorn/backupstore/util"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	"github.com/longhorn/longhorn-manager/util"
 )
 
 func (m *VolumeManager) ListSnapshotsCR(volumeName string) (map[string]*longhorn.Snapshot, error) {
@@ -27,10 +26,6 @@ func (m *VolumeManager) DeleteSnapshotCR(snapName string) error {
 func (m *VolumeManager) CreateSnapshotCR(snapshotName string, labels map[string]string, volumeName string) (*longhorn.Snapshot, error) {
 	if volumeName == "" {
 		return nil, fmt.Errorf("volume name required")
-	}
-
-	if err := util.VerifySnapshotLabels(labels); err != nil {
-		return nil, err
 	}
 
 	if err := m.checkVolumeNotInMigration(volumeName); err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -21,6 +21,7 @@ import (
 const (
 	LonghornKindNode                = "Node"
 	LonghornKindVolume              = "Volume"
+	LonghornKindVolumeAttachment    = "VolumeAttachment"
 	LonghornKindEngine              = "Engine"
 	LonghornKindReplica             = "Replica"
 	LonghornKindBackup              = "Backup"

--- a/webhook/resources/backingimage/validator.go
+++ b/webhook/resources/backingimage/validator.go
@@ -6,7 +6,6 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/longhorn/longhorn-manager/controller"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -60,7 +59,7 @@ func (b *backingImageValidator) Create(request *admission.Request, newObj runtim
 		}
 	case longhorn.BackingImageDataSourceTypeUpload:
 	case longhorn.BackingImageDataSourceTypeExportFromVolume:
-		volumeName := backingImage.Spec.SourceParameters[controller.DataSourceTypeExportFromVolumeParameterVolumeName]
+		volumeName := backingImage.Spec.SourceParameters[longhorn.DataSourceTypeExportFromVolumeParameterVolumeName]
 		if volumeName == "" {
 			return werror.NewInvalidError(fmt.Sprintf("invalid parameter %+v for source type %v", backingImage.Spec.SourceParameters, backingImage.Spec.SourceType), "")
 		}

--- a/webhook/resources/snapshot/validator.go
+++ b/webhook/resources/snapshot/validator.go
@@ -2,14 +2,17 @@ package snapshot
 
 import (
 	"fmt"
+	"reflect"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/longhorn/longhorn-manager/datastore"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	werror "github.com/longhorn/longhorn-manager/webhook/error"
-	admissionregv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 )
 
 type snapshotValidator struct {
@@ -36,9 +39,10 @@ func (o *snapshotValidator) Resource() admission.Resource {
 }
 
 func (o *snapshotValidator) Create(request *admission.Request, newObj runtime.Object) error {
-	_, ok := newObj.(*longhorn.Snapshot)
-	if !ok {
-		return werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.Snapshot", newObj), "")
+	snap := newObj.(*longhorn.Snapshot)
+
+	if err := util.VerifySnapshotLabels(snap.Labels); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
 	}
 
 	return nil


### PR DESCRIPTION
- [x] Implement interrupt mechanism for workload attachment tickets
- [x]  UI modification to work with new AD mechanism (Longhorn UI -> Longhorn API) (the GitHub ticket and logic is at https://github.com/longhorn/longhorn/issues/6004)
- [x] Fix unit test of AD and volume controller (This will be handled separately at https://github.com/longhorn/longhorn/issues/6005)
- [x] Consider how to upgrade from the previous Longhorn version which doesn't have VA resource yet 
- [x] Attachment creation and deletion functions are implemented in some controllers. We can probably make it reused by different controllers
- [x] TODO: hadndle cases in which NodeID is empty. Should we detach the volume from all nodes???
- [x] `func (m *VolumeManager) CreateSnapshotCR` is checking condition before creating the snapshot CR, perhaps this should be handle by webhook

longhorn/longhorn#3715

