### PR TITLE
Don't use updated golang.org/x/tools dependency for golint

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,7 +17,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLA
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.17.10.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get -u golang.org/x/lint/golint
+    go get golang.org/x/lint/golint
 
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/longhorn-manager
 ENV DAPPER_OUTPUT ./bin coverage.out


### PR DESCRIPTION
longhorn/longhorn#7330

cc @c3y1huang, since I think you have done the most around Go and dependency versions.