### PR TITLE
Add disable-snapshot-purge setting

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1756,6 +1756,8 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 		defer engineClientProxy.Close()
 
 		// If enabled, call and wait for SnapshotPurge to clean up system generated snapshot before rebuilding.
+		// It is not necessary to check the value of DisableSnapshotPurge here because the webhook prevents enabling
+		// AutoCleanupSystemGeneratedSnapshot and DisableSnapshot purge simultaneously.
 		if autoCleanupSystemGeneratedSnapshot {
 			if err := engineClientProxy.SnapshotPurge(e); err != nil {
 				log.WithError(err).Error("Failed to start snapshot purge before rebuilding")
@@ -1875,6 +1877,8 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 			"Replica %v with Address %v has been rebuilt for volume %v", replicaName, addr, e.Spec.VolumeName)
 
 		// If enabled, call SnapshotPurge to clean up system generated snapshot after rebuilding.
+		// It is not necessary to check the value of DisableSnapshotPurge here because the webhook prevents enabling
+		// AutoCleanupSystemGeneratedSnapshot and DisableSnapshot purge simultaneously.
 		if autoCleanupSystemGeneratedSnapshot {
 			log.Info("Starting snapshot purge after rebuilding")
 			if err := engineClientProxy.SnapshotPurge(e); err != nil {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -384,6 +384,22 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 				return err
 			}
 		}
+	case types.SettingNameAutoCleanupSystemGeneratedSnapshot:
+		disablePurgeValue, err := s.GetSettingAsBool(types.SettingNameDisableSnapshotPurge)
+		if err != nil {
+			return err
+		}
+		if value == "true" && disablePurgeValue {
+			return errors.Errorf("cannot set %v setting to true when %v setting is true", name, types.SettingNameDisableSnapshotPurge)
+		}
+	case types.SettingNameDisableSnapshotPurge:
+		autoCleanupValue, err := s.GetSettingAsBool(types.SettingNameAutoCleanupSystemGeneratedSnapshot)
+		if err != nil {
+			return err
+		}
+		if value == "true" && autoCleanupValue {
+			return errors.Errorf("cannot set %v setting to true when %v setting is true", name, types.SettingNameAutoCleanupSystemGeneratedSnapshot)
+		}
 	}
 	return nil
 }

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/engineapi"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 )
 
@@ -205,6 +206,14 @@ func (m *VolumeManager) RevertSnapshot(snapshotName, volumeName string) error {
 func (m *VolumeManager) PurgeSnapshot(volumeName string) error {
 	if volumeName == "" {
 		return fmt.Errorf("volume name required")
+	}
+
+	disablePurge, err := m.ds.GetSettingAsBool(types.SettingNameDisableSnapshotPurge)
+	if err != nil {
+		return err
+	}
+	if disablePurge {
+		return errors.Errorf("cannot purge snapshots while %v setting is true", types.SettingNameDisableSnapshotPurge)
 	}
 
 	if err := m.checkVolumeNotInMigration(volumeName); err != nil {

--- a/types/setting.go
+++ b/types/setting.go
@@ -113,6 +113,7 @@ const (
 	SettingNameReplicaDiskSoftAntiAffinity                              = SettingName("replica-disk-soft-anti-affinity")
 	SettingNameAllowEmptyNodeSelectorVolume                             = SettingName("allow-empty-node-selector-volume")
 	SettingNameAllowEmptyDiskSelectorVolume                             = SettingName("allow-empty-disk-selector-volume")
+	SettingNameDisableSnapshotPurge                                     = SettingName("disable-snapshot-purge")
 )
 
 var (
@@ -189,6 +190,7 @@ var (
 		SettingNameReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume,
+		SettingNameDisableSnapshotPurge,
 	}
 )
 
@@ -291,6 +293,7 @@ var (
 		SettingNameReplicaDiskSoftAntiAffinity:                              SettingDefinitionReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume:                             SettingDefinitionAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume:                             SettingDefinitionAllowEmptyDiskSelectorVolume,
+		SettingNameDisableSnapshotPurge:                                     SettingDefinitionDisableSnapshotPurge,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -1161,6 +1164,16 @@ var (
 		ReadOnly:    false,
 		Default:     "true",
 	}
+
+	SettingDefinitionDisableSnapshotPurge = SettingDefinition{
+		DisplayName: "Disable Snapshot Purge",
+		Description: "Temporarily prevent all attempts to purge volume snapshots",
+		Category:    SettingCategoryDangerZone,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "false",
+	}
 )
 
 type NodeDownPodDeletionPolicy string
@@ -1282,6 +1295,8 @@ func ValidateSetting(name, value string) (err error) {
 	case SettingNameAllowCollectingLonghornUsage:
 		fallthrough
 	case SettingNameReplicaDiskSoftAntiAffinity:
+		fallthrough
+	case SettingNameDisableSnapshotPurge:
 		if value != "true" && value != "false" {
 			return fmt.Errorf("value %v of setting %v should be true or false", value, sName)
 		}


### PR DESCRIPTION
longhorn/longhorn#7075

Key points:

- `disable-snapshot-purge` is meant to be enabled temporarily and for a very specific purpose.
- It would be confusing if `auto-cleanup-system-generated-snapshots` could be enabled at the same time as `disable-snapshot-purge`, since the behavior of one would outweigh the behavior of the other. This PR ensures only one can be enabled at a time.
- I originally took a simpler approach in the snapshot controller, but I realized it could lead to volumes being indefinitely attached for snapshot deletion while `disable-snapshot-purge` prevented that deletion from succeeding. The new approach is to log a warning, delete the detachment ticket, and do nothing as long as `disable-snapshot-purge` is enabled. Then, when it is disabled, ensure all snapshots with `deletionTimstamps` are requeued so we can clean them up.