### PR TITLE
Suppress nagging error logging.

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -665,7 +665,7 @@ func (sc *SettingController) updateCNI() error {
 	}
 
 	if !volumesDetached {
-		return errors.Errorf("failed to apply %v setting to Longhorn workloads when there are attached volumes", types.SettingNameStorageNetwork)
+		return &types.ErrorInvalidState{Reason: fmt.Sprintf("failed to apply %v setting to Longhorn workloads when there are attached volumes", types.SettingNameStorageNetwork)}
 	}
 
 	nadAnnot := string(types.CNIAnnotationNetworks)

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -62,6 +62,7 @@ func createOrUpdateAttachmentTicket(va *longhorn.VolumeAttachment, ticketID, nod
 
 func handleReconcileErrorLogging(logger logrus.FieldLogger, err error, mesg string) {
 	if types.ErrorIsInvalidState(err) {
+		logger.WithError(err).Trace(mesg)
 		return
 	}
 

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -61,6 +61,10 @@ func createOrUpdateAttachmentTicket(va *longhorn.VolumeAttachment, ticketID, nod
 }
 
 func handleReconcileErrorLogging(logger logrus.FieldLogger, err error, mesg string) {
+	if types.ErrorIsInvalidState(err) {
+		return
+	}
+
 	if apierrors.IsConflict(err) {
 		logger.WithError(err).Debug(mesg)
 	} else {

--- a/types/types.go
+++ b/types/types.go
@@ -273,6 +273,14 @@ func (e *NotFoundError) Error() string {
 	return fmt.Sprintf("cannot find %v", e.Name)
 }
 
+type ErrorInvalidState struct {
+	Reason string
+}
+
+func (e *ErrorInvalidState) Error() string {
+	return fmt.Sprintf("current state prevents this: %v", e.Reason)
+}
+
 const (
 	engineSuffix    = "-e"
 	replicaSuffix   = "-r"
@@ -704,6 +712,11 @@ func ErrorIsNotSupport(err error) bool {
 
 func ErrorAlreadyExists(err error) bool {
 	return strings.Contains(err.Error(), "already exists")
+}
+
+func ErrorIsInvalidState(err error) bool {
+	var dummy *ErrorInvalidState
+	return errors.As(err, &dummy)
 }
 
 func ValidateReplicaCount(count int) error {


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/6812

Removes all the "level=error" logging from longhorn-manager, but leaves the one kubernetes-layer log.  The only thing logged every hour will be 
```
[longhorn-manager-rjzn8] E1017 21:53:38.219480       1 setting_controller.go:205] failed to sync setting for longhorn-system/v2-data-engine: Current state prevents this: cannot apply v2-data-engine setting to Longhorn workloads when there are attached volumes
[longhorn-manager-rjzn8] E1017 21:53:38.219766       1 setting_controller.go:205] failed to sync setting for longhorn-system/storage-network: Current state prevents this: failed to apply storage-network setting to Longhorn workloads when there are attached volumes
```