### PR TITLE
Prevent orphan snapshot attachment tickets

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3607,6 +3607,18 @@ func (s *DataStore) GetSnapshot(name string) (*longhorn.Snapshot, error) {
 	return resultRO.DeepCopy(), nil
 }
 
+// UpdateSnapshot updates the given Longhorn Snapshot and verifies update
+func (s *DataStore) UpdateSnapshot(snap *longhorn.Snapshot) (*longhorn.Snapshot, error) {
+	obj, err := s.lhClient.LonghornV1beta2().Snapshots(s.namespace).Update(context.TODO(), snap, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	verifyUpdate(snap.Name, obj, func(name string) (runtime.Object, error) {
+		return s.GetSnapshotRO(name)
+	})
+	return obj, nil
+}
+
 // UpdateSnapshotStatus updates the given Longhorn snapshot status verifies update
 func (s *DataStore) UpdateSnapshotStatus(snap *longhorn.Snapshot) (*longhorn.Snapshot, error) {
 	obj, err := s.lhClient.LonghornV1beta2().Snapshots(s.namespace).UpdateStatus(context.TODO(), snap, metav1.UpdateOptions{})

--- a/types/types.go
+++ b/types/types.go
@@ -204,6 +204,8 @@ const (
 
 	CniNetworkNone          = ""
 	StorageNetworkInterface = "lhnet1"
+
+	AttachingForDeletionAnnotationKey = "longhorn.io/attaching-for-deletion"
 )
 
 const (

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -562,6 +562,26 @@ func ListAndUpdateRecurringJobsInProvidedCache(namespace string, lhClient *lhcli
 	return recurringJobs, nil
 }
 
+// ListAndUpdateVolumeAttachmentsInProvidedCache list all volumeAttachments and save them into the provided cached `resourceMap`. This method is not thread-safe.
+func ListAndUpdateVolumeAttachmentsInProvidedCache(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (map[string]*longhorn.VolumeAttachment, error) {
+	if v, ok := resourceMaps[types.LonghornKindVolumeAttachment]; ok {
+		return v.(map[string]*longhorn.VolumeAttachment), nil
+	}
+
+	volumeAttachments := map[string]*longhorn.VolumeAttachment{}
+	volumeAttachmentList, err := lhClient.LonghornV1beta2().VolumeAttachments(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i, volumeAttachment := range volumeAttachmentList.Items {
+		volumeAttachments[volumeAttachment.Name] = &volumeAttachmentList.Items[i]
+	}
+
+	resourceMaps[types.LonghornKindVolumeAttachment] = volumeAttachments
+
+	return volumeAttachments, nil
+}
+
 // CreateAndUpdateRecurringJobInProvidedCache creates a recurringJob and saves it into the provided cached `resourceMap`. This method is not thread-safe.
 func CreateAndUpdateRecurringJobInProvidedCache(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}, job *longhorn.RecurringJob) (*longhorn.RecurringJob, error) {
 	obj, err := lhClient.LonghornV1beta2().RecurringJobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{})
@@ -911,23 +931,21 @@ func updateOrphans(namespace string, lhClient *lhclientset.Clientset, orphans ma
 	return nil
 }
 
-func updateVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, volumeAttachment map[string]*longhorn.VolumeAttachment) error {
+func updateVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, volumeAttachments map[string]*longhorn.VolumeAttachment) error {
 	existingVolumeAttachmentList, err := lhClient.LonghornV1beta2().VolumeAttachments(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-
-	existingVolumeAttachmentMap := map[string]bool{}
-	for _, volume := range existingVolumeAttachmentList.Items {
-		existingVolumeAttachmentMap[volume.Name] = true
-	}
-
-	for _, va := range volumeAttachment {
-		if _, ok := existingVolumeAttachmentMap[va.Name]; ok {
+	for _, existingVolumeAttachment := range existingVolumeAttachmentList.Items {
+		volumeAttachment, ok := volumeAttachments[existingVolumeAttachment.Name]
+		if !ok {
 			continue
 		}
-		if _, err = lhClient.LonghornV1beta2().VolumeAttachments(namespace).Create(context.TODO(), va, metav1.CreateOptions{}); err != nil {
-			return err
+		if !reflect.DeepEqual(existingVolumeAttachment.Spec, volumeAttachment.Spec) ||
+			!reflect.DeepEqual(existingVolumeAttachment.ObjectMeta, volumeAttachment.ObjectMeta) {
+			if _, err = lhClient.LonghornV1beta2().VolumeAttachments(namespace).Update(context.TODO(), volumeAttachment, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/6652

It is possible for a snapshot to be reconciled again even after its finalizer is removed and it is deleted. Because of this, it is dangerous to create an `attachmentTicket` for a snapshot after its `deletionTimestamp` has been set. (If this is the last time we ever reconcile it and we fail to clean up the `attachmentTicket` in this reconcile loop, the `attachmentTicket` will exist forever).

This PR introduces a snapshot annotation. The FIRST time we successfully create an `attachmentTicket` after a snapshot's `deletionTimestamp` is set, we update the snapshot with this annotation. We NEVER create an `attachmentTicket` for this snapshot again (although we can update the `nodeID` for the existing one as necessary). This ensures we do not create an `attachmentTicket` on the final reconciliation.

This PR also adds upgrade logic to clean up existing orphan snapshot `attachmentTickets`.