### PR TITLE
improvement: driver deployer shouldn't cleanup previous deployment if Kubernetes version changes

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -39,9 +39,8 @@ const (
 	DefaultInContainerCSIRegistrationDir = "/registration"
 	DefaultCSILivenessProbePort          = 9808
 
-	AnnotationCSIGitCommit      = types.LonghornDriverName + "/git-commit"
-	AnnotationCSIVersion        = types.LonghornDriverName + "/version"
-	AnnotationKubernetesVersion = types.LonghornDriverName + "/kubernetes-version"
+	AnnotationCSIGitCommit = types.LonghornDriverName + "/git-commit"
+	AnnotationCSIVersion   = types.LonghornDriverName + "/version"
 )
 
 var (


### PR DESCRIPTION
Before this PR:
1. Deploy Longhorn master-head
1. Upgrade Kubernetes 
1. Crash longhorn-driver-deployer pod
1. Observer that the longhorn-driver-deployer clean up and redeploy csi-attacher/csi-provisioner/csi-resizer/csi-snapshotter/longhorn-csi-plugin/Longhorn csidrivers object. This is:
    1. Unnecessary as these components are still up to date 
    2. Even problematic as during this period Kubernetes cannot perform volume attach/detach/mount/unmount thus prevent kubernetes from draining the node

After this PR:

longhorn-driver-deployer does not clean up and redeploy csi-attacher/csi-provisioner/csi-resizer/csi-snapshotter/longhorn-csi-plugin/Longhorn csidrivers object after Kubernetes upgrade

Additional context:

The old behavior of longhorn-driver-deployer was necessary when upgrading Kubernetes from v1.11 to v1.12 (ref https://github.com/longhorn/longhorn/issues/426). However, it is no longer necessary now as we no longer support these Kubernetes versions

longhorn/longhorn#5474