### PR TITLE
fix: skip upgrade path for new installation

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -224,6 +224,11 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 		return err
 	}
 
+	if lhVersionBeforeUpgrade == "" {
+		logrus.Info("Skipping walking through the resource upgrade path for fresh Longhorn installation")
+		return nil
+	}
+
 	// When lhVersionBeforeUpgrade < v1.6.0, it is v1.5.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.5.x.
 	resourceMaps := map[string]interface{}{}
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.6.0") < 0 {


### PR DESCRIPTION
No need to walk through the resource upgrade path for fresh Longhorn installation.
(lhVersionBeforeUpgrade is an empty value)

Ref: longhorn/longhorn#6988