### PR TITLE
Improve log and minor cleanup

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2073,15 +2073,19 @@ func (ec *EngineController) isResponsibleFor(e *longhorn.Engine, defaultEngineIm
 		return isResponsible, nil
 	}
 
+	currentNodeEngineAvailable, err := ec.ds.CheckEngineImageReadiness(e.Status.CurrentImage, ec.controllerID)
+	if err != nil {
+		return false, err
+	}
+	if !currentNodeEngineAvailable {
+		// avoid redundant checking if the current node is not available
+		return false, nil
+	}
 	preferredOwnerEngineAvailable, err := ec.ds.CheckEngineImageReadiness(e.Status.CurrentImage, e.Spec.NodeID)
 	if err != nil {
 		return false, err
 	}
 	currentOwnerEngineAvailable, err := ec.ds.CheckEngineImageReadiness(e.Status.CurrentImage, e.Status.OwnerID)
-	if err != nil {
-		return false, err
-	}
-	currentNodeEngineAvailable, err := ec.ds.CheckEngineImageReadiness(e.Status.CurrentImage, ec.controllerID)
 	if err != nil {
 		return false, err
 	}

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -328,7 +328,7 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 		syncReplicaAddressMap = true
 	}
 	if syncReplicaAddressMap && !reflect.DeepEqual(engine.Status.CurrentReplicaAddressMap, engine.Spec.ReplicaAddressMap) {
-		log.Infof("Updating engine current replica address map to %+v", engine.Spec.ReplicaAddressMap)
+		log.Infof("Updating engine current replica address map to %+v. We need to wait for all replicas running then engine will be running.", engine.Spec.ReplicaAddressMap)
 		engine.Status.CurrentReplicaAddressMap = engine.Spec.ReplicaAddressMap
 		// Make sure the CurrentReplicaAddressMap persist in the etcd before continue
 		return nil

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1014,7 +1014,7 @@ func (nc *NodeController) syncInstanceManagers(node *longhorn.Node) error {
 				}
 			}
 			if cleanupRequired {
-				log.Infof("Cleaning up the redundant instance manager %v when there is no running/starting instance", im.Name)
+				log.Infof("Cleaning up the redundant instance manager %v when there is no running/starting instance: %v", im.Name, dumpInstanceState(im.Status.Instances))
 				if err := nc.ds.DeleteInstanceManager(im.Name); err != nil {
 					return err
 				}
@@ -1564,4 +1564,12 @@ func (nc *NodeController) shouldEvictReplica(node *longhorn.Node, kubeNode *core
 	}
 
 	return false, constant.EventReasonEvictionCanceled, nil
+}
+
+func dumpInstanceState(instanceMap map[string]longhorn.InstanceProcess) map[string]string {
+	output := map[string]string{}
+	for _, instance := range instanceMap {
+		output[instance.Spec.Name] = string(instance.Status.State)
+	}
+	return output
 }


### PR DESCRIPTION
related: https://github.com/longhorn/longhorn/issues/6396

I tried to modify some log outputs and added some logs for more clarity for investigation.

And also, do some minor changes as below:
1.  Reorder the checking order on `isResponsibleFor()`. If the `currentNodeEngineAvailable` is false we could conclude that it would be false.
2. Do not wait for all replicas to be running before we change the engine state to running. We could change the engine's desired state to running if we have enough replicas instead of all replicas.

Please help to review. Thanks!