### PR TITLE
feat(backup): multiple backup stores support

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -35,12 +35,21 @@ func (s *Server) BackupTargetGet(w http.ResponseWriter, req *http.Request) error
 func (s *Server) BackupTargetList(w http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 
-	backupTargets, err := s.m.ListBackupTargetsSorted()
+	bts, err := s.backupTargetList(apiContext)
 	if err != nil {
 		return err
 	}
-	apiContext.Write(toBackupTargetCollection(backupTargets, apiContext))
+
+	apiContext.Write(bts)
 	return nil
+}
+
+func (s *Server) backupTargetList(apiContext *api.ApiContext) (*client.GenericCollection, error) {
+	bts, err := s.m.ListBackupTargetsSorted()
+	if err != nil {
+		return nil, err
+	}
+	return toBackupTargetCollection(bts, apiContext), nil
 }
 
 func (s *Server) BackupTargetCreate(rw http.ResponseWriter, req *http.Request) error {

--- a/api/backup.go
+++ b/api/backup.go
@@ -3,23 +3,115 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
+
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
+
+func (s *Server) BackupTargetGet(w http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	backupTargetName := mux.Vars(req)["name"]
+	backupTarget, err := s.m.GetBackupTarget(backupTargetName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get backup target %v", backupTargetName)
+	}
+	apiContext.Write(toBackupTargetResource(backupTarget, apiContext))
+	return nil
+}
 
 func (s *Server) BackupTargetList(w http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 
 	backupTargets, err := s.m.ListBackupTargetsSorted()
 	if err != nil {
-		return errors.Wrap(err, "failed to list backup targets")
+		return err
 	}
 	apiContext.Write(toBackupTargetCollection(backupTargets, apiContext))
+	return nil
+}
+
+func (s *Server) BackupTargetCreate(rw http.ResponseWriter, req *http.Request) error {
+	var input BackupTarget
+	apiContext := api.GetApiContext(req)
+
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+
+	backupTargetSpec, err := newBackupTarget(input)
+	if err != nil {
+		return err
+	}
+
+	obj, err := s.m.CreateBackupTarget(input.Name, backupTargetSpec)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create backup target %v", input.Name)
+	}
+	apiContext.Write(toBackupTargetResource(obj, apiContext))
+	return nil
+}
+
+func newBackupTarget(input BackupTarget) (*longhorn.BackupTargetSpec, error) {
+	pollInterval, err := strconv.ParseInt(input.PollInterval, 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid backup target polling interval '%s'", input.PollInterval)
+	}
+
+	return &longhorn.BackupTargetSpec{
+		BackupTargetURL:  input.BackupTargetURL,
+		CredentialSecret: input.CredentialSecret,
+		PollInterval:     metav1.Duration{Duration: time.Duration(pollInterval) * time.Second}}, nil
+}
+
+func (s *Server) BackupTargetUpdate(rw http.ResponseWriter, req *http.Request) error {
+	var input BackupTarget
+
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+
+	name := input.Name
+	backupTargetSpec, err := newBackupTarget(input)
+	if err != nil {
+		return err
+	}
+
+	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
+		return s.m.UpdateBackupTarget(name, backupTargetSpec)
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update backup target %v", name)
+	}
+
+	backupTarget, ok := obj.(*longhorn.BackupTarget)
+	if !ok {
+		return fmt.Errorf("failed to convert %v to backup target", name)
+	}
+
+	apiContext.Write(toBackupTargetResource(backupTarget, apiContext))
+	return nil
+}
+
+func (s *Server) BackupTargetDelete(rw http.ResponseWriter, req *http.Request) error {
+	backupTargetName := mux.Vars(req)["name"]
+	if err := s.m.DeleteBackupTarget(backupTargetName); err != nil {
+		return errors.Wrapf(err, "failed to delete backup target %v", backupTargetName)
+	}
+
 	return nil
 }
 
@@ -172,6 +264,17 @@ func (s *Server) BackupVolumeDelete(w http.ResponseWriter, req *http.Request) er
 }
 
 func (s *Server) BackupList(w http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	bs, err := s.m.ListAllBackupsSorted()
+	if err != nil {
+		return errors.Wrapf(err, "failed to list all backups")
+	}
+	apiContext.Write(toBackupCollection(bs))
+	return nil
+}
+
+func (s *Server) BackupListByVolumeName(w http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 
 	volName := mux.Vars(req)["volName"]

--- a/api/backupbackingimage.go
+++ b/api/backupbackingimage.go
@@ -63,9 +63,16 @@ func (s *Server) BackupBackingImageRestore(w http.ResponseWriter, req *http.Requ
 }
 
 func (s *Server) BackupBackingImageCreate(w http.ResponseWriter, req *http.Request) error {
-	backupBackingImageName := mux.Vars(req)["name"]
-	if err := s.m.CreateBackupBackingImage(backupBackingImageName); err != nil {
-		return errors.Wrapf(err, "failed to create backup backing image '%s'", backupBackingImageName)
+	var input BackupBackingImage
+
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+
+	backingImageName := mux.Vars(req)["name"]
+	if err := s.m.CreateBackupBackingImage(input.Name, backingImageName, input.BackupTargetName); err != nil {
+		return errors.Wrapf(err, "failed to create backup backing image '%s'", input.Name)
 	}
 	return nil
 }

--- a/api/model.go
+++ b/api/model.go
@@ -187,6 +187,8 @@ type BackupBackingImage struct {
 	CompressionMethod string               `json:"compressionMethod"`
 	Secret            string               `json:"secret"`
 	SecretNamespace   string               `json:"secretNamespace"`
+	BackingImageName  string               `json:"backingImageName"`
+	BackupTargetName  string               `json:"backupTargetName"`
 }
 
 type Setting struct {
@@ -1878,6 +1880,8 @@ func toBackupBackingImageResource(bbi *longhorn.BackupBackingImage, apiContext *
 		CompressionMethod: string(bbi.Status.CompressionMethod),
 		Secret:            bbi.Status.Secret,
 		SecretNamespace:   bbi.Status.SecretNamespace,
+		BackingImageName:  bbi.Spec.BackingImage,
+		BackupTargetName:  bbi.Spec.BackupTargetName,
 	}
 
 	backupBackingImage.Actions = map[string]string{

--- a/api/model.go
+++ b/api/model.go
@@ -61,6 +61,7 @@ type Volume struct {
 	SnapshotMaxCount            int                                    `json:"snapshotMaxCount"`
 	SnapshotMaxSize             string                                 `json:"snapshotMaxSize"`
 	FreezeFilesystemForSnapshot longhorn.FreezeFilesystemForSnapshot   `json:"freezeFilesystemForSnapshot"`
+	BackupTargetName            string                                 `json:"backupTargetName"`
 
 	DiskSelector         []string                      `json:"diskSelector"`
 	NodeSelector         []string                      `json:"nodeSelector"`
@@ -1565,6 +1566,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		NodeSelector:                v.Spec.NodeSelector,
 		RestoreVolumeRecurringJob:   v.Spec.RestoreVolumeRecurringJob,
 		FreezeFilesystemForSnapshot: v.Spec.FreezeFilesystemForSnapshot,
+		BackupTargetName:            v.Spec.BackupTargetName,
 
 		State:                       v.Status.State,
 		Robustness:                  v.Status.Robustness,

--- a/api/router.go
+++ b/api/router.go
@@ -259,6 +259,10 @@ func NewRouter(s *Server) *mux.Router {
 	r.Path("/v1/ws/backupvolumes").Handler(f(schemas, backupVolumeStream))
 	r.Path("/v1/ws/{period}/backupvolumes").Handler(f(schemas, backupVolumeStream))
 
+	backupTargetStream := NewStreamHandlerFunc("backuptargets", s.wsc.NewWatcher("backupTarget"), s.backupTargetList)
+	r.Path("/v1/ws/backuptargets").Handler(f(schemas, backupTargetStream))
+	r.Path("/v1/ws/{period}/backuptargets").Handler(f(schemas, backupTargetStream))
+
 	// TODO:
 	// We haven't found a way to allow passing the volume name as a parameter to filter
 	// per-backup volume's backups change thru. WebSocket endpoint. Either by:

--- a/api/router.go
+++ b/api/router.go
@@ -122,11 +122,15 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/backuptargets").Handler(f(schemas, s.BackupTargetList))
 	r.Methods("PUT").Path("/v1/backuptargets").Handler(f(schemas, s.BackupTargetSyncAll))
 	backupTargetActions := map[string]func(http.ResponseWriter, *http.Request) error{
-		"backupTargetSync": s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupTargetSync),
+		"backupTargetSync":   s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupTargetSync),
+		"backupTargetUpdate": s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupTargetUpdate),
 	}
 	for name, action := range backupTargetActions {
 		r.Methods("POST").Path("/v1/backuptargets/{backupTargetName}").Queries("action", name).Handler(f(schemas, action))
 	}
+	r.Methods("GET").Path("/v1/backuptargets/{name}").Handler(f(schemas, s.BackupTargetGet))
+	r.Methods("POST").Path("/v1/backuptargets").Handler(f(schemas, s.BackupTargetCreate))
+	r.Methods("DELETE").Path("/v1/backuptargets/{name}").Handler(f(schemas, s.BackupTargetDelete))
 	r.Methods("GET").Path("/v1/backupvolumes").Handler(f(schemas, s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupVolumeList)))
 	r.Methods("PUT").Path("/v1/backupvolumes").Handler(f(schemas, s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupVolumeSyncAll)))
 	r.Methods("GET").Path("/v1/backupvolumes/{volName}").Handler(f(schemas, s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupVolumeGet)))

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -195,7 +195,7 @@ func (s *Server) SnapshotBackup(w http.ResponseWriter, req *http.Request) (err e
 		labels[types.KubernetesStatusLabel] = string(kubeStatus)
 	}
 
-	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), volName, input.Name, labels, input.BackupMode); err != nil {
+	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), vol.Spec.BackupTargetName, volName, input.Name, labels, input.BackupMode); err != nil {
 		return err
 	}
 

--- a/api/volume.go
+++ b/api/volume.go
@@ -105,7 +105,7 @@ func (s *Server) responseWithVolume(rw http.ResponseWriter, req *http.Request, i
 		return err
 	}
 	backups, err := s.m.ListBackupsForVolumeSorted(id)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	volumeAttachment, err := s.m.GetVolumeAttachment(v.Name)

--- a/client/generated_backup.go
+++ b/client/generated_backup.go
@@ -7,6 +7,8 @@ const (
 type Backup struct {
 	Resource `yaml:"-"`
 
+	BackupTargetName string `json:"backupTargetName,omitempty" yaml:"backup_target_name,omitempty"`
+
 	CompressionMethod string `json:"compressionMethod,omitempty" yaml:"compression_method,omitempty"`
 
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`

--- a/client/generated_backup_target.go
+++ b/client/generated_backup_target.go
@@ -15,6 +15,8 @@ type BackupTarget struct {
 
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
 	PollInterval string `json:"pollInterval,omitempty" yaml:"poll_interval,omitempty"`
 }
 

--- a/client/generated_backup_volume.go
+++ b/client/generated_backup_volume.go
@@ -11,6 +11,8 @@ type BackupVolume struct {
 
 	BackingImageName string `json:"backingImageName,omitempty" yaml:"backing_image_name,omitempty"`
 
+	BackupTargetName string `json:"backupTargetName,omitempty" yaml:"backup_target_name,omitempty"`
+
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`
 
 	DataStored string `json:"dataStored,omitempty" yaml:"data_stored,omitempty"`
@@ -28,6 +30,8 @@ type BackupVolume struct {
 	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 
 	StorageClassName string `json:"storageClassName,omitempty" yaml:"storage_class_name,omitempty"`
+
+	VolumeName string `json:"volumeName,omitempty" yaml:"volume_name,omitempty"`
 }
 
 type BackupVolumeCollection struct {

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -15,6 +15,8 @@ type Volume struct {
 
 	BackupStatus []BackupStatus `json:"backupStatus,omitempty" yaml:"backup_status,omitempty"`
 
+	BackupTargetName string `json:"backupTargetName,omitempty" yaml:"backup_target_name,omitempty"`
+
 	CloneStatus CloneStatus `json:"cloneStatus,omitempty" yaml:"clone_status,omitempty"`
 
 	Conditions map[string]interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -711,12 +711,12 @@ func (c *BackingImageDataSourceController) generateBackingImageDataSourcePodMani
 
 	if bids.Spec.SourceType == longhorn.BackingImageDataSourceTypeRestore {
 		var credential map[string]string
-		backupTarget, err := c.ds.GetBackupTargetRO(types.DefaultBackupTargetName)
+		backupTarget, err := c.ds.GetBackupTargetRO(bids.Spec.Parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName])
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil, err
 			}
-			return nil, errors.Wrapf(err, "failed to get the backup target %v", types.DefaultBackupTargetName)
+			return nil, errors.Wrapf(err, "failed to get the backup target %v", bids.Spec.Parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName])
 		}
 
 		backupType, err := util.CheckBackupType(backupTarget.Spec.BackupTargetURL)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -781,7 +781,7 @@ func (bc *BackupController) checkMonitor(backup *longhorn.Backup, volume *longho
 		}
 	}
 
-	clusterBackups, err := bc.ds.ListBackupsWithBackupVolumeName(volume.Name)
+	clusterBackups, err := bc.ds.ListBackupsWithBackupVolumeName(backupTarget.Name, volume.Name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list backups in the cluster")
 	}

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -668,7 +668,7 @@ func (btc *BackupTargetController) syncBackupBackingImage(backupTarget *longhorn
 			Spec: longhorn.BackupBackingImageSpec{
 				UserCreated:      false,
 				BackupTargetName: backupTarget.Name,
-				BackingImage:     backupBackingImageName,
+				BackingImage:     canonicalBackingImageName,
 			},
 		}
 		if _, err = btc.ds.CreateBackupBackingImage(backupBackingImage); err != nil && !apierrors.IsAlreadyExists(err) {

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -218,7 +218,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		return errors.Wrapf(err, "failed to get %s backup target", backupVolume.Spec.BackupTargetName)
 	}
 	if backupTarget == nil && backupVolume.DeletionTimestamp == nil {
-		return fmt.Errorf("failed to find the backup target %v for the backup volume %v", backupVolume.Spec.BackupTargetName, backupVolume.Name)
+		return errors.Wrapf(err, "failed to find the backup target %v for the backup volume %v", backupVolume.Spec.BackupTargetName, backupVolume.Name)
 	}
 
 	canonicalBVName := backupVolume.Spec.VolumeName

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -88,6 +88,7 @@ const (
 	TestDeploymentName = "test-deployment"
 
 	TestBackupTarget     = "s3://backupbucket@us-east-1/backupstore"
+	TestBackupTargetName = "default"
 	TestBackupVolumeName = "test-backup-volume-for-restoration"
 	TestBackupName       = "test-backup-for-restoration"
 

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1275,14 +1275,6 @@ func (sc *SettingController) enqueueSettingForNode(obj interface{}) {
 	}
 
 	sc.queue.Add(sc.namespace + "/" + string(types.SettingNameGuaranteedInstanceManagerCPU))
-	sc.queue.Add(sc.namespace + "/" + string(types.SettingNameBackupTarget))
-}
-
-func (sc *SettingController) enqueueSettingForBackupTarget(obj interface{}) {
-	if _, ok := obj.(*longhorn.BackupTarget); !ok {
-		return
-	}
-	sc.queue.Add(sc.namespace + "/" + string(types.SettingNameBackupTarget))
 }
 
 // updateInstanceManagerCPURequest deletes all instance manager pods immediately with the updated CPU request.

--- a/controller/system_backup_controller.go
+++ b/controller/system_backup_controller.go
@@ -1133,6 +1133,7 @@ func (c *SystemBackupController) generateSystemBackupYAMLsForLonghorn(dir string
 		"volumes":       c.ds.GetAllLonghornVolumes,
 		"recurringjobs": c.ds.GetAllLonghornRecurringJobs,
 		"backingimages": c.ds.GetAllLonghornBackingImages,
+		"backuptargets": c.ds.GetAllLonghornBackupTargets,
 	}
 
 	for name, fn := range resourceGetFns {

--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -804,7 +804,14 @@ func (c *UninstallController) deleteBackupTargets(backupTargets map[string]*long
 	}()
 	for _, bt := range backupTargets {
 		log := getLoggerForBackupTarget(c.logger, bt)
+		if bt.Annotations == nil {
+			bt.Annotations = make(map[string]string)
+		}
 		if bt.DeletionTimestamp == nil {
+			bt.Annotations[types.GetLonghornLabelKey(types.DeleteBackupTargetFromLonghorn)] = ""
+			if _, err := c.ds.UpdateBackupTarget(bt); err != nil {
+				return errors.Wrap(err, "failed to update backup target annotations to mark for deletion")
+			}
 			if errDelete := c.ds.DeleteBackupTarget(bt.Name); errDelete != nil {
 				if datastore.ErrorIsNotFound(errDelete) {
 					log.Info("BackupTarget is not found")

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -105,5 +105,13 @@ func checkIfRemoteDataCleanupIsNeeded(obj runtime.Object, bt *longhorn.BackupTar
 		return false, err
 	}
 
-	return !exists && bt.Spec.BackupTargetURL != "", nil
+	return !exists && isBackupTargetAvailable(bt), nil
+}
+
+// isBackupTargetAvailable returns a boolean that the backup target is available for true and not available for false
+func isBackupTargetAvailable(backupTarget *longhorn.BackupTarget) bool {
+	return backupTarget != nil &&
+		backupTarget.DeletionTimestamp == nil &&
+		backupTarget.Spec.BackupTargetURL != "" &&
+		backupTarget.Status.Available
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -4783,9 +4783,9 @@ func (c *VolumeController) ReconcileBackupVolumeState(volume *longhorn.Volume) e
 		backupVolumeName = volume.Name
 	}
 
-	bv, err := c.ds.GetBackupVolumeRO(backupVolumeName)
+	bv, err := c.ds.GetBackupVolumeByBackupTargetAndVolumeRO(volume.Spec.BackupTargetName, backupVolumeName)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to get backup volume %s for volume %v", backupVolumeName, volume.Name)
+		return errors.Wrapf(err, "failed to get backup volume %s for backup target %v and volume %v", backupVolumeName, volume.Spec.BackupTargetName, volume.Name)
 	}
 
 	// Clean up last backup if the BackupVolume CR gone

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3661,9 +3661,9 @@ func (c *VolumeController) getBackupVolumeInfo(v *longhorn.Volume) (string, stri
 		return "", "", "", errors.Wrapf(err, "failed to get backup %v for restoring volume %v", backupName, v.Name)
 	}
 
-	backupVolume, err := c.ds.GetBackupVolumeByBackupTargetAndVolumeRO(backup.Spec.BackupTargetName, canonicalBVName)
+	backupVolume, err := c.ds.GetBackupVolumeByBackupTargetAndVolumeRO(backup.Status.BackupTargetName, canonicalBVName)
 	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to get backup volume %v with backup target %v for restoring volume %v", canonicalBVName, backup.Spec.BackupTargetName, v.Name)
+		return "", "", "", errors.Wrapf(err, "failed to get backup volume %v with backup target %v for restoring volume %v", canonicalBVName, backup.Status.BackupTargetName, v.Name)
 	}
 
 	return canonicalBVName, backupVolume.Name, backupName, nil

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1137,6 +1137,7 @@ func newVolume(name string, replicaCount int) *longhorn.Volume {
 			StaleReplicaTimeout: TestVolumeStaleTimeout,
 			Image:               TestEngineImage,
 			DataEngine:          longhorn.DataEngineTypeV1,
+			BackupTargetName:    TestBackupTargetName,
 		},
 		Status: longhorn.VolumeStatus{
 			OwnerID: TestOwnerID1,
@@ -1383,6 +1384,14 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 					Finalizers: []string{
 						longhorn.SchemeGroupVersion.Group,
 					},
+					Labels: map[string]string{
+						types.LonghornLabelBackupTarget: TestBackupTargetName,
+						types.LonghornLabelBackupVolume: bvName,
+					},
+				},
+				Spec: longhorn.BackupVolumeSpec{
+					BackupTargetName: TestBackupTargetName,
+					VolumeName:       bvName,
 				},
 				Status: longhorn.BackupVolumeStatus{
 					LastBackupName: bName,

--- a/csi/util.go
+++ b/csi/util.go
@@ -208,6 +208,10 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		vol.FromBackup = fromBackup
 	}
 
+	if backupTargetName, ok := volOptions["backupTargetName"]; ok {
+		vol.BackupTargetName = backupTargetName
+	}
+
 	if dataSource, ok := volOptions["dataSource"]; ok {
 		vol.DataSource = dataSource
 	}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4463,6 +4463,16 @@ func (s *DataStore) GetBackupVolumeByBackupTargetAndVolumeRO(backupTargetName, v
 	return nil, nil
 }
 
+// GetBackupVolumeByBackupTargetAndVolume returns a copy of BackupVolume with the given backup target and volume name in the cluster
+func (s *DataStore) GetBackupVolumeByBackupTargetAndVolume(backupTargetName, volumeName string) (*longhorn.BackupVolume, error) {
+	resultRO, err := s.GetBackupVolumeByBackupTargetAndVolumeRO(backupTargetName, volumeName)
+	if err != nil {
+		return nil, err
+	}
+	// Cannot use cached object from lister
+	return resultRO.DeepCopy(), nil
+}
+
 func getBackupTargetSelector(backupTargetName string) (labels.Selector, error) {
 	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: types.GetBackupTargetLabels(backupTargetName),

--- a/datastore/uncached.go
+++ b/datastore/uncached.go
@@ -401,3 +401,12 @@ func (s *DataStore) GetLonghornSnapshotUncached(name string) (*longhorn.Snapshot
 func (s *DataStore) GetAllLonghornBackingImages() (runtime.Object, error) {
 	return s.lhClient.LonghornV1beta2().BackingImages(s.namespace).List(context.TODO(), metav1.ListOptions{})
 }
+
+// GetAllLonghornBackupTargets returns an uncached list of BackupTargets in
+// Longhorn namespace directly from the API server.
+// Using cached informers should be preferred but current lister doesn't have a
+// field selector.
+// Direct retrieval from the API server should only be used for one-shot tasks.
+func (s *DataStore) GetAllLonghornBackupTargets() (runtime.Object, error) {
+	return s.lhClient.LonghornV1beta2().BackupTargets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+}

--- a/engineapi/backup_backing_image.go
+++ b/engineapi/backup_backing_image.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/longhorn/backupstore/backupbackingimage"
 
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
 // parseBackupBackingImageConfig parses a backup backing image config
@@ -89,6 +89,7 @@ type BackupBackingImageMonitor struct {
 	client                 *BackingImageManagerClient
 
 	backupBackingImageStatus longhorn.BackupBackingImageStatus
+	backingImageName         string
 	backupStatusLock         sync.RWMutex
 
 	syncCallback func(key string)
@@ -101,10 +102,12 @@ type BackupBackingImageMonitor struct {
 func NewBackupBackingImageMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, bbi *longhorn.BackupBackingImage, backingImage *longhorn.BackingImage, backupTargetClient *BackupTargetClient,
 	compressionMethod longhorn.BackupCompressionMethod, concurrentLimit int, bimClient *BackingImageManagerClient, syncCallback func(key string)) (*BackupBackingImageMonitor, error) {
 	ctx, quit := context.WithCancel(context.Background())
+	biName := backingImage.Name
 	m := &BackupBackingImageMonitor{
 		logger: logger.WithFields(logrus.Fields{"backupBackingImage": bbi.Name}),
 
 		backupBackingImageName: bbi.Name,
+		backingImageName:       biName,
 		client:                 bimClient,
 
 		backupStatusLock: sync.RWMutex{},
@@ -120,7 +123,7 @@ func NewBackupBackingImageMonitor(logger logrus.FieldLogger, ds *datastore.DataS
 
 	// Call backing image manager API snapshot backup
 	if bbi.Status.State == longhorn.BackupStateNew {
-		err := m.client.BackupCreate(bbi.Name, backingImage.Status.UUID, bbi.Status.Checksum,
+		err := m.client.BackupCreate(biName, backingImage.Status.UUID, bbi.Status.Checksum,
 			backupTargetClient.URL, bbi.Spec.Labels, backupTargetClient.Credential, string(compressionMethod), concurrentLimit, backupBackingImageParameters)
 		if err != nil {
 			if !strings.Contains(err.Error(), "DeadlineExceeded") {
@@ -243,7 +246,8 @@ func (m *BackupBackingImageMonitor) syncBackupStatusFromBackingImageManager() (c
 	m.backupBackingImageStatus.DeepCopyInto(&currentBackupStatus)
 	m.backupStatusLock.RUnlock()
 
-	backupBackingImageStatus, err = m.client.BackupStatus(m.backupBackingImageName)
+	// Use backing image name instead of the backup backing image name because the backup backing image name is a random name after the feature `multiple backup target``.
+	backupBackingImageStatus, err = m.client.BackupStatus(m.backingImageName)
 	if err != nil {
 		return currentBackupStatus, err
 	}

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -164,6 +164,8 @@ type BackupVolume struct {
 	BackingImageName     string             `json:"backingImageName"`
 	BackingImageChecksum string             `json:"backingImageChecksum"`
 	StorageClassName     string             `json:"storageClassName"`
+	BackupTargetName     string             `json:"backupTargetName"`
+	VolumeName           string             `json:"volumeName"`
 }
 
 type Backup struct {
@@ -184,6 +186,7 @@ type Backup struct {
 	Parameters             map[string]string    `json:"parameters"`
 	NewlyUploadedDataSize  string               `json:"newlyUploadedDataSize"`
 	ReUploadedDataSize     string               `json:"reUploadedDataSize"`
+	BackupTargetName       string               `json:"backupTargetName"`
 }
 
 type ConfigMetadata struct {

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -636,8 +636,9 @@ spec:
             description: BackupBackingImageSpec defines the desired state of the Longhorn backing image backup
             properties:
               backingImage:
-                description: The backing image name..
-                nullable: true
+                description: |-
+                  The backing image name.
+                  Required
                 type: string
               backupTargetName:
                 description: The backup target name.
@@ -659,6 +660,7 @@ spec:
                   Required
                 type: boolean
             required:
+            - backingImage
             - userCreated
             type: object
           status:
@@ -709,7 +711,8 @@ spec:
                 description: Record the secret if this backup backing image is encrypted
                 type: string
               secretNamespace:
-                description: Record the secret namespace if this backup backing image is encrypted
+                description: Record the secret namespace if this backup backing image
+                  is encrypted
                 type: string
               size:
                 description: The backing image size.
@@ -814,6 +817,10 @@ spec:
       jsonPath: .status.snapshotCreatedAt
       name: SnapshotCreatedAt
       type: string
+    - description: The backup target name
+      jsonPath: .status.backupTarget
+      name: BackupTarget
+      type: string
     - description: The backup state
       jsonPath: .status.state
       name: State
@@ -855,9 +862,6 @@ spec:
                 - full
                 - incremental
                 - ""
-              backupTargetName:
-                description: The backup target name.
-                nullable: true
                 type: string
               labels:
                 additionalProperties:
@@ -878,6 +882,9 @@ spec:
             properties:
               backupCreatedAt:
                 description: The snapshot backup upload finished time.
+                type: string
+              backupTargetName:
+                description: The backup target name.
                 type: string
               compressionMethod:
                 description: Compression method
@@ -4108,7 +4115,8 @@ spec:
                 - gzip
                 type: string
               backupTargetName:
-                description: 'The backup target name that the volume will be backed up to or is synced.'
+                description: The backup target name that the volume will be backed
+                  up to or is synced.
                 type: string
               dataEngine:
                 enum:

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -4099,6 +4099,9 @@ spec:
                 - lz4
                 - gzip
                 type: string
+              backupTargetName:
+                description: 'The backup target name that the volume will be backed up to or is synced.'
+                type: string
               dataEngine:
                 enum:
                 - v1

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -635,6 +635,14 @@ spec:
           spec:
             description: BackupBackingImageSpec defines the desired state of the Longhorn backing image backup
             properties:
+              backingImage:
+                description: The backing image name..
+                nullable: true
+                type: string
+              backupTargetName:
+                description: The backup target name.
+                nullable: true
+                type: string
               labels:
                 additionalProperties:
                   type: string

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1246,10 +1246,17 @@ spec:
           spec:
             description: BackupVolumeSpec defines the desired state of the Longhorn backup volume
             properties:
+              backupTargetName:
+                description: The backup target name that the backup volume was synced.
+                nullable: true
+                type: string
               syncRequestedAt:
                 description: The time to request run sync the remote backup volume.
                 format: date-time
                 nullable: true
+                type: string
+              volumeName:
+                description: The volume name that the backup volume was used to backup.
                 type: string
             type: object
           status:

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -847,6 +847,9 @@ spec:
                 - full
                 - incremental
                 - ""
+              backupTargetName:
+                description: The backup target name.
+                nullable: true
                 type: string
               labels:
                 additionalProperties:

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimagedatasource.go
@@ -23,6 +23,7 @@ const (
 	DataSourceTypeExportFromVolumeParameterSnapshotName              = "snapshot-name"
 	DataSourceTypeExportFromVolumeParameterSenderAddress             = "sender-address"
 	DataSourceTypeExportFromVolumeParameterFileSyncHTTPClientTimeout = "file-sync-http-client-timeout"
+	DataSourceTypeRestoreParameterBackupTargetName                   = "backup-target-name"
 	DataSourceTypeRestoreParameterBackupURL                          = "backup-url"
 	DataSourceTypeRestoreParameterConcurrentLimit                    = "concurrent-limit"
 	DataSourceTypeCloneParameterBackingImage                         = "backing-image"

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -119,6 +119,9 @@ type BackupStatus struct {
 	// Size in bytes of reuploaded data
 	// +optional
 	ReUploadedDataSize string `json:"reUploadedDataSize"`
+	// The backup target name.
+	// +optional
+	BackupTargetName string `json:"backupTargetName"`
 }
 
 // +genclient
@@ -129,6 +132,7 @@ type BackupStatus struct {
 // +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.status.snapshotName`,description="The snapshot name"
 // +kubebuilder:printcolumn:name="SnapshotSize",type=string,JSONPath=`.status.size`,description="The snapshot size"
 // +kubebuilder:printcolumn:name="SnapshotCreatedAt",type=string,JSONPath=`.status.snapshotCreatedAt`,description="The snapshot creation time"
+// +kubebuilder:printcolumn:name="BackupTarget",type=string,JSONPath=`.status.backupTarget`,description="The backup target name"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The backup state"
 // +kubebuilder:printcolumn:name="LastSyncedAt",type=string,JSONPath=`.status.lastSyncedAt`,description="The backup last synced time"
 

--- a/k8s/pkg/apis/longhorn/v1beta2/backupbackingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backupbackingimage.go
@@ -4,6 +4,14 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // BackupBackingImageSpec defines the desired state of the Longhorn backing image backup
 type BackupBackingImageSpec struct {
+	// The backing image name.
+	// Required
+	// +kubebuilder:validation:Required
+	BackingImage string `json:"backingImage"`
+	// The backup target name.
+	// +optional
+	// +nullable
+	BackupTargetName string `json:"backupTargetName"`
 	// The time to request run sync the remote backing image backup.
 	// +optional
 	// +nullable

--- a/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
@@ -4,10 +4,17 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // BackupVolumeSpec defines the desired state of the Longhorn backup volume
 type BackupVolumeSpec struct {
+	// The backup target name that the backup volume was synced.
+	// +optional
+	// +nullable
+	BackupTargetName string `json:"backupTargetName"`
 	// The time to request run sync the remote backup volume.
 	// +optional
 	// +nullable
 	SyncRequestedAt metav1.Time `json:"syncRequestedAt"`
+	// The volume name that the backup volume was used to backup.
+	// +optional
+	VolumeName string `json:"volumeName"`
 }
 
 // BackupVolumeStatus defines the observed state of the Longhorn backup volume

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -302,6 +302,9 @@ type VolumeSpec struct {
 	// Setting that freezes the filesystem on the root partition before a snapshot is created.
 	// +optional
 	FreezeFilesystemForSnapshot FreezeFilesystemForSnapshot `json:"freezeFilesystemForSnapshot"`
+	// The backup target name that the volume will be backed up to or is synced.
+	// +optional
+	BackupTargetName string `json:"backupTargetName"`
 }
 
 // VolumeStatus defines the observed state of the Longhorn volume

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -252,7 +252,7 @@ func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 	return nil
 }
 
-func (m *VolumeManager) BackupSnapshot(backupName, volumeName, snapshotName string, labels map[string]string, backupMode string) error {
+func (m *VolumeManager) BackupSnapshot(backupName, backupTargetName, volumeName, snapshotName string, labels map[string]string, backupMode string) error {
 	if volumeName == "" || snapshotName == "" {
 		return fmt.Errorf("volume and snapshot name required")
 	}
@@ -264,6 +264,9 @@ func (m *VolumeManager) BackupSnapshot(backupName, volumeName, snapshotName stri
 	backupCR := &longhorn.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: backupName,
+			Labels: map[string]string{
+				types.LonghornLabelBackupTarget: backupTargetName,
+			},
 		},
 		Spec: longhorn.BackupSpec{
 			SnapshotName: snapshotName,

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -415,7 +415,11 @@ func (m *VolumeManager) ListAllBackupsSorted() ([]*longhorn.Backup, error) {
 }
 
 func (m *VolumeManager) ListBackupsForVolume(volumeName string) (map[string]*longhorn.Backup, error) {
-	return m.ds.ListBackupsWithBackupVolumeName(volumeName)
+	v, err := m.ds.GetVolumeRO(volumeName)
+	if err != nil {
+		return nil, err
+	}
+	return m.ds.ListBackupsWithBackupTargetAndBackupVolumeRO(v.Spec.BackupTargetName, volumeName)
 }
 
 func (m *VolumeManager) ListBackupsForVolumeSorted(volumeName string) ([]*longhorn.Backup, error) {

--- a/types/setting.go
+++ b/types/setting.go
@@ -359,8 +359,8 @@ var (
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
-		DisplayName: "Backup Target",
-		Description: "The endpoint used to access the backupstore. NFS, CIFS and S3 are supported.",
+		DisplayName: "Default Backup Target",
+		Description: "The endpoint used to access the default backupstore. NFS, CIFS and S3 are supported.",
 		Category:    SettingCategoryBackup,
 		Type:        SettingTypeString,
 		Required:    false,
@@ -368,8 +368,8 @@ var (
 	}
 
 	SettingDefinitionBackupTargetCredentialSecret = SettingDefinition{
-		DisplayName: "Backup Target Credential Secret",
-		Description: "The name of the Kubernetes secret associated with the backup target.",
+		DisplayName: "Default Backup Target Credential Secret",
+		Description: "The name of the Kubernetes secret associated with the default backup target.",
 		Category:    SettingCategoryBackup,
 		Type:        SettingTypeString,
 		Required:    false,
@@ -389,8 +389,8 @@ var (
 	}
 
 	SettingDefinitionBackupstorePollInterval = SettingDefinition{
-		DisplayName: "Backupstore Poll Interval",
-		Description: "In seconds. The backupstore poll interval determines how often Longhorn checks the backupstore for new backups. Set to 0 to disable the polling.",
+		DisplayName: "Default Backupstore Poll Interval",
+		Description: "In seconds. The default backupstore poll interval determines how often Longhorn checks the backupstore for new backups. Set to 0 to disable the polling.",
 		Category:    SettingCategoryBackup,
 		Type:        SettingTypeInt,
 		Required:    true,

--- a/types/types.go
+++ b/types/types.go
@@ -544,6 +544,13 @@ func GetBackingImageLabels() map[string]string {
 	return labels
 }
 
+func GetBackingImageWithBackupTargetLabels(backupTargetName, backingImageName string) map[string]string {
+	return map[string]string{
+		LonghornLabelBackingImage: backingImageName,
+		LonghornLabelBackupTarget: backupTargetName,
+	}
+}
+
 func GetBackingImageManagerLabels(nodeID, diskUUID string) map[string]string {
 	labels := GetBaseLabelsForSystemManagedComponent()
 	labels[GetLonghornLabelComponentKey()] = LonghornLabelBackingImageManager

--- a/types/types.go
+++ b/types/types.go
@@ -29,6 +29,7 @@ const (
 	LonghornKindEngine              = "Engine"
 	LonghornKindReplica             = "Replica"
 	LonghornKindBackupTarget        = "BackupTarget"
+	LonghornKindBackupVolume        = "BackupVolume"
 	LonghornKindBackup              = "Backup"
 	LonghornKindSnapshot            = "Snapshot"
 	LonghornKindEngineImage         = "EngineImage"

--- a/types/types.go
+++ b/types/types.go
@@ -131,6 +131,9 @@ const (
 
 	DeleteCustomResourceOnly = "delete-custom-resource-only"
 
+	// const value `DeleteBackupTargetFromLonghorn` is used for annotation to note that deleting backup target is by Longhorn during uninstalling.
+	DeleteBackupTargetFromLonghorn = "delete-backup-target-from-longhorn"
+
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"
 	KubernetesStatefulSet = "StatefulSet"
@@ -241,6 +244,7 @@ const (
 
 	BackupStoreTypeS3     = "s3"
 	BackupStoreTypeCIFS   = "cifs"
+	BackupStoreTypeNFS    = "nfs"
 	BackupStoreTypeAZBlob = "azblob"
 
 	AWSIAMRoleAnnotation = "iam.amazonaws.com/role"

--- a/types/types.go
+++ b/types/types.go
@@ -51,6 +51,7 @@ const (
 	LonghornKindSettingList      = "SettingList"
 	LonghornKindVolumeList       = "VolumeList"
 	LonghornKindBackingImageList = "BackingImageList"
+	LonghornKindBackupTargetList = "BackupTargetList"
 
 	KubernetesKindClusterRole           = "ClusterRole"
 	KubernetesKindClusterRoleBinding    = "ClusterRoleBinding"

--- a/types/types.go
+++ b/types/types.go
@@ -31,6 +31,7 @@ const (
 	LonghornKindBackupTarget        = "BackupTarget"
 	LonghornKindBackupVolume        = "BackupVolume"
 	LonghornKindBackup              = "Backup"
+	LonghornKindBackupBackingImage  = "BackupBackingImage"
 	LonghornKindSnapshot            = "Snapshot"
 	LonghornKindEngineImage         = "EngineImage"
 	LonghornKindInstanceManager     = "InstanceManager"

--- a/types/types.go
+++ b/types/types.go
@@ -158,6 +158,7 @@ const (
 	LonghornLabelManagedBy                  = "managed-by"
 	LonghornLabelSnapshotForCloningVolume   = "for-cloning-volume"
 	LonghornLabelBackingImageDataSource     = "backing-image-data-source"
+	LonghornLabelBackupTarget               = "backup-target"
 	LonghornLabelBackupVolume               = "backup-volume"
 	LonghornLabelRecurringJob               = "job"
 	LonghornLabelRecurringJobGroup          = "job-group"
@@ -562,6 +563,19 @@ func GetBackingImageDataSourceLabels(name, nodeID, diskUUID string) map[string]s
 		labels[GetLonghornLabelKey(LonghornLabelNode)] = nodeID
 	}
 	return labels
+}
+
+func GetBackupVolumeWithBackupTargetLabels(backupTargetName, volumeName string) map[string]string {
+	return map[string]string{
+		LonghornLabelBackupVolume: volumeName,
+		LonghornLabelBackupTarget: backupTargetName,
+	}
+}
+
+func GetBackupTargetLabels(backupTargetName string) map[string]string {
+	return map[string]string{
+		LonghornLabelBackupTarget: backupTargetName,
+	}
 }
 
 func GetBackupVolumeLabels(volumeName string) map[string]string {

--- a/types/types.go
+++ b/types/types.go
@@ -28,6 +28,7 @@ const (
 	LonghornKindVolumeAttachment    = "VolumeAttachment"
 	LonghornKindEngine              = "Engine"
 	LonghornKindReplica             = "Replica"
+	LonghornKindBackupTarget        = "BackupTarget"
 	LonghornKindBackup              = "Backup"
 	LonghornKindSnapshot            = "Snapshot"
 	LonghornKindEngineImage         = "EngineImage"
@@ -720,6 +721,18 @@ func GetConfigMapNameFromHostname(hostname string) string {
 
 func GetShareManagerNameFromShareManagerPodName(podName string) string {
 	return strings.TrimPrefix(podName, shareManagerPrefix)
+}
+
+func GetBackupVolumeNameFromVolumeName(volumeName string) string {
+	return generateBackupResourceName(volumeName)
+}
+
+func generateBackupResourceName(resourceName string) string {
+	return util.GetStringChecksum(strings.TrimSpace(resourceName))[:util.RandomIDLength] + "-" + util.RandomID()
+}
+
+func GetBackupBackingImageNameFromBIName(backingImageName string) string {
+	return generateBackupResourceName(backingImageName)
 }
 
 func ValidateEngineImageChecksumName(name string) bool {

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -309,6 +309,13 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 			return err
 		}
 	}
+	// When lhVersionBeforeUpgrade < v1.8.0, it is v1.7.x. The `CheckUpgradePath` method would have failed us out earlier if it was not v1.7.x.
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.8.0") < 0 {
+		logrus.Info("Walking through the resource status upgrade path v1.7.x to v1.8.0")
+		if err := v17xto180.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
 	if err := upgradeutil.UpdateResourcesStatus(namespace, lhClient, resourceMaps); err != nil {
 		return err
 	}

--- a/upgrade/v17xto180/upgrade.go
+++ b/upgrade/v17xto180/upgrade.go
@@ -1,13 +1,17 @@
 package v17xto180
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/longhorn/longhorn-manager/types"
 
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
 )
@@ -17,7 +21,176 @@ const (
 )
 
 func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	if resourceMaps == nil {
+		return errors.New("resourceMaps cannot be nil")
+	}
+
+	if err := upgradeVolumes(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeBackupVolumes(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+	if err := upgradeBackups(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeBackupBackingImages(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeBackingImageDataSources(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
 	return upgradeBackingImages(namespace, lhClient, resourceMaps)
+}
+
+func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade volume failed")
+	}()
+
+	volumesMap, err := upgradeutil.ListAndUpdateVolumesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn volumes during the volume upgrade")
+	}
+
+	for _, v := range volumesMap {
+		backupTargetName := setDefaultBackupTargetIfEmpty(v.Spec.BackupTargetName)
+		v.Spec.BackupTargetName = backupTargetName
+	}
+
+	return nil
+}
+
+func setDefaultBackupTargetIfEmpty(backupTargetName string) string {
+	if backupTargetName == "" {
+		return types.DefaultBackupTargetName
+	}
+	return backupTargetName
+}
+
+func upgradeBackupVolumes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backup volume failed")
+	}()
+
+	backupVolumeMap, err := upgradeutil.ListAndUpdateBackupVolumesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn BackupVolumes during the Longhorn BackupVolume upgrade")
+	}
+
+	for _, bv := range backupVolumeMap {
+		backupTargetName := bv.Spec.BackupTargetName
+		bv.Spec.BackupTargetName = setDefaultBackupTargetIfEmpty(backupTargetName)
+
+		// volumeName is used to synchronize the backup volume between the cluster and remote backup target instead of the BackupVolume CR name.
+		// It used the BackupVolume CR name as the volume name before, but now the BackupVolume CR name is a random name.
+		if bv.Spec.VolumeName == "" {
+			bv.Spec.VolumeName = bv.Name
+		}
+		bv.Labels = addLabel(bv.Labels, types.LonghornLabelBackupTarget, bv.Spec.BackupTargetName)
+		bv.Labels = addLabel(bv.Labels, types.LonghornLabelBackupVolume, bv.Spec.VolumeName)
+	}
+
+	return nil
+}
+
+func addLabel(labels map[string]string, key, value string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, exists := labels[key]; !exists {
+		labels[key] = value
+	}
+	return labels
+}
+
+func upgradeBackups(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backup failed")
+	}()
+
+	backupMap, err := upgradeutil.ListAndUpdateBackupsInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn Backups during the Longhorn Backup upgrade")
+	}
+
+	for _, b := range backupMap {
+		backupTargetName := types.DefaultBackupTargetName
+		vol, err := lhClient.LonghornV1beta2().Volumes(namespace).Get(context.TODO(), b.Status.VolumeName, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "failed to get volume %v of backup %v", b.Status.VolumeName, b.Name)
+			}
+		} else {
+			backupTargetName = vol.Spec.BackupTargetName
+		}
+		b.Labels = addLabel(b.Labels, types.LonghornLabelBackupTarget, backupTargetName)
+	}
+
+	return nil
+}
+
+func upgradeBackupBackingImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backup backing images failed")
+	}()
+
+	backupBackingImageMap, err := upgradeutil.ListAndUpdateBackupBackingImagesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn BackupBackingImages during the Longhorn Backup Backing Images upgrade")
+	}
+
+	for _, bbi := range backupBackingImageMap {
+		backupTargetName := setDefaultBackupTargetIfEmpty(bbi.Spec.BackupTargetName)
+		bbi.Spec.BackupTargetName = backupTargetName
+		if bbi.Spec.BackingImage == "" {
+			bbi.Spec.BackingImage = bbi.Status.BackingImage
+		}
+		bbi.Labels = addLabel(bbi.Labels, types.LonghornLabelBackupTarget, bbi.Spec.BackupTargetName)
+		bbi.Labels = addLabel(bbi.Labels, types.LonghornLabelBackingImage, bbi.Spec.BackingImage)
+	}
+
+	return nil
+}
+
+func upgradeBackingImageDataSources(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backing image data source failed")
+	}()
+
+	backingImageDataSourcesMap, err := upgradeutil.ListAndUpdateBackingImageDataSourcesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn BackupImagesDataSources during the Longhorn Backup Images Data Sources upgrade")
+	}
+
+	for _, bids := range backingImageDataSourcesMap {
+		if bids.Spec.Parameters == nil {
+			bids.Spec.Parameters = map[string]string{longhorn.DataSourceTypeRestoreParameterBackupTargetName: types.DefaultBackupTargetName}
+		} else {
+			backupTargetName := bids.Spec.Parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName]
+			bids.Spec.Parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName] = setDefaultBackupTargetIfEmpty(backupTargetName)
+		}
+	}
+	return nil
 }
 
 func upgradeBackingImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {

--- a/util/util.go
+++ b/util/util.go
@@ -78,7 +78,7 @@ const (
 	MaxExt4VolumeSize = 16 * TiB
 	MaxXfsVolumeSize  = 8*EiB - 1
 
-	RandomIDLenth = 8
+	RandomIDLength = 8
 
 	DeterministicUUIDNamespace = "08958d54-65cd-4d87-8627-9831a1eab170" // Arbitrarily generated.
 )
@@ -185,7 +185,7 @@ func WaitForDevice(dev string, timeout int) error {
 }
 
 func RandomID() string {
-	return UUID()[:RandomIDLenth]
+	return UUID()[:RandomIDLength]
 }
 
 // DeterministicUUID returns a string representation of a version 5 UUID based on the provided string. The output is
@@ -198,7 +198,7 @@ func DeterministicUUID(data string) string {
 }
 
 func ValidateRandomID(id string) bool {
-	regex := fmt.Sprintf(`^[a-zA-Z0-9]{%d}$`, RandomIDLenth)
+	regex := fmt.Sprintf(`^[a-zA-Z0-9]{%d}$`, RandomIDLength)
 	validName := regexp.MustCompile(regex)
 	return validName.MatchString(id)
 }

--- a/webhook/resources/backingimage/mutator.go
+++ b/webhook/resources/backingimage/mutator.go
@@ -3,6 +3,7 @@ package backingimage
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -91,6 +92,14 @@ func (b *backingImageMutator) Create(request *admission.Request, newObj runtime.
 			}
 			parameters[longhorn.DataSourceTypeRestoreParameterConcurrentLimit] = strconv.FormatInt(concurrentLimit, 10)
 		}
+
+		if parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName] == "" {
+			backupTargetName, err := b.findBackupTargetName(parameters[longhorn.DataSourceTypeRestoreParameterBackupURL])
+			if err != nil {
+				return nil, err
+			}
+			parameters[longhorn.DataSourceTypeRestoreParameterBackupTargetName] = backupTargetName
+		}
 	}
 
 	if longhorn.BackingImageDataSourceType(backingImage.Spec.SourceType) == longhorn.BackingImageDataSourceTypeClone {
@@ -158,6 +167,49 @@ func (b *backingImageMutator) Create(request *admission.Request, newObj runtime.
 	patchOps = append(patchOps, patchOp)
 
 	return patchOps, nil
+}
+
+func (b *backingImageMutator) findBackupTargetName(backupURL string) (string, error) {
+	bbis, err := b.ds.ListBackupBackingImagesRO()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to list backup backing images")
+	}
+
+	backupTargetURL, backingImageName, err := getBackupTargetURLAndBackingImageName(backupURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse backup URL %v", backupURL)
+	}
+
+	for _, bbi := range bbis {
+		bbiBackupTargetURL, bbiBackingImageName, err := getBackupTargetURLAndBackingImageName(bbi.Status.URL)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to parse URL %v of backup backing image %v", bbi.Status.URL, bbi.Name)
+			continue
+		}
+		if backupTargetURL == bbiBackupTargetURL && backingImageName == bbiBackingImageName {
+			return bbi.Spec.BackupTargetName, nil
+		}
+	}
+
+	return "", errors.Errorf("no matching backup found for URL %v and backing image %v", backupTargetURL, backingImageName)
+}
+
+func getBackupTargetURLAndBackingImageName(backupURL string) (string, string, error) {
+	parsedURL, err := url.Parse(backupURL)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "failed to parse backup URL %v", backupURL)
+	}
+	backingImageName := parsedURL.Query().Get("backingImage")
+	if backingImageName == "" {
+		return "", "", errors.Errorf("backup URL %v is missing required 'backingImage' parameter", backupURL)
+	}
+	switch parsedURL.Scheme {
+	case types.BackupStoreTypeCIFS, types.BackupStoreTypeNFS, types.BackupStoreTypeAZBlob, types.BackupStoreTypeS3:
+		parsedURL.RawQuery = ""
+		return parsedURL.String(), backingImageName, nil
+	default:
+		return "", "", errors.Errorf("unsupported backupURL scheme %v", parsedURL.Scheme)
+	}
 }
 
 func (b *backingImageMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {

--- a/webhook/resources/backuptarget/mutator.go
+++ b/webhook/resources/backuptarget/mutator.go
@@ -1,0 +1,70 @@
+package backuptarget
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	common "github.com/longhorn/longhorn-manager/webhook/common"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type backupTargetMutator struct {
+	admission.DefaultMutator
+	ds *datastore.DataStore
+}
+
+func NewMutator(ds *datastore.DataStore) admission.Mutator {
+	return &backupTargetMutator{ds: ds}
+}
+
+func (b *backupTargetMutator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backuptargets",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackupTarget{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (b *backupTargetMutator) Create(request *admission.Request, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+func (b *backupTargetMutator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) (admission.PatchOps, error) {
+	return mutate(newObj)
+}
+
+// mutate contains functionality shared by Create and Update.
+func mutate(newObj runtime.Object) (admission.PatchOps, error) {
+	backupTarget, ok := newObj.(*longhorn.BackupTarget)
+	if !ok {
+		return nil, werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.BackupTarget", newObj), "")
+	}
+
+	var patchOps admission.PatchOps
+
+	patchOp, err := common.GetLonghornFinalizerPatchOpIfNeeded(backupTarget)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to get finalizer patch for backupTarget %v", backupTarget.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	if patchOp != "" {
+		patchOps = append(patchOps, patchOp)
+	}
+
+	return patchOps, nil
+}

--- a/webhook/resources/backuptarget/validator.go
+++ b/webhook/resources/backuptarget/validator.go
@@ -1,0 +1,200 @@
+package backuptarget
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type backupTargetValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &backupTargetValidator{ds: ds}
+}
+
+func (b *backupTargetValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "backuptargets",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   longhorn.SchemeGroupVersion.Group,
+		APIVersion: longhorn.SchemeGroupVersion.Version,
+		ObjectType: &longhorn.BackupTarget{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+			admissionregv1.Delete,
+		},
+	}
+}
+
+func (b *backupTargetValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	backupTarget := newObj.(*longhorn.BackupTarget)
+
+	if !util.ValidateName(backupTarget.Name) {
+		return werror.NewInvalidError(fmt.Sprintf("invalid name %v", backupTarget.Name), "")
+	}
+
+	if err := b.ds.ValidateBackupTargetURL(backupTarget.Spec.BackupTargetURL); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := b.validateCredentialSecret(backupTarget.Spec.CredentialSecret); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	if err := b.handleAWSIAMRoleAnnotation(backupTarget, nil); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	return nil
+}
+
+func (b *backupTargetValidator) handleAWSIAMRoleAnnotation(newBackupTarget, oldBackupTarget *longhorn.BackupTarget) error {
+	oldBackupTargetURL := ""
+	oldBackupTargetSecret := ""
+	if oldBackupTarget != nil {
+		oldBackupTargetURL = oldBackupTarget.Spec.BackupTargetURL
+		oldBackupTargetSecret = oldBackupTarget.Spec.CredentialSecret
+	}
+	uOld, err := url.Parse(oldBackupTargetURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse %v as url", oldBackupTargetURL)
+	}
+	newBackupTargetURL := newBackupTarget.Spec.BackupTargetURL
+	u, err := url.Parse(newBackupTargetURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse %v as url", newBackupTargetURL)
+	}
+	if u.Scheme == types.BackupStoreTypeS3 || (uOld.Scheme == types.BackupStoreTypeS3 && newBackupTargetURL == "") {
+		if err := b.ds.HandleSecretsForAWSIAMRoleAnnotation(newBackupTargetURL, oldBackupTargetSecret, newBackupTarget.Spec.CredentialSecret, oldBackupTargetURL != newBackupTargetURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *backupTargetValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	oldBackupTarget := oldObj.(*longhorn.BackupTarget)
+	newBackupTarget := newObj.(*longhorn.BackupTarget)
+
+	urlChanged := oldBackupTarget.Spec.BackupTargetURL != newBackupTarget.Spec.BackupTargetURL
+	secretChanged := oldBackupTarget.Spec.CredentialSecret != newBackupTarget.Spec.CredentialSecret
+
+	if urlChanged {
+		if err := b.ds.ValidateBackupTargetURL(newBackupTarget.Spec.BackupTargetURL); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	if secretChanged {
+		if err := b.validateCredentialSecret(newBackupTarget.Spec.CredentialSecret); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	if urlChanged || secretChanged {
+		if err := b.validateDRVolume(newBackupTarget); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+	}
+
+	return nil
+}
+
+func (b *backupTargetValidator) validateCredentialSecret(secretName string) error {
+	namespace, err := b.ds.GetLonghornNamespace()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get Longhorn namespace")
+	}
+	secret, err := b.ds.GetSecretRO(namespace.Name, secretName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to get the secret before modifying backup target credential secret")
+		}
+		return nil
+	}
+	checkKeyList := []string{
+		types.AWSIAMRoleAnnotation,
+		types.AWSIAMRoleArn,
+		types.AWSAccessKey,
+		types.AWSSecretKey,
+		types.AWSEndPoint,
+		types.AWSCert,
+		types.CIFSUsername,
+		types.CIFSPassword,
+		types.AZBlobAccountName,
+		types.AZBlobAccountKey,
+		types.AZBlobEndpoint,
+		types.AZBlobCert,
+		types.HTTPSProxy,
+		types.HTTPProxy,
+		types.NOProxy,
+		types.VirtualHostedStyle,
+	}
+	for _, checkKey := range checkKeyList {
+		if value, ok := secret.Data[checkKey]; ok {
+			if strings.TrimSpace(string(value)) != string(value) {
+				return fmt.Errorf("there is space or new line in %s", checkKey)
+			}
+		}
+	}
+	return nil
+}
+
+func (b *backupTargetValidator) validateDRVolume(backupTarget *longhorn.BackupTarget) error {
+	vs, err := b.ds.ListDRVolumesRO()
+	if err != nil {
+		return errors.Wrapf(err, "failed to list standby volume when modifying BackupTarget")
+	}
+
+	standbyVolumeNames := sets.NewString()
+	for k := range vs {
+		standbyVolumeNames.Insert(k)
+	}
+	if standbyVolumeNames.Len() != 0 {
+		return fmt.Errorf("cannot modify BackupTarget since there are existing standby volumes: %v", standbyVolumeNames)
+	}
+
+	return nil
+}
+
+func (b *backupTargetValidator) Delete(request *admission.Request, oldObj runtime.Object) error {
+	backupTarget := oldObj.(*longhorn.BackupTarget)
+
+	if backupTarget.Name == types.DefaultBackupTargetName {
+		exists := false
+		if backupTarget.Annotations != nil {
+			// Annotations `DeleteBackupTargetFromLonghorn` is used to note that deleting backup target is by Longhorn during uninstalling.
+			// When `exists` is true, the backup target is deleted by Longhorn.
+			_, exists = backupTarget.Annotations[types.GetLonghornLabelKey(types.DeleteBackupTargetFromLonghorn)]
+		}
+		if !exists {
+			return werror.NewInvalidError("deleting default backup target is not allowed", "")
+		}
+	}
+
+	if err := b.validateDRVolume(backupTarget); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	return nil
+}

--- a/webhook/resources/backupvolume/mutator.go
+++ b/webhook/resources/backupvolume/mutator.go
@@ -66,7 +66,7 @@ func (b *backupVolumeMutator) Update(request *admission.Request, oldObj runtime.
 }
 
 func (b *backupVolumeMutator) addBackupsDeleteCustomResourceLabel(bv *longhorn.BackupVolume) error {
-	backups, err := b.ds.ListBackupsWithBackupVolumeName(bv.Name)
+	backups, err := b.ds.ListBackupsWithBackupVolumeName(bv.Spec.BackupTargetName, bv.Spec.VolumeName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list backups of the backup volume")
 	}

--- a/webhook/server/mutation.go
+++ b/webhook/server/mutation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimagemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backup"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backupbackingimage"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backuptarget"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backupvolume"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engine"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engineimage"
@@ -42,6 +43,7 @@ func Mutation(ds *datastore.DataStore) (http.Handler, []admission.Resource, erro
 		engineimage.NewMutator(ds),
 		orphan.NewMutator(ds),
 		sharemanager.NewMutator(ds),
+		backuptarget.NewMutator(ds),
 		backupvolume.NewMutator(ds),
 		snapshot.NewMutator(ds),
 		replica.NewMutator(ds),

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -10,6 +10,8 @@ import (
 	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	"github.com/longhorn/longhorn-manager/webhook/resources/backingimage"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backup"
+	"github.com/longhorn/longhorn-manager/webhook/resources/backuptarget"
 	"github.com/longhorn/longhorn-manager/webhook/resources/engine"
 	"github.com/longhorn/longhorn-manager/webhook/resources/instancemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
@@ -38,6 +40,8 @@ func Validation(ds *datastore.DataStore) (http.Handler, []admission.Resource, er
 		setting.NewValidator(ds),
 		recurringjob.NewValidator(ds),
 		backingimage.NewValidator(ds),
+		backup.NewValidator(ds),
+		backuptarget.NewValidator(ds),
 		volume.NewValidator(ds, currentNodeID),
 		orphan.NewValidator(ds),
 		snapshot.NewValidator(ds),


### PR DESCRIPTION
Support multiple backup stores to create, delete, and update them.
Adding a flag `ReadOnly` in `BackupTarget` CR spec prevents backups from being created and stored on this remote backup target.
And provide HTTP endpoints to create, delete, update, and list secrets.

Ref: longhorn/longhorn#5411