### PR TITLE
webhook: Disable the engine image check for v2 volume

### DIFF
--- a/webhook/resources/engine/validator.go
+++ b/webhook/resources/engine/validator.go
@@ -66,8 +66,10 @@ func (e *engineValidator) Create(request *admission.Request, newObj runtime.Obje
 		}
 	}
 
-	if err := e.ds.CheckEngineImageCompatiblityByImage(engine.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "engine.spec.image")
+	if datastore.IsBackendStoreDriverV1(engine.Spec.BackendStoreDriver) {
+		if err := e.ds.CheckEngineImageCompatiblityByImage(engine.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "engine.spec.image")
+		}
 	}
 
 	return e.validateNumberOfEngines(engine, volume)
@@ -90,8 +92,10 @@ func (e *engineValidator) Update(request *admission.Request, oldObj runtime.Obje
 		}
 	}
 
-	if err := e.ds.CheckEngineImageCompatiblityByImage(newEngine.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "engine.spec.image")
+	if datastore.IsBackendStoreDriverV1(newEngine.Spec.BackendStoreDriver) {
+		if err := e.ds.CheckEngineImageCompatiblityByImage(newEngine.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "engine.spec.image")
+		}
 	}
 
 	return nil

--- a/webhook/resources/replica/validator.go
+++ b/webhook/resources/replica/validator.go
@@ -57,8 +57,10 @@ func (r *replicaValidator) Create(request *admission.Request, newObj runtime.Obj
 		}
 	}
 
-	if err := r.ds.CheckEngineImageCompatiblityByImage(replica.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "replica.spec.image")
+	if datastore.IsBackendStoreDriverV1(replica.Spec.BackendStoreDriver) {
+		if err := r.ds.CheckEngineImageCompatiblityByImage(replica.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "replica.spec.image")
+		}
 	}
 
 	return nil
@@ -80,8 +82,10 @@ func (r *replicaValidator) Update(request *admission.Request, oldObj runtime.Obj
 		}
 	}
 
-	if err := r.ds.CheckEngineImageCompatiblityByImage(newReplica.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "replica.spec.image")
+	if datastore.IsBackendStoreDriverV1(newReplica.Spec.BackendStoreDriver) {
+		if err := r.ds.CheckEngineImageCompatiblityByImage(newReplica.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "replica.spec.image")
+		}
 	}
 
 	return nil

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -151,8 +151,10 @@ func (v *volumeValidator) Create(request *admission.Request, newObj runtime.Obje
 		}
 	}
 
-	if err := v.ds.CheckEngineImageCompatiblityByImage(volume.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "volume.spec.image")
+	if datastore.IsBackendStoreDriverV1(volume.Spec.BackendStoreDriver) {
+		if err := v.ds.CheckEngineImageCompatiblityByImage(volume.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "volume.spec.image")
+		}
 	}
 
 	return nil
@@ -204,8 +206,10 @@ func (v *volumeValidator) Update(request *admission.Request, oldObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "")
 	}
 
-	if err := v.ds.CheckEngineImageCompatiblityByImage(newVolume.Spec.Image); err != nil {
-		return werror.NewInvalidError(err.Error(), "volume.spec.image")
+	if datastore.IsBackendStoreDriverV1(newVolume.Spec.BackendStoreDriver) {
+		if err := v.ds.CheckEngineImageCompatiblityByImage(newVolume.Spec.Image); err != nil {
+			return werror.NewInvalidError(err.Error(), "volume.spec.image")
+		}
 	}
 
 	if newVolume.Spec.DataLocality == longhorn.DataLocalityStrictLocal {


### PR DESCRIPTION
Otherwise, creating, updating, and deleting v2 volumes will get stuck