### PR TITLE
Prevent from complains in spdk_tgt when deleting a v2 volume

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -296,7 +296,7 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 	// TODO: Will remove this reference kind correcting after all Longhorn components having used the new kinds
 	if len(ds.OwnerReferences) < 1 || ds.OwnerReferences[0].Kind != types.LonghornKindEngineImage {
 		ds.OwnerReferences = datastore.GetOwnerReferencesForEngineImage(engineImage)
-		ds, err = ic.kubeClient.AppsV1().DaemonSets(ic.namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
+		_, err = ic.kubeClient.AppsV1().DaemonSets(ic.namespace).Update(context.TODO(), ds, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -550,6 +550,9 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) error {
 	if canDeleteInstance(r) {
 		cleanupRequired = true
 	}
+
+	log.Info("Deleting replica instance")
+
 	err = c.InstanceDelete(r.Spec.DataEngine, r.Name, string(longhorn.InstanceManagerTypeReplica), r.Spec.DiskID, cleanupRequired)
 	if err != nil && !types.ErrorIsNotFound(err) {
 		return err

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -834,13 +834,13 @@ func (sc *SettingController) updateDataEngine(setting types.SettingName) error {
 }
 
 func (sc *SettingController) cleanupInstanceManager(dataEngine longhorn.DataEngineType) error {
-	sc.logger.Infof("Cleaning up the instance manager for %v data engine", dataEngine)
 	imMap, err := sc.ds.ListInstanceManagersBySelectorRO("", "", longhorn.InstanceManagerTypeAllInOne, dataEngine)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list instance managers for cleaning up %v data engine", dataEngine)
 	}
 
 	for _, im := range imMap {
+		sc.logger.Infof("Cleaning up the instance manager for %v data engine", dataEngine)
 		if err := sc.ds.DeleteInstanceManager(im.Name); err != nil {
 			return err
 		}

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -840,7 +840,7 @@ func (sc *SettingController) cleanupInstanceManager(dataEngine longhorn.DataEngi
 	}
 
 	for _, im := range imMap {
-		sc.logger.Infof("Cleaning up the instance manager for %v data engine", dataEngine)
+		sc.logger.Infof("Cleaning up the instance manager %v for %v data engine", im.Name, dataEngine)
 		if err := sc.ds.DeleteInstanceManager(im.Name); err != nil {
 			return err
 		}

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -312,31 +312,6 @@ func (m *VolumeManager) Detach(name, attachmentID, hostID string, forceDetach bo
 	return v, nil
 }
 
-func (m *VolumeManager) isVolumeAvailableOnNode(volume, node string) bool {
-	es, _ := m.ds.ListVolumeEngines(volume)
-	for _, e := range es {
-		if e.Spec.NodeID != node {
-			continue
-		}
-		if e.DeletionTimestamp != nil {
-			continue
-		}
-		if e.Spec.DesireState != longhorn.InstanceStateRunning || e.Status.CurrentState != longhorn.InstanceStateRunning {
-			continue
-		}
-		hasAvailableReplica := false
-		for _, mode := range e.Status.ReplicaModeMap {
-			hasAvailableReplica = hasAvailableReplica || mode == longhorn.ReplicaModeRW
-		}
-		if !hasAvailableReplica {
-			continue
-		}
-		return true
-	}
-
-	return false
-}
-
 func (m *VolumeManager) Salvage(volumeName string, replicaNames []string) (v *longhorn.Volume, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "unable to salvage volume %v", volumeName)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7568

#### What this PR does / why we need it:

spdk_tgt complains the improper sequence of deleting engines and replicas.
Replicas should be deleted before deleting its engine.

#### Special notes for your reviewer:

#### Additional documentation or context
