### PR TITLE
Support instance-manager pod for v2 volumes on selected nodes

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1061,22 +1061,41 @@ func (nc *NodeController) syncInstanceManagers(node *longhorn.Node) error {
 					return fmt.Errorf("instance manager %v nodeID %v is not consistent with the label %v=%v",
 						im.Name, im.Spec.NodeID, types.GetLonghornLabelKey(types.LonghornLabelNode), im.Labels[types.GetLonghornLabelKey(types.LonghornLabelNode)])
 				}
+
+				runningOrStartingInstanceFound := false
+				if im.Status.CurrentState == longhorn.InstanceManagerStateRunning && im.DeletionTimestamp == nil {
+					// nolint:all
+					for _, instance := range types.ConsolidateInstances(im.Status.InstanceEngines, im.Status.InstanceReplicas, im.Status.Instances) {
+						if instance.Status.State == longhorn.InstanceStateRunning || instance.Status.State == longhorn.InstanceStateStarting {
+							runningOrStartingInstanceFound = true
+							break
+						}
+					}
+				}
+
 				cleanupRequired := true
 
 				if im.Spec.Image == defaultInstanceManagerImage && im.Spec.DataEngine == dataEngine {
 					// Create default instance manager if needed.
 					defaultInstanceManagerCreated = true
 					cleanupRequired = false
-				} else {
-					// Clean up old instance managers if there is no running instance.
-					if im.Status.CurrentState == longhorn.InstanceManagerStateRunning && im.DeletionTimestamp == nil {
-						for _, instance := range types.ConsolidateInstances(im.Status.InstanceEngines, im.Status.InstanceReplicas, im.Status.Instances) {
-							if instance.Status.State == longhorn.InstanceStateRunning || instance.Status.State == longhorn.InstanceStateStarting {
-								cleanupRequired = false
-								break
-							}
+
+					if datastore.IsDataEngineV2(dataEngine) {
+						disabled, err := nc.ds.IsV2DataEngineDisabledForNode(node.Name)
+						if err != nil {
+							return errors.Wrapf(err, "failed to check if v2 data engine is disabled on node %v", node.Name)
+						}
+						if disabled && !runningOrStartingInstanceFound {
+							log.Infof("Cleaning up instance manager %v since v2 data engine is disabled for node %v", im.Name, node.Name)
+							cleanupRequired = true
 						}
 					}
+				} else {
+					// Clean up old instance managers if there is no running instance.
+					if runningOrStartingInstanceFound {
+						cleanupRequired = false
+					}
+
 					if im.Status.CurrentState == longhorn.InstanceManagerStateUnknown && im.DeletionTimestamp == nil {
 						cleanupRequired = false
 						log.Debugf("Skipping cleaning up non-default unknown instance manager %s", im.Name)
@@ -1094,6 +1113,16 @@ func (nc *NodeController) syncInstanceManagers(node *longhorn.Node) error {
 				if err != nil {
 					return err
 				}
+				if datastore.IsDataEngineV2(dataEngine) {
+					disabled, err := nc.ds.IsV2DataEngineDisabledForNode(node.Name)
+					if err != nil {
+						return errors.Wrapf(err, "failed to check if v2 data engine is disabled on node %v", node.Name)
+					}
+					if disabled {
+						continue
+					}
+				}
+
 				log.Infof("Creating default instance manager %v, image: %v, dataEngine: %v", imName, defaultInstanceManagerImage, dataEngine)
 				if _, err := nc.createInstanceManager(node, imName, defaultInstanceManagerImage, imType, dataEngine); err != nil {
 					return err

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4916,3 +4916,16 @@ func (s *DataStore) GetDataEngines() map[longhorn.DataEngineType]struct{} {
 
 	return dataEngines
 }
+
+// IsV2VolumeDisabledForNode returns true if the node disables v2 data engine
+func (s *DataStore) IsV2DataEngineDisabledForNode(nodeName string) (bool, error) {
+	kubeNode, err := s.GetKubernetesNodeRO(nodeName)
+	if err != nil {
+		return false, err
+	}
+	val, ok := kubeNode.Labels[types.NodeDisableV2DataEngineLabelKey]
+	if ok && val == types.NodeDisableV2DataEngineLabelKeyTrue {
+		return true, nil
+	}
+	return false, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -124,6 +124,8 @@ const (
 	NodeCreateDefaultDiskLabelKey             = "node.longhorn.io/create-default-disk"
 	NodeCreateDefaultDiskLabelValueTrue       = "true"
 	NodeCreateDefaultDiskLabelValueConfig     = "config"
+	NodeDisableV2DataEngineLabelKey           = "node.longhorn.io/disable-v2-data-engine"
+	NodeDisableV2DataEngineLabelKeyTrue       = "true"
 	KubeNodeDefaultDiskConfigAnnotationKey    = "node.longhorn.io/default-disks-config"
 	KubeNodeDefaultNodeTagConfigAnnotationKey = "node.longhorn.io/default-node-tags"
 


### PR DESCRIPTION
When a kubernetes node is labeled with `node.longhorn.io/disable-v2-volume: "true"`, the v2 volume feature on the node is not supported.

The PR is based on https://github.com/longhorn/longhorn-manager/pull/2272
    
Longhorn/longhorn#7015