### PR TITLE
fix(util): resource name should only contain lower case

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4137,7 +4137,7 @@ func ValidateRecurringJob(job longhorn.RecurringJobSpec) error {
 		return fmt.Errorf("job name %v must be %v characters or less", job.Name, NameMaximumLength)
 	}
 	for _, group := range job.Groups {
-		if !util.ValidateName(group) {
+		if !util.ValidateString(group) {
 			return fmt.Errorf("invalid group name %v", group)
 		}
 	}

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -158,7 +158,9 @@ func parseBackupVolumeNamesList(output string) ([]string, error) {
 
 	volumeNames := []string{}
 	for volumeName := range data {
-		volumeNames = append(volumeNames, volumeName)
+		if util.ValidateName(volumeName) {
+			volumeNames = append(volumeNames, volumeName)
+		}
 	}
 	sort.Strings(volumeNames)
 	return volumeNames, nil

--- a/util/util.go
+++ b/util/util.go
@@ -261,8 +261,13 @@ func TimestampWithinLimit(latest time.Time, ts string, limit time.Duration) bool
 	return deadline.After(latest)
 }
 
-func ValidateName(name string) bool {
+func ValidateString(name string) bool {
 	validName := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+	return validName.MatchString(name)
+}
+
+func ValidateName(name string) bool {
+	validName := regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]+$`)
 	return validName.MatchString(name)
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
ref: https://github.com/longhorn/longhorn/issues/7543

#### What this PR does / why we need it:

> K8s resource name should follow the following constraints
> - contain at most 63 characters
> - contain only lowercase alphanumeric characters or '-'
> - start with an alphanumeric character
> - end with an alphanumeric character

But our regex allows uppper case which is invalid.
Also add the validation to the BackupVolume vame list, so it won't create BackupVolume with invalid name.

#### Special notes for your reviewer:
This util function is mostly used in webhook validation so it won't effect those functions
The only part effected is the group name of the recurring job. It is okay to have uppercase, so I create another util function `ValidateString()` for it.

![Screenshot from 2024-01-05 11-55-43](https://github.com/longhorn/longhorn-manager/assets/7100904/3d6b234d-23da-4d9b-aff4-934c0e900f38)


#### Additional documentation or context
