### PR TITLE
refactor: replace resource lister and informer abbreviations

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -143,36 +143,36 @@ func NewDataStore(
 	cacheSyncs = append(cacheSyncs, nodeInformer.Informer().HasSynced)
 	settingInformer := lhInformerFactory.Longhorn().V1beta2().Settings()
 	cacheSyncs = append(cacheSyncs, settingInformer.Informer().HasSynced)
-	imInformer := lhInformerFactory.Longhorn().V1beta2().InstanceManagers()
-	cacheSyncs = append(cacheSyncs, imInformer.Informer().HasSynced)
-	smInformer := lhInformerFactory.Longhorn().V1beta2().ShareManagers()
-	cacheSyncs = append(cacheSyncs, smInformer.Informer().HasSynced)
-	biInformer := lhInformerFactory.Longhorn().V1beta2().BackingImages()
-	cacheSyncs = append(cacheSyncs, biInformer.Informer().HasSynced)
-	bimInformer := lhInformerFactory.Longhorn().V1beta2().BackingImageManagers()
-	cacheSyncs = append(cacheSyncs, bimInformer.Informer().HasSynced)
-	bidsInformer := lhInformerFactory.Longhorn().V1beta2().BackingImageDataSources()
-	cacheSyncs = append(cacheSyncs, bidsInformer.Informer().HasSynced)
-	btInformer := lhInformerFactory.Longhorn().V1beta2().BackupTargets()
-	cacheSyncs = append(cacheSyncs, btInformer.Informer().HasSynced)
-	bvInformer := lhInformerFactory.Longhorn().V1beta2().BackupVolumes()
-	cacheSyncs = append(cacheSyncs, bvInformer.Informer().HasSynced)
-	bInformer := lhInformerFactory.Longhorn().V1beta2().Backups()
-	cacheSyncs = append(cacheSyncs, bInformer.Informer().HasSynced)
-	rjInformer := lhInformerFactory.Longhorn().V1beta2().RecurringJobs()
-	cacheSyncs = append(cacheSyncs, rjInformer.Informer().HasSynced)
-	oInformer := lhInformerFactory.Longhorn().V1beta2().Orphans()
-	cacheSyncs = append(cacheSyncs, oInformer.Informer().HasSynced)
-	snapInformer := lhInformerFactory.Longhorn().V1beta2().Snapshots()
-	cacheSyncs = append(cacheSyncs, snapInformer.Informer().HasSynced)
+	instanceManagerInformer := lhInformerFactory.Longhorn().V1beta2().InstanceManagers()
+	cacheSyncs = append(cacheSyncs, instanceManagerInformer.Informer().HasSynced)
+	shareManagerInformer := lhInformerFactory.Longhorn().V1beta2().ShareManagers()
+	cacheSyncs = append(cacheSyncs, shareManagerInformer.Informer().HasSynced)
+	backingImageInformer := lhInformerFactory.Longhorn().V1beta2().BackingImages()
+	cacheSyncs = append(cacheSyncs, backingImageInformer.Informer().HasSynced)
+	backingImageManagerInformer := lhInformerFactory.Longhorn().V1beta2().BackingImageManagers()
+	cacheSyncs = append(cacheSyncs, backingImageManagerInformer.Informer().HasSynced)
+	backingImageDataSourceInformer := lhInformerFactory.Longhorn().V1beta2().BackingImageDataSources()
+	cacheSyncs = append(cacheSyncs, backingImageDataSourceInformer.Informer().HasSynced)
+	backupTargetInformer := lhInformerFactory.Longhorn().V1beta2().BackupTargets()
+	cacheSyncs = append(cacheSyncs, backupTargetInformer.Informer().HasSynced)
+	backupVolumeInformer := lhInformerFactory.Longhorn().V1beta2().BackupVolumes()
+	cacheSyncs = append(cacheSyncs, backupVolumeInformer.Informer().HasSynced)
+	backupInformer := lhInformerFactory.Longhorn().V1beta2().Backups()
+	cacheSyncs = append(cacheSyncs, backupInformer.Informer().HasSynced)
+	recurringJobInformer := lhInformerFactory.Longhorn().V1beta2().RecurringJobs()
+	cacheSyncs = append(cacheSyncs, recurringJobInformer.Informer().HasSynced)
+	orphanInformer := lhInformerFactory.Longhorn().V1beta2().Orphans()
+	cacheSyncs = append(cacheSyncs, orphanInformer.Informer().HasSynced)
+	snapshotInformer := lhInformerFactory.Longhorn().V1beta2().Snapshots()
+	cacheSyncs = append(cacheSyncs, snapshotInformer.Informer().HasSynced)
 	supportBundleInformer := lhInformerFactory.Longhorn().V1beta2().SupportBundles()
 	cacheSyncs = append(cacheSyncs, supportBundleInformer.Informer().HasSynced)
 	systemBackupInformer := lhInformerFactory.Longhorn().V1beta2().SystemBackups()
 	cacheSyncs = append(cacheSyncs, systemBackupInformer.Informer().HasSynced)
 	systemRestoreInformer := lhInformerFactory.Longhorn().V1beta2().SystemRestores()
 	cacheSyncs = append(cacheSyncs, systemRestoreInformer.Informer().HasSynced)
-	lhVAInformer := lhInformerFactory.Longhorn().V1beta2().VolumeAttachments()
-	cacheSyncs = append(cacheSyncs, lhVAInformer.Informer().HasSynced)
+	lhVolumeAttachmentInformer := lhInformerFactory.Longhorn().V1beta2().VolumeAttachments()
+	cacheSyncs = append(cacheSyncs, lhVolumeAttachmentInformer.Informer().HasSynced)
 
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	cacheSyncs = append(cacheSyncs, podInformer.Informer().HasSynced)
@@ -200,8 +200,8 @@ func NewDataStore(
 	cacheSyncs = append(cacheSyncs, csiDriverInformer.Informer().HasSynced)
 	storageclassInformer := kubeInformerFactory.Storage().V1().StorageClasses()
 	cacheSyncs = append(cacheSyncs, storageclassInformer.Informer().HasSynced)
-	pdbInformer := kubeInformerFactory.Policy().V1().PodDisruptionBudgets()
-	cacheSyncs = append(cacheSyncs, pdbInformer.Informer().HasSynced)
+	podDisruptionBudgetInformer := kubeInformerFactory.Policy().V1().PodDisruptionBudgets()
+	cacheSyncs = append(cacheSyncs, podDisruptionBudgetInformer.Informer().HasSynced)
 	serviceInformer := kubeInformerFactory.Core().V1().Services()
 	cacheSyncs = append(cacheSyncs, serviceInformer.Informer().HasSynced)
 
@@ -223,36 +223,36 @@ func NewDataStore(
 		NodeInformer:                   nodeInformer.Informer(),
 		settingLister:                  settingInformer.Lister(),
 		SettingInformer:                settingInformer.Informer(),
-		instanceManagerLister:          imInformer.Lister(),
-		InstanceManagerInformer:        imInformer.Informer(),
-		shareManagerLister:             smInformer.Lister(),
-		ShareManagerInformer:           smInformer.Informer(),
-		backingImageLister:             biInformer.Lister(),
-		BackingImageInformer:           biInformer.Informer(),
-		backingImageManagerLister:      bimInformer.Lister(),
-		BackingImageManagerInformer:    bimInformer.Informer(),
-		backingImageDataSourceLister:   bidsInformer.Lister(),
-		BackingImageDataSourceInformer: bidsInformer.Informer(),
-		backupTargetLister:             btInformer.Lister(),
-		BackupTargetInformer:           btInformer.Informer(),
-		backupVolumeLister:             bvInformer.Lister(),
-		BackupVolumeInformer:           bvInformer.Informer(),
-		backupLister:                   bInformer.Lister(),
-		BackupInformer:                 bInformer.Informer(),
-		recurringJobLister:             rjInformer.Lister(),
-		RecurringJobInformer:           rjInformer.Informer(),
-		orphanLister:                   oInformer.Lister(),
-		OrphanInformer:                 oInformer.Informer(),
-		snapshotLister:                 snapInformer.Lister(),
-		SnapshotInformer:               snapInformer.Informer(),
+		instanceManagerLister:          instanceManagerInformer.Lister(),
+		InstanceManagerInformer:        instanceManagerInformer.Informer(),
+		shareManagerLister:             shareManagerInformer.Lister(),
+		ShareManagerInformer:           shareManagerInformer.Informer(),
+		backingImageLister:             backingImageInformer.Lister(),
+		BackingImageInformer:           backingImageInformer.Informer(),
+		backingImageManagerLister:      backingImageManagerInformer.Lister(),
+		BackingImageManagerInformer:    backingImageManagerInformer.Informer(),
+		backingImageDataSourceLister:   backingImageDataSourceInformer.Lister(),
+		BackingImageDataSourceInformer: backingImageDataSourceInformer.Informer(),
+		backupTargetLister:             backupTargetInformer.Lister(),
+		BackupTargetInformer:           backupTargetInformer.Informer(),
+		backupVolumeLister:             backupVolumeInformer.Lister(),
+		BackupVolumeInformer:           backupVolumeInformer.Informer(),
+		backupLister:                   backupInformer.Lister(),
+		BackupInformer:                 backupInformer.Informer(),
+		recurringJobLister:             recurringJobInformer.Lister(),
+		RecurringJobInformer:           recurringJobInformer.Informer(),
+		orphanLister:                   orphanInformer.Lister(),
+		OrphanInformer:                 orphanInformer.Informer(),
+		snapshotLister:                 snapshotInformer.Lister(),
+		SnapshotInformer:               snapshotInformer.Informer(),
 		supportBundleLister:            supportBundleInformer.Lister(),
 		SupportBundleInformer:          supportBundleInformer.Informer(),
 		systemBackupLister:             systemBackupInformer.Lister(),
 		SystemBackupInformer:           systemBackupInformer.Informer(),
 		systemRestoreLister:            systemRestoreInformer.Lister(),
 		SystemRestoreInformer:          systemRestoreInformer.Informer(),
-		lhVolumeAttachmentLister:       lhVAInformer.Lister(),
-		LHVolumeAttachmentInformer:     lhVAInformer.Informer(),
+		lhVolumeAttachmentLister:       lhVolumeAttachmentInformer.Lister(),
+		LHVolumeAttachmentInformer:     lhVolumeAttachmentInformer.Informer(),
 
 		kubeClient:                    kubeClient,
 		podLister:                     podInformer.Lister(),
@@ -281,8 +281,8 @@ func NewDataStore(
 		CSIDriverInformer:             csiDriverInformer.Informer(),
 		storageclassLister:            storageclassInformer.Lister(),
 		StorageClassInformer:          storageclassInformer.Informer(),
-		podDisruptionBudgetLister:     pdbInformer.Lister(),
-		PodDisruptionBudgetInformer:   pdbInformer.Informer(),
+		podDisruptionBudgetLister:     podDisruptionBudgetInformer.Lister(),
+		PodDisruptionBudgetInformer:   podDisruptionBudgetInformer.Informer(),
 		serviceLister:                 serviceInformer.Lister(),
 		ServiceInformer:               serviceInformer.Informer(),
 

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -113,7 +113,7 @@ type DataStore struct {
 	storageclassLister            storagelisters_v1.StorageClassLister
 	StorageClassInformer          cache.SharedInformer
 	pdbLister                     policylisters.PodDisruptionBudgetLister
-	PodDistrptionBudgetInformer   cache.SharedInformer
+	PodDisruptionBudgetInformer   cache.SharedInformer
 	svLister                      corelisters.ServiceLister
 	ServiceInformer               cache.SharedInformer
 
@@ -282,7 +282,7 @@ func NewDataStore(
 		storageclassLister:            storageclassInformer.Lister(),
 		StorageClassInformer:          storageclassInformer.Informer(),
 		pdbLister:                     pdbInformer.Lister(),
-		PodDistrptionBudgetInformer:   pdbInformer.Informer(),
+		PodDisruptionBudgetInformer:   pdbInformer.Informer(),
 		svLister:                      serviceInformer.Lister(),
 		ServiceInformer:               serviceInformer.Informer(),
 

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -42,79 +42,79 @@ type DataStore struct {
 	cacheSyncs []cache.InformerSynced
 
 	lhClient                       lhclientset.Interface
-	vLister                        lhlisters.VolumeLister
+	volumeLister                   lhlisters.VolumeLister
 	VolumeInformer                 cache.SharedInformer
-	eLister                        lhlisters.EngineLister
+	engineLister                   lhlisters.EngineLister
 	EngineInformer                 cache.SharedInformer
-	rLister                        lhlisters.ReplicaLister
+	replicaLister                  lhlisters.ReplicaLister
 	ReplicaInformer                cache.SharedInformer
-	iLister                        lhlisters.EngineImageLister
+	engineImageLister              lhlisters.EngineImageLister
 	EngineImageInformer            cache.SharedInformer
-	nLister                        lhlisters.NodeLister
+	nodeLister                     lhlisters.NodeLister
 	NodeInformer                   cache.SharedInformer
-	sLister                        lhlisters.SettingLister
+	settingLister                  lhlisters.SettingLister
 	SettingInformer                cache.SharedInformer
-	imLister                       lhlisters.InstanceManagerLister
+	instanceManagerLister          lhlisters.InstanceManagerLister
 	InstanceManagerInformer        cache.SharedInformer
-	smLister                       lhlisters.ShareManagerLister
+	shareManagerLister             lhlisters.ShareManagerLister
 	ShareManagerInformer           cache.SharedInformer
-	biLister                       lhlisters.BackingImageLister
+	backingImageLister             lhlisters.BackingImageLister
 	BackingImageInformer           cache.SharedInformer
-	bimLister                      lhlisters.BackingImageManagerLister
+	backingImageManagerLister      lhlisters.BackingImageManagerLister
 	BackingImageManagerInformer    cache.SharedInformer
-	bidsLister                     lhlisters.BackingImageDataSourceLister
+	backingImageDataSourceLister   lhlisters.BackingImageDataSourceLister
 	BackingImageDataSourceInformer cache.SharedInformer
-	btLister                       lhlisters.BackupTargetLister
+	backupTargetLister             lhlisters.BackupTargetLister
 	BackupTargetInformer           cache.SharedInformer
-	bvLister                       lhlisters.BackupVolumeLister
+	backupVolumeLister             lhlisters.BackupVolumeLister
 	BackupVolumeInformer           cache.SharedInformer
-	bLister                        lhlisters.BackupLister
+	backupLister                   lhlisters.BackupLister
 	BackupInformer                 cache.SharedInformer
-	rjLister                       lhlisters.RecurringJobLister
+	recurringJobLister             lhlisters.RecurringJobLister
 	RecurringJobInformer           cache.SharedInformer
-	oLister                        lhlisters.OrphanLister
+	orphanLister                   lhlisters.OrphanLister
 	OrphanInformer                 cache.SharedInformer
-	snapLister                     lhlisters.SnapshotLister
+	snapshotLister                 lhlisters.SnapshotLister
 	SnapshotInformer               cache.SharedInformer
 	supportBundleLister            lhlisters.SupportBundleLister
 	SupportBundleInformer          cache.SharedInformer
-	sbLister                       lhlisters.SystemBackupLister
+	systemBackupLister             lhlisters.SystemBackupLister
 	SystemBackupInformer           cache.SharedInformer
-	srLister                       lhlisters.SystemRestoreLister
+	systemRestoreLister            lhlisters.SystemRestoreLister
 	SystemRestoreInformer          cache.SharedInformer
-	lhVALister                     lhlisters.VolumeAttachmentLister
+	lhVolumeAttachmentLister       lhlisters.VolumeAttachmentLister
 	LHVolumeAttachmentInformer     cache.SharedInformer
 
 	kubeClient                    clientset.Interface
-	pLister                       corelisters.PodLister
+	podLister                     corelisters.PodLister
 	PodInformer                   cache.SharedInformer
-	cjLister                      batchlisters_v1.CronJobLister
+	cronJobLister                 batchlisters_v1.CronJobLister
 	CronJobInformer               cache.SharedInformer
-	dsLister                      appslisters.DaemonSetLister
+	daemonSetLister               appslisters.DaemonSetLister
 	DaemonSetInformer             cache.SharedInformer
-	dpLister                      appslisters.DeploymentLister
+	deploymentLister              appslisters.DeploymentLister
 	DeploymentInformer            cache.SharedInformer
-	pvLister                      corelisters.PersistentVolumeLister
+	persistentVolumeLister        corelisters.PersistentVolumeLister
 	PersistentVolumeInformer      cache.SharedInformer
-	pvcLister                     corelisters.PersistentVolumeClaimLister
+	persistentVolumeClaimLister   corelisters.PersistentVolumeClaimLister
 	PersistentVolumeClaimInformer cache.SharedInformer
-	vaLister                      storagelisters_v1.VolumeAttachmentLister
+	volumeAttachmentLister        storagelisters_v1.VolumeAttachmentLister
 	VolumeAttachmentInformer      cache.SharedInformer
-	cfmLister                     corelisters.ConfigMapLister
+	configMapLister               corelisters.ConfigMapLister
 	ConfigMapInformer             cache.SharedInformer
 	secretLister                  corelisters.SecretLister
 	SecretInformer                cache.SharedInformer
-	knLister                      corelisters.NodeLister
+	kubeNodeLister                corelisters.NodeLister
 	KubeNodeInformer              cache.SharedInformer
-	pcLister                      schedulinglisters.PriorityClassLister
+	priorityClassLister           schedulinglisters.PriorityClassLister
 	PriorityClassInformer         cache.SharedInformer
 	csiDriverLister               storagelisters_v1.CSIDriverLister
 	CSIDriverInformer             cache.SharedInformer
 	storageclassLister            storagelisters_v1.StorageClassLister
 	StorageClassInformer          cache.SharedInformer
-	pdbLister                     policylisters.PodDisruptionBudgetLister
+	podDisruptionBudgetLister     policylisters.PodDisruptionBudgetLister
 	PodDisruptionBudgetInformer   cache.SharedInformer
-	svLister                      corelisters.ServiceLister
+	serviceLister                 corelisters.ServiceLister
 	ServiceInformer               cache.SharedInformer
 
 	extensionsClient apiextensionsclientset.Interface
@@ -211,79 +211,79 @@ func NewDataStore(
 		cacheSyncs: cacheSyncs,
 
 		lhClient:                       lhClient,
-		vLister:                        volumeInformer.Lister(),
+		volumeLister:                   volumeInformer.Lister(),
 		VolumeInformer:                 volumeInformer.Informer(),
-		eLister:                        engineInformer.Lister(),
+		engineLister:                   engineInformer.Lister(),
 		EngineInformer:                 engineInformer.Informer(),
-		rLister:                        replicaInformer.Lister(),
+		replicaLister:                  replicaInformer.Lister(),
 		ReplicaInformer:                replicaInformer.Informer(),
-		iLister:                        engineImageInformer.Lister(),
+		engineImageLister:              engineImageInformer.Lister(),
 		EngineImageInformer:            engineImageInformer.Informer(),
-		nLister:                        nodeInformer.Lister(),
+		nodeLister:                     nodeInformer.Lister(),
 		NodeInformer:                   nodeInformer.Informer(),
-		sLister:                        settingInformer.Lister(),
+		settingLister:                  settingInformer.Lister(),
 		SettingInformer:                settingInformer.Informer(),
-		imLister:                       imInformer.Lister(),
+		instanceManagerLister:          imInformer.Lister(),
 		InstanceManagerInformer:        imInformer.Informer(),
-		smLister:                       smInformer.Lister(),
+		shareManagerLister:             smInformer.Lister(),
 		ShareManagerInformer:           smInformer.Informer(),
-		biLister:                       biInformer.Lister(),
+		backingImageLister:             biInformer.Lister(),
 		BackingImageInformer:           biInformer.Informer(),
-		bimLister:                      bimInformer.Lister(),
+		backingImageManagerLister:      bimInformer.Lister(),
 		BackingImageManagerInformer:    bimInformer.Informer(),
-		bidsLister:                     bidsInformer.Lister(),
+		backingImageDataSourceLister:   bidsInformer.Lister(),
 		BackingImageDataSourceInformer: bidsInformer.Informer(),
-		btLister:                       btInformer.Lister(),
+		backupTargetLister:             btInformer.Lister(),
 		BackupTargetInformer:           btInformer.Informer(),
-		bvLister:                       bvInformer.Lister(),
+		backupVolumeLister:             bvInformer.Lister(),
 		BackupVolumeInformer:           bvInformer.Informer(),
-		bLister:                        bInformer.Lister(),
+		backupLister:                   bInformer.Lister(),
 		BackupInformer:                 bInformer.Informer(),
-		rjLister:                       rjInformer.Lister(),
+		recurringJobLister:             rjInformer.Lister(),
 		RecurringJobInformer:           rjInformer.Informer(),
-		oLister:                        oInformer.Lister(),
+		orphanLister:                   oInformer.Lister(),
 		OrphanInformer:                 oInformer.Informer(),
-		snapLister:                     snapInformer.Lister(),
+		snapshotLister:                 snapInformer.Lister(),
 		SnapshotInformer:               snapInformer.Informer(),
 		supportBundleLister:            supportBundleInformer.Lister(),
 		SupportBundleInformer:          supportBundleInformer.Informer(),
-		sbLister:                       systemBackupInformer.Lister(),
+		systemBackupLister:             systemBackupInformer.Lister(),
 		SystemBackupInformer:           systemBackupInformer.Informer(),
-		srLister:                       systemRestoreInformer.Lister(),
+		systemRestoreLister:            systemRestoreInformer.Lister(),
 		SystemRestoreInformer:          systemRestoreInformer.Informer(),
-		lhVALister:                     lhVAInformer.Lister(),
+		lhVolumeAttachmentLister:       lhVAInformer.Lister(),
 		LHVolumeAttachmentInformer:     lhVAInformer.Informer(),
 
 		kubeClient:                    kubeClient,
-		pLister:                       podInformer.Lister(),
+		podLister:                     podInformer.Lister(),
 		PodInformer:                   podInformer.Informer(),
-		cjLister:                      cronJobInformer.Lister(),
+		cronJobLister:                 cronJobInformer.Lister(),
 		CronJobInformer:               cronJobInformer.Informer(),
-		dsLister:                      daemonSetInformer.Lister(),
+		daemonSetLister:               daemonSetInformer.Lister(),
 		DaemonSetInformer:             daemonSetInformer.Informer(),
-		dpLister:                      deploymentInformer.Lister(),
+		deploymentLister:              deploymentInformer.Lister(),
 		DeploymentInformer:            deploymentInformer.Informer(),
-		pvLister:                      persistentVolumeInformer.Lister(),
+		persistentVolumeLister:        persistentVolumeInformer.Lister(),
 		PersistentVolumeInformer:      persistentVolumeInformer.Informer(),
-		pvcLister:                     persistentVolumeClaimInformer.Lister(),
+		persistentVolumeClaimLister:   persistentVolumeClaimInformer.Lister(),
 		PersistentVolumeClaimInformer: persistentVolumeClaimInformer.Informer(),
-		vaLister:                      volumeAttachmentInformer.Lister(),
+		volumeAttachmentLister:        volumeAttachmentInformer.Lister(),
 		VolumeAttachmentInformer:      volumeAttachmentInformer.Informer(),
-		cfmLister:                     configMapInformer.Lister(),
+		configMapLister:               configMapInformer.Lister(),
 		ConfigMapInformer:             configMapInformer.Informer(),
 		secretLister:                  secretInformer.Lister(),
 		SecretInformer:                secretInformer.Informer(),
-		knLister:                      kubeNodeInformer.Lister(),
+		kubeNodeLister:                kubeNodeInformer.Lister(),
 		KubeNodeInformer:              kubeNodeInformer.Informer(),
-		pcLister:                      priorityClassInformer.Lister(),
+		priorityClassLister:           priorityClassInformer.Lister(),
 		PriorityClassInformer:         priorityClassInformer.Informer(),
 		csiDriverLister:               csiDriverInformer.Lister(),
 		CSIDriverInformer:             csiDriverInformer.Informer(),
 		storageclassLister:            storageclassInformer.Lister(),
 		StorageClassInformer:          storageclassInformer.Informer(),
-		pdbLister:                     pdbInformer.Lister(),
+		podDisruptionBudgetLister:     pdbInformer.Lister(),
 		PodDisruptionBudgetInformer:   pdbInformer.Informer(),
-		svLister:                      serviceInformer.Lister(),
+		serviceLister:                 serviceInformer.Lister(),
 		ServiceInformer:               serviceInformer.Informer(),
 
 		extensionsClient: extensionsClient,

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -88,7 +88,7 @@ func (s *DataStore) GetManagerNodeIPMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	podList, err := s.pLister.Pods(s.namespace).List(selector)
+	podList, err := s.podLister.Pods(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (s *DataStore) GetCronJobROByRecurringJob(recurringJob *longhorn.RecurringJ
 	itemMap := map[string]*batchv1.CronJob{
 		recurringJob.Name: nil,
 	}
-	list, err := s.cjLister.CronJobs(s.namespace).List(selector)
+	list, err := s.cronJobLister.CronJobs(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (s *DataStore) CreateEngineImageDaemonSet(ds *appsv1.DaemonSet) error {
 // GetEngineImageDaemonSet get DaemonSet for the given name and namespace, and
 // returns a new DaemonSet object
 func (s *DataStore) GetEngineImageDaemonSet(name string) (*appsv1.DaemonSet, error) {
-	resultRO, err := s.dsLister.DaemonSets(s.namespace).Get(name)
+	resultRO, err := s.daemonSetLister.DaemonSets(s.namespace).Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -214,14 +214,14 @@ func (s *DataStore) DeletePDB(name string) error {
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) GetPDBRO(name string) (*policyv1.PodDisruptionBudget, error) {
-	return s.pdbLister.PodDisruptionBudgets(s.namespace).Get(name)
+	return s.podDisruptionBudgetLister.PodDisruptionBudgets(s.namespace).Get(name)
 }
 
 // ListPDBs gets a map of PDB in s.namespace
 func (s *DataStore) ListPDBs() (map[string]*policyv1.PodDisruptionBudget, error) {
 	itemMap := map[string]*policyv1.PodDisruptionBudget{}
 
-	list, err := s.pdbLister.PodDisruptionBudgets(s.namespace).List(labels.Everything())
+	list, err := s.podDisruptionBudgetLister.PodDisruptionBudgets(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -307,12 +307,12 @@ func (s *DataStore) UpdateStorageClass(obj *storagev1.StorageClass) (*storagev1.
 // the list contains direct references to the internal cache objects and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListPodsRO(namespace string) ([]*corev1.Pod, error) {
-	return s.pLister.Pods(namespace).List(labels.Everything())
+	return s.podLister.Pods(namespace).List(labels.Everything())
 }
 
 // GetPod returns a mutable Pod object for the given name and namespace
 func (s *DataStore) GetPod(name string) (*corev1.Pod, error) {
-	resultRO, err := s.pLister.Pods(s.namespace).Get(name)
+	resultRO, err := s.podLister.Pods(s.namespace).Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -323,7 +323,7 @@ func (s *DataStore) GetPod(name string) (*corev1.Pod, error) {
 }
 
 func (s *DataStore) GetPodRO(namespace, name string) (*corev1.Pod, error) {
-	return s.pLister.Pods(namespace).Get(name)
+	return s.podLister.Pods(namespace).Get(name)
 }
 
 // GetPodContainerLog dumps the log of a container in a Pod object for the given name and namespace.
@@ -343,12 +343,12 @@ func (s *DataStore) CreateDaemonSet(daemonSet *appsv1.DaemonSet) (*appsv1.Daemon
 
 // GetDaemonSet gets the DaemonSet for the given name and namespace
 func (s *DataStore) GetDaemonSet(name string) (*appsv1.DaemonSet, error) {
-	return s.dsLister.DaemonSets(s.namespace).Get(name)
+	return s.daemonSetLister.DaemonSets(s.namespace).Get(name)
 }
 
 // ListDaemonSet gets a list of all DaemonSet for the given namespace
 func (s *DataStore) ListDaemonSet() ([]*appsv1.DaemonSet, error) {
-	return s.dsLister.DaemonSets(s.namespace).List(labels.Everything())
+	return s.daemonSetLister.DaemonSets(s.namespace).List(labels.Everything())
 }
 
 func (s *DataStore) ListDaemonSetWithLabels(labels map[string]string) ([]*appsv1.DaemonSet, error) {
@@ -356,7 +356,7 @@ func (s *DataStore) ListDaemonSetWithLabels(labels map[string]string) ([]*appsv1
 	if err != nil {
 		return nil, err
 	}
-	return s.dsLister.DaemonSets(s.namespace).List(selector)
+	return s.daemonSetLister.DaemonSets(s.namespace).List(selector)
 }
 
 // UpdateDaemonSet updates the DaemonSet for the given DaemonSet object and namespace
@@ -378,12 +378,12 @@ func (s *DataStore) CreateDeployment(obj *appsv1.Deployment) (*appsv1.Deployment
 
 // GetDeployment gets the Deployment for the given name and namespace
 func (s *DataStore) GetDeployment(name string) (*appsv1.Deployment, error) {
-	return s.dpLister.Deployments(s.namespace).Get(name)
+	return s.deploymentLister.Deployments(s.namespace).Get(name)
 }
 
 // ListDeployment gets a list of all Deployment for the given namespace
 func (s *DataStore) ListDeployment() ([]*appsv1.Deployment, error) {
-	return s.dpLister.Deployments(s.namespace).List(labels.Everything())
+	return s.deploymentLister.Deployments(s.namespace).List(labels.Everything())
 }
 
 func (s *DataStore) ListDeploymentWithLabels(labels map[string]string) ([]*appsv1.Deployment, error) {
@@ -391,7 +391,7 @@ func (s *DataStore) ListDeploymentWithLabels(labels map[string]string) ([]*appsv
 	if err != nil {
 		return nil, err
 	}
-	return s.dpLister.Deployments(s.namespace).List(selector)
+	return s.deploymentLister.Deployments(s.namespace).List(selector)
 }
 
 // UpdateDeployment updates Deployment for the given Deployment object and namespace
@@ -495,7 +495,7 @@ func (s *DataStore) GetSupportBundleManagerPod(supportBundle *longhorn.SupportBu
 }
 
 func (s *DataStore) ListPodsBySelector(selector labels.Selector) ([]*corev1.Pod, error) {
-	podList, err := s.pLister.Pods(s.namespace).List(selector)
+	podList, err := s.podLister.Pods(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -511,12 +511,12 @@ func (s *DataStore) ListPodsBySelector(selector labels.Selector) ([]*corev1.Pod,
 // the list contains direct references to the internal cache objects and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListKubeNodesRO() ([]*corev1.Node, error) {
-	return s.knLister.List(labels.Everything())
+	return s.kubeNodeLister.List(labels.Everything())
 }
 
 // GetKubernetesNode gets the Node from the index for the given name
 func (s *DataStore) GetKubernetesNode(name string) (*corev1.Node, error) {
-	return s.knLister.Get(name)
+	return s.kubeNodeLister.Get(name)
 }
 
 // IsKubeNodeUnschedulable checks if the Kubernetes Node resource is
@@ -552,12 +552,12 @@ func (s *DataStore) UpdatePersistentVolume(pv *corev1.PersistentVolume) (*corev1
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) GetPersistentVolumeRO(pvName string) (*corev1.PersistentVolume, error) {
-	return s.pvLister.Get(pvName)
+	return s.persistentVolumeLister.Get(pvName)
 }
 
 // GetPersistentVolume gets a mutable PersistentVolume for the given name
 func (s *DataStore) GetPersistentVolume(pvName string) (*corev1.PersistentVolume, error) {
-	resultRO, err := s.pvLister.Get(pvName)
+	resultRO, err := s.persistentVolumeLister.Get(pvName)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (s *DataStore) GetPersistentVolume(pvName string) (*corev1.PersistentVolume
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListPersistentVolumesRO() ([]*corev1.PersistentVolume, error) {
-	return s.pvLister.List(labels.Everything())
+	return s.persistentVolumeLister.List(labels.Everything())
 }
 
 // CreatePersistentVolumeClaim creates a PersistentVolumeClaim resource
@@ -595,12 +595,12 @@ func (s *DataStore) UpdatePersistentVolumeClaim(namespace string, pvc *corev1.Pe
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) GetPersistentVolumeClaimRO(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
-	return s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+	return s.persistentVolumeClaimLister.PersistentVolumeClaims(namespace).Get(pvcName)
 }
 
 // GetPersistentVolumeClaim gets a mutable PersistentVolumeClaim for the given name and namespace
 func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
-	resultRO, err := s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+	resultRO, err := s.persistentVolumeClaimLister.PersistentVolumeClaims(namespace).Get(pvcName)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +612,7 @@ func (s *DataStore) GetPersistentVolumeClaim(namespace, pvcName string) (*corev1
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListVolumeAttachmentsRO() ([]*storagev1.VolumeAttachment, error) {
-	return s.vaLister.List(labels.Everything())
+	return s.volumeAttachmentLister.List(labels.Everything())
 }
 
 // CreateConfigMap creates a ConfigMap resource
@@ -629,12 +629,12 @@ func (s *DataStore) UpdateConfigMap(configMap *corev1.ConfigMap) (*corev1.Config
 // This function returns direct reference to the internal cache object and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) GetConfigMapRO(namespace, name string) (*corev1.ConfigMap, error) {
-	return s.cfmLister.ConfigMaps(namespace).Get(name)
+	return s.configMapLister.ConfigMaps(namespace).Get(name)
 }
 
 // GetConfigMap return a new ConfigMap object for the given namespace and name
 func (s *DataStore) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
-	resultRO, err := s.cfmLister.ConfigMaps(namespace).Get(name)
+	resultRO, err := s.configMapLister.ConfigMaps(namespace).Get(name)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (s *DataStore) GetSecret(namespace, name string) (*corev1.Secret, error) {
 // GetPriorityClass gets the PriorityClass from the index for the
 // given name
 func (s *DataStore) GetPriorityClass(pcName string) (*schedulingv1.PriorityClass, error) {
-	return s.pcLister.Get(pcName)
+	return s.priorityClassLister.Get(pcName)
 }
 
 // GetPodContainerLogRequest returns the Pod log for the given pod name,
@@ -696,7 +696,7 @@ func (s *DataStore) CreateService(ns string, service *corev1.Service) (*corev1.S
 
 // GetService gets the Service for the given name and namespace
 func (s *DataStore) GetService(namespace, name string) (*corev1.Service, error) {
-	return s.svLister.Services(namespace).Get(name)
+	return s.serviceLister.Services(namespace).Get(name)
 }
 
 // DeleteService deletes the Service for the given name and namespace

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -464,7 +464,7 @@ func (s *DataStore) AreAllVolumesDetached() (bool, error) {
 }
 
 func (s *DataStore) getSettingRO(name string) (*longhorn.Setting, error) {
-	return s.sLister.Settings(s.namespace).Get(name)
+	return s.settingLister.Settings(s.namespace).Get(name)
 }
 
 // GetSettingExact returns the Setting for the given name and namespace
@@ -518,7 +518,7 @@ func (s *DataStore) GetSettingValueExisted(sName types.SettingName) (string, err
 func (s *DataStore) ListSettings() (map[types.SettingName]*longhorn.Setting, error) {
 	itemMap := make(map[types.SettingName]*longhorn.Setting)
 
-	list, err := s.sLister.Settings(s.namespace).List(labels.Everything())
+	list, err := s.settingLister.Settings(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -721,12 +721,12 @@ func (s *DataStore) RemoveFinalizerForVolume(obj *longhorn.Volume) error {
 }
 
 func (s *DataStore) GetVolumeRO(name string) (*longhorn.Volume, error) {
-	return s.vLister.Volumes(s.namespace).Get(name)
+	return s.volumeLister.Volumes(s.namespace).Get(name)
 }
 
 // GetVolume returns a new volume object for the given namespace and name
 func (s *DataStore) GetVolume(name string) (*longhorn.Volume, error) {
-	resultRO, err := s.vLister.Volumes(s.namespace).Get(name)
+	resultRO, err := s.volumeLister.Volumes(s.namespace).Get(name)
 	if err != nil {
 		return nil, err
 	}
@@ -736,7 +736,7 @@ func (s *DataStore) GetVolume(name string) (*longhorn.Volume, error) {
 
 // ListVolumesRO returns a list of all Volumes for the given namespace
 func (s *DataStore) ListVolumesRO() ([]*longhorn.Volume, error) {
-	return s.vLister.Volumes(s.namespace).List(labels.Everything())
+	return s.volumeLister.Volumes(s.namespace).List(labels.Everything())
 }
 
 // ListVolumesROWithBackupVolumeName returns a single object contains all volumes
@@ -746,12 +746,12 @@ func (s *DataStore) ListVolumesROWithBackupVolumeName(backupVolumeName string) (
 	if err != nil {
 		return nil, err
 	}
-	return s.vLister.Volumes(s.namespace).List(selector)
+	return s.volumeLister.Volumes(s.namespace).List(selector)
 }
 
 // ListVolumesBySelectorRO returns a list of all Volumes for the given namespace
 func (s *DataStore) ListVolumesBySelectorRO(selector labels.Selector) ([]*longhorn.Volume, error) {
-	return s.vLister.Volumes(s.namespace).List(selector)
+	return s.volumeLister.Volumes(s.namespace).List(selector)
 }
 
 // ListVolumes returns an object contains all Volume
@@ -1119,7 +1119,7 @@ func (s *DataStore) RemoveFinalizerForEngine(obj *longhorn.Engine) error {
 }
 
 func (s *DataStore) GetEngineRO(name string) (*longhorn.Engine, error) {
-	return s.eLister.Engines(s.namespace).Get(name)
+	return s.engineLister.Engines(s.namespace).Get(name)
 }
 
 // GetEngine returns the Engine for the given name and namespace
@@ -1134,7 +1134,7 @@ func (s *DataStore) GetEngine(name string) (*longhorn.Engine, error) {
 }
 
 func (s *DataStore) listEngines(selector labels.Selector) (map[string]*longhorn.Engine, error) {
-	list, err := s.eLister.Engines(s.namespace).List(selector)
+	list, err := s.engineLister.Engines(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1153,7 +1153,7 @@ func (s *DataStore) ListEngines() (map[string]*longhorn.Engine, error) {
 
 // ListEnginesRO returns a list of all Engine for the given namespace
 func (s *DataStore) ListEnginesRO() ([]*longhorn.Engine, error) {
-	return s.eLister.Engines(s.namespace).List(labels.Everything())
+	return s.engineLister.Engines(s.namespace).List(labels.Everything())
 }
 
 // ListVolumeEngines returns an object contains all Engines with the given
@@ -1295,11 +1295,11 @@ func (s *DataStore) GetReplica(name string) (*longhorn.Replica, error) {
 }
 
 func (s *DataStore) GetReplicaRO(name string) (*longhorn.Replica, error) {
-	return s.rLister.Replicas(s.namespace).Get(name)
+	return s.replicaLister.Replicas(s.namespace).Get(name)
 }
 
 func (s *DataStore) listReplicas(selector labels.Selector) (map[string]*longhorn.Replica, error) {
-	list, err := s.rLister.Replicas(s.namespace).List(selector)
+	list, err := s.replicaLister.Replicas(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1319,7 +1319,7 @@ func (s *DataStore) ListReplicas() (map[string]*longhorn.Replica, error) {
 
 // ListReplicasRO returns a list of all replicas for the given namespace
 func (s *DataStore) ListReplicasRO() ([]*longhorn.Replica, error) {
-	return s.rLister.Replicas(s.namespace).List(labels.Everything())
+	return s.replicaLister.Replicas(s.namespace).List(labels.Everything())
 }
 
 // ListVolumeReplicas returns an object contains all Replica with the given
@@ -1472,7 +1472,7 @@ func (s *DataStore) RemoveFinalizerForEngineImage(obj *longhorn.EngineImage) err
 }
 
 func (s *DataStore) getEngineImageRO(name string) (*longhorn.EngineImage, error) {
-	return s.iLister.EngineImages(s.namespace).Get(name)
+	return s.engineImageLister.EngineImages(s.namespace).Get(name)
 }
 
 // GetEngineImage returns a new EngineImage object for the given name and
@@ -1505,7 +1505,7 @@ func (s *DataStore) GetEngineImageByImage(image string) (*longhorn.EngineImage, 
 func (s *DataStore) ListEngineImages() (map[string]*longhorn.EngineImage, error) {
 	itemMap := map[string]*longhorn.EngineImage{}
 
-	list, err := s.iLister.EngineImages(s.namespace).List(labels.Everything())
+	list, err := s.engineImageLister.EngineImages(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -1670,7 +1670,7 @@ func (s *DataStore) RemoveFinalizerForBackingImage(obj *longhorn.BackingImage) e
 }
 
 func (s *DataStore) getBackingImageRO(name string) (*longhorn.BackingImage, error) {
-	return s.biLister.BackingImages(s.namespace).Get(name)
+	return s.backingImageLister.BackingImages(s.namespace).Get(name)
 }
 
 // GetBackingImage returns a new BackingImage object for the given name and
@@ -1688,7 +1688,7 @@ func (s *DataStore) GetBackingImage(name string) (*longhorn.BackingImage, error)
 func (s *DataStore) ListBackingImages() (map[string]*longhorn.BackingImage, error) {
 	itemMap := map[string]*longhorn.BackingImage{}
 
-	list, err := s.biLister.BackingImages(s.namespace).List(labels.Everything())
+	list, err := s.backingImageLister.BackingImages(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -1818,7 +1818,7 @@ func (s *DataStore) RemoveFinalizerForBackingImageManager(obj *longhorn.BackingI
 }
 
 func (s *DataStore) getBackingImageManagerRO(name string) (*longhorn.BackingImageManager, error) {
-	return s.bimLister.BackingImageManagers(s.namespace).Get(name)
+	return s.backingImageManagerLister.BackingImageManagers(s.namespace).Get(name)
 }
 
 // GetBackingImageManager returns a new BackingImageManager object for the given name and
@@ -1835,7 +1835,7 @@ func (s *DataStore) GetBackingImageManager(name string) (*longhorn.BackingImageM
 func (s *DataStore) listBackingImageManagers(selector labels.Selector) (map[string]*longhorn.BackingImageManager, error) {
 	itemMap := map[string]*longhorn.BackingImageManager{}
 
-	list, err := s.bimLister.BackingImageManagers(s.namespace).List(selector)
+	list, err := s.backingImageManagerLister.BackingImageManagers(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1982,7 +1982,7 @@ func (s *DataStore) RemoveFinalizerForBackingImageDataSource(obj *longhorn.Backi
 }
 
 func (s *DataStore) getBackingImageDataSourceRO(name string) (*longhorn.BackingImageDataSource, error) {
-	return s.bidsLister.BackingImageDataSources(s.namespace).Get(name)
+	return s.backingImageDataSourceLister.BackingImageDataSources(s.namespace).Get(name)
 }
 
 // GetBackingImageDataSource returns a new BackingImageDataSource object for the given name and
@@ -2040,7 +2040,7 @@ func (s *DataStore) ListBackingImageDataSourcesByNode(nodeName string) (map[stri
 func (s *DataStore) listBackingImageDataSources(selector labels.Selector) (map[string]*longhorn.BackingImageDataSource, error) {
 	itemMap := map[string]*longhorn.BackingImageDataSource{}
 
-	list, err := s.bidsLister.BackingImageDataSources(s.namespace).List(selector)
+	list, err := s.backingImageDataSourceLister.BackingImageDataSources(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -2138,7 +2138,7 @@ func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
 }
 
 func (s *DataStore) GetNodeRO(name string) (*longhorn.Node, error) {
-	return s.nLister.Nodes(s.namespace).Get(name)
+	return s.nodeLister.Nodes(s.namespace).Get(name)
 }
 
 // GetNode gets Longhorn Node for the given name and namespace
@@ -2241,7 +2241,7 @@ func (s *DataStore) ListNodes() (map[string]*longhorn.Node, error) {
 // the list contains direct references to the internal cache objects and should not be mutated.
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListNodesRO() ([]*longhorn.Node, error) {
-	return s.nLister.Nodes(s.namespace).List(labels.Everything())
+	return s.nodeLister.Nodes(s.namespace).List(labels.Everything())
 }
 
 func (s *DataStore) ListNodesWithEngineImage(ei *longhorn.EngineImage) (map[string]*longhorn.Node, error) {
@@ -2509,7 +2509,7 @@ func (s *DataStore) ListReplicasByBackingImage(backingImageName string) ([]*long
 	if err != nil {
 		return nil, err
 	}
-	return s.rLister.Replicas(s.namespace).List(backingImageSelector)
+	return s.replicaLister.Replicas(s.namespace).List(backingImageSelector)
 }
 
 // ListReplicasByNodeRO returns a list of all Replicas on node Name for the given namespace,
@@ -2520,7 +2520,7 @@ func (s *DataStore) ListReplicasByNodeRO(name string) ([]*longhorn.Replica, erro
 	if err != nil {
 		return nil, err
 	}
-	return s.rLister.Replicas(s.namespace).List(nodeSelector)
+	return s.replicaLister.Replicas(s.namespace).List(nodeSelector)
 }
 
 func labelNode(nodeID string, obj runtime.Object) error {
@@ -2794,7 +2794,7 @@ func (s *DataStore) DeleteNode(name string) error {
 // Consider using this function when you can guarantee read only access and don't want the overhead of deep copies
 func (s *DataStore) ListEnginesByNodeRO(name string) ([]*longhorn.Engine, error) {
 	nodeSelector, err := getNodeSelector(name)
-	engineList, err := s.eLister.Engines(s.namespace).List(nodeSelector)
+	engineList, err := s.engineLister.Engines(s.namespace).List(nodeSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -2853,7 +2853,7 @@ func (s *DataStore) DeleteInstanceManager(name string) error {
 }
 
 func (s *DataStore) GetInstanceManagerRO(name string) (*longhorn.InstanceManager, error) {
-	return s.imLister.InstanceManagers(s.namespace).Get(name)
+	return s.instanceManagerLister.InstanceManagers(s.namespace).Get(name)
 }
 
 // GetInstanceManager gets the InstanceManager for the given name and namespace.
@@ -2926,7 +2926,7 @@ func (s *DataStore) ListInstanceManagersBySelector(node, instanceManagerImage st
 		return nil, err
 	}
 
-	listRO, err := s.imLister.InstanceManagers(s.namespace).List(selector)
+	listRO, err := s.instanceManagerLister.InstanceManagers(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -2989,7 +2989,7 @@ func (s *DataStore) ListInstanceManagersByNode(node string, imType longhorn.Inst
 func (s *DataStore) ListInstanceManagers() (map[string]*longhorn.InstanceManager, error) {
 	itemMap := map[string]*longhorn.InstanceManager{}
 
-	list, err := s.imLister.InstanceManagers(s.namespace).List(labels.Everything())
+	list, err := s.instanceManagerLister.InstanceManagers(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3213,7 +3213,7 @@ func (s *DataStore) RemoveFinalizerForShareManager(obj *longhorn.ShareManager) e
 }
 
 func (s *DataStore) getShareManagerRO(name string) (*longhorn.ShareManager, error) {
-	return s.smLister.ShareManagers(s.namespace).Get(name)
+	return s.shareManagerLister.ShareManagers(s.namespace).Get(name)
 }
 
 // GetShareManager gets the ShareManager for the given name and namespace.
@@ -3230,7 +3230,7 @@ func (s *DataStore) GetShareManager(name string) (*longhorn.ShareManager, error)
 func (s *DataStore) ListShareManagers() (map[string]*longhorn.ShareManager, error) {
 	itemMap := map[string]*longhorn.ShareManager{}
 
-	list, err := s.smLister.ShareManagers(s.namespace).List(labels.Everything())
+	list, err := s.shareManagerLister.ShareManagers(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3267,7 +3267,7 @@ func (s *DataStore) CreateBackupTarget(backupTarget *longhorn.BackupTarget) (*lo
 
 // ListBackupTargets returns an object contains all backup targets in the cluster BackupTargets CR
 func (s *DataStore) ListBackupTargets() (map[string]*longhorn.BackupTarget, error) {
-	list, err := s.btLister.BackupTargets(s.namespace).List(labels.Everything())
+	list, err := s.backupTargetLister.BackupTargets(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3286,7 +3286,7 @@ func (s *DataStore) GetDefaultBackupTargetRO() (*longhorn.BackupTarget, error) {
 
 // GetBackupTargetRO returns the BackupTarget with the given backup target name in the cluster
 func (s *DataStore) GetBackupTargetRO(backupTargetName string) (*longhorn.BackupTarget, error) {
-	return s.btLister.BackupTargets(s.namespace).Get(backupTargetName)
+	return s.backupTargetLister.BackupTargets(s.namespace).Get(backupTargetName)
 }
 
 // GetBackupTarget returns a copy of BackupTarget with the given backup target name in the cluster
@@ -3353,7 +3353,7 @@ func (s *DataStore) CreateBackupVolume(backupVolume *longhorn.BackupVolume) (*lo
 
 // ListBackupVolumes returns an object contains all backup volumes in the cluster BackupVolumes CR
 func (s *DataStore) ListBackupVolumes() (map[string]*longhorn.BackupVolume, error) {
-	list, err := s.bvLister.BackupVolumes(s.namespace).List(labels.Everything())
+	list, err := s.backupVolumeLister.BackupVolumes(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3373,7 +3373,7 @@ func getBackupVolumeSelector(backupVolumeName string) (labels.Selector, error) {
 
 // GetBackupVolumeRO returns the BackupVolume with the given backup volume name in the cluster
 func (s *DataStore) GetBackupVolumeRO(backupVolumeName string) (*longhorn.BackupVolume, error) {
-	return s.bvLister.BackupVolumes(s.namespace).Get(backupVolumeName)
+	return s.backupVolumeLister.BackupVolumes(s.namespace).Get(backupVolumeName)
 }
 
 // GetBackupVolume returns a copy of BackupVolume with the given backup volume name in the cluster
@@ -3469,7 +3469,7 @@ func (s *DataStore) ListBackupsWithBackupVolumeName(backupVolumeName string) (ma
 		return nil, err
 	}
 
-	list, err := s.bLister.Backups(s.namespace).List(selector)
+	list, err := s.backupLister.Backups(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -3483,12 +3483,12 @@ func (s *DataStore) ListBackupsWithBackupVolumeName(backupVolumeName string) (ma
 
 // ListBackupsRO returns a list of all Backups for the given namespace
 func (s *DataStore) ListBackupsRO() ([]*longhorn.Backup, error) {
-	return s.bLister.Backups(s.namespace).List(labels.Everything())
+	return s.backupLister.Backups(s.namespace).List(labels.Everything())
 }
 
 // ListBackups returns an object contains all backups in the cluster Backups CR
 func (s *DataStore) ListBackups() (map[string]*longhorn.Backup, error) {
-	list, err := s.bLister.Backups(s.namespace).List(labels.Everything())
+	list, err := s.backupLister.Backups(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3502,7 +3502,7 @@ func (s *DataStore) ListBackups() (map[string]*longhorn.Backup, error) {
 
 // GetBackupRO returns the Backup with the given backup name in the cluster
 func (s *DataStore) GetBackupRO(backupName string) (*longhorn.Backup, error) {
-	return s.bLister.Backups(s.namespace).Get(backupName)
+	return s.backupLister.Backups(s.namespace).Get(backupName)
 }
 
 // GetBackup returns a copy of Backup with the given backup name in the cluster
@@ -3594,7 +3594,7 @@ func (s *DataStore) CreateSnapshot(snapshot *longhorn.Snapshot) (*longhorn.Snaps
 
 // GetSnapshotRO returns the Snapshot with the given snapshot name in the cluster
 func (s *DataStore) GetSnapshotRO(snapName string) (*longhorn.Snapshot, error) {
-	return s.snapLister.Snapshots(s.namespace).Get(snapName)
+	return s.snapshotLister.Snapshots(s.namespace).Get(snapName)
 }
 
 // GetSnapshot returns a copy of Snapshot with the given snapshot name in the cluster
@@ -3640,7 +3640,7 @@ func (s *DataStore) RemoveFinalizerForSnapshot(snapshot *longhorn.Snapshot) erro
 }
 
 func (s *DataStore) ListSnapshotsRO(selector labels.Selector) (map[string]*longhorn.Snapshot, error) {
-	list, err := s.snapLister.Snapshots(s.namespace).List(selector)
+	list, err := s.snapshotLister.Snapshots(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -3652,7 +3652,7 @@ func (s *DataStore) ListSnapshotsRO(selector labels.Selector) (map[string]*longh
 }
 
 func (s *DataStore) ListSnapshots() (map[string]*longhorn.Snapshot, error) {
-	list, err := s.snapLister.Snapshots(s.namespace).List(labels.Everything())
+	list, err := s.snapshotLister.Snapshots(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3705,7 +3705,7 @@ func (s *DataStore) CreateRecurringJob(recurringJob *longhorn.RecurringJob) (*lo
 func (s *DataStore) ListRecurringJobs() (map[string]*longhorn.RecurringJob, error) {
 	itemMap := map[string]*longhorn.RecurringJob{}
 
-	list, err := s.rjLister.RecurringJobs(s.namespace).List(labels.Everything())
+	list, err := s.recurringJobLister.RecurringJobs(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3721,7 +3721,7 @@ func (s *DataStore) ListRecurringJobs() (map[string]*longhorn.RecurringJob, erro
 func (s *DataStore) ListRecurringJobsRO() (map[string]*longhorn.RecurringJob, error) {
 	itemMap := map[string]*longhorn.RecurringJob{}
 
-	list, err := s.rjLister.RecurringJobs(s.namespace).List(labels.Everything())
+	list, err := s.recurringJobLister.RecurringJobs(s.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -3734,7 +3734,7 @@ func (s *DataStore) ListRecurringJobsRO() (map[string]*longhorn.RecurringJob, er
 }
 
 func (s *DataStore) getRecurringJobRO(name string) (*longhorn.RecurringJob, error) {
-	return s.rjLister.RecurringJobs(s.namespace).Get(name)
+	return s.recurringJobLister.RecurringJobs(s.namespace).Get(name)
 }
 
 // GetRecurringJob gets the RecurringJob for the given name and namespace.
@@ -3748,7 +3748,7 @@ func (s *DataStore) GetRecurringJob(name string) (*longhorn.RecurringJob, error)
 }
 
 func (s *DataStore) getRecurringJob(name string) (*longhorn.RecurringJob, error) {
-	return s.rjLister.RecurringJobs(s.namespace).Get(name)
+	return s.recurringJobLister.RecurringJobs(s.namespace).Get(name)
 }
 
 // UpdateRecurringJob updates Longhorn RecurringJob and verifies update
@@ -3871,7 +3871,7 @@ func (s *DataStore) CreateOrphan(orphan *longhorn.Orphan) (*longhorn.Orphan, err
 
 // GetOrphanRO returns the Orphan with the given orphan name in the cluster
 func (s *DataStore) GetOrphanRO(orphanName string) (*longhorn.Orphan, error) {
-	return s.oLister.Orphans(s.namespace).Get(orphanName)
+	return s.orphanLister.Orphans(s.namespace).Get(orphanName)
 }
 
 // GetOrphan returns a copy of Orphan with the given orphan name in the cluster
@@ -3929,7 +3929,7 @@ func (s *DataStore) RemoveFinalizerForOrphan(orphan *longhorn.Orphan) error {
 }
 
 func (s *DataStore) listOrphans(selector labels.Selector) (map[string]*longhorn.Orphan, error) {
-	list, err := s.oLister.Orphans(s.namespace).List(selector)
+	list, err := s.orphanLister.Orphans(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -3958,7 +3958,7 @@ func (s *DataStore) ListOrphansByNode(name string) (map[string]*longhorn.Orphan,
 
 // ListOrphansRO returns a list of all Orphans for the given namespace
 func (s *DataStore) ListOrphansRO() ([]*longhorn.Orphan, error) {
-	return s.oLister.Orphans(s.namespace).List(labels.Everything())
+	return s.orphanLister.Orphans(s.namespace).List(labels.Everything())
 }
 
 // ListOrphansByNodeRO returns a list of all Orphans on node Name for the given namespace,
@@ -3969,7 +3969,7 @@ func (s *DataStore) ListOrphansByNodeRO(name string) ([]*longhorn.Orphan, error)
 	if err != nil {
 		return nil, err
 	}
-	return s.oLister.Orphans(s.namespace).List(nodeSelector)
+	return s.orphanLister.Orphans(s.namespace).List(nodeSelector)
 }
 
 // DeleteOrphan won't result in immediately deletion since finalizer was set by default
@@ -4031,7 +4031,7 @@ func (s *DataStore) CreateLHVolumeAttachment(va *longhorn.VolumeAttachment) (*lo
 
 // GetLHVolumeAttachmentRO returns the VolumeAttachment with the given name in the cluster
 func (s *DataStore) GetLHVolumeAttachmentRO(name string) (*longhorn.VolumeAttachment, error) {
-	return s.lhVALister.VolumeAttachments(s.namespace).Get(name)
+	return s.lhVolumeAttachmentLister.VolumeAttachments(s.namespace).Get(name)
 }
 
 // GetLHVolumeAttachment returns a copy of VolumeAttachment with the given name in the cluster
@@ -4224,7 +4224,7 @@ func (s *DataStore) GetSystemBackup(name string) (*longhorn.SystemBackup, error)
 
 // GetSystemBackupRO returns the SystemBackup with the given name
 func (s *DataStore) GetSystemBackupRO(name string) (*longhorn.SystemBackup, error) {
-	return s.sbLister.SystemBackups(s.namespace).Get(name)
+	return s.systemBackupLister.SystemBackups(s.namespace).Get(name)
 }
 
 // ListSystemBackups returns a copy of the object contains all SystemBackups
@@ -4243,7 +4243,7 @@ func (s *DataStore) ListSystemBackups() (map[string]*longhorn.SystemBackup, erro
 
 // ListSystemBackupsRO returns an object contains all SystemBackups
 func (s *DataStore) ListSystemBackupsRO() ([]*longhorn.SystemBackup, error) {
-	return s.sbLister.SystemBackups(s.namespace).List(labels.Everything())
+	return s.systemBackupLister.SystemBackups(s.namespace).List(labels.Everything())
 }
 
 func LabelSystemBackupVersion(version string, obj runtime.Object) error {
@@ -4397,7 +4397,7 @@ func (s *DataStore) GetSystemRestore(name string) (*longhorn.SystemRestore, erro
 
 // GetSystemRestoreRO returns the SystemRestore with the given CR name
 func (s *DataStore) GetSystemRestoreRO(name string) (*longhorn.SystemRestore, error) {
-	return s.srLister.SystemRestores(s.namespace).Get(name)
+	return s.systemRestoreLister.SystemRestores(s.namespace).Get(name)
 }
 
 // GetSystemRestoreInProgress validate the given name and returns the only
@@ -4445,7 +4445,7 @@ func (s *DataStore) getSystemRestoreInProgressSelector() (labels.Selector, error
 }
 
 func (s *DataStore) listSystemRestores(selector labels.Selector) (map[string]*longhorn.SystemRestore, error) {
-	list, err := s.srLister.SystemRestores(s.namespace).List(selector)
+	list, err := s.systemRestoreLister.SystemRestores(s.namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -4495,7 +4495,7 @@ func (s *DataStore) ListLonghornVolumeAttachmentByVolumeRO(name string) ([]*long
 	if err != nil {
 		return nil, err
 	}
-	return s.lhVALister.VolumeAttachments(s.namespace).List(volumeSelector)
+	return s.lhVolumeAttachmentLister.VolumeAttachments(s.namespace).List(volumeSelector)
 }
 
 // RemoveFinalizerForLHVolumeAttachment will result in deletion if DeletionTimestamp was set


### PR DESCRIPTION
As Longhorn has expanded with additional Custom Resource Definitions (CRDs), the use of abbreviations may lose its clarity. Therefore, this PR proposes substituting the resource lister and informer abbreviations with their full names to improve readability.