### PR TITLE
Fix bug volume stuck in live engine upgrading forever if it was degraded during live engine upgrade

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2688,8 +2688,42 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 		return nil
 	}
 
-	// only start live upgrade if volume is healthy
+	// Only start live upgrade if volume is healthy
 	if v.Status.State != longhorn.VolumeStateAttached || v.Status.Robustness != longhorn.VolumeRobustnessHealthy {
+		if v.Status.State != longhorn.VolumeStateAttached || v.Status.Robustness != longhorn.VolumeRobustnessDegraded {
+			return nil
+		}
+		// Clean up inactive replica corresponding to non-existing active replica.
+		// This will allow volume controller to schedule and rebuild a new active replica
+		// and make the volume healthy again for the live upgrade to be able to continue.
+		// https://github.com/longhorn/longhorn/issues/7012
+
+		// sort the replica by name so that we don't select multiple replicas when running this logic repeatedly quickly
+		var sortedReplicaNames []string
+		for rName := range rs {
+			sortedReplicaNames = append(sortedReplicaNames, rName)
+		}
+		sort.Strings(sortedReplicaNames)
+
+		var inactiveReplicaToCleanup *longhorn.Replica
+		for _, rName := range sortedReplicaNames {
+			r := rs[rName]
+			if !r.Spec.Active && !hasMatchingActiveReplica(r, rs) {
+				inactiveReplicaToCleanup = r
+				break
+			}
+		}
+		if inactiveReplicaToCleanup != nil {
+			log.Infof("Cleaning up inactive replica %v which doesn't have corresponding active replica", inactiveReplicaToCleanup.Name)
+			if err := c.deleteReplica(inactiveReplicaToCleanup, rs); err != nil {
+				return errors.Wrapf(err, "failed to cleanup inactive replica %v", inactiveReplicaToCleanup.Name)
+			}
+			return nil
+		}
+
+		// When the volume is degraded, even though we don't start the live engine upgrade, try to mark it as finished if it already started
+		c.finishLiveEngineUpgrade(v, e, rs, log)
+
 		return nil
 	}
 
@@ -2796,9 +2830,14 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 			e.Spec.Image = v.Spec.Image
 		}
 	}
+	c.finishLiveEngineUpgrade(v, e, rs, log)
+	return nil
+}
+
+func (c *VolumeController) finishLiveEngineUpgrade(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica, log *logrus.Entry) {
 	if e.Status.CurrentImage != v.Spec.Image ||
 		e.Status.CurrentState != longhorn.InstanceStateRunning {
-		return nil
+		return
 	}
 
 	c.switchActiveReplicas(rs, func(r *longhorn.Replica, image string) bool {
@@ -2810,8 +2849,6 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 	// cleanupCorruptedOrStaleReplicas() will take care of old replicas
 	log.Infof("Engine %v has been upgraded from %v to %v", e.Name, v.Status.CurrentImage, v.Spec.Image)
 	v.Status.CurrentImage = v.Spec.Image
-
-	return nil
 }
 
 func (c *VolumeController) updateRequestedBackupForVolumeRestore(v *longhorn.Volume, e *longhorn.Engine) (err error) {


### PR DESCRIPTION
Quick summary of [the live engine upgrade logic](https://github.com/longhorn/longhorn-manager/blob/ae6b6aa99d0e2eb12fd0d868f5e67105bb6b685c/controller/volume_controller.go#L2631):
1. Volume controller check for the volume is attached and healthy
1. Check the old engine image and new engine image is ready
1. Create new inactive replicas set from old active replica set. Note that new inactive replicas will use new engine image and the old set is still using the old engine image
1. Start the new inactive replica set
1. Set the `e.Spec.UpgradedReplicaAddressMap` to the new inactive replica set and `e.Spec.Image` to the new engine image to start the upgrading inside engine process
1. Once the engine controller finish the image upgrade for engine, it will set `e.Status.CurrentImage` to new image. At this point, volume controller can:
    1. Set the inactive replica set to active and set the old active replica to inactive
    1. Clear  `e.Spec.UpgradedReplicaAddressMap` and set `v.Status.CurrentImage` to new image to indicate that the live upgrade finished 

This fix considers 2 cases:

1. If volume becomes degraded before engine starts the upgrading (i.e. before step 5 above), we will clean up the inactive replica which is corresponding to the non-existing active replica. This way, the volume can starts rebuilding a new active replica using old engine image. Then the volume will become healthy again and the live upgrade logic can finish.

    To demonstrate this case, let's consider the following test before the fix:

    1. Create/attach a volume using engine image v1.5.3
    1. Start a live upgrade by upgrade the engine for the volume to master-head
    1. Immediately delete a replica before the engine starts upgrading (i.e. before `engine.Spec.Image` is set to `master-head`)
    1. At this moment, `v.Spec.Image` is  `master-head`, `v.Status.CurrentImage` is  `1.5.3`, `engine.Spec.Image`  is  `1.5.3`, and `engine.Status.CurrentImage`  is  `1.5.3`. 
    1. The volume becomes degraded because it is missing an active replica. However, a new replica cannot be rebuilt as there already exists an inactive replica on the same disk
        ```
        [longhorn-manager-8254x] time="2023-12-14T02:57:52Z" level=error msg="There's no available disk for replica testvol-r-14cee1bd, size 10737418240" func="scheduler.(*ReplicaScheduler).ScheduleReplica" file="replica_scheduler.go:95"
        ```
    1. The live upgrade also cannot proceed as the volume is not healthy https://github.com/longhorn/longhorn-manager/blob/ae6b6aa99d0e2eb12fd0d868f5e67105bb6b685c/controller/volume_controller.go#L2692
    1. The result is volume stuck in degraded and live upgrade forever 
        ![Screenshot from 2023-12-13 19-00-41](https://github.com/longhorn/longhorn-manager/assets/22139961/7cad9c39-704f-4b05-b15a-983772ded90d)

     This PR fixes it so that we cleanup the inactive replica which doesn't have a corresponding active replica. This allow the replica scheduler schedules the active stopped replica in the above picture. So the volume becomes healthy again and be able to start and finish the live upgrade


1. If volume becomes degraded after engine starts the upgrading  (i.e. after step 5 above), the engine already uses the newly inactive replicas. We cannot rebuild a new active replica because that replica will use old engine image. It will be problematic as the engine will issue IO to some inactive replica (with new engine image) and the newly rebuilt active replica (with old engine image). Instead, we should continue and finish the live upgrade. Then the volume can start rebuilding new replica with new engine image

    To demonstrate this case, let's consider the following test before the fix:

    1. Create/attach a volume using engine image v1.5.3
    1. Start a live upgrade by upgrade the engine for the volume to master-head
    1. Wait for `engine.Spec.Image`  is  `master-head` (engine started to upgrade) then delete an old active replica 
    1. At this moment, `v.Spec.Image` is  `master-head`, `v.Status.CurrentImage` is  `1.5.3`, `engine.Spec.Image`  is  `master-head`, and `engine.Status.CurrentImage`  is  `1.5.3`. 
    1. Eventually, the engine controller performed the upgrade and set `engine.Status.CurrentImage` to  `master-head`. 
    1. The volume becomes degraded because it is missing an active replica. However, a new replica cannot be rebuilt as there already exists an inactive replica on the same disk
        ```
        [longhorn-manager-8254x] time="2023-12-14T02:57:52Z" level=error msg="There's no available disk for replica testvol-r-14cee1bd, size 10737418240" func="scheduler.(*ReplicaScheduler).ScheduleReplica" file="replica_scheduler.go:95"
        ```
     1. Even with the fix # 1 (which is deleting the inactive replica corresponding to the non-existing active replica), the volume still stuck in degrading and live upgrade. The reason is that at this moment, the engine already performed the upgrade and set `replicaModeMap: null` [link](https://github.com/longhorn/longhorn-manager/blob/ae6b6aa99d0e2eb12fd0d868f5e67105bb6b685c/controller/engine_controller.go#L1982). Engine controller is waiting for volume controller to mark the volume as finished live upgrading and clear `e.Spec.UpgradedReplicaAddressMap` the [link](https://github.com/longhorn/longhorn-manager/blob/ae6b6aa99d0e2eb12fd0d868f5e67105bb6b685c/controller/engine_controller.go#L824)
     1. However, volume controller is waiting for engine controller to refresh `e.Status.replicaModeMap` first [link](https://github.com/longhorn/longhorn-manager/blob/ae6b6aa99d0e2eb12fd0d868f5e67105bb6b685c/controller/volume_controller.go#L637) 
     1. The result is deadlock
        ![Screenshot from 2023-12-13 19-35-08](https://github.com/longhorn/longhorn-manager/assets/22139961/9fcaa96a-8e1e-4bfb-9f77-010ad1299e98)

     This PR fixes it so that we when the volume is degraded, even though we don't start the live engine upgrade, try to mark it as finished if it already started. Thus solving the deadlock above

longhorn/longhorn#7012