### PR TITLE
Filter Kubernetes resources by longhorn-system namespace

### DIFF
--- a/app/system_rollout.go
+++ b/app/system_rollout.go
@@ -88,9 +88,10 @@ func systemRollout(c *cli.Context) error {
 	}
 
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
+	kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, informers.WithNamespace(namespace))
 	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Second*30)
 
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, namespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, namespace)
 
 	logger := logrus.StandardLogger()
 	logrus.SetLevel(logrus.DebugLevel)
@@ -98,6 +99,7 @@ func systemRollout(c *cli.Context) error {
 	doneCh := make(chan struct{})
 	go lhInformerFactory.Start(doneCh)
 	go kubeInformerFactory.Start(doneCh)
+	go kubeFilteredInformerFactory.Start(doneCh)
 
 	ctrl := controller.NewSystemRolloutController(
 		systemRestoreName,

--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -79,9 +79,10 @@ func uninstall(c *cli.Context) error {
 	}
 
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
+	kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, informers.WithNamespace(namespace))
 	lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, time.Second*30)
 
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, namespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, namespace)
 
 	logger := logrus.StandardLogger()
 
@@ -97,5 +98,6 @@ func uninstall(c *cli.Context) error {
 	)
 	go lhInformerFactory.Start(doneCh)
 	go kubeInformerFactory.Start(doneCh)
+	go kubeFilteredInformerFactory.Start(doneCh)
 	return ctrl.Run()
 }

--- a/controller/kubernetes_pv_controller_test.go
+++ b/controller/kubernetes_pv_controller_test.go
@@ -169,9 +169,9 @@ func newPodWithPVC(podName string) *corev1.Pod {
 	}
 }
 
-func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
+func newTestKubernetesPVController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory, kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset, kubeClient *fake.Clientset, extensionsClient *apiextensionsfake.Clientset) *KubernetesPVController {
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	logger := logrus.StandardLogger()
 	kc := NewKubernetesPVController(logger, ds, scheme.Scheme, kubeClient, TestNode1)
@@ -462,6 +462,7 @@ func (s *TestSuite) runKubernetesTestCases(c *C, testCases map[string]*Kubernete
 
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformerfactory.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -473,7 +474,7 @@ func (s *TestSuite) runKubernetesTestCases(c *C, testCases map[string]*Kubernete
 
 		extensionsClient := apiextensionsfake.NewSimpleClientset()
 
-		kc := newTestKubernetesPVController(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient, extensionsClient)
+		kc := newTestKubernetesPVController(lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory, lhClient, kubeClient, extensionsClient)
 
 		// Need to create pv, pvc, pod and longhorn volume
 		var v *longhorn.Volume

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -51,9 +51,9 @@ type NodeTestCase struct {
 	expectOrphans          []*longhorn.Orphan
 }
 
-func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
+func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory, kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset, kubeClient *fake.Clientset, extensionsClient *apiextensionsfake.Clientset, controllerID string) *NodeController {
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	logger := logrus.StandardLogger()
 	nc := NewNodeController(logger, ds, scheme.Scheme, kubeClient, TestNamespace, controllerID)
@@ -725,6 +725,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		fmt.Printf("testing %v\n", name)
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformerfactory.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -755,7 +756,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 
 		extensionsClient := apiextensionsfake.NewSimpleClientset()
 
-		nc := newTestNodeController(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient, extensionsClient, TestNode1)
+		nc := newTestNodeController(lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory, lhClient, kubeClient, extensionsClient, TestNode1)
 		c.Assert(err, IsNil)
 
 		// create manager pod

--- a/controller/support_bundle_controller_test.go
+++ b/controller/support_bundle_controller_test.go
@@ -161,6 +161,7 @@ func (s *TestSuite) TestReconcileSupportBundle(c *C) {
 
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -172,7 +173,7 @@ func (s *TestSuite) TestReconcileSupportBundle(c *C) {
 		fakeSupportBundleFailedHistoryLimitSetting(tc.supportBundleFailedHistoryLimit, c, lhInformerFactory, lhClient)
 
 		supportBundleController := newFakeSupportBundleController(
-			lhInformerFactory, kubeInformerFactory,
+			lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory,
 			lhClient, kubeClient, extensionsClient,
 			tc.controllerID,
 		)
@@ -222,12 +223,13 @@ func (s *TestSuite) TestReconcileSupportBundle(c *C) {
 func newFakeSupportBundleController(
 	lhInformerFactory lhinformers.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
+	kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset,
 	kubeClient *fake.Clientset,
 	extensionsClient *apiextensionsfake.Clientset,
 	controllerID string) *SupportBundleController {
 
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	logger := logrus.StandardLogger()
 	logrus.SetLevel(logrus.DebugLevel)

--- a/controller/system_backup_controller_test.go
+++ b/controller/system_backup_controller_test.go
@@ -231,6 +231,7 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -246,7 +247,7 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 		extensionsClient := apiextensionsfake.NewSimpleClientset()
 
 		systemBackupController := newFakeSystemBackupController(
-			lhInformerFactory, kubeInformerFactory,
+			lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory,
 			lhClient, kubeClient, extensionsClient,
 			tc.controllerID,
 		)
@@ -318,12 +319,13 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 func newFakeSystemBackupController(
 	lhInformerFactory lhinformers.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
+	kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset,
 	kubeClient *fake.Clientset,
 	extensionsClient *apiextensionsfake.Clientset,
 	controllerID string) *SystemBackupController {
 
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	logger := logrus.StandardLogger()
 	logrus.SetLevel(logrus.DebugLevel)

--- a/controller/system_restore_controller_test.go
+++ b/controller/system_restore_controller_test.go
@@ -112,6 +112,7 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformers.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -124,7 +125,7 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 		extensionsClient := apiextensionsfake.NewSimpleClientset()
 
 		systemRestoreController := newFakeSystemRestoreController(
-			lhInformerFactory, kubeInformerFactory,
+			lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory,
 			lhClient, kubeClient, extensionsClient,
 			tc.controllerID,
 		)
@@ -170,12 +171,13 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 func newFakeSystemRestoreController(
 	lhInformerFactory lhinformers.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
+	kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset,
 	kubeClient *fake.Clientset,
 	extensionsClient *apiextensionsfake.Clientset,
 	controllerID string) *SystemRestoreController {
 
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	logger := logrus.StandardLogger()
 	logrus.SetLevel(logrus.DebugLevel)

--- a/controller/volume_attachment_controller_test.go
+++ b/controller/volume_attachment_controller_test.go
@@ -426,8 +426,9 @@ func (s *TestSuite) runVolumeAttachmentTestCase(c *C, tc *volumeAttachmentTestCa
 	lhClient := lhfake.NewSimpleClientset()
 	extensionsClient := apiextensionsfake.NewSimpleClientset()
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0, informers.WithNamespace(TestNamespace))
 	lhInformerFactory := lhinformerfactory.NewSharedInformerFactory(lhClient, 0)
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 	logger := logrus.StandardLogger()
 
 	volumeIndexer := lhInformerFactory.Longhorn().V1beta2().Volumes().Informer().GetIndexer()

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -52,10 +52,10 @@ func initSettingsNameValue(name, value string) *longhorn.Setting {
 	return setting
 }
 
-func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
+func newTestVolumeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory, kubeFilteredInformerFactory informers.SharedInformerFactory,
 	lhClient *lhfake.Clientset, kubeClient *fake.Clientset, extensionsClient *apiextensionsfake.Clientset,
 	controllerID string) *VolumeController {
-	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeClient, extensionsClient, TestNamespace)
+	ds := datastore.NewDataStore(lhInformerFactory, lhClient, kubeInformerFactory, kubeFilteredInformerFactory, kubeClient, extensionsClient, TestNamespace)
 
 	proxyConnCounter := util.NewAtomicCounter()
 
@@ -1334,6 +1334,7 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 
 		kubeClient := fake.NewSimpleClientset()
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
+		kubeFilteredInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, controller.NoResyncPeriodFunc(), informers.WithNamespace(TestNamespace))
 
 		lhClient := lhfake.NewSimpleClientset()
 		lhInformerFactory := lhinformerfactory.NewSharedInformerFactory(lhClient, controller.NoResyncPeriodFunc())
@@ -1348,7 +1349,7 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 
 		extensionsClient := apiextensionsfake.NewSimpleClientset()
 
-		vc := newTestVolumeController(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient, extensionsClient, TestOwnerID1)
+		vc := newTestVolumeController(lhInformerFactory, kubeInformerFactory, kubeFilteredInformerFactory, lhClient, kubeClient, extensionsClient, TestOwnerID1)
 
 		// Need to create daemon pod for node
 		daemon1 := newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, nil)


### PR DESCRIPTION
When a Kubernetes cluster contains numerous secrets, configmaps, and other Kubernetes resources, the synchronization of the cache can lead to longhorn-manager pod's high memory consumption. This ticket focuses on optimizing the resource cache to prevent high memory usage caused by the cache synchronization. For instance, secret is used for the backup target and share manager, so caching all secrets doesn't make sense. We need to avoid caching them.

Longhorn/longhorn#6954