### PR TITLE
Run backing-image-manager pod as privileged

### DIFF
--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -666,6 +666,7 @@ func (c *BackingImageDataSourceController) generateBackingImageDataSourcePodMani
 		cmd = append(cmd, "--checksum", bids.Spec.Checksum)
 	}
 
+	privileged := true
 	podSpec := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            types.GetBackingImageDataSourcePodName(bids.Name),
@@ -711,6 +712,9 @@ func (c *BackingImageDataSourceController) generateBackingImageDataSourcePodMani
 								},
 							},
 						},
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
 					},
 				},
 			},

--- a/controller/backing_image_manager_controller.go
+++ b/controller/backing_image_manager_controller.go
@@ -806,6 +806,7 @@ func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(b
 		return nil, err
 	}
 
+	privileged := true
 	podSpec := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            bim.Name,
@@ -856,6 +857,9 @@ func (c *BackingImageManagerController) generateBackingImageManagerPodManifest(b
 								},
 							},
 						},
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
 					},
 				},
 			},


### PR DESCRIPTION
longhorn/longhorn#6108

See https://github.com/longhorn/longhorn/issues/6108#issuecomment-1593527996 for analysis. Even though it doesn't need privileged for any other reason (currently), backing-image-manager still needs privileged for SELinux.

Need https://github.com/longhorn/longhorn-tests/pull/1426 to test on Jenkins.

This is currently not working as expected (tests are FAILED, instead of ERROR). I will have to return to it tomorrow.