### PR TITLE
Fix bug: if the snapshot is no longer in engine CR, don't block the removal process

### DIFF
--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -335,7 +335,8 @@ func (sc *SnapshotController) reconcile(snapshotName string) (err error) {
 			}
 		}()
 
-		if _, ok := snapshot.Status.Children["volume-head"]; ok && snapshot.Status.MarkRemoved {
+		_, snapshotExistInEngineCR := engine.Status.Snapshots[snapshot.Name]
+		if _, hasVolumeHeadChild := snapshot.Status.Children["volume-head"]; snapshotExistInEngineCR && hasVolumeHeadChild && snapshot.Status.MarkRemoved {
 			// This snapshot is the parent of volume-head, so it cannot be purged immediately.
 			// We do not want to keep the volume stuck in attached state.
 			return sc.handleAttachmentTicketDeletion(snapshot)


### PR DESCRIPTION
longhorn/longhorn#6298