### PR TITLE
fix(setting): put settings' ReadOnly into effect

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -166,8 +166,14 @@ func (s *DataStore) createOrUpdateSetting(name types.SettingName, value, default
 		setting.Annotations = map[string]string{}
 	}
 
+	if existingSettingCMResourceVersion, isExist := setting.Annotations[types.GetLonghornLabelKey(types.ConfigMapResourceVersionKey)]; isExist {
+		if existingSettingCMResourceVersion == defaultSettingCMResourceVersion && setting.Value == value {
+			return nil
+		}
+	}
 	setting.Annotations[types.GetLonghornLabelKey(types.ConfigMapResourceVersionKey)] = defaultSettingCMResourceVersion
 	setting.Value = value
+
 	_, err = s.UpdateSetting(setting)
 	return err
 }
@@ -236,10 +242,18 @@ func (s *DataStore) CreateSetting(setting *longhorn.Setting) (*longhorn.Setting,
 
 // UpdateSetting updates the given Longhorn Settings and verifies update
 func (s *DataStore) UpdateSetting(setting *longhorn.Setting) (*longhorn.Setting, error) {
+	setting.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
 	obj, err := s.lhClient.LonghornV1beta2().Settings(s.namespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
+
+	delete(obj.Annotations, types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn))
+	obj, err = s.lhClient.LonghornV1beta2().Settings(s.namespace).Update(context.TODO(), obj, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	verifyUpdate(setting.Name, obj, func(name string) (runtime.Object, error) {
 		return s.getSettingRO(name)
 	})

--- a/types/setting.go
+++ b/types/setting.go
@@ -1576,6 +1576,7 @@ func UnmarshalNodeSelector(nodeSelectorSetting string) (map[string]string, error
 	return nodeSelector, nil
 }
 
+// GetSettingDefinition gets the setting definition in `settingDefinitions` by the parameter `name`
 func GetSettingDefinition(name SettingName) (SettingDefinition, bool) {
 	settingDefinitionsLock.RLock()
 	defer settingDefinitionsLock.RUnlock()
@@ -1583,6 +1584,7 @@ func GetSettingDefinition(name SettingName) (SettingDefinition, bool) {
 	return setting, ok
 }
 
+// SetSettingDefinition sets the setting definition in `settingDefinitions` by the parameter `name` and `definition`
 func SetSettingDefinition(name SettingName, definition SettingDefinition) {
 	settingDefinitionsLock.Lock()
 	defer settingDefinitionsLock.Unlock()

--- a/types/types.go
+++ b/types/types.go
@@ -127,6 +127,7 @@ const (
 	LastAppliedTolerationAnnotationKeySuffix = "last-applied-tolerations"
 
 	ConfigMapResourceVersionKey = "configmap-resource-version"
+	UpdateSettingFromLonghorn   = "update-setting-from-longhorn"
 
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -164,6 +164,12 @@ func CreateOrUpdateLonghornVersionSetting(namespace string, lhClient *lhclientse
 
 	if s.Value != meta.Version {
 		s.Value = meta.Version
+		s.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
+		s, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), s, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		delete(s.Annotations, types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn))
 		_, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), s, metav1.UpdateOptions{})
 		return err
 	}
@@ -894,6 +900,12 @@ func updateSettings(namespace string, lhClient *lhclientset.Clientset, settings 
 		}
 
 		if !reflect.DeepEqual(existingSetting.Value, setting.Value) {
+			setting.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
+			setting, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			delete(setting.Annotations, types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn))
 			if _, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), setting, metav1.UpdateOptions{}); err != nil {
 				return err
 			}


### PR DESCRIPTION
Add an annotation to mark that the updating is from Longhorn and it should be able to update successfully even if setting definition is set to be read-only.

Ref: longhorn/longhorn#5989