### PR TITLE
[WIP e2e test] fix(backup): detach the volume when the status is synced

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -328,12 +328,12 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		if _, err := bc.ds.UpdateBackupStatus(backup); err != nil && apierrors.IsConflict(errors.Cause(err)) {
 			log.WithError(err).Debugf("Requeue %v due to conflict", backupName)
 			bc.enqueueBackup(backup)
+			err = nil
+			return
 		}
-	}()
-
-	defer func() {
 		if !backup.Status.LastSyncedAt.IsZero() || backup.Spec.SnapshotName == "" {
 			err = bc.handleAttachmentTicketDeletion(backup, backupVolumeName)
+			return
 		}
 	}()
 


### PR DESCRIPTION
ref: [longhorn/longhorn#6124](https://github.com/longhorn/longhorn/issues/6124)

Detach the volume only when the status and the backup is synced