### PR TITLE
Set v.Status.CurrentNodeID before successfully attaching to a node

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1434,8 +1434,9 @@ func (c *VolumeController) reconcileAttachDetachStateMachine(v *longhorn.Volume,
 				if err := c.openVolumeDependentResources(v, e, rs, log); err != nil {
 					return err
 				}
+
+				v.Status.CurrentNodeID = v.Spec.NodeID
 				if c.areVolumeDependentResourcesOpened(e, rs) {
-					v.Status.CurrentNodeID = v.Spec.NodeID
 					v.Status.State = longhorn.VolumeStateAttached
 					c.eventRecorder.Eventf(v, corev1.EventTypeNormal, constant.EventReasonAttached, "volume %v has been attached to %v", v.Name, v.Status.CurrentNodeID)
 				}


### PR DESCRIPTION
Set v.Status.CurrentNodeID before successfully attaching to a node. There's a chance to detach the volume if the volume engine fails in volume attaching stage, so it won't be stuck at attaching stage.

Longhorn/longhorn#6155