### PR TITLE
6217 engine rebuilds deleted replica

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -348,7 +348,10 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 		// we allow across monitoring temporarily due to migration case
 		if !ec.isMonitoring(engine) {
 			ec.startMonitoring(engine)
-		} else if engine.Status.ReplicaModeMap != nil {
+		} else if engine.Status.ReplicaModeMap != nil && engine.Spec.DesireState != longhorn.InstanceStateStopped {
+			// If engine.Spec.DesireState == longhorn.InstanceStateStopped, we have likely already issued a command to
+			// shut down the engine. It is potentially dangerous to attempt to communicate with it now, as a new engine
+			// may start using its address.
 			if err := ec.ReconcileEngineState(engine); err != nil {
 				return err
 			}


### PR DESCRIPTION
longhorn/longhorn#6217

There are two fixes here. I will test each independently to confirm it fixes the issue, but would like to see both merged:

1. Don't delete rebuilding replicas until the engine is stopped when a volume detaches. This completely eliminates the recreate and avoids any awkward fail outs during engine reconciliation.
2. Check if an engine's `spec.desireState = stopped` before proceeding from snapshot purge to rebuild. This is kind of awkward, but it provides broader protection. There may be a way to trigger the issue different from the existing recreate, and this should help there.