### PR TITLE
Fix migration stuck due to snapshot chains in old engine and new engine mismatch

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -409,12 +408,29 @@ func (m *VolumeManager) checkMigratingEngineSyncSnapshots(vol *longhorn.Volume) 
 		return false, fmt.Errorf("failed to find the migrating engine for volume %v", vol.Name)
 	}
 
-	if !reflect.DeepEqual(oldEngine.Status.Snapshots, migratingEngine.Status.Snapshots) {
+	// map[string]*longhorn.SnapshotInfo can't be compared directly because SnapshotInfo.Created
+	// and SnapshotInfo.Size field might be different when old engine and new engine fetches them
+	// from different replicas
+	if !hasSameKeys(oldEngine.Status.Snapshots, migratingEngine.Status.Snapshots) {
 		logrus.Debugf("Volume migration (%v) is in progress for synchronizing snapshots", vol.Name)
 		return false, nil
 	}
 
 	return true, nil
+}
+
+func hasSameKeys(map1, map2 map[string]*longhorn.SnapshotInfo) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for key := range map1 {
+		if _, ok := map2[key]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (m *VolumeManager) Salvage(volumeName string, replicaNames []string) (v *longhorn.Volume, err error) {


### PR DESCRIPTION
The symptom is similar to https://github.com/longhorn/longhorn/issues/6215#issuecomment-1612222566. But this one is at API level instead of inside the AD controller

longhorn/longhorn#6238