### PR TITLE
offline rebuilding: check spc.backendStoreDriver using a defensive way

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -681,15 +681,13 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 		}
 	}
 
-	if v.Spec.BackendStoreDriver == longhorn.BackendStoreDriverTypeV2 {
-		shouldStop, err := c.shouldStopOfflineReplicaRebuilding(v, healthyCount)
-		if err != nil {
-			log.WithError(err).Errorf("Failed to check if offline replica rebuilding should be stopped")
-			return err
-		}
-		if shouldStop {
-			v.Status.OfflineReplicaRebuildingRequired = false
-		}
+	shouldStop, err := c.shouldStopOfflineReplicaRebuilding(v, healthyCount)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to check if offline replica rebuilding should be stopped")
+		return err
+	}
+	if shouldStop {
+		v.Status.OfflineReplicaRebuildingRequired = false
 	}
 
 	// Cannot continue evicting or replenishing replicas during engine migration.
@@ -731,9 +729,7 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 			}
 		}
 
-		if v.Spec.BackendStoreDriver == longhorn.BackendStoreDriverTypeV2 {
-			v.Status.OfflineReplicaRebuildingRequired = false
-		}
+		v.Status.OfflineReplicaRebuildingRequired = false
 	} else { // healthyCount < v.Spec.NumberOfReplicas
 		v.Status.Robustness = longhorn.VolumeRobustnessDegraded
 		if oldRobustness != longhorn.VolumeRobustnessDegraded {
@@ -797,6 +793,10 @@ func areAllReplicasFailed(rs map[string]*longhorn.Replica) bool {
 }
 
 func (c *VolumeController) shouldStopOfflineReplicaRebuilding(v *longhorn.Volume, healthyCount int) (bool, error) {
+	if v.Spec.BackendStoreDriver != longhorn.BackendStoreDriverTypeV2 {
+		return true, nil
+	}
+
 	if healthyCount == v.Spec.NumberOfReplicas {
 		return true, nil
 	}
@@ -2856,7 +2856,7 @@ func (c *VolumeController) updateRequestedBackupForVolumeRestore(v *longhorn.Vol
 func (c *VolumeController) checkAndInitVolumeOfflineReplicaRebuilding(v *longhorn.Volume, rs map[string]*longhorn.Replica) error {
 	log := getLoggerForVolume(c.logger, v)
 
-	if v.Spec.BackendStoreDriver == longhorn.BackendStoreDriverTypeV1 {
+	if v.Spec.BackendStoreDriver != longhorn.BackendStoreDriverTypeV2 {
 		return nil
 	}
 


### PR DESCRIPTION
This is inspired by https://github.com/longhorn/longhorn/issues/6688.
Currently, we haven't figured out the root cause of the issue yet, and the volume spec fields are correct. 
However, we can adopt a defensive way when checking the spec fields.

Longhorn/longhorn#6688