### PR TITLE
fix(setting): checking setting annotation is nil or not

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -242,6 +242,9 @@ func (s *DataStore) CreateSetting(setting *longhorn.Setting) (*longhorn.Setting,
 
 // UpdateSetting updates the given Longhorn Settings and verifies update
 func (s *DataStore) UpdateSetting(setting *longhorn.Setting) (*longhorn.Setting, error) {
+	if setting.Annotations == nil {
+		setting.Annotations = make(map[string]string)
+	}
 	setting.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
 	obj, err := s.lhClient.LonghornV1beta2().Settings(s.namespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
 	if err != nil {

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -164,6 +164,9 @@ func CreateOrUpdateLonghornVersionSetting(namespace string, lhClient *lhclientse
 
 	if s.Value != meta.Version {
 		s.Value = meta.Version
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
 		s.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
 		s, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), s, metav1.UpdateOptions{})
 		if err != nil {
@@ -900,6 +903,9 @@ func updateSettings(namespace string, lhClient *lhclientset.Clientset, settings 
 		}
 
 		if !reflect.DeepEqual(existingSetting.Value, setting.Value) {
+			if setting.Annotations == nil {
+				setting.Annotations = make(map[string]string)
+			}
 			setting.Annotations[types.GetLonghornLabelKey(types.UpdateSettingFromLonghorn)] = ""
 			setting, err = lhClient.LonghornV1beta2().Settings(namespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
 			if err != nil {


### PR DESCRIPTION
Checking the annotation of the `Settings` object is not nil before adding a new annotation for a Setting object.

Ref: longhorn/longhorn#6987, longhorn/longhorn#6947