### PR TITLE
Update vendor files for backupstore.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
 	github.com/longhorn/backing-image-manager v1.4.0-rc1.0.20230521151917-38ff27cc2cbb
-	github.com/longhorn/backupstore v0.0.0-20230917124937-b5235e5ee814
+	github.com/longhorn/backupstore v0.0.0-20231025000449-5316e8b5320d
 	github.com/longhorn/go-iscsi-helper v0.0.0-20230802055236-4ec8edae3fad
 	github.com/longhorn/go-spdk-helper v0.0.0-20231002161457-6c31a95f76e8
 	github.com/longhorn/longhorn-engine v1.4.0-rc1.0.20230914160943-b42224518443

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/longhorn/backing-image-manager v1.4.0-rc1.0.20230521151917-38ff27cc2cbb h1:y59M4Z8jvOowAwdXcATyHjG31ZbaMJvjIPY+SpVmeII=
 github.com/longhorn/backing-image-manager v1.4.0-rc1.0.20230521151917-38ff27cc2cbb/go.mod h1:yhfIPKYbnFpRmrJOz0biNthyoyBpN4SrUk8ZQNMcW1o=
-github.com/longhorn/backupstore v0.0.0-20230917124937-b5235e5ee814 h1:Kz/mCeQvHUWCemdds1EDsL+AairEmOFZwpZmA8t/y/g=
-github.com/longhorn/backupstore v0.0.0-20230917124937-b5235e5ee814/go.mod h1:wiEYTbvxEAIUxAAY1DmvMeuFuGqwWmJTzfVhZiBKlNo=
+github.com/longhorn/backupstore v0.0.0-20231025000449-5316e8b5320d h1:WrjW6b0VmaapZWBKLSJTyZ7A5xzN0mciraLbPG9rExE=
+github.com/longhorn/backupstore v0.0.0-20231025000449-5316e8b5320d/go.mod h1:wiEYTbvxEAIUxAAY1DmvMeuFuGqwWmJTzfVhZiBKlNo=
 github.com/longhorn/go-iscsi-helper v0.0.0-20230802055236-4ec8edae3fad h1:1eZBx9ZSopMM969E/BTTUIhM0O2klBOgh8qnmGnXftA=
 github.com/longhorn/go-iscsi-helper v0.0.0-20230802055236-4ec8edae3fad/go.mod h1:hxy8Ra38KtX4MFmXZRAZUpJZSYcaI1pmnWmKA3ICA2c=
 github.com/longhorn/go-spdk-helper v0.0.0-20231002161457-6c31a95f76e8 h1:tV7DKLG7xKdM3CratmRLF2JsOA1BpzFGj90nu0PiNCc=

--- a/vendor/github.com/longhorn/backupstore/backupstore.go
+++ b/vendor/github.com/longhorn/backupstore/backupstore.go
@@ -112,12 +112,24 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 }
 
 func EncodeBackupURL(backupName, volumeName, destURL string) string {
-	v := url.Values{}
+	u, err := url.Parse(destURL)
+	if err != nil {
+		return ""
+	}
+
+	v, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		// Just start with empty values list then
+		v = url.Values{}
+	}
+
 	v.Add("volume", volumeName)
 	if backupName != "" {
 		v.Add("backup", backupName)
 	}
-	return destURL + "?" + v.Encode()
+
+	u.RawQuery = v.Encode()
+	return u.String()
 }
 
 func DecodeBackupURL(backupURL string) (string, string, string, error) {
@@ -134,7 +146,10 @@ func DecodeBackupURL(backupURL string) (string, string, string, error) {
 	if backupName != "" && !util.ValidateName(backupName) {
 		return "", "", "", fmt.Errorf("invalid backup name parsed, got %v", backupName)
 	}
-	u.RawQuery = ""
+
+	v.Del("volume")
+	v.Del("backup")
+	u.RawQuery = v.Encode()
 	destURL := u.String()
 	return backupName, volumeName, destURL, nil
 }

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -1085,6 +1085,7 @@ func checkBlockReferenceCount(blockInfos map[string]*BlockInfo, backup *Backup, 
 // backup.SnapshotCreatedAt time is greater than the lastBackup
 func getLatestBackup(backup *Backup, lastBackup *Backup) error {
 	if lastBackup.SnapshotCreatedAt == "" {
+		// FIXME - go lint points out that this copies a potentially locked sync.mutex
 		*lastBackup = *backup
 		return nil
 	}
@@ -1100,6 +1101,7 @@ func getLatestBackup(backup *Backup, lastBackup *Backup) error {
 	}
 
 	if backupTime.After(lastBackupTime) {
+		// FIXME - go lint points out that this copies a potentially locked sync.mutex
 		*lastBackup = *backup
 	}
 

--- a/vendor/github.com/longhorn/backupstore/util/util.go
+++ b/vendor/github.com/longhorn/backupstore/util/util.go
@@ -407,3 +407,14 @@ func CheckBackupType(backupTarget string) (string, error) {
 
 	return u.Scheme, nil
 }
+
+func SplitMountOptions(options []string) []string {
+	logrus.Infof("Splitting array of %d strings %v ", len(options), options)
+	if len(options) > 1 {
+		// Options in the form "nfsOptions=soft&nfsOptions=timeo=450&nfsOptions=retrans=3" are legal and
+		// are already split by url.Parse.
+		return options
+	}
+	// Options in the form "nfsOptions=soft,timeo=450,retrans=3" are more likely, but we must split them.
+	return strings.Split(options[0], ",")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -219,7 +219,7 @@ github.com/longhorn/backing-image-manager/pkg/meta
 github.com/longhorn/backing-image-manager/pkg/rpc
 github.com/longhorn/backing-image-manager/pkg/types
 github.com/longhorn/backing-image-manager/pkg/util
-# github.com/longhorn/backupstore v0.0.0-20230917124937-b5235e5ee814
+# github.com/longhorn/backupstore v0.0.0-20231025000449-5316e8b5320d
 ## explicit; go 1.17
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/logging


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/6608

Accept NFS mount options as a query appended to the backup target URL.

This PR is a placeholder for the vendor update to be done after backupstore is merged.