### PR TITLE
Fix engine migration crash

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1757,6 +1757,12 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			log.WithField("replica", r.Name).Warn("Replica is running but Port is empty")
 			continue
 		}
+		if _, ok := e.Spec.ReplicaAddressMap[r.Name]; !ok && isVolumeMigrating(v) && e.Spec.NodeID == v.Spec.NodeID {
+			// The volume is migrating from this engine. Don't allow new replicas to be added until migration is
+			// complete per https://github.com/longhorn/longhorn/issues/6961.
+			log.WithField("replica", r.Name).Warn("Replica is running, but can't be added while migration is ongoing")
+			continue
+		}
 		replicaAddressMap[r.Name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
 	}
 	if len(replicaAddressMap) == 0 {
@@ -3995,6 +4001,8 @@ func (c *VolumeController) prepareReplicasAndEngineForMigration(v *longhorn.Volu
 				return false, true, nil
 			case longhorn.ReplicaModeRW:
 				currentAvailableReplicas[dataPath] = r
+			case "":
+				log.Warnf("Running replica %v wasn't added to engine, will ignore it and continue migration", r.Name)
 			default:
 				log.Warnf("Unexpected mode %v for the current replica %v, will ignore it and continue migration", currentEngine.Status.ReplicaModeMap[r.Name], r.Name)
 				continue

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2851,11 +2851,9 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 		return nil
 	}
 
-	if err := c.switchActiveReplicas(rs, func(r *longhorn.Replica, image string) bool {
+	c.switchActiveReplicas(rs, func(r *longhorn.Replica, image string) bool {
 		return r.Spec.Image == image && r.DeletionTimestamp.IsZero()
-	}, v.Spec.Image); err != nil {
-		return err
-	}
+	}, v.Spec.Image)
 
 	e.Spec.ReplicaAddressMap = e.Spec.UpgradedReplicaAddressMap
 	e.Spec.UpgradedReplicaAddressMap = map[string]string{}
@@ -3775,7 +3773,7 @@ func (c *VolumeController) deleteInvalidMigrationReplicas(rs, pathToOldRs, pathT
 }
 
 func (c *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica,
-	activeCondFunc func(r *longhorn.Replica, obj string) bool, obj string) error {
+	activeCondFunc func(r *longhorn.Replica, obj string) bool, obj string) {
 
 	// Deletion of an active replica will trigger the cleanup process to
 	// delete the volume data on the disk.
@@ -3786,7 +3784,6 @@ func (c *VolumeController) switchActiveReplicas(rs map[string]*longhorn.Replica,
 			r.Spec.Active = !r.Spec.Active
 		}
 	}
-	return nil
 }
 
 func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*longhorn.Engine, rs map[string]*longhorn.Replica) (err error) {
@@ -3854,11 +3851,9 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 		currentEngine.Spec.Active = true
 
 		// cleanupCorruptedOrStaleReplicas() will take care of old replicas
-		if err := c.switchActiveReplicas(rs, func(r *longhorn.Replica, engineName string) bool {
-			return r.Spec.EngineName == engineName
-		}, currentEngine.Name); err != nil {
-			return err
-		}
+		c.switchActiveReplicas(rs, func(r *longhorn.Replica, engineName string) bool {
+			return r.Spec.EngineName == engineName && r.Spec.HealthyAt != ""
+		}, currentEngine.Name)
 
 		// migration rollback or confirmation finished
 		v.Status.CurrentMigrationNodeID = ""
@@ -4005,7 +4000,6 @@ func (c *VolumeController) prepareReplicasAndEngineForMigration(v *longhorn.Volu
 				log.Warnf("Running replica %v wasn't added to engine, will ignore it and continue migration", r.Name)
 			default:
 				log.Warnf("Unexpected mode %v for the current replica %v, will ignore it and continue migration", currentEngine.Status.ReplicaModeMap[r.Name], r.Name)
-				continue
 			}
 		} else if r.Spec.EngineName == migrationEngine.Name {
 			migrationReplicas[dataPath] = r


### PR DESCRIPTION
longhorn/longhorn#6961

Just https://github.com/longhorn/longhorn-manager/commit/be6aca60ae375d212256d9bc3363f70bce86a767 is sufficient to prevent the engine from crashing under the circumstances from https://github.com/longhorn/longhorn/issues/6961#issuecomment-1785634706. However, this commit alone leads to orphaned data once the migration is complete (as the replica we refuse to add to the engine becomes inactive without an active counterpart).

I experimented with a path to making use of this newly inactive replica after the migration (to avoid unnecessary rebuilding), but I ultimately decided that the migration logic refactor this required was outside the scope of the ticket.

The other commits are an attempt to ensure we don't orphan the newly inactive replica's directory by providing a path to cleaning it up.

I need more time to test this because I'm running into issues with backing image download checksums. For some reason, the download of the backing image to the uncordoned node is consistently failing with checksum issues.