### PR TITLE
feat: pass support bundle issueURL and description

### DIFF
--- a/controller/support_bundle_controller.go
+++ b/controller/support_bundle_controller.go
@@ -699,6 +699,14 @@ func (c *SupportBundleController) newSupportBundleManager(supportBundle *longhor
 									Value: supportBundle.Name,
 								},
 								{
+									Name:  "SUPPORT_BUNDLE_ISSUE_URL",
+									Value: supportBundle.Spec.IssueURL,
+								},
+								{
+									Name:  "SUPPORT_BUNDLE_DESCRIPTION",
+									Value: supportBundle.Spec.Description,
+								},
+								{
 									Name:  "SUPPORT_BUNDLE_DEBUG",
 									Value: "true",
 								},


### PR DESCRIPTION
## Problem

There is a issue https://github.com/harvester/harvester/issues/4630 in harvester. The description and issue url are empty from downloaded support bundle. And LH manager has the same issue here.

[Related downstream PR](https://github.com/rancher/support-bundle-kit/pull/81)