### PR TITLE
Fix strict-local volume restore stuck in attaching state

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1564,11 +1564,14 @@ func (c *VolumeController) reconcileVolumeCondition(v *longhorn.Volume, e *longh
 			continue
 		}
 		if v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
-			if v.Spec.NodeID == "" {
-				continue
+			if v.Status.RestoreRequired {
+				r.Spec.HardNodeAffinity = v.Status.OwnerID
+			} else {
+				if v.Spec.NodeID == "" {
+					continue
+				}
+				r.Spec.HardNodeAffinity = v.Spec.NodeID
 			}
-
-			r.Spec.HardNodeAffinity = v.Spec.NodeID
 		}
 		scheduledReplica, multiError, err := c.scheduler.ScheduleReplica(r, rs, v)
 		if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -256,8 +256,7 @@ const (
 )
 
 // SettingsRelatedToVolume should match the items in datastore.GetLabelsForVolumesFollowsGlobalSettings
-//
-//	TODO: May need to add the data locality check
+// TODO: May need to add the data locality check
 var SettingsRelatedToVolume = map[string]string{
 	string(SettingNameReplicaAutoBalance):                  LonghornLabelValueIgnored,
 	string(SettingNameSnapshotDataIntegrity):               LonghornLabelValueIgnored,


### PR DESCRIPTION
For a volume being restored, the spec.nodeID is empyty but the status.ownerID is set. Thus, set r.Spec.HardNodeAffinity to volume.status.ownerID instead.

Longhorn/longhorn#6239