### PR TITLE
ci: add tests for unknown node conditions

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -475,7 +475,7 @@ func newBackup(name string) *longhorn.Backup {
 	}
 }
 
-func newKubernetesNode(name string, readyStatus, diskPressureStatus, memoryStatus, outOfDiskStatus, pidStatus, networkStatus, kubeletStatus corev1.ConditionStatus) *corev1.Node {
+func newKubernetesNode(name string, readyStatus, diskPressureStatus, memoryStatus, pidStatus, networkStatus, kubeletStatus corev1.ConditionStatus) *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -229,7 +229,7 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 
 		// Create Nodes for test. Conditionally add the first Node.
 		if !tc.nodeDown {
-			kubeNode1 := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+			kubeNode1 := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
 			err = kubeNodeIndexer.Add(kubeNode1)
 			c.Assert(err, IsNil)
 			_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode1, metav1.CreateOptions{})
@@ -242,7 +242,7 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 			c.Assert(err, IsNil)
 		}
 
-		kubeNode2 := newKubernetesNode(TestNode2, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode2 := newKubernetesNode(TestNode2, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
 		err = kubeNodeIndexer.Add(kubeNode2)
 		c.Assert(err, IsNil)
 		_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode2, metav1.CreateOptions{})

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -891,8 +891,7 @@ func (s *NodeControllerSuite) TestCreateDefaultInstanceManager(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
 			},
-			Type:   longhorn.DiskTypeFilesystem,
-			FSType: TestDiskPathFSType,
+			Type: longhorn.DiskTypeFilesystem,
 		},
 	}
 
@@ -1007,8 +1006,7 @@ func (s *NodeControllerSuite) TestCleanupRedundantInstanceManagers(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
 			},
-			Type:   longhorn.DiskTypeFilesystem,
-			FSType: TestDiskPathFSType,
+			Type: longhorn.DiskTypeFilesystem,
 		},
 	}
 
@@ -1290,7 +1288,7 @@ func (s *NodeControllerSuite) TestEventOnNotReady(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 			"node1-not-ready": {
 				Type:    "Warning",
@@ -1382,7 +1380,7 @@ func (s *NodeControllerSuite) TestEventOnDiskPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 			"node1-disk-pressure": {
 				Type:    "Warning",
@@ -1474,7 +1472,7 @@ func (s *NodeControllerSuite) TestEventOnMemoryPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 			"node1-memory-pressure": {
 				Type:    "Warning",
@@ -1566,7 +1564,7 @@ func (s *NodeControllerSuite) TestEventOnPidPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 			"node1-pid-pressure": {
 				Type:    "Warning",
@@ -1658,7 +1656,7 @@ func (s *NodeControllerSuite) TestEventOnNetworkPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 			"node1-network-pressure": {
 				Type:    "Warning",
@@ -1756,7 +1754,7 @@ func (s *NodeControllerSuite) TestNoEventOnUnknownTrueNodeCondition(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
 			},
 		},
 	}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -159,13 +159,11 @@ func (s *NodeControllerSuite) TestManagerPodUp(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -244,13 +242,11 @@ func (s *NodeControllerSuite) TestManagerPodDown(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -330,13 +326,11 @@ func (s *NodeControllerSuite) TestKubeNodeDown(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -416,13 +410,11 @@ func (s *NodeControllerSuite) TestKubeNodePressure(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -531,13 +523,11 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -671,13 +661,11 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -814,13 +802,11 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -935,13 +921,11 @@ func (s *NodeControllerSuite) TestCreateDefaultInstanceManager(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -1074,13 +1058,11 @@ func (s *NodeControllerSuite) TestCleanupRedundantInstanceManagers(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -1184,13 +1166,11 @@ func (s *NodeControllerSuite) TestCleanupAllInstanceManagers(c *C) {
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
-				corev1.ConditionFalse,
 				corev1.ConditionTrue,
 			),
 			TestNode2: newKubernetesNode(
 				TestNode2,
 				corev1.ConditionTrue,
-				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
 				corev1.ConditionFalse,
@@ -1243,13 +1223,472 @@ func (s *NodeControllerSuite) TestCleanupAllInstanceManagers(c *C) {
 	s.checkInstanceManagers(c, expectation)
 }
 
+func (s *NodeControllerSuite) TestEventOnNotReady(c *C) {
+	var err error
+
+	node1 := newKubernetesNode(
+		TestNode1,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	node2 := newKubernetesNode(
+		TestNode2,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode1: newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+			TestNode2: newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		lhInstanceManagers: map[string]*longhorn.InstanceManager{
+			TestInstanceManagerName: DefaultInstanceManagerTestNode1,
+		},
+		lhOrphans: map[string]*longhorn.Orphan{
+			DefaultOrphanTestNode1.Name: DefaultOrphanTestNode1,
+		},
+		pods: map[string]*corev1.Pod{
+			TestDaemon1: newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, &MountPropagationBidirectional),
+			TestDaemon2: newDaemonPod(corev1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2, &MountPropagationBidirectional),
+		},
+		nodes: map[string]*corev1.Node{
+			TestNode1: node1,
+			TestNode2: node2,
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		events: map[string]*corev1.Event{
+			"node1-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-1 is ready",
+			},
+			"node2-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-2 is ready",
+			},
+			"node-schedulable": {
+				Type:    "Normal",
+				Reason:  "Schedulable",
+				Message: "",
+			},
+			"": {
+				Type:    "Warning",
+				Reason:  "Schedulable",
+				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+			},
+			"node1-not-ready": {
+				Type:    "Warning",
+				Reason:  "Ready",
+				Message: "Kubernetes node test-node-name-1 not ready",
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	for _, node := range fixture.lhNodes {
+		if s.controller.controllerID == node.Name {
+			err = s.controller.diskMonitor.RunOnce()
+			c.Assert(err, IsNil)
+		}
+
+		err = s.controller.syncNode(getKey(node, c))
+		c.Assert(err, IsNil)
+	}
+
+	s.checkEvents(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestEventOnDiskPressure(c *C) {
+	var err error
+
+	node1 := newKubernetesNode(
+		TestNode1,
+		corev1.ConditionTrue,
+		corev1.ConditionTrue,  // disk
+		corev1.ConditionFalse, // memory
+		corev1.ConditionFalse, // pid
+		corev1.ConditionFalse, // network
+		corev1.ConditionTrue,
+	)
+
+	node2 := newKubernetesNode(
+		TestNode2,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode1: newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+			TestNode2: newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		lhInstanceManagers: map[string]*longhorn.InstanceManager{
+			TestInstanceManagerName: DefaultInstanceManagerTestNode1,
+		},
+		lhOrphans: map[string]*longhorn.Orphan{
+			DefaultOrphanTestNode1.Name: DefaultOrphanTestNode1,
+		},
+		pods: map[string]*corev1.Pod{
+			TestDaemon1: newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, &MountPropagationBidirectional),
+			TestDaemon2: newDaemonPod(corev1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2, &MountPropagationBidirectional),
+		},
+		nodes: map[string]*corev1.Node{
+			TestNode1: node1,
+			TestNode2: node2,
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		events: map[string]*corev1.Event{
+			"node1-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-1 is ready",
+			},
+			"node2-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-2 is ready",
+			},
+			"node-schedulable": {
+				Type:    "Normal",
+				Reason:  "Schedulable",
+				Message: "",
+			},
+			"": {
+				Type:    "Warning",
+				Reason:  "Schedulable",
+				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+			},
+			"node1-disk-pressure": {
+				Type:    "Warning",
+				Reason:  "Ready",
+				Message: "Kubernetes node test-node-name-1 has pressure",
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	for _, node := range fixture.lhNodes {
+		if s.controller.controllerID == node.Name {
+			err = s.controller.diskMonitor.RunOnce()
+			c.Assert(err, IsNil)
+		}
+
+		err = s.controller.syncNode(getKey(node, c))
+		c.Assert(err, IsNil)
+	}
+
+	s.checkEvents(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestEventOnMemoryPressure(c *C) {
+	var err error
+
+	node1 := newKubernetesNode(
+		TestNode1,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse, // disk
+		corev1.ConditionTrue,  // memory
+		corev1.ConditionFalse, // pid
+		corev1.ConditionFalse, // network
+		corev1.ConditionTrue,
+	)
+
+	node2 := newKubernetesNode(
+		TestNode2,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode1: newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+			TestNode2: newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		lhInstanceManagers: map[string]*longhorn.InstanceManager{
+			TestInstanceManagerName: DefaultInstanceManagerTestNode1,
+		},
+		lhOrphans: map[string]*longhorn.Orphan{
+			DefaultOrphanTestNode1.Name: DefaultOrphanTestNode1,
+		},
+		pods: map[string]*corev1.Pod{
+			TestDaemon1: newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, &MountPropagationBidirectional),
+			TestDaemon2: newDaemonPod(corev1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2, &MountPropagationBidirectional),
+		},
+		nodes: map[string]*corev1.Node{
+			TestNode1: node1,
+			TestNode2: node2,
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		events: map[string]*corev1.Event{
+			"node1-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-1 is ready",
+			},
+			"node2-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-2 is ready",
+			},
+			"node-schedulable": {
+				Type:    "Normal",
+				Reason:  "Schedulable",
+				Message: "",
+			},
+			"": {
+				Type:    "Warning",
+				Reason:  "Schedulable",
+				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+			},
+			"node1-memory-pressure": {
+				Type:    "Warning",
+				Reason:  "Ready",
+				Message: "Kubernetes node test-node-name-1 has pressure",
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	for _, node := range fixture.lhNodes {
+		if s.controller.controllerID == node.Name {
+			err = s.controller.diskMonitor.RunOnce()
+			c.Assert(err, IsNil)
+		}
+
+		err = s.controller.syncNode(getKey(node, c))
+		c.Assert(err, IsNil)
+	}
+
+	s.checkEvents(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestEventOnPidPressure(c *C) {
+	var err error
+
+	node1 := newKubernetesNode(
+		TestNode1,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse, // disk
+		corev1.ConditionFalse, // memory
+		corev1.ConditionTrue,  // pid
+		corev1.ConditionFalse, // network
+		corev1.ConditionTrue,
+	)
+
+	node2 := newKubernetesNode(
+		TestNode2,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode1: newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+			TestNode2: newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		lhInstanceManagers: map[string]*longhorn.InstanceManager{
+			TestInstanceManagerName: DefaultInstanceManagerTestNode1,
+		},
+		lhOrphans: map[string]*longhorn.Orphan{
+			DefaultOrphanTestNode1.Name: DefaultOrphanTestNode1,
+		},
+		pods: map[string]*corev1.Pod{
+			TestDaemon1: newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, &MountPropagationBidirectional),
+			TestDaemon2: newDaemonPod(corev1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2, &MountPropagationBidirectional),
+		},
+		nodes: map[string]*corev1.Node{
+			TestNode1: node1,
+			TestNode2: node2,
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		events: map[string]*corev1.Event{
+			"node1-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-1 is ready",
+			},
+			"node2-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-2 is ready",
+			},
+			"node-schedulable": {
+				Type:    "Normal",
+				Reason:  "Schedulable",
+				Message: "",
+			},
+			"": {
+				Type:    "Warning",
+				Reason:  "Schedulable",
+				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+			},
+			"node1-pid-pressure": {
+				Type:    "Warning",
+				Reason:  "Ready",
+				Message: "Kubernetes node test-node-name-1 has pressure",
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	for _, node := range fixture.lhNodes {
+		if s.controller.controllerID == node.Name {
+			err = s.controller.diskMonitor.RunOnce()
+			c.Assert(err, IsNil)
+		}
+
+		err = s.controller.syncNode(getKey(node, c))
+		c.Assert(err, IsNil)
+	}
+
+	s.checkEvents(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestEventOnNetworkPressure(c *C) {
+	var err error
+
+	node1 := newKubernetesNode(
+		TestNode1,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse, // disk
+		corev1.ConditionFalse, // memory
+		corev1.ConditionFalse, // pid
+		corev1.ConditionTrue,  // network
+		corev1.ConditionTrue,
+	)
+
+	node2 := newKubernetesNode(
+		TestNode2,
+		corev1.ConditionTrue,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionFalse,
+		corev1.ConditionTrue,
+	)
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode1: newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+			TestNode2: newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, ""),
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		lhInstanceManagers: map[string]*longhorn.InstanceManager{
+			TestInstanceManagerName: DefaultInstanceManagerTestNode1,
+		},
+		lhOrphans: map[string]*longhorn.Orphan{
+			DefaultOrphanTestNode1.Name: DefaultOrphanTestNode1,
+		},
+		pods: map[string]*corev1.Pod{
+			TestDaemon1: newDaemonPod(corev1.PodRunning, TestDaemon1, TestNamespace, TestNode1, TestIP1, &MountPropagationBidirectional),
+			TestDaemon2: newDaemonPod(corev1.PodRunning, TestDaemon2, TestNamespace, TestNode2, TestIP2, &MountPropagationBidirectional),
+		},
+		nodes: map[string]*corev1.Node{
+			TestNode1: node1,
+			TestNode2: node2,
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		events: map[string]*corev1.Event{
+			"node1-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-1 is ready",
+			},
+			"node2-ready": {
+				Type:    "Normal",
+				Reason:  "Ready",
+				Message: "Node test-node-name-2 is ready",
+			},
+			"node-schedulable": {
+				Type:    "Normal",
+				Reason:  "Schedulable",
+				Message: "",
+			},
+			"": {
+				Type:    "Warning",
+				Reason:  "Schedulable",
+				Message: "the disk fsid(/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+			},
+			"node1-network-pressure": {
+				Type:    "Warning",
+				Reason:  "Ready",
+				Message: "Kubernetes node test-node-name-1 has pressure",
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	for _, node := range fixture.lhNodes {
+		if s.controller.controllerID == node.Name {
+			err = s.controller.diskMonitor.RunOnce()
+			c.Assert(err, IsNil)
+		}
+
+		err = s.controller.syncNode(getKey(node, c))
+		c.Assert(err, IsNil)
+	}
+
+	s.checkEvents(c, expectation)
+}
+
 func (s *NodeControllerSuite) TestNoEventOnUnknownTrueNodeCondition(c *C) {
 	var err error
 
 	node1 := newKubernetesNode(
 		TestNode1,
 		corev1.ConditionTrue,
-		corev1.ConditionFalse,
 		corev1.ConditionFalse,
 		corev1.ConditionFalse,
 		corev1.ConditionFalse,
@@ -1266,7 +1705,6 @@ func (s *NodeControllerSuite) TestNoEventOnUnknownTrueNodeCondition(c *C) {
 	node2 := newKubernetesNode(
 		TestNode2,
 		corev1.ConditionTrue,
-		corev1.ConditionFalse,
 		corev1.ConditionFalse,
 		corev1.ConditionFalse,
 		corev1.ConditionFalse,

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1405,7 +1405,7 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 			if condition.Status != longhorn.ConditionStatusTrue {
 				knodeCondition = corev1.ConditionFalse
 			}
-			knode := newKubernetesNode(node.Name, knodeCondition, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+			knode := newKubernetesNode(node.Name, knodeCondition, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
 			kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
 			c.Assert(err, IsNil)
 			err = knIndexer.Add(kn)


### PR DESCRIPTION
Add test ensuring that an unknown node condition does not emit a K8s event.

related-to: longhorn/longhorn#7290