### PR TITLE
Prevent orphan snapshot attachment tickets

### DIFF
--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -344,7 +344,7 @@ func (sc *SnapshotController) reconcile(snapshotName string) (err error) {
 			return sc.handleAttachmentTicketDeletion(snapshot)
 		}
 
-		if err := sc.handleAttachmentTicketCreation(snapshot); err != nil {
+		if err := sc.handleAttachmentTicketCreation(snapshot, true); err != nil {
 			return err
 		}
 
@@ -387,7 +387,7 @@ func (sc *SnapshotController) reconcile(snapshotName string) (err error) {
 
 	// newly created snapshotCR by user
 	if requestCreateNewSnapshot && !alreadyCreatedBefore {
-		if err := sc.handleAttachmentTicketCreation(snapshot); err != nil {
+		if err := sc.handleAttachmentTicketCreation(snapshot, false); err != nil {
 			return err
 		}
 		if engine.Status.CurrentState != longhorn.InstanceStateRunning {
@@ -451,7 +451,8 @@ func (sc *SnapshotController) handleAttachmentTicketDeletion(snap *longhorn.Snap
 }
 
 // handleAttachmentTicketCreation check and create attachment so that the source volume is attached if needed
-func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snapshot) (err error) {
+func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snapshot,
+	checkIfSnapshotExists bool) (err error) {
 	defer func() {
 		err = errors.Wrap(err, "handleAttachmentTicketCreation: failed to create/update attachment")
 	}()
@@ -468,11 +469,18 @@ func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snap
 
 	existingVA := va.DeepCopy()
 	defer func() {
-		if err != nil {
-			return
-		}
 		if reflect.DeepEqual(existingVA.Spec, va.Spec) {
 			return
+		}
+
+		if checkIfSnapshotExists {
+			// It is possible we are reconciling a cached version of a deleted snapshot (only if deletionTimestamp is
+			// set). Confirm that the snapshot still exists on the API server before creating an attachment ticket to
+			// prevent an orphan attachment (see longhorn/longhorn#6652). Avoid checking until here to limit
+			// requests to the API server.
+			if _, err = sc.ds.GetLonghornSnapshotUncached(snap.Name); err != nil {
+				return // Either the snapshot no longer exists or we failed to check.
+			}
 		}
 
 		if _, err = sc.ds.UpdateLHVolumeAttachment(va); err != nil {

--- a/datastore/uncached.go
+++ b/datastore/uncached.go
@@ -392,3 +392,10 @@ func (s *DataStore) GetAllLonghornCustomResourceDefinitions() (runtime.Object, e
 func (s *DataStore) GetConfigMapWithoutCache(namespace, name string) (*corev1.ConfigMap, error) {
 	return s.kubeClient.CoreV1().ConfigMaps(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
+
+// GetLonghornSnapshotUncached returns the uncached Snapshot in the Longhorn namespace directly from the API server.
+// Direct retrieval from the API server should ideally only be used for one-shot tasks, but there may be other limited
+// situations in which it is necessary.
+func (s *DataStore) GetLonghornSnapshotUncached(name string) (*longhorn.Snapshot, error) {
+	return s.lhClient.LonghornV1beta2().Snapshots(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -562,6 +562,26 @@ func ListAndUpdateRecurringJobsInProvidedCache(namespace string, lhClient *lhcli
 	return recurringJobs, nil
 }
 
+// ListAndUpdateVolumeAttachmentsInProvidedCache list all volumeAttachments and save them into the provided cached `resourceMap`. This method is not thread-safe.
+func ListAndUpdateVolumeAttachmentsInProvidedCache(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (map[string]*longhorn.VolumeAttachment, error) {
+	if v, ok := resourceMaps[types.LonghornKindVolumeAttachment]; ok {
+		return v.(map[string]*longhorn.VolumeAttachment), nil
+	}
+
+	volumeAttachments := map[string]*longhorn.VolumeAttachment{}
+	volumeAttachmentList, err := lhClient.LonghornV1beta2().VolumeAttachments(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i, volumeAttachment := range volumeAttachmentList.Items {
+		volumeAttachments[volumeAttachment.Name] = &volumeAttachmentList.Items[i]
+	}
+
+	resourceMaps[types.LonghornKindVolumeAttachment] = volumeAttachments
+
+	return volumeAttachments, nil
+}
+
 // CreateAndUpdateRecurringJobInProvidedCache creates a recurringJob and saves it into the provided cached `resourceMap`. This method is not thread-safe.
 func CreateAndUpdateRecurringJobInProvidedCache(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}, job *longhorn.RecurringJob) (*longhorn.RecurringJob, error) {
 	obj, err := lhClient.LonghornV1beta2().RecurringJobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{})
@@ -911,23 +931,21 @@ func updateOrphans(namespace string, lhClient *lhclientset.Clientset, orphans ma
 	return nil
 }
 
-func updateVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, volumeAttachment map[string]*longhorn.VolumeAttachment) error {
+func updateVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, volumeAttachments map[string]*longhorn.VolumeAttachment) error {
 	existingVolumeAttachmentList, err := lhClient.LonghornV1beta2().VolumeAttachments(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-
-	existingVolumeAttachmentMap := map[string]bool{}
-	for _, volume := range existingVolumeAttachmentList.Items {
-		existingVolumeAttachmentMap[volume.Name] = true
-	}
-
-	for _, va := range volumeAttachment {
-		if _, ok := existingVolumeAttachmentMap[va.Name]; ok {
+	for _, existingVolumeAttachment := range existingVolumeAttachmentList.Items {
+		volumeAttachment, ok := volumeAttachments[existingVolumeAttachment.Name]
+		if !ok {
 			continue
 		}
-		if _, err = lhClient.LonghornV1beta2().VolumeAttachments(namespace).Create(context.TODO(), va, metav1.CreateOptions{}); err != nil {
-			return err
+		if !reflect.DeepEqual(existingVolumeAttachment.Spec, volumeAttachment.Spec) ||
+			!reflect.DeepEqual(existingVolumeAttachment.ObjectMeta, volumeAttachment.ObjectMeta) {
+			if _, err = lhClient.LonghornV1beta2().VolumeAttachments(namespace).Update(context.TODO(), volumeAttachment, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
longhorn/longhorn#6652

Given the possibility of the scenario @PhanLe1010 suggested and the related comments from @innobead in a previous PR (https://github.com/longhorn/longhorn-manager/pull/2147#discussion_r1329341605), it seems a simpler approach is simply to do an uncached GET of a snapshot before creating an attachment ticket while the snapshot is deleting. If the snapshot no longer exists, the GET fails, and we don't proceed to create the attachment ticket. This eliminates the need for the extra annotations that PR introduced, is less susceptible to logical errors, and still prevents us from creating an attachment ticket on the last reconcile of a cached snapshot (after the garbage collector has already delete it).

In order to avoid unnecessarily hammering the API server, we only do the uncached GET if:

- The snapshot is deleting.
- We have decided we want to create/modify the associated attachment ticket.