### PR TITLE
fix: ignore unknown node condition

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -452,10 +452,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 						fmt.Sprintf("Kubernetes node %v has pressure: %v, %v", node.Name, con.Reason, con.Message),
 						nc.eventRecorder, node, corev1.EventTypeWarning)
 				}
-			default:
-				if con.Status == corev1.ConditionTrue {
-					nc.eventRecorder.Eventf(node, corev1.EventTypeWarning, longhorn.NodeConditionReasonUnknownNodeConditionTrue, "Unknown condition true of kubernetes node %v: condition type is %v, reason is %v, message is %v", node.Name, con.Type, con.Reason, con.Message)
-				}
 			}
 		}
 


### PR DESCRIPTION
Longhorn exposed all unknown (to longhorn) node conditions as K8s events. This is a mechanism that only has informational value and is used as such in Longhorn as well, as it only serves to relay information to the UI.

In particular, the condition in question is `EtcdIsVoter` and is a K3s specific condition, indicating the membership details of an etcd node on that K3s node and is irrelevant to Longhorn, but other non-standard node conditions should be ignored too, if Longhorn doesn't derive any actionable value from them.

related-to: longhorn/longhorn#7290