### PR TITLE
fix(backing): disable block type disk for v1 type backing iamge

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -2388,6 +2388,10 @@ func (s *DataStore) GetRandomReadyNodeDisk() (*longhorn.Node, string, error) {
 			if !exists {
 				continue
 			}
+			// TODO: Jack add block type disk for spdk version BackingImage
+			if diskSpec.Type != longhorn.DiskTypeFilesystem {
+				continue
+			}
 			if !diskSpec.AllowScheduling {
 				continue
 			}


### PR DESCRIPTION
ref: [longhorn/longhorn#7062](https://github.com/longhorn/longhorn/issues/7062)

When selecting disk/node for backingimage
we should skip block type disk

In the future we will support backing image in spdk and we should distinguish them when selecting disk type
ref: https://github.com/longhorn/longhorn/issues/6341