### PR TITLE
Be more careful while cleaning up stale replicas

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1893,9 +1893,7 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 					return
 				}
 
-				now := util.Now()
-				replica.Spec.FailedAt = now
-				replica.Spec.LastFailedAt = now
+				setReplicaFailedAt(replica, util.Now())
 				replica.Spec.DesireState = longhorn.InstanceStateStopped
 				if _, err := ec.ds.UpdateReplica(replica); err != nil {
 					log.WithError(err).Errorf("Unable to mark failed rebuild on replica %v", replicaName)

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1893,7 +1893,9 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 					return
 				}
 
-				replica.Spec.FailedAt = util.Now()
+				now := util.Now()
+				replica.Spec.FailedAt = now
+				replica.Spec.LastFailedAt = now
 				replica.Spec.DesireState = longhorn.InstanceStateStopped
 				if _, err := ec.ds.UpdateReplica(replica); err != nil {
 					log.WithError(err).Errorf("Unable to mark failed rebuild on replica %v", replicaName)

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -72,3 +72,12 @@ func handleReconcileErrorLogging(logger logrus.FieldLogger, err error, mesg stri
 		logger.WithError(err).Error(mesg)
 	}
 }
+
+// r.Spec.FailedAt and r.Spec.LastFailedAt should both be set when a replica failure occurs.
+// r.Spec.FailedAt may be cleared (before rebuilding), but r.Spec.LastFailedAt must not be.
+func setReplicaFailedAt(r *longhorn.Replica, timestamp string) {
+	r.Spec.FailedAt = timestamp
+	if timestamp != "" {
+		r.Spec.LastFailedAt = timestamp
+	}
+}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -916,6 +916,7 @@ func isDefinitelyHealthyAndActiveReplica(r *longhorn.Replica) bool {
 	// An empty r.Spec.FailedAt doesn't necessarily indicate a healthy replica. The replica could be caught in an
 	// autosalvage loop. If it is, its r.Spec.FailedAt is repeatedly transitioning between empty and some time. Ensure
 	// the replica has become healthyAt since it last became failedAt.
+	// We know r.Spec.LastHealthyAt != "" because r.Spec.HealthyAt != "" from isHealthyAndActiveReplica.
 	if r.Spec.LastFailedAt != "" && !util.TimestampAfterTimestamp(r.Spec.LastHealthyAt, r.Spec.LastFailedAt) {
 		return false
 	}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -654,7 +654,9 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 					r.Name, r.Status.CurrentState, r.Spec.EngineName, r.Spec.Active, isNoAvailableBackend)
 				e.Spec.LogRequested = true
 				r.Spec.LogRequested = true
-				r.Spec.FailedAt = c.nowHandler()
+				now := c.nowHandler()
+				r.Spec.FailedAt = now
+				r.Spec.LastFailedAt = now
 				r.Spec.DesireState = longhorn.InstanceStateStopped
 			}
 		}
@@ -708,7 +710,9 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 			}
 			if r.Spec.FailedAt == "" {
 				log.Warnf("Replica %v is marked as failed, current state %v, mode %v, engine name %v, active %v", r.Name, r.Status.CurrentState, mode, r.Spec.EngineName, r.Spec.Active)
-				r.Spec.FailedAt = c.nowHandler()
+				now := c.nowHandler()
+				r.Spec.FailedAt = now
+				r.Spec.LastFailedAt = now
 				e.Spec.LogRequested = true
 				r.Spec.LogRequested = true
 			}
@@ -719,7 +723,9 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 			// from replica failed during rebuilding
 			if r.Spec.HealthyAt == "" {
 				c.backoff.DeleteEntry(r.Name)
-				r.Spec.HealthyAt = c.nowHandler()
+				now := c.nowHandler()
+				r.Spec.HealthyAt = now
+				r.Spec.LastHealthyAt = now
 				r.Spec.RebuildRetryCount = 0
 			}
 			healthyCount++
@@ -733,7 +739,9 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 				r.Name, r.Status.CurrentState, r.Spec.EngineName, r.Spec.Active)
 			e.Spec.LogRequested = true
 			r.Spec.LogRequested = true
-			r.Spec.FailedAt = c.nowHandler()
+			now := c.nowHandler()
+			r.Spec.FailedAt = now
+			r.Spec.LastFailedAt = now
 			r.Spec.DesireState = longhorn.InstanceStateStopped
 		}
 	}
@@ -888,10 +896,46 @@ func isFirstAttachment(rs map[string]*longhorn.Replica) bool {
 	return true
 }
 
+func isHealthyAndActiveReplica(r *longhorn.Replica) bool {
+	if r.Spec.FailedAt != "" {
+		return false
+	}
+	if r.Spec.HealthyAt == "" {
+		return false
+	}
+	if !r.Spec.Active {
+		return false
+	}
+	return true
+}
+
+func isDefinitelyHealthyAndActiveReplica(r *longhorn.Replica) bool {
+	if !isHealthyAndActiveReplica(r) {
+		return false
+	}
+	// An empty r.Spec.FailedAt doesn't necessarily indicate a healthy replica. The replica could be caught in an
+	// autosalvage loop. If it is, its r.Spec.FailedAt is repeatedly transitioning between empty and some time. Ensure
+	// the replica has become healthyAt since it last became failedAt.
+	if r.Spec.LastFailedAt != "" && !util.TimestampAfterTimestamp(r.Spec.LastHealthyAt, r.Spec.LastFailedAt) {
+		return false
+	}
+	return true
+}
+
 func getHealthyAndActiveReplicaCount(rs map[string]*longhorn.Replica) int {
 	count := 0
 	for _, r := range rs {
-		if r.Spec.FailedAt == "" && r.Spec.HealthyAt != "" && r.Spec.Active {
+		if isHealthyAndActiveReplica(r) {
+			count++
+		}
+	}
+	return count
+}
+
+func getDefinitelyHealthyAndActiveReplicaCount(rs map[string]*longhorn.Replica) int {
+	count := 0
+	for _, r := range rs {
+		if isDefinitelyHealthyAndActiveReplica(r) {
 			count++
 		}
 	}
@@ -944,7 +988,7 @@ func (c *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*lo
 }
 
 func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) error {
-	healthyCount := getHealthyAndActiveReplicaCount(rs)
+	healthyCount := getDefinitelyHealthyAndActiveReplicaCount(rs)
 	cleanupLeftoverReplicas := !c.isVolumeUpgrading(v) && !isVolumeMigrating(v)
 	log := getLoggerForVolume(c.logger, v)
 
@@ -972,19 +1016,8 @@ func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, r
 			continue
 		}
 
-		staled := false
-		if v.Spec.StaleReplicaTimeout > 0 &&
-			util.TimestampAfterTimeout(r.Spec.FailedAt, time.Duration(int64(v.Spec.StaleReplicaTimeout*60))*time.Second) {
-
-			staled = true
-		}
-
 		if datastore.IsDataEngineV1(v.Spec.DataEngine) {
-			// 1. failed for multiple times or failed at rebuilding (`Spec.RebuildRetryCount` of a newly created rebuilding replica
-			//    is `FailedReplicaMaxRetryCount`) before ever became healthy/ mode RW,
-			// 2. failed too long ago, became stale and unnecessary to keep around, unless we don't have any healthy replicas
-			// 3. failed for race condition at upgrading when waiting IM-r to start and it would never became healty
-			if (r.Spec.RebuildRetryCount >= scheduler.FailedReplicaMaxRetryCount) || (healthyCount != 0 && staled) || (r.Spec.Image != v.Status.CurrentImage) {
+			if shouldCleanUpFailedReplicaV1(r, v.Spec.StaleReplicaTimeout, healthyCount, v.Spec.Image) {
 				log.WithField("replica", r.Name).Info("Cleaning up corrupted, staled replica")
 				if err := c.deleteReplica(r, rs); err != nil {
 					return errors.Wrapf(err, "cannot clean up staled replica %v", r.Name)
@@ -1004,6 +1037,8 @@ func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, r
 }
 
 func (c *VolumeController) cleanupFailedToScheduledReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) (err error) {
+	// We don't need the more rigorous getDefinitelyHealthyAndActiveReplicaCount here, because the replicas we will
+	// potentially delete are definitely worthless (contain no data).
 	healthyCount := getHealthyAndActiveReplicaCount(rs)
 	hasEvictionRequestedReplicas := hasReplicaEvictionRequested(rs)
 
@@ -1025,7 +1060,7 @@ func (c *VolumeController) cleanupFailedToScheduledReplicas(v *longhorn.Volume, 
 }
 
 func (c *VolumeController) cleanupExtraHealthyReplicas(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (err error) {
-	healthyCount := getHealthyAndActiveReplicaCount(rs)
+	healthyCount := getDefinitelyHealthyAndActiveReplicaCount(rs)
 	if healthyCount <= v.Spec.NumberOfReplicas {
 		return nil
 	}
@@ -1799,7 +1834,9 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 				}
 				log.WithField("replica", r.Name).Warn(msg)
 				if r.Spec.FailedAt == "" {
-					r.Spec.FailedAt = c.nowHandler()
+					now := c.nowHandler()
+					r.Spec.FailedAt = now
+					r.Spec.LastFailedAt = now
 				}
 				r.Spec.DesireState = longhorn.InstanceStateStopped
 			}
@@ -1921,7 +1958,9 @@ func (c *VolumeController) closeVolumeDependentResources(v *longhorn.Volume, e *
 	for _, r := range rs {
 		if r.Spec.HealthyAt == "" && r.Spec.FailedAt == "" && dataExists {
 			// This replica must have been rebuilding. Mark it as failed.
-			r.Spec.FailedAt = c.nowHandler()
+			now := c.nowHandler()
+			r.Spec.FailedAt = now
+			r.Spec.LastFailedAt = now
 			// Unscheduled replicas are marked failed here when volume is detached.
 			// Check if NodeId or DiskID is empty to avoid deleting reusableFailedReplica when replenished.
 			if r.Spec.NodeID == "" || r.Spec.DiskID == "" {
@@ -4470,4 +4509,28 @@ func (c *VolumeController) ReconcilePersistentVolume(volume *longhorn.Volume) er
 		}
 	}
 	return nil
+}
+
+func shouldCleanUpFailedReplicaV1(r *longhorn.Replica, staleReplicaTimeout, definitelyHealthyCount int,
+	volumeCurrentImage string) bool {
+	// Even if healthyAt == "", lastHealthyAt != "" indicates this replica has some (potentially invalid) data. We MUST
+	// NOT delete it until we're sure the engine can start with another replica. In the worst case scenario, maybe we
+	// can recover data from this replica.
+	if r.Spec.LastHealthyAt != "" && definitelyHealthyCount == 0 {
+		return false
+	}
+	// Failed to rebuild too many times.
+	if r.Spec.RebuildRetryCount >= scheduler.FailedReplicaMaxRetryCount {
+		return true
+	}
+	// Failed too long ago to be useful during a rebuild.
+	if staleReplicaTimeout > 0 &&
+		util.TimestampAfterTimeout(r.Spec.FailedAt, time.Duration(staleReplicaTimeout)*time.Minute) {
+		return true
+	}
+	// Failed for race condition at upgrading when waiting for instance-manager-r to start. Can never become healthy.
+	if r.Spec.Image != volumeCurrentImage {
+		return true
+	}
+	return false
 }

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -236,6 +236,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.CurrentNodeID = tc.volume.Spec.NodeID
 	for _, r := range tc.expectReplicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 	}
 	testCases["volume attached"] = tc
 
@@ -258,6 +259,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for _, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Spec.Image = TestEngineImage
 		r.Status.CurrentState = longhorn.InstanceStateRunning
@@ -313,6 +315,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Spec.Image = TestEngineImage
 		r.Status.CurrentState = longhorn.InstanceStateRunning
@@ -368,6 +371,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
 		r.Status.Port = randomPort()
@@ -414,6 +418,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
 		r.Status.Port = randomPort()
@@ -441,6 +446,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		longhorn.VolumeConditionTypeRestore, longhorn.ConditionStatusFalse, "", "")
 	for _, r := range tc.expectReplicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 	}
 	testCases["try to detach newly restored volume after restoration completed"] = tc
 
@@ -477,6 +483,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
 		r.Status.Port = randomPort()
@@ -494,6 +501,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.Robustness = longhorn.VolumeRobustnessUnknown
 	for _, r := range tc.expectReplicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 	}
 	testCases["newly restored volume is being detaching after restoration completed"] = tc
 
@@ -539,6 +547,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for name, r := range tc.replicas {
 		r.Spec.NodeID = TestNode1
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		if name != failedReplicaName {
 			r.Status.CurrentState = longhorn.InstanceStateRunning
@@ -610,6 +619,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
 		r.Status.Port = randomPort()
@@ -643,6 +653,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for _, r := range tc.expectReplicas {
 		r.Spec.FailedAt = getTestNow()
+		r.Spec.LastFailedAt = r.Spec.FailedAt
 		r.Spec.DesireState = longhorn.InstanceStateStopped
 		r.Spec.LogRequested = true
 	}
@@ -669,6 +680,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for _, r := range tc.replicas {
 		r.Spec.HealthyAt = ""
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.CurrentState = longhorn.InstanceStateStopped
 	}
 	tc.copyCurrentToExpect()
@@ -712,6 +724,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	for name, r := range tc.replicas {
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Status.CurrentState = longhorn.InstanceStateRunning
 		r.Status.IP = randomIP()
@@ -745,6 +758,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for name, r := range tc.replicas {
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.CurrentState = longhorn.InstanceStateRunning
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
@@ -779,6 +793,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for name, r := range tc.replicas {
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.CurrentState = longhorn.InstanceStateRunning
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
@@ -819,6 +834,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for _, r := range tc.replicas {
 		// Assume the volume is previously attached then detached.
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.CurrentState = longhorn.InstanceStateStopped
 	}
 	tc.copyCurrentToExpect()
@@ -829,6 +845,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		if r.Spec.NodeID == TestNode2 {
 			r.Spec.DesireState = longhorn.InstanceStateStopped
 			r.Spec.FailedAt = getTestNow()
+			r.Spec.LastFailedAt = r.Spec.FailedAt
 		} else {
 			r.Spec.DesireState = longhorn.InstanceStateRunning
 		}
@@ -887,7 +904,9 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for _, r := range tc.replicas {
 		r.Status.CurrentState = longhorn.InstanceStateStopped
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Spec.FailedAt = getTestNow()
+		r.Spec.LastFailedAt = r.Spec.FailedAt
 		r.Spec.DesireState = longhorn.InstanceStateStopped
 	}
 
@@ -904,6 +923,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for _, r := range tc.expectReplicas {
 		r.Spec.DesireState = longhorn.InstanceStateStopped
 		r.Spec.FailedAt = ""
+		// r.Spec.LastFailedAt will NOT be "".
 		expectRs[r.Name] = r
 	}
 	tc.expectReplicas = expectRs
@@ -950,6 +970,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	for name, r := range tc.replicas {
 		r.Spec.DesireState = longhorn.InstanceStateRunning
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		r.Status.CurrentState = longhorn.InstanceStateRunning
 		r.Status.IP = randomIP()
 		r.Status.StorageIP = r.Status.IP
@@ -992,6 +1013,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 			r.Spec.DesireState = longhorn.InstanceStateStopped
 			r.Status.CurrentState = longhorn.InstanceStateStopped
 			r.Spec.FailedAt = getTestNow()
+			r.Spec.LastFailedAt = r.Spec.FailedAt
 			failedReplica = r
 		} else {
 			r.Spec.DesireState = longhorn.InstanceStateRunning
@@ -1001,6 +1023,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 			r.Status.Port = randomPort()
 		}
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		for _, e := range tc.engines {
 			if r.Spec.FailedAt == "" {
 				e.Status.ReplicaModeMap[name] = "RW"
@@ -1013,7 +1036,9 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		if r.Name == failedReplica.Name {
 			r.Spec.DesireState = longhorn.InstanceStateRunning
 			r.Spec.FailedAt = ""
+			// r.Spec.LastFailedAt will NOT be "".
 			r.Spec.HealthyAt = ""
+			// r.Spec.LastHealthyAt will NOT be "".
 			r.Spec.RebuildRetryCount = 1
 			break
 		}
@@ -1045,6 +1070,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 			r.Spec.DesireState = longhorn.InstanceStateStopped
 			r.Status.CurrentState = longhorn.InstanceStateStopped
 			r.Spec.FailedAt = time.Now().UTC().Format(time.RFC3339)
+			r.Spec.LastFailedAt = r.Spec.FailedAt
 			failedReplica = r
 		} else {
 			r.Spec.DesireState = longhorn.InstanceStateRunning

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1080,6 +1080,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 			r.Status.Port = randomPort()
 		}
 		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
 		for _, e := range tc.engines {
 			if r.Spec.FailedAt == "" {
 				e.Status.ReplicaModeMap[name] = "RW"

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2640,16 +2640,20 @@ spec:
               evictionRequested:
                 type: boolean
               failedAt:
+                description: FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason. FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage.
                 type: string
               hardNodeAffinity:
                 type: string
               healthyAt:
+                description: HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have useful (though possibly stale) data. HealthyAt is cleared before a rebuild.
                 type: string
               image:
                 type: string
               lastFailedAt:
+                description: LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared. LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to LastHealthyAt to help prevent dangerous replica deletion in some corner cases.
                 type: string
               lastHealthyAt:
+                description: LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases.
                 type: string
               logRequested:
                 type: boolean

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2647,6 +2647,10 @@ spec:
                 type: string
               image:
                 type: string
+              lastFailedAt:
+                type: string
+              lastHealthyAt:
+                type: string
               logRequested:
                 type: boolean
               nodeID:

--- a/k8s/pkg/apis/longhorn/v1beta2/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/replica.go
@@ -27,7 +27,11 @@ type ReplicaSpec struct {
 	// +optional
 	HealthyAt string `json:"healthyAt"`
 	// +optional
+	LastHealthyAt string `json:"lastHealthyAt"`
+	// +optional
 	FailedAt string `json:"failedAt"`
+	// +optional
+	LastFailedAt string `json:"lastFailedAt"`
 	// +optional
 	DiskID string `json:"diskID"`
 	// +optional

--- a/k8s/pkg/apis/longhorn/v1beta2/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/replica.go
@@ -25,12 +25,27 @@ type ReplicaSpec struct {
 	// +optional
 	EngineName string `json:"engineName"`
 	// +optional
+	// HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt
+	// indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have
+	// useful (though possibly stale) data. HealthyAt is cleared before a rebuild.
 	HealthyAt string `json:"healthyAt"`
 	// +optional
+	// LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is
+	// never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a
+	// replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be
+	// compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases.
 	LastHealthyAt string `json:"lastHealthyAt"`
 	// +optional
+	// FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason.
+	// FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful
+	// (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can
+	// be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage.
 	FailedAt string `json:"failedAt"`
 	// +optional
+	// LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared.
+	// LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with
+	// LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to
+	// LastHealthyAt to help prevent dangerous replica deletion in some corner cases.
 	LastFailedAt string `json:"lastFailedAt"`
 	// +optional
 	DiskID string `json:"diskID"`

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -28,6 +28,7 @@ import (
 	"github.com/longhorn/longhorn-manager/upgrade/v14xto150"
 	"github.com/longhorn/longhorn-manager/upgrade/v151to152"
 	"github.com/longhorn/longhorn-manager/upgrade/v15xto160"
+	"github.com/longhorn/longhorn-manager/upgrade/v16xto170"
 	"github.com/longhorn/longhorn-manager/upgrade/v1beta1"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -257,6 +258,13 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.6.0") < 0 {
 		logrus.Info("Walking through the resource upgrade path v1.5.x to v1.6.0")
 		if err := v15xto160.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	// When lhVersionBeforeUpgrade < v1.7.0, it is v1.6.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.6.x.
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.7.0") < 0 {
+		logrus.Info("Walking through the resource upgrade path v1.6.x to v1.7.0")
+		if err := v16xto170.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
 			return err
 		}
 	}

--- a/upgrade/v16xto170/upgrade.go
+++ b/upgrade/v16xto170/upgrade.go
@@ -1,0 +1,56 @@
+package v16xto170
+
+import (
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clientset "k8s.io/client-go/kubernetes"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.6.x to v1.7.0: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	// We will probably need to upgrade other resources as well. See upgradeReplicas or previous Longhorn versions for
+	// examples.
+	return upgradeReplicas(namespace, lhClient, resourceMaps)
+}
+
+func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	// Currently there are no statuses to upgrade. See UpgradeResources -> upgradeVolumes or previous Longhorn versions
+	// for examples.
+	return nil
+}
+
+func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade replica failed")
+	}()
+
+	replicaMap, err := upgradeutil.ListAndUpdateReplicasInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn replicas during the replica upgrade")
+	}
+
+	for _, r := range replicaMap {
+		if r.Spec.LastHealthyAt == "" {
+			// We could attempt to figure out if the replica is currently RW in an engine and set its
+			// Spec.LastHealthyAt = now, but it is safer and easier to start updating it after the upgrade.
+			r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		}
+		if r.Spec.LastFailedAt == "" {
+			// There is no way for us to know the right time for Spec.LastFailedAt if the replica isn't currently
+			// failed. Start updating it after the upgrade.
+			r.Spec.LastFailedAt = r.Spec.FailedAt
+		}
+	}
+
+	return nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -261,18 +261,18 @@ func TimestampWithinLimit(latest time.Time, ts string, limit time.Duration) bool
 	return deadline.After(latest)
 }
 
-func TimestampAfterTimestamp(after string, before string) bool {
-	afterT, err := time.Parse(time.RFC3339, after)
+// TimestampAfterTimestamp returns true if timestamp1 is after timestamp2. It returns false otherwise and an error if
+// either timestamp cannot be parsed.
+func TimestampAfterTimestamp(timestamp1 string, timestamp2 string) (bool, error) {
+	time1, err := time.Parse(time.RFC3339, timestamp1)
 	if err != nil {
-		logrus.Errorf("Cannot parse after time %v", after)
-		return false
+		return false, errors.Wrapf(err, "cannot parse timestamp %v", timestamp1)
 	}
-	beforeT, err := time.Parse(time.RFC3339, before)
+	time2, err := time.Parse(time.RFC3339, timestamp2)
 	if err != nil {
-		logrus.Errorf("Cannot parse before time %v", before)
-		return false
+		return false, errors.Wrapf(err, "cannot parse timestamp %v", timestamp2)
 	}
-	return afterT.After(beforeT)
+	return time1.After(time2), nil
 }
 
 func ValidateString(name string) bool {

--- a/util/util.go
+++ b/util/util.go
@@ -261,6 +261,20 @@ func TimestampWithinLimit(latest time.Time, ts string, limit time.Duration) bool
 	return deadline.After(latest)
 }
 
+func TimestampAfterTimestamp(after string, before string) bool {
+	afterT, err := time.Parse(time.RFC3339, after)
+	if err != nil {
+		logrus.Errorf("Cannot parse after time %v", after)
+		return false
+	}
+	beforeT, err := time.Parse(time.RFC3339, before)
+	if err != nil {
+		logrus.Errorf("Cannot parse before time %v", before)
+		return false
+	}
+	return afterT.After(beforeT)
+}
+
 func ValidateString(name string) bool {
 	validName := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
 	return validName.MatchString(name)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "gopkg.in/check.v1"
@@ -180,5 +181,27 @@ func (s *TestSuite) TestGetValidMountPoint(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(validMountPoint, Equals, expectedMountPointPath)
 		}
+	}
+}
+
+func TestTimestampAfterTimestamp(t *testing.T) {
+	tests := map[string]struct {
+		before string
+		after  string
+		want   bool
+	}{
+		"beforeBadFormat": {"2024-01-02T18:37Z", "2024-01-02T18:16:37Z", false},
+		"afterBadFormat":  {"2024-01-02T18:16:37Z", "2024-01-02T18:37Z", false},
+		"actuallyAfter":   {"2024-01-02T18:17:37Z", "2024-01-02T18:16:37Z", true},
+		"actuallyBefore":  {"2024-01-02T18:16:37Z", "2024-01-02T18:17:37Z", false},
+		"sameTime":        {"2024-01-02T18:16:37Z", "2024-01-02T18:16:37Z", false},
+	}
+
+	assert := assert.New(t)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TimestampAfterTimestamp(tc.before, tc.after)
+			assert.Equal(tc.want, got)
+		})
 	}
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -186,22 +186,28 @@ func (s *TestSuite) TestGetValidMountPoint(c *C) {
 
 func TestTimestampAfterTimestamp(t *testing.T) {
 	tests := map[string]struct {
-		before string
-		after  string
-		want   bool
+		timestamp1 string
+		timestamp2 string
+		want       bool
+		wantErr    bool
 	}{
-		"beforeBadFormat": {"2024-01-02T18:37Z", "2024-01-02T18:16:37Z", false},
-		"afterBadFormat":  {"2024-01-02T18:16:37Z", "2024-01-02T18:37Z", false},
-		"actuallyAfter":   {"2024-01-02T18:17:37Z", "2024-01-02T18:16:37Z", true},
-		"actuallyBefore":  {"2024-01-02T18:16:37Z", "2024-01-02T18:17:37Z", false},
-		"sameTime":        {"2024-01-02T18:16:37Z", "2024-01-02T18:16:37Z", false},
+		"timestamp1BadFormat": {"2024-01-02T18:37Z", "2024-01-02T18:16:37Z", false, true},
+		"timestamp2BadFormat": {"2024-01-02T18:16:37Z", "2024-01-02T18:37Z", false, true},
+		"timestamp1After":     {"2024-01-02T18:17:37Z", "2024-01-02T18:16:37Z", true, false},
+		"timestamp2NotAfter":  {"2024-01-02T18:16:37Z", "2024-01-02T18:17:37Z", false, false},
+		"sameTime":            {"2024-01-02T18:16:37Z", "2024-01-02T18:16:37Z", false, false},
 	}
 
 	assert := assert.New(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := TimestampAfterTimestamp(tc.before, tc.after)
+			got, err := TimestampAfterTimestamp(tc.timestamp1, tc.timestamp2)
 			assert.Equal(tc.want, got)
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
longhorn/longhorn#7425

#### What this PR does / why we need it:

- The `replica.Spec.HealthyAt` field tells us if a replica has ever been healthy.
- The `replica.Spec.FailedAt` field is set every time we detect a replica failure.
- Before we rebuild a replica, we set `replica.Spec.HealthyAt == ""` and `replica.Spec.FailedAt == ""`. The `replica.Spec.HealthyAt == ""` should be a solid indicator that we cannot trust the data on the replica and should never try to use it.
- If all replicas have `replica.Spec.FailedAt != ""`, we select replicas with `replica.Spec.HealthyAt != ""` to salvage (by removing clearing its `replica.Spec.FailedAt`.
- In some situations, we have seen a replica that was previously corrupted by a failed rebuild have a `replica.Spec.HealthyAt != ""` and be used by the engine.
- Longhorn tries to use this replica to rebuild other failed replicas, but it is impossible. The engine cannot start with this replica.
- Eventually, other replicas become stale and are deleted by Longhorn, leaving only this replica.

It is currently very difficult for Longhorn to automatically understand this situation. It knows not to clean up other replicas if there is no `replica.Spec.HealthyAt != ""` replica. But there IS a replica with `replica.Spec.HealthyAt != ""`. There is no path for us to decide that some replica with `replica.Spec.HealthyAt != ""` actually is NOT healthy.

This PR introduces a `replica.Spec.LastHealthyAt` field and a `replica.Spec.LastFailedAt` field. We set `replica.Spec.LastHealthyAt` every time a replica goes RW instead of just the first time and never clear it. Now we remember the most recent time this replica was working. We set `replica.Spec.LastFailedAt` every time we set `replica.Spec.FailedAt` and never clear it. Now we remember the most recent time this replica failed (even if it is currently being used for a rebuild or salvage).

Now we can look at a replica with `replica.Spec.HealthyAt` and ask, "Has it been healthy recently?" More specifically, we can ask, "Has it become healthy (RW) since the last time it failed?" A replica in an autosalvage loop cannot become healthy, so the answer to this question is, "no." If "no", we should not delete any replicas that have ever been healthy. In the worst case scenario where a user/customer has a volume that cannot attach due to its only "healthy" replica being corrupt, hopefully we will still have these other replicas around and can potentially extract data from them.

TBH, this is best-effort. We do not know exactly how a replica can be rebuilding (and then fail to be rebuilt) while its `replica.Spec.HealthyAt != ""`. I have demonstrated one (artificial) situation in https://github.com/longhorn/longhorn-manager/pull/2432#issuecomment-1894675916 that this fix can be beneficial in, but I do not know if it would help us in the real world or not.

#### Special notes for your reviewer:

~@innobead, this still needs another work day of additional testing and upgrade logic. I'm opening this draft so you can get a quick idea of what I'm thinking and make a decision whether we should try to push for v1.6.0 or not.~