### PR TITLE
Add privileged security context to be able to mount socket-dir

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -406,6 +406,9 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									MountPath: GetInContainerCSISocketDir(),
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.BoolPtr(true),
+							},
 						},
 						{
 							Name: types.CSIPluginName,

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -133,6 +134,9 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 									Name:      "socket-dir",
 									MountPath: GetInContainerCSISocketDir(),
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.BoolPtr(true),
 							},
 						},
 					},


### PR DESCRIPTION
Longhorn pods (csi-plugin, csi-(attacher/resizer/provisioner/snapshotter) got stuck after trying to reboot some nodes. Found out it didn't have socket-dir mounted (found out in the logs that it was waiting for csi.sock)
After applying privileged: true longhorn was finally up and running