### PR TITLE
Clean up e.spec.upgradedReplicaAddressMap when live upgrade is no longer needed

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2696,6 +2696,12 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 		if e.Spec.Image != v.Spec.Image {
 			e.Spec.Image = v.Spec.Image
 			e.Spec.UpgradedReplicaAddressMap = map[string]string{}
+			return nil
+		}
+		// If the engine already has new engine image or it has been stopped,
+		// live upgrade is not needed, there is no point to keep e.Spec.UpgradedReplicaAddressMap
+		if e.Spec.Image == e.Status.CurrentImage || e.Status.CurrentImage == "" {
+			e.Spec.UpgradedReplicaAddressMap = map[string]string{}
 		}
 		return nil
 	}


### PR DESCRIPTION
longhorn/longhorn#6762