### PR TITLE
fix(backup): backupInfo might be nil

### DIFF
--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -323,8 +323,10 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 				"backupvolume": backupVolumeName,
 				"backuptarget": backupURL}).Warn("Failed to get backupInfo from remote backup target")
 		} else {
-			if accessMode, exist := backupInfo.Labels[types.GetLonghornLabelKey(types.LonghornLabelVolumeAccessMode)]; exist {
-				backupLabelMap[types.GetLonghornLabelKey(types.LonghornLabelVolumeAccessMode)] = accessMode
+			if backupInfo != nil && backupInfo.Labels != nil {
+				if accessMode, exist := backupInfo.Labels[types.GetLonghornLabelKey(types.LonghornLabelVolumeAccessMode)]; exist {
+					backupLabelMap[types.GetLonghornLabelKey(types.LonghornLabelVolumeAccessMode)] = accessMode
+				}
 			}
 		}
 


### PR DESCRIPTION
The `backupInfo` would be nil when we try to pull the backups from the remote backup target.

Ref: longhorn/longhorn#6998