### PR TITLE
fix(backup): set backup error if backup target invalid

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -375,6 +375,10 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 
 		monitor, err := bc.checkMonitor(backup, volume, backupTarget)
 		if err != nil {
+			if backup.Status.State == longhorn.BackupStateError {
+				log.WithError(err).Warnf("Failed to enable the backup monitor for backup %v", backup.Name)
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
When starting a backup monitor, it will start to take a snapshot backup procedure and it will be failed if the s3 backup target is invalid (nfs backup target will be not be failed because of timeout and test the backup when it is in progress.)
Set the backup state as `Error` if starting the backup procedure returns an error.

Ref: longhorn/longhorn#1249