### PR TITLE
Add replicaName argument to ReplicaRebuildVerify

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1305,7 +1305,7 @@ func syncWithRestoreStatus(log logrus.FieldLogger, engine *longhorn.Engine, rsMa
 				replicaName := addressReplicaMap[engineapi.GetAddressFromBackendReplicaURL(url)]
 				if mode, exists := engine.Status.ReplicaModeMap[replicaName]; exists && mode == longhorn.ReplicaModeWO {
 					log.Infof("Verifying the rebuild of replica %v after restore completion", url)
-					if err := engineClientProxy.ReplicaRebuildVerify(engine, url); err != nil {
+					if err := engineClientProxy.ReplicaRebuildVerify(engine, replicaName, url); err != nil {
 						log.WithError(err).Errorf("Failed to verify the rebuild of replica %v after restore completion", url)
 						engine.Status.ReplicaModeMap[url] = longhorn.ReplicaModeERR
 						return false

--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -290,11 +290,21 @@ func (e *EngineBinary) VolumeUnmapMarkSnapChainRemovedSet(engine *longhorn.Engin
 
 // ReplicaRebuildVerify calls engine binary
 // TODO: Deprecated, replaced by gRPC proxy
-func (e *EngineBinary) ReplicaRebuildVerify(engine *longhorn.Engine, url string) error {
+func (e *EngineBinary) ReplicaRebuildVerify(engine *longhorn.Engine, replicaName, url string) error {
 	if err := ValidateReplicaURL(url); err != nil {
 		return err
 	}
+
+	version, err := e.VersionGet(engine, true)
+	if err != nil {
+		return err
+	}
+
 	cmd := []string{"verify-rebuild-replica", url}
+	if version.ClientVersion.CLIAPIVersion >= 9 {
+		cmd = append(cmd, "--replica-instance-name", replicaName)
+	}
+
 	if _, err := e.ExecuteEngineBinaryWithoutTimeout([]string{}, cmd...); err != nil {
 		return errors.Wrapf(err, "failed to verify rebuilding for the replica from address %s", url)
 	}

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -245,7 +245,7 @@ func (e *EngineSimulator) VolumeUnmapMarkSnapChainRemovedSet(*longhorn.Engine) e
 	return fmt.Errorf(ErrNotImplement)
 }
 
-func (e *EngineSimulator) ReplicaRebuildVerify(engine *longhorn.Engine, url string) error {
+func (e *EngineSimulator) ReplicaRebuildVerify(engine *longhorn.Engine, replicaName, url string) error {
 	return fmt.Errorf(ErrNotImplement)
 }
 

--- a/engineapi/proxy_replica.go
+++ b/engineapi/proxy_replica.go
@@ -49,11 +49,12 @@ func (p *Proxy) ReplicaRebuildStatus(e *longhorn.Engine) (status map[string]*lon
 	return status, nil
 }
 
-func (p *Proxy) ReplicaRebuildVerify(e *longhorn.Engine, url string) (err error) {
+func (p *Proxy) ReplicaRebuildVerify(e *longhorn.Engine, replicaName, url string) (err error) {
 	if err := ValidateReplicaURL(url); err != nil {
 		return err
 	}
-	return p.grpcClient.ReplicaVerifyRebuild(string(e.Spec.BackendStoreDriver), e.Name, e.Spec.VolumeName, p.DirectToURL(e), url, "")
+	return p.grpcClient.ReplicaVerifyRebuild(string(e.Spec.BackendStoreDriver), e.Name, e.Spec.VolumeName,
+		p.DirectToURL(e), url, replicaName)
 }
 
 func (p *Proxy) ReplicaModeUpdate(e *longhorn.Engine, url, mode string) (err error) {

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -83,7 +83,7 @@ type EngineClient interface {
 	ReplicaAdd(engine *longhorn.Engine, replicaName, url string, isRestoreVolume, fastSync bool, replicaFileSyncHTTPClientTimeout int64) error
 	ReplicaRemove(engine *longhorn.Engine, url string) error
 	ReplicaRebuildStatus(*longhorn.Engine) (map[string]*longhorn.RebuildStatus, error)
-	ReplicaRebuildVerify(engine *longhorn.Engine, url string) error
+	ReplicaRebuildVerify(engine *longhorn.Engine, replicaName, url string) error
 	ReplicaModeUpdate(engine *longhorn.Engine, url string, mode string) error
 
 	SnapshotCreate(engine *longhorn.Engine, name string, labels map[string]string) (string, error)


### PR DESCRIPTION
longhorn/longhorn#6522

I added the replicaName argument to instance-manager's ReplicaRebuildVerify client method (and the associated gRPC request) as a part of longhorn/longhorn#5845, but I did not create a way for longhorn-manager to provide it. This PR fixes the issue and allows the tests mentioned in longhorn/longhorn#6522 to pass.