### PR TITLE
feat(node drain): add DetachManuallyAttachedVolumesDuringDrain setting

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4702,6 +4702,11 @@ func (s *DataStore) ListLonghornVolumeAttachmentByVolumeRO(name string) ([]*long
 	return s.lhVolumeAttachmentLister.VolumeAttachments(s.namespace).List(volumeSelector)
 }
 
+// ListLHVolumeAttachmentsRO returns a list of all VolumeAttachments for the given namespace
+func (s *DataStore) ListLHVolumeAttachmentsRO() ([]*longhorn.VolumeAttachment, error) {
+	return s.lhVolumeAttachmentLister.VolumeAttachments(s.namespace).List(labels.Everything())
+}
+
 // RemoveFinalizerForLHVolumeAttachment will result in deletion if DeletionTimestamp was set
 func (s *DataStore) RemoveFinalizerForLHVolumeAttachment(va *longhorn.VolumeAttachment) error {
 	if !util.FinalizerExists(longhornFinalizerKey, va) {

--- a/types/setting.go
+++ b/types/setting.go
@@ -74,6 +74,7 @@ const (
 	SettingNameReplicaZoneSoftAntiAffinity                              = SettingName("replica-zone-soft-anti-affinity")
 	SettingNameNodeDownPodDeletionPolicy                                = SettingName("node-down-pod-deletion-policy")
 	SettingNameNodeDrainPolicy                                          = SettingName("node-drain-policy")
+	SettingNameDetachManuallyAttachedVolumesWhenCordoned                = SettingName("detach-manually-attached-volumes-when-cordoned")
 	SettingNamePriorityClass                                            = SettingName("priority-class")
 	SettingNameDisableRevisionCounter                                   = SettingName("disable-revision-counter")
 	SettingNameReplicaReplenishmentWaitInterval                         = SettingName("replica-replenishment-wait-interval")
@@ -150,6 +151,7 @@ var (
 		SettingNameReplicaZoneSoftAntiAffinity,
 		SettingNameNodeDownPodDeletionPolicy,
 		SettingNameNodeDrainPolicy,
+		SettingNameDetachManuallyAttachedVolumesWhenCordoned,
 		SettingNamePriorityClass,
 		SettingNameDisableRevisionCounter,
 		SettingNameReplicaReplenishmentWaitInterval,
@@ -252,6 +254,7 @@ var (
 		SettingNameReplicaZoneSoftAntiAffinity:                              SettingDefinitionReplicaZoneSoftAntiAffinity,
 		SettingNameNodeDownPodDeletionPolicy:                                SettingDefinitionNodeDownPodDeletionPolicy,
 		SettingNameNodeDrainPolicy:                                          SettingDefinitionNodeDrainPolicy,
+		SettingNameDetachManuallyAttachedVolumesWhenCordoned:                SettingDefinitionDetachManuallyAttachedVolumesWhenCordoned,
 		SettingNamePriorityClass:                                            SettingDefinitionPriorityClass,
 		SettingNameDisableRevisionCounter:                                   SettingDefinitionDisableRevisionCounter,
 		SettingNameReplicaReplenishmentWaitInterval:                         SettingDefinitionReplicaReplenishmentWaitInterval,
@@ -714,6 +717,16 @@ var (
 			string(NodeDrainPolicyAllowIfReplicaIsStopped),
 			string(NodeDrainPolicyAlwaysAllow),
 		},
+	}
+
+	SettingDefinitionDetachManuallyAttachedVolumesWhenCordoned = SettingDefinition{
+		DisplayName: "Detach Manually Attached Volumes When Cordoned",
+		Description: "Automatically detach volumes that are attached manually when node is cordoned.",
+		Category:    SettingCategoryGeneral,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "false",
 	}
 
 	SettingDefinitionPriorityClass = SettingDefinition{
@@ -1280,6 +1293,8 @@ func ValidateSetting(name, value string) (err error) {
 	case SettingNameAllowEmptyDiskSelectorVolume:
 		fallthrough
 	case SettingNameAllowCollectingLonghornUsage:
+		fallthrough
+	case SettingNameDetachManuallyAttachedVolumesWhenCordoned:
 		fallthrough
 	case SettingNameReplicaDiskSoftAntiAffinity:
 		if value != "true" && value != "false" {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6978

iterate the volumeattachment ticket
if there is `AttacherTypeLonghornAPI` ticket and the target node is being drained, then delete the ticket
in the next function `handleVolumeDetachment` will detach the volume if the volume is currently attached by this ticket.