### PR TITLE
fix(backup): AWS IAM Role Annotation

### DIFF
--- a/controller/kubernetes_secret_controller.go
+++ b/controller/kubernetes_secret_controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -244,7 +243,10 @@ func (ks *KubernetesSecretController) annotateAWSIAMRoleArn(awsIAMRoleArn string
 		}
 
 		ks.logger.Infof("Updating AWS IAM role for pod %v/%v", pod.Namespace, pod.Name)
-		if _, err = ks.kubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+		if _, err := ks.ds.UpdatePod(pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return err
 		}
 	}

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -239,6 +239,11 @@ func (s *DataStore) DeletePod(name string) error {
 	return s.kubeClient.CoreV1().Pods(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
+// UpdatePod updates Pod for the given Pod object and namespace
+func (s *DataStore) UpdatePod(obj *corev1.Pod) (*corev1.Pod, error) {
+	return s.kubeClient.CoreV1().Pods(s.namespace).Update(context.TODO(), obj, metav1.UpdateOptions{})
+}
+
 // DeleteLease deletes Lease with the given name in s.namespace
 func (s *DataStore) DeleteLease(name string) error {
 	return s.kubeClient.CoordinationV1().Leases(s.namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
@@ -662,6 +667,11 @@ func (s *DataStore) GetSecret(namespace, name string) (*corev1.Secret, error) {
 	}
 	// Cannot use cached object from lister
 	return resultRO.DeepCopy(), nil
+}
+
+// UpdateSecret updates the Secret resource with the given object and namespace
+func (s *DataStore) UpdateSecret(namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
+	return s.kubeClient.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 }
 
 // GetPriorityClass gets the PriorityClass from the index for the


### PR DESCRIPTION
AWS IAM Role Annotation will not be added to longhorn-manager pods if the secret is created first and then set the `backup-target` and `backup-target-credential-secret`.

Ref: longhorn/longhorn#6947