### PR TITLE
Fix unexpected attachment and detachment behaviors of RWX volumes

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -395,10 +395,12 @@ func (c *ShareManagerController) isShareManagerRequiredForVolume(volume *longhor
 
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
 		if isRegularRWXVolume(volume) && (isCSIAttacherTicket(attachmentTicket) || isUpgraderTicket(attachmentTicket)) {
-			return true
+			// no active workload, there is no need to keep the share manager around
+			if hasActiveWorkload(volume) {
+				return true
+			}
 		}
 	}
-
 	return false
 }
 

--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -394,7 +394,7 @@ func (c *ShareManagerController) isShareManagerRequiredForVolume(volume *longhor
 	}
 
 	for _, attachmentTicket := range va.Spec.AttachmentTickets {
-		if isCSIAttacherTicketOfRegularRWXVolume(attachmentTicket, volume) {
+		if isRegularRWXVolume(volume) && (isCSIAttacherTicket(attachmentTicket) || isUpgraderTicket(attachmentTicket)) {
 			return true
 		}
 	}

--- a/controller/volume_attachment_controller.go
+++ b/controller/volume_attachment_controller.go
@@ -777,13 +777,29 @@ func getLoggerForLHVolumeAttachment(logger logrus.FieldLogger, va *longhorn.Volu
 	)
 }
 
-func isCSIAttacherTicketOfRegularRWXVolume(attachmentTicket *longhorn.AttachmentTicket, vol *longhorn.Volume) bool {
-	if attachmentTicket == nil || vol == nil {
+func isCSIAttacherTicketOfRegularRWXVolume(attachmentTicket *longhorn.AttachmentTicket, v *longhorn.Volume) bool {
+	return isRegularRWXVolume(v) && isCSIAttacherTicket(attachmentTicket)
+}
+
+func isRegularRWXVolume(v *longhorn.Volume) bool {
+	if v == nil {
 		return false
 	}
-	isRegularRWXVolume := vol.Spec.AccessMode == longhorn.AccessModeReadWriteMany && !vol.Spec.Migratable
-	isCSIAttacherTicket := attachmentTicket.Type == longhorn.AttacherTypeCSIAttacher
-	return isRegularRWXVolume && isCSIAttacherTicket
+	return v.Spec.AccessMode == longhorn.AccessModeReadWriteMany && !v.Spec.Migratable
+}
+
+func isUpgraderTicket(ticket *longhorn.AttachmentTicket) bool {
+	if ticket == nil {
+		return false
+	}
+	return ticket.Type == longhorn.AttacherTypeLonghornUpgrader
+}
+
+func isCSIAttacherTicket(ticket *longhorn.AttachmentTicket) bool {
+	if ticket == nil {
+		return false
+	}
+	return ticket.Type == longhorn.AttacherTypeCSIAttacher
 }
 
 func isMigratingCSIAttacherTicket(attachmentTicket *longhorn.AttachmentTicket, vol *longhorn.Volume) bool {


### PR DESCRIPTION
- Do not detach attached RWX volumes while upgrading Longhorn system 
- RWX volume is not required if there is no active workload using it

longhorn/longhorn#6120