### PR TITLE
fix: scope of err variable while migrating volume

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3881,9 +3881,9 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 
 		log.Warnf("The migration engine or all migration replicas crashed, will clean them up now")
 
-		currentEngine, err := c.getCurrentEngineAndCleanupOthers(v, es)
-		if err != nil {
-			err = errors.Wrap(err, "failed to get the current engine and clean up others during the migration revert")
+		currentEngine, err2 := c.getCurrentEngineAndCleanupOthers(v, es)
+		if err2 != nil {
+			err = errors.Wrapf(err, "failed to get the current engine and clean up others during the migration revert: %v", err2)
 			return
 		}
 
@@ -3891,8 +3891,8 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 			if r.Spec.EngineName == currentEngine.Name {
 				continue
 			}
-			if err := c.deleteReplica(r, rs); err != nil {
-				err = errors.Wrapf(err, "failed to delete the migration replica %v during the migration revert", r.Name)
+			if err2 := c.deleteReplica(r, rs); err2 != nil {
+				err = errors.Wrapf(err, "failed to delete the migration replica %v during the migration revert: %v", r.Name, err2)
 				return
 			}
 		}


### PR DESCRIPTION
Fix the scope of the err variable while migrating a volume.

The root of this problem is that in case a migration revert is attempted, `err` is re-defined in a defer'ed anonymous function. This shadows the definition of the variable `err` in the outer scope, which causes the original error during the migration to be lost. The simple fix is to define a different error and wrap the original error with a message containing the new error. This avoids redefining `err`, making it available with its original value in the defer'ed function.

related: longhorn/longhorn#7009