### PR TITLE
fix(backup): secret annotations might be nil

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -441,6 +441,9 @@ func (sc *SettingController) updateSecretForAWSIAMRoleAnnotation(backupTargetURL
 		delete(secret.Annotations, types.GetLonghornLabelKey(string(types.SettingNameBackupTarget)))
 		isArnExists = secret.Data[types.AWSIAMRoleArn] != nil
 	} else {
+		if secret.Annotations == nil {
+			secret.Annotations = make(map[string]string)
+		}
 		secret.Annotations[types.GetLonghornLabelKey(string(types.SettingNameBackupTarget))] = backupTargetURL
 	}
 


### PR DESCRIPTION
Secret annotations might be nil (such kubectl `create` -f secret.yaml -n longhorn-system) when adding a backup-target annotation to a object. Initialize the annotaion if it is nil before we add a backup-target annotation.

regression testing: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/5186

Ref: longhorn/longhorn#6947