### PR TITLE
Fix strict-local volume restore stuck in attaching state

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1208,11 +1208,14 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 			continue
 		}
 		if v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
-			if v.Spec.NodeID == "" {
-				continue
+			if v.Status.RestoreRequired {
+				r.Spec.HardNodeAffinity = v.Status.OwnerID
+			} else {
+				if v.Spec.NodeID == "" {
+					continue
+				}
+				r.Spec.HardNodeAffinity = v.Spec.NodeID
 			}
-
-			r.Spec.HardNodeAffinity = v.Spec.NodeID
 		}
 
 		scheduledReplica, multiError, err := vc.scheduler.ScheduleReplica(r, rs, v)

--- a/types/types.go
+++ b/types/types.go
@@ -239,7 +239,7 @@ const (
 )
 
 // SettingsRelatedToVolume should match the items in datastore.GetLabelsForVolumesFollowsGlobalSettings
-//   TODO: May need to add the data locality check
+// TODO: May need to add the data locality check
 var SettingsRelatedToVolume = map[string]string{
 	string(SettingNameReplicaAutoBalance):                  LonghornLabelValueIgnored,
 	string(SettingNameSnapshotDataIntegrity):               LonghornLabelValueIgnored,


### PR DESCRIPTION
For a volume being restored, the spec.nodeID is empyty but the status.ownerID is set. Thus, set r.Spec.HardNodeAffinity to volume.status.ownerID instead.

Longhorn/longhorn#6239