### PR TITLE
Fix bug cannot mount xfs PV

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.5
 
-RUN zypper -n install iputils iproute2 nfs-client cifs-utils bind-utils e2fsprogs && \
+RUN zypper -n install iputils iproute2 nfs-client cifs-utils bind-utils e2fsprogs xfsprogs && \
     rm -rf /var/cache/zypp/*
 
 COPY bin package/launch-manager package/nsmounter /usr/local/sbin/


### PR DESCRIPTION
Add the `xfsprogs` back to longhorn-manger image so that longhorn-csi-plugin can run `mkfs.xfs` to mount the xfs PV

longhorn/longhorn#7140