### PR TITLE
feat(setting): lazy update for volume-related settings

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -134,6 +134,7 @@ func ParseResourceRequirement(val string) (*corev1.ResourceRequirements, error) 
 	}, nil
 }
 
+// GetInstanceManagerCPURequirement returns the instance manager CPU requirement
 func GetInstanceManagerCPURequirement(ds *datastore.DataStore, imName string) (*corev1.ResourceRequirements, error) {
 	im, err := ds.GetInstanceManager(imName)
 	if err != nil {
@@ -210,6 +211,7 @@ func EnhancedDefaultControllerRateLimiter() workqueue.RateLimiter {
 	)
 }
 
+// IsSameGuaranteedCPURequirement returns true if the resource requirement a is equal to the resource requirement b
 func IsSameGuaranteedCPURequirement(a, b *corev1.ResourceRequirements) bool {
 	var aQ, bQ resource.Quantity
 	if a != nil && a.Requests != nil {

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/longhorn/longhorn-manager/datastore"
@@ -272,6 +273,12 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 
 		if tc.currentPodStatus != nil {
 			pod := newPod(tc.currentPodStatus, im.Name, im.Namespace, im.Spec.NodeID)
+			var containers []corev1.Container
+			containers = append(containers, corev1.Container{
+				Name:      "instance-manager",
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("480m")}}},
+			)
+			pod.Spec.Containers = containers
 			err = pIndexer.Add(pod)
 			c.Assert(err, IsNil)
 			_, err = kubeClient.CoreV1().Pods(im.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
-	monitor "github.com/longhorn/longhorn-manager/controller/monitor"
+	"github.com/longhorn/longhorn-manager/controller/monitor"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
@@ -1003,7 +1003,7 @@ func (nc *NodeController) getImTypeDataEngines(node *longhorn.Node) map[longhorn
 				dataEngines[longhorn.InstanceManagerTypeReplica] = append(dataEngines[longhorn.InstanceManagerTypeReplica], longhorn.DataEngineTypeV1)
 			}
 		case types.SettingNameV2DataEngine:
-			if err := nc.ds.ValidateV2DataEngineEnabled(enabled); err == nil {
+			if _, err := nc.ds.ValidateV2DataEngineEnabled(enabled); err == nil {
 				dataEngines[longhorn.InstanceManagerTypeAllInOne] = append(dataEngines[longhorn.InstanceManagerTypeAllInOne], longhorn.DataEngineTypeV2)
 			} else {
 				log.WithError(err).Warnf("Failed to validate %v setting", types.SettingNameV2DataEngine)

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2801,6 +2801,7 @@ spec:
           metadata:
             type: object
           value:
+            description: The value of the setting.
             type: string
         required:
         - value

--- a/k8s/pkg/apis/longhorn/v1beta2/setting.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/setting.go
@@ -15,6 +15,7 @@ type Setting struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// The value of the setting.
 	Value string `json:"value"`
 }
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -16,6 +16,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/longhorn/longhorn-manager/meta"
 	"github.com/longhorn/longhorn-manager/util"
 
@@ -1164,7 +1166,7 @@ var (
 		DisplayName: "V1 Data Engine",
 		Description: "Setting that allows you to enable the V1 Data Engine. \n\n" +
 			"  - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached volumes. \n\n",
-		Category: SettingCategoryGeneral,
+		Category: SettingCategoryDangerZone,
 		Type:     SettingTypeBool,
 		Required: true,
 		ReadOnly: false,
@@ -1177,7 +1179,7 @@ var (
 			"  - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached volumes. \n\n" +
 			"  - When applying the setting, Longhorn will restart all instance-manager pods. \n\n" +
 			"  - When the V2 Data Engine is enabled, each instance-manager pod utilizes 1 CPU core. This high CPU usage is attributed to the spdk_tgt process running within each instance-manager pod. The spdk_tgt process is responsible for handling input/output (IO) operations and requires intensive polling. As a result, it consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations. \n\n",
-		Category: SettingCategoryV2DataEngine,
+		Category: SettingCategoryDangerZone,
 		Type:     SettingTypeBool,
 		Required: true,
 		ReadOnly: false,
@@ -1201,7 +1203,7 @@ var (
 			"  - Value 0 means unsetting CPU requests for instance manager pods for v2 data engine. \n\n" +
 			"  - This integer value is range from 1000 to 8000. \n\n" +
 			"  - After this setting is changed, all instance manager pods using this global setting on all the nodes will be automatically restarted. In other words, DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. \n\n",
-		Category: SettingCategoryV2DataEngine,
+		Category: SettingCategoryDangerZone,
 		Type:     SettingTypeInt,
 		Required: true,
 		ReadOnly: false,
@@ -1725,4 +1727,15 @@ func SetSettingDefinition(name SettingName, definition SettingDefinition) {
 	settingDefinitionsLock.Lock()
 	defer settingDefinitionsLock.Unlock()
 	settingDefinitions[name] = definition
+}
+
+func GetDangerZoneSettings() sets.Set[SettingName] {
+	settingList := sets.New[SettingName]()
+	for settingName, setting := range settingDefinitions {
+		if setting.Category == SettingCategoryDangerZone {
+			settingList = settingList.Insert(settingName)
+		}
+	}
+
+	return settingList
 }

--- a/webhook/resources/systemrestore/validator.go
+++ b/webhook/resources/systemrestore/validator.go
@@ -42,7 +42,7 @@ func (v *systemRestoreValidator) Create(request *admission.Request, newObj runti
 		return werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.SystemRestore", newObj), "")
 	}
 
-	areAllVolumesDetached, err := v.ds.AreAllVolumesDetached(longhorn.DataEngineTypeAll)
+	areAllVolumesDetached, _, err := v.ds.AreAllVolumesDetached(longhorn.DataEngineTypeAll)
 	if err != nil {
 		return werror.NewInvalidError(err.Error(), "")
 	}


### PR DESCRIPTION
For settings `taint-toleration`, `guaranteed-instance-manager-cpu`, `system-managed-components-node-selector`, and `priority-class`, users can customize the settings, and the settings will only take effect when all volumes are detached.

Ref: longhorn/longhorn#7173