### PR TITLE
Add finalizer with webhook instead of controllers

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1419,10 +1419,6 @@ func (s *DataStore) CreateEngineImage(img *longhorn.EngineImage) (*longhorn.Engi
 
 // UpdateEngineImage updates Longhorn EngineImage and verifies update
 func (s *DataStore) UpdateEngineImage(img *longhorn.EngineImage) (*longhorn.EngineImage, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, img); err != nil {
-		return nil, err
-	}
-
 	obj, err := s.lhClient.LonghornV1beta2().EngineImages(s.namespace).Update(context.TODO(), img, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
@@ -1621,9 +1617,6 @@ func (s *DataStore) CreateBackingImage(backingImage *longhorn.BackingImage) (*lo
 
 // UpdateBackingImage updates Longhorn BackingImage and verifies update
 func (s *DataStore) UpdateBackingImage(backingImage *longhorn.BackingImage) (*longhorn.BackingImage, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImage); err != nil {
-		return nil, err
-	}
 	obj, err := s.lhClient.LonghornV1beta2().BackingImages(s.namespace).Update(context.TODO(), backingImage, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
@@ -1766,9 +1759,6 @@ func initBackingImageManager(backingImageManager *longhorn.BackingImageManager) 
 
 // UpdateBackingImageManager updates Longhorn BackingImageManager and verifies update
 func (s *DataStore) UpdateBackingImageManager(backingImageManager *longhorn.BackingImageManager) (*longhorn.BackingImageManager, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImageManager); err != nil {
-		return nil, err
-	}
 	if err := labelLonghornNode(backingImageManager.Spec.NodeID, backingImageManager); err != nil {
 		return nil, err
 	}
@@ -1908,9 +1898,6 @@ func (s *DataStore) CreateBackingImageDataSource(backingImageDataSource *longhor
 	if err := initBackingImageDataSource(backingImageDataSource); err != nil {
 		return nil, err
 	}
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImageDataSource); err != nil {
-		return nil, err
-	}
 	ret, err := s.lhClient.LonghornV1beta2().BackingImageDataSources(s.namespace).Create(context.TODO(), backingImageDataSource, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -1942,10 +1929,6 @@ func initBackingImageDataSource(backingImageDataSource *longhorn.BackingImageDat
 
 // UpdateBackingImageDataSource updates Longhorn BackingImageDataSource and verifies update
 func (s *DataStore) UpdateBackingImageDataSource(backingImageDataSource *longhorn.BackingImageDataSource) (*longhorn.BackingImageDataSource, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, backingImageDataSource); err != nil {
-		return nil, err
-	}
-
 	obj, err := s.lhClient.LonghornV1beta2().BackingImageDataSources(s.namespace).Update(context.TODO(), backingImageDataSource, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
@@ -3181,10 +3164,6 @@ func (s *DataStore) CreateShareManager(sm *longhorn.ShareManager) (*longhorn.Sha
 
 // UpdateShareManager updates Longhorn ShareManager resource and verifies update
 func (s *DataStore) UpdateShareManager(sm *longhorn.ShareManager) (*longhorn.ShareManager, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, sm); err != nil {
-		return nil, err
-	}
-
 	obj, err := s.lhClient.LonghornV1beta2().ShareManagers(s.namespace).Update(context.TODO(), sm, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err

--- a/webhook/common/common.go
+++ b/webhook/common/common.go
@@ -18,13 +18,17 @@ var (
 	longhornFinalizerKey = longhorn.SchemeGroupVersion.Group
 )
 
-func GetLonghornFinalizerPatchOp(obj runtime.Object) (string, error) {
-	if err := util.AddFinalizer(longhornFinalizerKey, obj); err != nil {
-		return "", err
-	}
-
+func GetLonghornFinalizerPatchOpIfNeeded(obj runtime.Object) (string, error) {
 	metadata, err := meta.Accessor(obj)
 	if err != nil {
+		return "", err
+	}
+	if metadata.GetDeletionTimestamp() != nil {
+		// We should not add a finalizer to an object that is being deleted.
+		return "", nil
+	}
+
+	if err := util.AddFinalizer(longhornFinalizerKey, obj); err != nil {
 		return "", err
 	}
 

--- a/webhook/resources/backingimagemanager/mutator.go
+++ b/webhook/resources/backingimagemanager/mutator.go
@@ -23,7 +23,7 @@ func NewMutator(ds *datastore.DataStore) admission.Mutator {
 
 func (b *backingImageManagerMutator) Resource() admission.Resource {
 	return admission.Resource{
-		Name:       "backingImageManagers",
+		Name:       "backingimagemanagers",
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   longhorn.SchemeGroupVersion.Group,
 		APIVersion: longhorn.SchemeGroupVersion.Version,

--- a/webhook/resources/backingimagemanager/mutator.go
+++ b/webhook/resources/backingimagemanager/mutator.go
@@ -36,33 +36,29 @@ func (b *backingImageManagerMutator) Resource() admission.Resource {
 }
 
 func (b *backingImageManagerMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	backingImageManager := newObj.(*longhorn.BackingImageManager)
-
-	patchOps, err := mutate(newObj)
-	if err != nil {
-		return nil, werror.NewInvalidError(err.Error(), "")
-	}
-
-	patchOp, err := common.GetLonghornFinalizerPatchOp(backingImageManager)
-	if err != nil {
-		err := errors.Wrapf(err, "failed to get finalizer patch for backingImageManager %v", backingImageManager.Name)
-		return nil, werror.NewInvalidError(err.Error(), "")
-	}
-	patchOps = append(patchOps, patchOp)
-
-	return patchOps, nil
+	return mutate(newObj)
 }
 
 func (b *backingImageManagerMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
 	return mutate(newObj)
 }
 
+// mutate contains functionality shared by Create and Update.
 func mutate(newObj runtime.Object) (admission.PatchOps, error) {
 	backingImageManager := newObj.(*longhorn.BackingImageManager)
 	var patchOps admission.PatchOps
 
 	if backingImageManager.Spec.BackingImages == nil {
 		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/backingImages", "value": {}}`)
+	}
+
+	patchOp, err := common.GetLonghornFinalizerPatchOpIfNeeded(backingImageManager)
+	if err != nil {
+		err := errors.Wrapf(err, "failed to get finalizer patch for backingImageManager %v", backingImageManager.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	if patchOp != "" {
+		patchOps = append(patchOps, patchOp)
 	}
 
 	return patchOps, nil

--- a/webhook/resources/recurringjob/mutator.go
+++ b/webhook/resources/recurringjob/mutator.go
@@ -38,9 +38,8 @@ func (r *recurringJobMutator) Resource() admission.Resource {
 }
 
 func (r *recurringJobMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
-	var patchOps admission.PatchOps
-
 	recurringjob := newObj.(*longhorn.RecurringJob)
+	var patchOps admission.PatchOps
 
 	name := util.AutoCorrectName(recurringjob.Name, datastore.NameMaximumLength)
 	if name != recurringjob.Name {
@@ -79,9 +78,8 @@ func (r *recurringJobMutator) Create(request *admission.Request, newObj runtime.
 }
 
 func (r *recurringJobMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
-	var patchOps admission.PatchOps
-
 	newRecurringjob := newObj.(*longhorn.RecurringJob)
+	var patchOps admission.PatchOps
 
 	if newRecurringjob.Spec.Name == "" {
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/name", "value": "%s"}`, newRecurringjob.Name))

--- a/webhook/resources/sharemanager/mutator.go
+++ b/webhook/resources/sharemanager/mutator.go
@@ -30,20 +30,32 @@ func (s *shareManagerMutator) Resource() admission.Resource {
 		ObjectType: &longhorn.ShareManager{},
 		OperationTypes: []admissionregv1.OperationType{
 			admissionregv1.Create,
+			admissionregv1.Update,
 		},
 	}
 }
 
 func (s *shareManagerMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+func (s *shareManagerMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+// mutate contains functionality shared by Create and Update.
+func mutate(newObj runtime.Object) (admission.PatchOps, error) {
 	shareManager := newObj.(*longhorn.ShareManager)
 	var patchOps admission.PatchOps
 
-	patchOp, err := common.GetLonghornFinalizerPatchOp(shareManager)
+	patchOp, err := common.GetLonghornFinalizerPatchOpIfNeeded(shareManager)
 	if err != nil {
 		err := errors.Wrapf(err, "failed to get finalizer patch for shareManager %v", shareManager.Name)
 		return nil, werror.NewInvalidError(err.Error(), "")
 	}
-	patchOps = append(patchOps, patchOp)
+	if patchOp != "" {
+		patchOps = append(patchOps, patchOp)
+	}
 
 	return patchOps, nil
 }

--- a/webhook/resources/supportbundle/mutator.go
+++ b/webhook/resources/supportbundle/mutator.go
@@ -33,21 +33,32 @@ func (m *supportBundleMutator) Resource() admission.Resource {
 		ObjectType: &longhorn.SupportBundle{},
 		OperationTypes: []admissionregv1.OperationType{
 			admissionregv1.Create,
+			admissionregv1.Update,
 		},
 	}
 }
 
 func (m *supportBundleMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+func (m *supportBundleMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+// mutate contains functionality shared by Create and Update.
+func mutate(newObj runtime.Object) (admission.PatchOps, error) {
+	supportBundle := newObj.(*longhorn.SupportBundle)
 	var patchOps admission.PatchOps
 
-	supportBundle := newObj.(*longhorn.SupportBundle)
-
-	patchOp, err := common.GetLonghornFinalizerPatchOp(supportBundle)
+	patchOp, err := common.GetLonghornFinalizerPatchOpIfNeeded(supportBundle)
 	if err != nil {
 		err := errors.Wrapf(err, "failed to get finalizer patch for supportBundle %v", supportBundle.Name)
 		return nil, werror.NewInvalidError(err.Error(), "")
 	}
-	patchOps = append(patchOps, patchOp)
+	if patchOp != "" {
+		patchOps = append(patchOps, patchOp)
+	}
 
 	return patchOps, nil
 }


### PR DESCRIPTION
longhorn/longhorn#4872

This work was started in https://github.com/longhorn/longhorn-manager/pull/1535. In that PR, we ensured that the webhook only added the finalizer during CREATE operations and not during UPDATE operations to avoid resources that cannot be deleted (e.g. we attempt to remove a resource's finalizer, but the finalizer is added back when we do so). After reading some discussion on the internet and thinking on it a bit, I decided a better approach would be for the webhook to always add the finalizer on both CREATE and UPDATE except when the deletion timestamp is set. After reviewing our code, every time longhorn-manager removes the finalizer, the deletion timestamp has already been set on an object. This approach has two benefits:

- The finalizer cannot be accidentally deleted by a user unless the object is already being deleted. Previously, a user could update an object so that it did not have a finalizer. This could have been problematic later when the object was deleted.
- Consistency/code cleanliness. We always do the same thing on CREATE and UPDATE and can share logic between the two.

Otherwise, I also tried to clean up the webhook resources slightly. Code was organized differently between resources and some code was duplicated. Since I was already doing a webhook refactor, I spent some time (hopefully) improving this.

Keeping this as a draft until regression tests pass: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4596/console.