### PR TITLE
Waiting for old Longhorn manager to be fully removed before starting upgrade path

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -149,7 +149,7 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
-	if err := upgrade.Upgrade(kubeconfigPath, currentNodeID); err != nil {
+	if err := upgrade.Upgrade(kubeconfigPath, currentNodeID, managerImage); err != nil {
 		return err
 	}
 

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -51,11 +51,7 @@ func labelMapToLabelSelector(labels map[string]string) (labels.Selector, error) 
 }
 
 func (s *DataStore) GetManagerLabel() map[string]string {
-	return map[string]string{
-		// TODO standardize key
-		// longhornSystemKey: longhornSystemManager,
-		"app": types.LonghornManagerDaemonSetName,
-	}
+	return types.GetManagerLabels()
 }
 
 func (s *DataStore) getManagerSelector() (labels.Selector, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -380,6 +380,11 @@ func GetLonghornLabelCRDAPIVersionKey() string {
 	return GetLonghornLabelKey(LonghornLabelCRDAPIVersion)
 }
 
+func GetManagerLabels() map[string]string {
+	return map[string]string{
+		"app": LonghornManagerDaemonSetName,
+	}
+}
 func GetEngineImageLabels(engineImageName string) map[string]string {
 	labels := GetBaseLabelsForSystemManagedComponent()
 	labels[GetLonghornLabelComponentKey()] = LonghornLabelEngineImage

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -110,6 +110,16 @@ func ListIMPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, er
 	return imPodsList.Items, nil
 }
 
+func ListManagerPods(namespace string, kubeClient *clientset.Clientset) ([]v1.Pod, error) {
+	managerPodsList, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.Set(types.GetManagerLabels()).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return managerPodsList.Items, nil
+}
+
 func MergeStringMaps(baseMap, overwriteMap map[string]string) map[string]string {
 	result := map[string]string{}
 	for k, v := range baseMap {


### PR DESCRIPTION
Fix the issue that both old and new Longhorn managers are running at the same time causing the problem for the upgrade logic

longhorn/longhorn#6294