### PR TITLE
ci: import test script

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -22,7 +22,7 @@ RUN wget -O - https://storage.googleapis.com/golang/go1.20.3.linux-${!GOLANG_ARC
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/longhorn-manager
 ENV DAPPER_OUTPUT ./bin coverage.out
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_ENV IMAGE REPO VERSION TAG
+ENV DAPPER_ENV IMAGE REPO VERSION TAG TESTS
 ENV DAPPER_RUN_ARGS --privileged --tmpfs /go/src/github.com/longhorn/longhorn/integration/.venv:exec --tmpfs /go/src/github.com/longhorn/longhorn/integration/.tox:exec -v /dev:/host/dev
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ longhorn-uninstall   1/1           20s        20s
 
 Tip: If you try `kubectl delete -Rf deploy/install` first and get stuck there, pressing `Ctrl C` then running `kubectl create -f deploy/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components by running `kubectl delete -f deploy/uninstall/uninstall.yaml`.
 
+## Unit Test
+
+To execute all unit tests, make sure there are no uncommitted changes and run:
+
+```
+make test
+```
+
+If there are uncommitted changes, only the affected modules will be tested.
+To execute specific unit tests or all tests matching a regex, run:
+
+```
+TESTS=="NodeControllerSuite.*" make test
+```
 
 ## Integration test
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+TESTS=${TESTS:-""}
 
-args=$1
+cd "$(dirname "$0")/.."
 
-echo Running tests
+args=("$@")
 
-PACKAGES="$(find . -name '*.go' | xargs -I{} dirname {} | sort -u | grep -Ev '(.git|.trash-cache|vendor|bin|k8s)')"
+echo "Running tests ${TESTS}"
 
-echo Packages: ${PACKAGES}
+if ! git diff --name-only | grep -Ev '(.git|.trash-cache|vendor|bin|k8s)' | grep -E '.*\.go' ; then
+  PACKAGES="$(find . -name '*.go' -exec dirname {} \; | sort -u | grep -Ev '(.git|.trash-cache|vendor|bin|k8s)')"
+else
+  PACKAGES="$(git diff --name-only | grep -E '.*\.go' | xargs -I{} dirname ./{} | sort -u | grep -Ev '(.git|.trash-cache|vendor|bin|k8s)')"
+fi
+
+echo Packages: "${PACKAGES}"
 
 [ "${ARCH}" == "amd64" ] && RACE=-race
-go test ${RACE} ${args} ${PACKAGES}
+if [ -n "${TESTS}" ]; then
+  go test -v "${RACE}" "${args[@]}" ${PACKAGES} -check.f "${TESTS}"
+else
+  go test -v "${RACE}" "${args[@]}" ${PACKAGES}
+fi


### PR DESCRIPTION
- By default run only tests on affected modules, if there are uncomitted changes in the git worktree. This speeds up local unit test runtime during development by only running tests on affected modules. In the CI pipeline or when changes have been committed, all unit tests are run for complete coverage.

- Make it possible to run particular tests using the TESTS environment variable. This is helpful when writing tests, as it helps both with turnaround times as well as reduce the output to only include the test under development.