### PR TITLE
[Backport-v1.4.4] Make the new engine name deterministic based on the existing engine (backport #2180)

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1159,7 +1159,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[stri
 
 	if e == nil {
 		// first time creation
-		e, err = vc.createEngine(v, true)
+		e, err = vc.createEngine(v, "")
 		if err != nil {
 			return err
 		}
@@ -3028,12 +3028,12 @@ func (vc *VolumeController) getInfoFromBackupURL(v *longhorn.Volume) (string, st
 	return backupVolumeName, backupName, err
 }
 
-func (vc *VolumeController) createEngine(v *longhorn.Volume, isNewEngine bool) (*longhorn.Engine, error) {
+func (vc *VolumeController) createEngine(v *longhorn.Volume, currentEngineName string) (*longhorn.Engine, error) {
 	log := getLoggerForVolume(vc.logger, v)
 
 	engine := &longhorn.Engine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            types.GenerateEngineNameForVolume(v.Name),
+			Name:            types.GenerateEngineNameForVolume(v.Name, currentEngineName),
 			OwnerReferences: datastore.GetOwnerReferencesForVolume(v),
 		},
 		Spec: longhorn.EngineSpec{
@@ -3068,7 +3068,7 @@ func (vc *VolumeController) createEngine(v *longhorn.Volume, isNewEngine bool) (
 	}
 	engine.Spec.UnmapMarkSnapChainRemovedEnabled = unmapMarkEnabled
 
-	if isNewEngine {
+	if currentEngineName == "" {
 		engine.Spec.Active = true
 	}
 
@@ -3586,7 +3586,7 @@ func (vc *VolumeController) processMigration(v *longhorn.Volume, es map[string]*
 	}
 
 	if migrationEngine == nil {
-		migrationEngine, err = vc.createEngine(v, false)
+		migrationEngine, err = vc.createEngine(v, currentEngine.Name)
 		if err != nil {
 			return err
 		}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -423,13 +423,15 @@ func (vc *VolumeController) syncVolume(key string) (err error) {
 			// Make sure that we don't update condition's LastTransitionTime if the condition's values hasn't changed
 			handleConditionLastTransitionTime(&existingVolume.Status, &volume.Status)
 			if !reflect.DeepEqual(existingVolume.Status, volume.Status) {
-				// reuse err
-				_, err = vc.ds.UpdateVolumeStatus(volume)
+				_, lastErr = vc.ds.UpdateVolumeStatus(volume)
 			}
 		}
+		if err == nil {
+			err = lastErr
+		}
 		// requeue if it's conflict
-		if apierrors.IsConflict(errors.Cause(err)) || apierrors.IsConflict(errors.Cause(lastErr)) {
-			log.Debugf("Requeue volume due to error %v or %v", err, lastErr)
+		if apierrors.IsConflict(errors.Cause(err)) {
+			log.Debugf("Requeue volume due to error %v", err)
 			vc.enqueueVolume(volume)
 			err = nil
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -273,10 +273,17 @@ const (
 	replicaManagerPrefix  = instanceManagerPrefix + "r-"
 )
 
-func GenerateEngineNameForVolume(vName string) string {
-	return vName + engineSuffix + "-" + util.RandomID()
+func GenerateEngineNameForVolume(vName, currentEngineName string) string {
+	if currentEngineName == "" {
+		return vName + engineSuffix + "-" + "0"
+	}
+	parts := strings.Split(currentEngineName, "-")
+	suffix, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return vName + engineSuffix + "-" + "1"
+	}
+	return vName + engineSuffix + "-" + strconv.Itoa(suffix+1)
 }
-
 func GenerateReplicaNameForVolume(vName string) string {
 	return vName + replicaSuffix + "-" + util.RandomID()
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -163,3 +163,61 @@ func (s *TestSuite) TestIsSelectorsInTags(c *C) {
 		c.Assert(actual, Equals, testCase.expected, Commentf(TestErrResultFmt, testName))
 	}
 }
+
+func (s *TestSuite) TestGenerateEngineNameForVolume(c *C) {
+	type testCase struct {
+		volumeName        string
+		currentEngineName string
+
+		expectedEngineName string
+	}
+	testCases := map[string]testCase{
+		"case 1: testvol, new engine": {
+			volumeName:         "testvol",
+			currentEngineName:  "",
+			expectedEngineName: "testvol-e-0",
+		},
+		"case 2: testvol, new engine from old engine version": {
+			volumeName:         "testvol",
+			currentEngineName:  "testvol-e-abcdefgh",
+			expectedEngineName: "testvol-e-1",
+		},
+		"case 3: testvol, new engine from new engine version": {
+			volumeName:         "testvol",
+			currentEngineName:  "testvol-e-0",
+			expectedEngineName: "testvol-e-1",
+		},
+		"case 4: testvol, newer engine from new engine version": {
+			volumeName:         "testvol",
+			currentEngineName:  "testvol-e-1",
+			expectedEngineName: "testvol-e-2",
+		},
+		"case 5: test-vol, new engine": {
+			volumeName:         "test-vol",
+			currentEngineName:  "",
+			expectedEngineName: "test-vol-e-0",
+		},
+		"case 6: test-vol, new engine from old engine version": {
+			volumeName:         "test-vol",
+			currentEngineName:  "test-vol-e-xxxxxxxx",
+			expectedEngineName: "test-vol-e-1",
+		},
+		"case 7: test-vol, new engine from new engine version": {
+			volumeName:         "test-vol",
+			currentEngineName:  "test-vol-e-0",
+			expectedEngineName: "test-vol-e-1",
+		},
+		"case 8: test-vol, newer engine from new engine version": {
+			volumeName:         "test-vol",
+			currentEngineName:  "test-vol-e-1",
+			expectedEngineName: "test-vol-e-2",
+		},
+	}
+
+	for testName, testCase := range testCases {
+		fmt.Printf("testing %v\n", testName)
+
+		actual := GenerateEngineNameForVolume(testCase.volumeName, testCase.currentEngineName)
+		c.Assert(actual, Equals, testCase.expectedEngineName, Commentf(TestErrResultFmt, testName))
+	}
+}


### PR DESCRIPTION
This is a backport of the pull request https://github.com/longhorn/longhorn-manager/pull/2180