### PR TITLE
Handling of 16TiB+ volumes with ext4 as the underlying file system

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -107,6 +107,8 @@ const (
 
 	TestCustomResourceDefinitionName = "test-crd"
 	TestVolumeAttachmentName         = "test-volume"
+
+	TestDiskPathFSType = "ext4"
 )
 
 var (
@@ -539,6 +541,7 @@ func newNode(name, namespace string, allowScheduling bool, status longhorn.Condi
 					},
 					DiskUUID: TestDiskID1,
 					Type:     longhorn.DiskTypeFilesystem,
+					FSType:   TestDiskPathFSType,
 				},
 			},
 		},

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -720,7 +720,7 @@ func (nc *NodeController) syncDiskStatus(node *longhorn.Node, collectedDataInfo 
 
 	for _, diskInfoMap := range readyDiskInfoMap {
 		nc.updateReadyDiskStatusReadyCondition(node, diskInfoMap)
-		nc.updateReadyDiskStatusFileSystemType(node, diskInfoMap)
+		nc.updateDiskStatusFileSystemType(node, diskInfoMap)
 	}
 
 	return nc.updateDiskStatusSchedulableCondition(node)
@@ -843,7 +843,7 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 	}
 }
 
-func (nc *NodeController) updateReadyDiskStatusFileSystemType(node *longhorn.Node, diskInfoMap map[string]*monitor.CollectedDiskInfo) {
+func (nc *NodeController) updateDiskStatusFileSystemType(node *longhorn.Node, diskInfoMap map[string]*monitor.CollectedDiskInfo) {
 	diskStatusMap := node.Status.DiskStatus
 	for diskName, info := range diskInfoMap {
 		diskStatus := diskStatusMap[diskName]

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -720,6 +720,7 @@ func (nc *NodeController) syncDiskStatus(node *longhorn.Node, collectedDataInfo 
 
 	for _, diskInfoMap := range readyDiskInfoMap {
 		nc.updateReadyDiskStatusReadyCondition(node, diskInfoMap)
+		nc.updateReadyDiskStatusFileSystemType(node, diskInfoMap)
 	}
 
 	return nc.updateDiskStatusSchedulableCondition(node)
@@ -837,6 +838,17 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 				longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue,
 				"", fmt.Sprintf("Disk %v(%v) on node %v is ready", diskName, diskInfoMap[diskName].Path, node.Name),
 				nc.eventRecorder, node, corev1.EventTypeNormal)
+		}
+		diskStatusMap[diskName] = diskStatus
+	}
+}
+
+func (nc *NodeController) updateReadyDiskStatusFileSystemType(node *longhorn.Node, diskInfoMap map[string]*monitor.CollectedDiskInfo) {
+	diskStatusMap := node.Status.DiskStatus
+	for diskName, info := range diskInfoMap {
+		diskStatus := diskStatusMap[diskName]
+		if diskStatus.DiskUUID == info.DiskUUID && diskStatus.Type == longhorn.DiskTypeFilesystem {
+			diskStatus.FSType = info.DiskStat.Type
 		}
 		diskStatusMap[diskName] = diskStatus
 	}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -472,6 +472,7 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 			StorageScheduled: 0,
 			StorageAvailable: 0,
 			Type:             longhorn.DiskTypeFilesystem,
+			FSType:           TestDiskPathFSType,
 		},
 	}
 	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
@@ -482,7 +483,8 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusUnknown, ""),
 			},
-			Type: longhorn.DiskTypeFilesystem,
+			Type:   longhorn.DiskTypeFilesystem,
+			FSType: TestDiskPathFSType,
 		},
 	}
 
@@ -555,6 +557,7 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 						},
 						DiskUUID: TestDiskID1,
 						Type:     longhorn.DiskTypeFilesystem,
+						FSType:   TestDiskPathFSType,
 					},
 				},
 			},
@@ -570,7 +573,8 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 						Conditions: []longhorn.Condition{
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusUnknown, ""),
 						},
-						Type: longhorn.DiskTypeFilesystem,
+						Type:   longhorn.DiskTypeFilesystem,
+						FSType: TestDiskPathFSType,
 					},
 				},
 			},
@@ -627,6 +631,7 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 			StorageScheduled: 0,
 			StorageAvailable: 0,
 			Type:             longhorn.DiskTypeFilesystem,
+			FSType:           TestDiskPathFSType,
 		},
 	}
 
@@ -691,6 +696,7 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 						ScheduledReplica: map[string]int64{},
 						DiskUUID:         TestDiskID1,
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},
@@ -704,6 +710,7 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 						StorageScheduled: 0,
 						StorageAvailable: 0,
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},
@@ -757,6 +764,7 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 			},
 			DiskUUID: "new-uuid",
 			Type:     longhorn.DiskTypeFilesystem,
+			FSType:   TestDiskPathFSType,
 		},
 	}
 
@@ -766,6 +774,7 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 			StorageScheduled: 0,
 			StorageAvailable: 0,
 			Type:             longhorn.DiskTypeFilesystem,
+			FSType:           TestDiskPathFSType,
 		},
 	}
 
@@ -830,6 +839,7 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 						ScheduledReplica: map[string]int64{},
 						DiskUUID:         "new-uuid",
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},
@@ -843,6 +853,7 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 						StorageScheduled: 0,
 						StorageAvailable: 0,
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},
@@ -884,7 +895,8 @@ func (s *NodeControllerSuite) TestCreateDefaultInstanceManager(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
 			},
-			Type: longhorn.DiskTypeFilesystem,
+			Type:   longhorn.DiskTypeFilesystem,
+			FSType: TestDiskPathFSType,
 		},
 	}
 
@@ -948,6 +960,7 @@ func (s *NodeControllerSuite) TestCreateDefaultInstanceManager(c *C) {
 						ScheduledReplica: map[string]int64{},
 						DiskUUID:         TestDiskID1,
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},
@@ -1000,7 +1013,8 @@ func (s *NodeControllerSuite) TestCleanupRedundantInstanceManagers(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
 			},
-			Type: longhorn.DiskTypeFilesystem,
+			Type:   longhorn.DiskTypeFilesystem,
+			FSType: TestDiskPathFSType,
 		},
 	}
 
@@ -1085,6 +1099,7 @@ func (s *NodeControllerSuite) TestCleanupRedundantInstanceManagers(c *C) {
 						ScheduledReplica: map[string]int64{},
 						DiskUUID:         TestDiskID1,
 						Type:             longhorn.DiskTypeFilesystem,
+						FSType:           TestDiskPathFSType,
 					},
 				},
 			},

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4881,3 +4881,15 @@ func IsBackendStoreDriverV1(backendstoreDriver longhorn.BackendStoreDriverType) 
 func IsBackendStoreDriverV2(backendstoreDriver longhorn.BackendStoreDriverType) bool {
 	return backendstoreDriver == longhorn.BackendStoreDriverTypeV2
 }
+
+// IsSupportedVolumeSize returns turn if the v1 volume size is supported by the given fsType file system.
+func IsSupportedVolumeSize(backendstoreDriver longhorn.BackendStoreDriverType, fsType string, volumeSize int64) bool {
+	// TODO: check the logical volume maximum size limit
+	if IsBackendStoreDriverV1(backendstoreDriver) {
+		// unix.Statfs can not differentiate the ext2/ext3/ext4 file systems.
+		if (strings.HasPrefix(fsType, "ext") && volumeSize >= util.MaxExt4VolumeSize) || (fsType == "xfs" && volumeSize >= util.MaxXfsVolumeSize) {
+			return false
+		}
+	}
+	return true
+}

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2019,6 +2019,8 @@ spec:
                       type: string
                     diskUUID:
                       type: string
+                    filesystemType:
+                      type: string
                     scheduledReplica:
                       additionalProperties:
                         format: int64

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -93,6 +93,8 @@ type DiskStatus struct {
 	DiskUUID string `json:"diskUUID"`
 	// +optional
 	Type DiskType `json:"diskType"`
+	// +optional
+	FSType string `json:"filesystemType"`
 }
 
 // NodeSpec defines the desired state of the Longhorn node

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -317,6 +318,13 @@ func (rcs *ReplicaScheduler) filterNodeDisksForReplica(node *longhorn.Node, disk
 		if !(datastore.IsBackendStoreDriverV1(volume.Spec.BackendStoreDriver) && diskSpec.Type == longhorn.DiskTypeFilesystem) &&
 			!(datastore.IsBackendStoreDriverV2(volume.Spec.BackendStoreDriver) && diskSpec.Type == longhorn.DiskTypeBlock) {
 			logrus.Debugf("Volume %v is not compatible with disk %v", volume.Name, diskName)
+			continue
+		}
+
+		volumeSize := volume.Spec.Size
+		// unix.Statfs can not differentiate the ext2/ext3/ext4 file systems.
+		if (strings.HasPrefix(diskStatus.FSType, "ext") && volumeSize >= util.MaxExt4VolumeSize) || (diskStatus.FSType == "xfs" && volumeSize >= util.MaxXfsVolumeSize) {
+			logrus.Debugf("Volume %v size %v is not compatible with the file system %v of the disk %v", volume.Name, volume.Spec.Size, diskStatus.Type, diskName)
 			continue
 		}
 

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -321,9 +320,7 @@ func (rcs *ReplicaScheduler) filterNodeDisksForReplica(node *longhorn.Node, disk
 			continue
 		}
 
-		volumeSize := volume.Spec.Size
-		// unix.Statfs can not differentiate the ext2/ext3/ext4 file systems.
-		if (strings.HasPrefix(diskStatus.FSType, "ext") && volumeSize >= util.MaxExt4VolumeSize) || (diskStatus.FSType == "xfs" && volumeSize >= util.MaxXfsVolumeSize) {
+		if !datastore.IsSupportedVolumeSize(volume.Spec.BackendStoreDriver, diskStatus.FSType, volume.Spec.Size) {
 			logrus.Debugf("Volume %v size %v is not compatible with the file system %v of the disk %v", volume.Name, volume.Spec.Size, diskStatus.Type, diskName)
 			continue
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -51,6 +51,13 @@ import (
 )
 
 const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+	EiB = 1024 * PiB
+
 	VolumeStackPrefix     = "volume-"
 	ControllerServiceName = "controller"
 	ReplicaServiceName    = "replica"
@@ -66,6 +73,9 @@ const (
 
 	SizeAlignment     = 2 * 1024 * 1024
 	MinimalVolumeSize = 10 * 1024 * 1024
+
+	MaxExt4VolumeSize = 16 * TiB
+	MaxXfsVolumeSize  = 8*EiB - 1
 
 	RandomIDLenth = 8
 

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -341,6 +341,23 @@ func (v *volumeValidator) validateExpansionSize(oldVolume *longhorn.Volume, newV
 		return fmt.Errorf("shrinking volume %v size from %v to %v is not supported", newVolume.Name, oldSize, newSize)
 	}
 
+	replicas, err := v.ds.ListVolumeReplicasRO(newVolume.Name)
+	if err != nil {
+		return err
+	}
+	for _, replica := range replicas {
+		diskUUID := replica.Spec.DiskID
+		node, diskName, err := v.ds.GetReadyDiskNode(diskUUID)
+		if err != nil {
+			return err
+		}
+		diskStatus := node.Status.DiskStatus[diskName]
+		if !datastore.IsSupportedVolumeSize(replica.Spec.BackendStoreDriver, diskStatus.FSType, newSize) {
+			return fmt.Errorf("file system %s does not support volume size %v", diskStatus.Type, newSize)
+		}
+		break
+	}
+
 	newKubernetesStatus := &newVolume.Status.KubernetesStatus
 	namespace := newKubernetesStatus.Namespace
 	pvcName := newKubernetesStatus.PVCName


### PR DESCRIPTION
Get the storage class of the PVC to check if the new volume size is bigger than the maximum size of the file system in the storage class for the volume expansion.

If the file system format of the disk is `ext4` and the volume size of this replica is bigger than 16TiB, it will not schedule replicas to this disk.

Ref: longhorn/longhorn#7423