### PR TITLE
fix(backup): fix backup status if target becomes invalid during creating backup

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -346,13 +346,13 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 	}()
 
 	// Perform backup snapshot to the remote backup target
-	// If the Backup CR is created by the user/API layer (spec.snapshotName != "") and has not been synced (status.lastSyncedAt == ""),
-	// it means creating a backup from a volume snapshot is required.
+	// If the Backup CR is created by the user/API layer (spec.snapshotName != ""), has not been synced (status.lastSyncedAt == "")
+	// and is not in final state, it means creating a backup from a volume snapshot is required.
 	// Hence the source of truth is the engine/replica and the controller needs to sync the status with it.
 	// Otherwise, the Backup CR is created by the backup volume controller, which means the backup already
 	// exists in the remote backup target before the CR creation.
 	// What the controller needs to do for this case is retrieve the info from the remote backup target.
-	if backup.Status.LastSyncedAt.IsZero() && backup.Spec.SnapshotName != "" {
+	if backup.Status.LastSyncedAt.IsZero() && backup.Spec.SnapshotName != "" && bc.backupNotInFinalState(backup) {
 		volume, err := bc.ds.GetVolume(backupVolumeName)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -810,4 +810,10 @@ func (bc *BackupController) syncBackupStatusWithSnapshotCreationTimeAndVolumeSiz
 	}
 
 	backup.Status.SnapshotCreatedAt = snap.Created
+}
+
+func (bc *BackupController) backupNotInFinalState(backup *longhorn.Backup) bool {
+	return backup.Status.State != longhorn.BackupStateCompleted &&
+		backup.Status.State != longhorn.BackupStateError &&
+		backup.Status.State != longhorn.BackupStateUnknown
 }

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -5,12 +5,14 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type BackupState string
 
 const (
+	// non-final state
 	BackupStateNew        = BackupState("")
 	BackupStatePending    = BackupState("Pending")
 	BackupStateInProgress = BackupState("InProgress")
-	BackupStateCompleted  = BackupState("Completed")
-	BackupStateError      = BackupState("Error")
-	BackupStateUnknown    = BackupState("Unknown")
+	// final state
+	BackupStateCompleted = BackupState("Completed")
+	BackupStateError     = BackupState("Error")
+	BackupStateUnknown   = BackupState("Unknown")
 )
 
 type BackupCompressionMethod string


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6491


If BackupTarget becomes unavailable during creating Backup
- Backup creation is an async call, so it will keep uploading in Engine/Replica
- Backup creation status will keep in the Engine memory which will sync with Replica
- Backup Controller will sync with the status in Engine memory
So even BackupTarget is unavailable, it will keep uploading the Backup and the updating the progress in CRD [here](https://github.com/longhorn/longhorn-manager/blob/master/controller/backup_controller.go#L386)

Now the problem is when Backup is `Completed`, we do `BackupInspect()` which will fail because Target is now unavailable.
So the `backup.Status.LastSyncedAt` is never set, we only set `backup.Status.State=Completed`.

In the next reconcile loop, Controller then goes into [here](https://github.com/longhorn/longhorn-manager/blob/master/controller/backup_controller.go#L355) again try to create the Backup and setup the monitor
However, since `backup.Status.State=Completed`, we don't ask engine to create Backup again [here](https://github.com/longhorn/longhorn-manager/blob/master/engineapi/backup_monitor.go#L77), but only new the monitor which contains empty state info initially.
Thus, our Backup status becomes empty again until monitor sync the state with Engine memory and get `Completed` state again. It then loop again and again

That's why the status loop in `Completed` and `""`.

---

The solution here is to prevent Controller goes into the creating Backup block again by checking the Backup state.
Then if the Target is unavailable during Backup creation
1. Backup will keep uploading
2. Backup state will keep syncing with the Monitor until it is `Completed` and disable the Monitor
3. Then Controller will never goes into the creation block again since Backup is now `Completed`
4. If we fix the Target to make it available, Controller will successfully inspect the info in backupstore and update the CRD status correctly.

