### PR TITLE
Try to reattach volume if volume is detached or engine is dead unexpectedly

### DIFF
--- a/constant/events.go
+++ b/constant/events.go
@@ -42,9 +42,9 @@ const (
 	EventReasonUnknown        = "Unknown"
 	EventReasonFailedEviction = "FailedEviction"
 
-	EventReasonDetachedUnexpectly = "DetachedUnexpectly"
-	EventReasonRemount            = "Remount"
-	EventReasonAutoSalvaged       = "AutoSalvaged"
+	EventReasonDetachedUnexpectedly = "DetachedUnexpectedly"
+	EventReasonRemount              = "Remount"
+	EventReasonAutoSalvaged         = "AutoSalvaged"
 
 	EventReasonFetching = "Fetching"
 	EventReasonFetched  = "Fetched"

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -754,7 +754,7 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 			return nil, err
 		}
 		if image != defaultEngineImage {
-			return nil, fmt.Errorf("updrading to %v is not allowed. "+
+			return nil, fmt.Errorf("upgrading to %v is not allowed. "+
 				"Only allow to upgrade to the default engine image %v because the setting "+
 				"`Concurrent Automatic Engine Upgrade Per Node Limit` is greater than 0",
 				image, defaultEngineImage)


### PR DESCRIPTION
Reattach volume if
- volume is detached unexpectedly and there are still healthy replicas
- engine dead unexpectedly and there are still healthy replicas when the volume is not attached

Longhorn/longhorn#6155