### PR TITLE
fix(node): the deploy driver failed with linkerd

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -931,15 +931,23 @@ func (nc *NodeController) updateDiskStatusSchedulableCondition(node *longhorn.No
 
 func (nc *NodeController) syncNodeStatus(pod *corev1.Pod, node *longhorn.Node) error {
 	// sync bidirectional mount propagation for node status to check whether the node could deploy CSI driver
-	for _, mount := range pod.Spec.Containers[0].VolumeMounts {
+	var mgrContainer *corev1.Container
+	for _, container := range pod.Spec.Containers {
+		if container.Name == types.LonghornManagerContainerName {
+			mgrContainer = &container
+			break
+		}
+	}
+	if mgrContainer == nil {
+		return fmt.Errorf("failed to find the %v container in the pod %v", types.LonghornManagerDaemonSetName, pod.Name)
+	}
+	for _, mount := range mgrContainer.VolumeMounts {
 		if mount.Name == types.LonghornSystemKey {
 			mountPropagationStr := ""
-			if mount.MountPropagation == nil {
-				mountPropagationStr = "nil"
-			} else {
+			if mount.MountPropagation != nil {
 				mountPropagationStr = string(*mount.MountPropagation)
 			}
-			if mount.MountPropagation == nil || *mount.MountPropagation != corev1.MountPropagationBidirectional {
+			if mountPropagationStr != string(corev1.MountPropagationBidirectional) {
 				node.Status.Conditions = types.SetCondition(node.Status.Conditions, longhorn.NodeConditionTypeMountPropagation, longhorn.ConditionStatusFalse,
 					string(longhorn.NodeConditionReasonNoMountPropagationSupport),
 					fmt.Sprintf("The MountPropagation value %s is not detected from pod %s, node %s", mountPropagationStr, pod.Name, pod.Spec.NodeName))

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1173,7 +1173,7 @@ func newDaemonPod(phase corev1.PodPhase, name, namespace, nodeID, podIP string, 
 			NodeName: nodeID,
 			Containers: []corev1.Container{
 				{
-					Name:  "test-container",
+					Name:  "longhorn-manager",
 					Image: TestEngineImage,
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/types/deploy.go
+++ b/types/deploy.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	LonghornManagerDaemonSetName = "longhorn-manager"
+	LonghornManagerContainerName = LonghornManagerDaemonSetName
 	LonghornUIDeploymentName     = "longhorn-ui"
 
 	DriverDeployerName = "longhorn-driver-deployer"


### PR DESCRIPTION
Linkerd will inject a container `linkerd-proxy` in the longhorn-manger pod by adding the annotation `linkerd.io/inject: enabled`. It will fail when we check the `MountPropagation` for the first container that is `linkerd-proxy`. What we want to check is the `longhorn-manager` container.

Ref: longhorn/longhorn#3809