### PR TITLE
refactor: remove duplicated ready node filtering

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -2530,7 +2530,7 @@ func (s *DataStore) ListReadyAndSchedulableNodesRO() (map[string]*longhorn.Node,
 		return nil, err
 	}
 
-	return filterSchedulableNodes(filterReadyNodes(nodes)), nil
+	return filterSchedulableNodes(nodes), nil
 }
 
 func (s *DataStore) ListReadyNodesContainingEngineImageRO(image string) (map[string]*longhorn.Node, error) {


### PR DESCRIPTION
Already filtered in [ListReadyNodesRO](https://github.com/longhorn/longhorn-manager/blob/d4700d32d656a560712c27b3212b19224eda01e1/datastore/longhorn.go#L2523).