### PR TITLE
`CheckDataEngineImageReadiness()` should handle v2 data engine as well.

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1781,16 +1781,23 @@ func (s *DataStore) CheckEngineImageReadiness(image string, nodes ...string) (is
 
 func (s *DataStore) CheckDataEngineImageReadiness(image string, dataEngine longhorn.DataEngineType, nodes ...string) (isReady bool, err error) {
 	if IsDataEngineV2(dataEngine) {
+		if len(nodes) == 0 {
+			return false, nil
+		}
+		if len(nodes) == 1 && nodes[0] == "" {
+			return false, nil
+		}
 		return true, nil
 	}
+	// For data engine v1, we need to check the engine image readiness
 	return s.CheckEngineImageReadiness(image, nodes...)
 }
 
-// CheckImageReadyOnAtLeastOneVolumeReplica checks if the IMAGE is deployed on the NODEID and on at least one of the the volume's replicas
-func (s *DataStore) CheckImageReadyOnAtLeastOneVolumeReplica(image, volumeName, nodeID string, dataLocality longhorn.DataLocality, dataEngine longhorn.DataEngineType) (bool, error) {
+// CheckDataEngineImageReadyOnAtLeastOneVolumeReplica checks if the IMAGE is deployed on the NODEID and on at least one of the the volume's replicas
+func (s *DataStore) CheckDataEngineImageReadyOnAtLeastOneVolumeReplica(image, volumeName, nodeID string, dataLocality longhorn.DataLocality, dataEngine longhorn.DataEngineType) (bool, error) {
 	isReady, err := s.CheckDataEngineImageReadiness(image, dataEngine, nodeID)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to check image readiness of node %v", nodeID)
+		return false, errors.Wrapf(err, "failed to check data engine image readiness of node %v", nodeID)
 	}
 
 	if !isReady || dataLocality == longhorn.DataLocalityStrictLocal {

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -225,11 +225,11 @@ func (m *VolumeManager) Attach(name, nodeID string, disableFrontend bool, attach
 		return nil, err
 	}
 
-	if isReady, err := m.ds.CheckImageReadyOnAtLeastOneVolumeReplica(v.Spec.Image, v.Name, node.Name, v.Spec.DataLocality, v.Spec.DataEngine); !isReady {
+	if isReady, err := m.ds.CheckDataEngineImageReadyOnAtLeastOneVolumeReplica(v.Spec.Image, v.Name, node.Name, v.Spec.DataLocality, v.Spec.DataEngine); !isReady {
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot attach volume %v with image %v", v.Name, v.Spec.Image)
 		}
-		return nil, fmt.Errorf("cannot attach volume %v because the image %v is not deployed on at least one of the the replicas' nodes or the node that the volume is going to attach to", v.Name, v.Spec.Image)
+		return nil, fmt.Errorf("cannot attach volume %v because the data engine image %v is not deployed on at least one of the the replicas' nodes or the node that the volume is going to attach to", v.Name, v.Spec.Image)
 	}
 
 	restoreCondition := types.GetCondition(v.Status.Conditions, longhorn.VolumeConditionTypeRestore)


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7570

#### What this PR does / why we need it:

`CheckDataEngineImageReadiness()` should handle v2 data engine as well.

#### Special notes for your reviewer:

#### Additional documentation or context
