### PR TITLE
Add a startup probe to the longhorn-csi-plugin container

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -344,6 +344,21 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt(DefaultCSILivenessProbePort),
+									},
+								},
+								InitialDelaySeconds: datastore.PodProbeInitialDelay,
+								TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
+								PeriodSeconds:       datastore.PodProbePeriodSeconds,
+								// Ensure we are allowed at least the maximum container restart backoff time (five
+								// minutes) in case the livenessprobe container is in CrashLoopBackoff. See
+								// https://github.com/longhorn/longhorn/issues/7116.
+								FailureThreshold: (300 + datastore.PodProbePeriodSeconds - 1) / datastore.PodProbePeriodSeconds,
+							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
longhorn/longhorn#7116

If we can't get upstream changes in a reasonable amount of time, this works in the interim. It prevents a liveness probe from killing the `longhorn-csi-plugin` container for five minutes so we can get a successful liveness probe when the `livenessprobe` container comes back.