### PR TITLE
fix(backup): ensure volume attached before taking backup

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -659,7 +659,9 @@ func (bc *BackupController) checkMonitor(backup *longhorn.Backup, volume *longho
 		return nil, err
 	}
 
-	if engine.Status.CurrentState != longhorn.InstanceStateRunning {
+	if engine.Status.CurrentState != longhorn.InstanceStateRunning ||
+		engine.Spec.DesireState != longhorn.InstanceStateRunning ||
+		volume.Status.State != longhorn.VolumeStateAttached {
 		return nil, fmt.Errorf("waiting for engine %v to be running before enabling backup monitor", engine.Name)
 	}
 


### PR DESCRIPTION
ref: [longhorn/longhorn#6699](https://github.com/longhorn/longhorn/issues/6699)

need to ensure engine status and desired statue are the same before taking backup