### PR TITLE
Refuse to create a duplicate engine

### DIFF
--- a/webhook/resources/engine/validator.go
+++ b/webhook/resources/engine/validator.go
@@ -41,6 +41,15 @@ func (e *engineValidator) Resource() admission.Resource {
 func (e *engineValidator) Create(request *admission.Request, newObj runtime.Object) error {
 	engine := newObj.(*longhorn.Engine)
 
+	volume, err := e.ds.GetVolume(engine.Spec.VolumeName)
+	if err != nil {
+		if datastore.ErrorIsNotFound(err) {
+			return werror.NewInvalidError("volume does not exist for engine", "spec.volumeName")
+		}
+		err = errors.Wrap(err, "failed to get volume for engine")
+		return werror.NewInternalError(err.Error())
+	}
+
 	if engine.Spec.BackendStoreDriver == longhorn.BackendStoreDriverTypeV2 {
 		v2DataEngineEnabled, err := e.ds.GetSettingAsBool(types.SettingNameV2DataEngine)
 		if err != nil {
@@ -52,7 +61,7 @@ func (e *engineValidator) Create(request *admission.Request, newObj runtime.Obje
 		}
 	}
 
-	return nil
+	return e.validateNumberOfEngines(engine, volume)
 }
 
 func (e *engineValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
@@ -64,6 +73,26 @@ func (e *engineValidator) Update(request *admission.Request, oldObj runtime.Obje
 			err := fmt.Errorf("changing backend store driver for engine %v is not supported", oldEngine.Name)
 			return werror.NewInvalidError(err.Error(), "")
 		}
+	}
+
+	return nil
+}
+
+func (e *engineValidator) validateNumberOfEngines(newEngine *longhorn.Engine, volume *longhorn.Volume) error {
+	volumeEngines, err := e.ds.ListVolumeEnginesUncached(newEngine.Spec.VolumeName)
+	if err != nil {
+		err = errors.Wrap(err, "failed to list engines for volume")
+		return werror.NewInternalError(err.Error())
+	}
+
+	newNumVolumeEngines := len(volumeEngines) + 1
+	if volume.Spec.Migratable && newNumVolumeEngines > 2 {
+		message := fmt.Sprintf("engine creation would result in %d engines for migratable volume", newNumVolumeEngines)
+		return werror.NewInvalidError(message, "")
+	}
+	if !volume.Spec.Migratable && newNumVolumeEngines > 1 {
+		message := fmt.Sprintf("engine creation would result in %d engines for non-migratable volume", newNumVolumeEngines)
+		return werror.NewInvalidError(message, "")
 	}
 
 	return nil


### PR DESCRIPTION
longhorn/longhorn#6682

I have tested this PR and it accomplishes its objective in the "normal" case. However, I think it may be just as susceptible to corner cases as the volume controller is without it. If the webhook's engine cache is out-of-date when it is listing engines (e.g. if one volume controller or two volume controllers decided to create duplicate engines nearly simultaneously), it will still allow the creation of duplicates. I'll discuss this further in the linked issue.