### PR TITLE
fix(crypto): minimal encrypted volume size

### DIFF
--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -16,6 +16,12 @@ const (
 	CryptoKeyDefaultHash   = "sha256"
 	CryptoKeyDefaultSize   = "256"
 	CryptoDefaultPBKDF     = "argon2i"
+
+	// Luks2MinimalVolumeSize the minimal volume size for the LUKS2format encryption.
+	//  https://gitlab.com/cryptsetup/cryptsetup/-/wikis/FrequentlyAskedQuestions
+	//  Section 10.10 What about the size of the LUKS2 header
+	//  The default size is 16MB
+	Luks2MinimalVolumeSize = 16 * 1024 * 1024
 )
 
 // EncryptParams keeps the customized cipher options from the secret CR

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -22,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/csi/crypto"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
@@ -628,6 +629,11 @@ func CheckVolume(v *longhorn.Volume) error {
 	if v.Name == "" || size == 0 || v.Spec.NumberOfReplicas == 0 {
 		return fmt.Errorf("BUG: missing required field %+v", v)
 	}
+
+	if v.Spec.Encrypted && size <= crypto.Luks2MinimalVolumeSize {
+		return fmt.Errorf("invalid volume size %v, need to be bigger than 16MiB, default LUKS2 header size for encryption", v.Spec.Size)
+	}
+
 	errs := validation.IsDNS1123Label(v.Name)
 	if len(errs) != 0 {
 		return fmt.Errorf("invalid volume name: %+v", errs)


### PR DESCRIPTION
The minimal encrypted volume size should be bigger than 16MiB because the default LUKS2 header size is 16MiB.

Ref: longhorn/longhorn#7033