### PR TITLE
feat(instance status): reset instance error status when it is not running

### DIFF
--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imapi "github.com/longhorn/longhorn-instance-manager/pkg/api"
+	imtypes "github.com/longhorn/longhorn-instance-manager/pkg/types"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
@@ -79,6 +80,10 @@ func newEngine(name, currentImage, imName, nodeName, ip string, port int, starte
 	var conditions []longhorn.Condition
 	conditions = types.SetCondition(conditions,
 		longhorn.InstanceConditionTypeInstanceCreation, longhorn.ConditionStatusTrue,
+		"", "")
+
+	conditions = types.SetCondition(conditions,
+		imtypes.EngineConditionFilesystemReadOnly, longhorn.ConditionStatusFalse,
 		"", "")
 
 	return &longhorn.Engine{


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6386

When the pod is recreated and the engine is relaunched
There might be a time gap that the error condition is not sync from the instance-manager and remains `error=true`
And keep requesting remount.

Should reset error condition when the instance is not running