### PR TITLE
fix(upgrade): skip upgrade path check

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -43,6 +43,7 @@ const (
 	FlagSupportBundleManagerImage = "support-bundle-manager-image"
 	FlagServiceAccount            = "service-account"
 	FlagKubeConfig                = "kube-config"
+	FlagUpgradeVersionCheck       = "upgrade-version-check"
 )
 
 func DaemonCmd() cli.Command {
@@ -80,6 +81,10 @@ func DaemonCmd() cli.Command {
 			cli.StringFlag{
 				Name:  FlagKubeConfig,
 				Usage: "Specify path to kube config (optional)",
+			},
+			cli.BoolFlag{
+				Name:  FlagUpgradeVersionCheck,
+				Usage: "Enforce version checking for upgrades. If disabled, there will be no requirement for the necessary upgrade source version",
 			},
 		},
 		Action: func(c *cli.Context) {
@@ -159,7 +164,7 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
-	if err := upgrade.Upgrade(kubeconfigPath, currentNodeID, managerImage); err != nil {
+	if err := upgrade.Upgrade(kubeconfigPath, currentNodeID, managerImage, c.Bool(FlagUpgradeVersionCheck)); err != nil {
 		return err
 	}
 

--- a/app/pre_upgrade.go
+++ b/app/pre_upgrade.go
@@ -52,7 +52,7 @@ func preUpgrade(c *cli.Context) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	if err := upgradeutil.CheckUpgradePathSupported(namespace, lhClient); err != nil {
+	if err := upgradeutil.CheckUpgradePath(namespace, lhClient, nil, true); err != nil {
 		return err
 	}
 

--- a/constant/events.go
+++ b/constant/events.go
@@ -62,5 +62,7 @@ const (
 	EventReasonReady    = "Ready"
 	EventReasonUploaded = "Uploaded"
 
+	EventReasonUpgrade = "Uppgrade"
+
 	EventReasonRolloutSkippedFmt = "RolloutSkipped: %v %v"
 )

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/longhorn/longhorn-manager/meta"
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/upgrade/v14xto150"
+	"github.com/longhorn/longhorn-manager/upgrade/v151to152"
 	"github.com/longhorn/longhorn-manager/upgrade/v15xto160"
 	"github.com/longhorn/longhorn-manager/upgrade/v1beta1"
 
@@ -229,8 +231,21 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 		return nil
 	}
 
-	// When lhVersionBeforeUpgrade < v1.6.0, it is v1.5.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.5.x.
+	// When lhVersionBeforeUpgrade < v1.5.0, it is v1.4.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.4.x.
 	resourceMaps := map[string]interface{}{}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.5.0") < 0 {
+		logrus.Info("Walking through the resource upgrade path v1.4.x to v1.5.0")
+		if err := v14xto150.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.5.2") < 0 {
+		logrus.Info("Walking through the resource upgrade path v1.5.1 to v1.5.2")
+		if err := v151to152.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	// When lhVersionBeforeUpgrade < v1.6.0, it is v1.5.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.5.x.
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.6.0") < 0 {
 		logrus.Info("Walking through the resource upgrade path v1.5.x to v1.6.0")
 		if err := v15xto160.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
@@ -241,8 +256,15 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 		return err
 	}
 
-	// When lhVersionBeforeUpgrade < v1.6.0, it is v1.5.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.5.x.
+	// When lhVersionBeforeUpgrade < v1.5.0, it is v1.4.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.4.x.
 	resourceMaps = map[string]interface{}{}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.5.0") < 0 {
+		logrus.Info("Walking through the resource status upgrade path v1.4.x to v1.5.0")
+		if err := v14xto150.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	// When lhVersionBeforeUpgrade < v1.6.0, it is v1.5.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.5.x.
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.6.0") < 0 {
 		logrus.Info("Walking through the resource status upgrade path v1.5.x to v1.6.0")
 		if err := v15xto160.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -210,20 +210,20 @@ func CreateOrUpdateLonghornVersionSetting(namespace string, lhClient *lhclientse
 }
 
 func CheckUpgradePath(namespace string, lhClient lhclientset.Interface, eventRecorder record.EventRecorder, enableUpgradeVersionCheck bool) error {
-	if err := checkLHUpgradePathSupported(namespace, lhClient, eventRecorder, enableUpgradeVersionCheck); err != nil {
+	if err := checkLHUpgradePath(namespace, lhClient, eventRecorder, enableUpgradeVersionCheck); err != nil {
 		return err
 	}
 
-	return checkEngineUpgradePathSupported(namespace, lhClient, emeta.GetVersion())
+	return checkEngineUpgradePath(namespace, lhClient, emeta.GetVersion())
 }
 
-// checkLHUpgradePathSupported returns if the upgrade path from lhCurrentVersion to meta.Version is supported.
+// checkLHUpgradePath returns if the upgrade path from lhCurrentVersion to meta.Version is supported.
 //
 //	For example: upgrade path is from x.y.z to a.b.c,
 //	0 <= a-x <= 1 is supported, and y should be after a specific version if a-x == 1
 //	0 <= b-y <= 1 is supported when a-x == 0
 //	all downgrade is not supported
-func checkLHUpgradePathSupported(namespace string, lhClient lhclientset.Interface, eventRecorder record.EventRecorder, enableUpgradeVersionCheck bool) error {
+func checkLHUpgradePath(namespace string, lhClient lhclientset.Interface, eventRecorder record.EventRecorder, enableUpgradeVersionCheck bool) error {
 	lhCurrentVersion, err := GetCurrentLonghornVersion(namespace, lhClient)
 	if err != nil {
 		return err
@@ -290,9 +290,9 @@ func checkLHUpgradePathSupported(namespace string, lhClient lhclientset.Interfac
 	return nil
 }
 
-// checkEngineUpgradePathSupported returns error if the upgrade path from
-// current EngineImage version to emeta.ControllerAPIVersion is not supported.
-func checkEngineUpgradePathSupported(namespace string, lhClient lhclientset.Interface, newEngineVersion emeta.VersionOutput) (err error) {
+// checkEngineUpgradePath returns error if the upgrade path from
+// the current EngineImage version to emeta.ControllerAPIVersion is not supported.
+func checkEngineUpgradePath(namespace string, lhClient lhclientset.Interface, newEngineVersion emeta.VersionOutput) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "failed checking Engine upgrade path")
 	}()

--- a/upgrade/util/util_test.go
+++ b/upgrade/util/util_test.go
@@ -188,7 +188,7 @@ func TestCheckUpgradePathSupported(t *testing.T) {
 }
 
 func newCheckLHUpgradePathSupported(lhClient lhclientset.Interface) error {
-	return checkLHUpgradePathSupported(TestNamespace, lhClient)
+	return checkLHUpgradePathSupported(TestNamespace, lhClient, nil, true)
 }
 
 func Test(t *testing.T) { TestingT(t) }

--- a/upgrade/util/util_test.go
+++ b/upgrade/util/util_test.go
@@ -188,7 +188,7 @@ func TestCheckUpgradePathSupported(t *testing.T) {
 }
 
 func newCheckLHUpgradePathSupported(lhClient lhclientset.Interface) error {
-	return checkLHUpgradePathSupported(TestNamespace, lhClient, nil, true)
+	return checkLHUpgradePath(TestNamespace, lhClient, nil, true)
 }
 
 func Test(t *testing.T) { TestingT(t) }
@@ -209,7 +209,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 		expectError     bool
 	}
 	testCases := map[string]testCase{
-		"checkEngineUpgradePathSupported(...)": {
+		"checkEngineUpgradePath(...)": {
 			currentVersions: []emeta.VersionOutput{
 				{
 					ControllerAPIVersion: emeta.ControllerAPIMinVersion,
@@ -217,7 +217,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 				},
 			},
 		},
-		"checkEngineUpgradePathSupported(...): multiple engine": {
+		"checkEngineUpgradePath(...): multiple engine": {
 			currentVersions: []emeta.VersionOutput{
 				{
 					ControllerAPIVersion: emeta.ControllerAPIMinVersion + 1,
@@ -235,7 +235,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 				CLIAPIMinVersion:        emeta.CLIAPIMinVersion,
 			},
 		},
-		"checkEngineUpgradePathSupported(...): single engine upgrade path not supported": {
+		"checkEngineUpgradePath(...): single engine upgrade path not supported": {
 			currentVersions: []emeta.VersionOutput{
 				{
 					ControllerAPIVersion: emeta.ControllerAPIMinVersion - 1,
@@ -244,7 +244,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 			},
 			expectError: true,
 		},
-		"checkEngineUpgradePathSupported(...): multiple engine upgrade path not supported": {
+		"checkEngineUpgradePath(...): multiple engine upgrade path not supported": {
 			currentVersions: []emeta.VersionOutput{
 				{
 					ControllerAPIVersion: emeta.ControllerAPIMinVersion,
@@ -257,7 +257,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 			},
 			expectError: true,
 		},
-		"checkEngineUpgradePathSupported(...): downgrade": {
+		"checkEngineUpgradePath(...): downgrade": {
 			currentVersions: []emeta.VersionOutput{
 				{
 					ControllerAPIVersion: emeta.ControllerAPIVersion + 1,
@@ -266,7 +266,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 			},
 			expectError: true,
 		},
-		"checkEngineUpgradePathSupported(...): engine image not found": {
+		"checkEngineUpgradePath(...): engine image not found": {
 			currentVersions: []emeta.VersionOutput{},
 		},
 	}
@@ -305,7 +305,7 @@ func (s *TestSuite) TestCheckEngineUpgradePathSupported(c *C) {
 			}
 		}
 
-		err = checkEngineUpgradePathSupported(TestNamespace, lhClient, *testCase.upgradeVersion)
+		err = checkEngineUpgradePath(TestNamespace, lhClient, *testCase.upgradeVersion)
 		if testCase.expectError {
 			c.Assert(err, NotNil)
 		} else {

--- a/upgrade/v14xto150/upgrade.go
+++ b/upgrade/v14xto150/upgrade.go
@@ -1,0 +1,391 @@
+package v14xto150
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	"github.com/longhorn/longhorn-manager/types"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+	"github.com/longhorn/longhorn-manager/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.4.x to v1.5.0: "
+
+	maxRetryForDeploymentDeletion = 300
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	if err := upgradeCSIPlugin(namespace, kubeClient); err != nil {
+		return err
+	}
+
+	if err := upgradeWebhookAndRecoveryService(namespace, kubeClient); err != nil {
+		return err
+	}
+
+	if err := upgradeWebhookPDB(namespace, kubeClient); err != nil {
+		return err
+	}
+
+	if err := upgradeVolumes(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeVolumeAttachments(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeNodes(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeEngines(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := upgradeReplicas(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	return upgradeOrphans(namespace, lhClient, resourceMaps)
+}
+
+func upgradeNodes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade node failed")
+	}()
+
+	nodeMap, err := upgradeutil.ListAndUpdateNodesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn nodes during the node upgrade")
+	}
+
+	for _, n := range nodeMap {
+		if n.Spec.Disks != nil {
+			for name, disk := range n.Spec.Disks {
+				if disk.Type == "" {
+					disk.Type = longhorn.DiskTypeFilesystem
+					n.Spec.Disks[name] = disk
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade volume failed")
+	}()
+
+	volumeMap, err := upgradeutil.ListAndUpdateVolumesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn volumes during the volume upgrade")
+	}
+
+	for _, v := range volumeMap {
+		if v.Spec.BackupCompressionMethod == "" {
+			v.Spec.BackupCompressionMethod = longhorn.BackupCompressionMethodGzip
+		}
+		if v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
+			v.Spec.RevisionCounterDisabled = true
+		}
+		if v.Spec.ReplicaSoftAntiAffinity == "" {
+			v.Spec.ReplicaSoftAntiAffinity = longhorn.ReplicaSoftAntiAffinityDefault
+		}
+		if v.Spec.ReplicaZoneSoftAntiAffinity == "" {
+			v.Spec.ReplicaZoneSoftAntiAffinity = longhorn.ReplicaZoneSoftAntiAffinityDefault
+		}
+		if v.Spec.BackendStoreDriver == "" {
+			v.Spec.BackendStoreDriver = longhorn.BackendStoreDriverTypeV1
+		}
+		if v.Spec.OfflineReplicaRebuilding == "" {
+			v.Spec.OfflineReplicaRebuilding = longhorn.OfflineReplicaRebuildingDisabled
+		}
+	}
+
+	return nil
+}
+
+func upgradeVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade VolumeAttachment failed")
+	}()
+
+	volumeList, err := lhClient.LonghornV1beta2().Volumes(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list all existing Longhorn volumes during the Longhorn VolumeAttachment upgrade")
+	}
+	kubeVAList, err := kubeClient.StorageV1().VolumeAttachments().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list all Kubernetes VolumeAttachments during the Longhorn VolumeAttachment upgrade")
+	}
+	smList, err := lhClient.LonghornV1beta2().ShareManagers(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list all share manager during the Longhorn VolumeAttachment upgrade")
+	}
+
+	// We don't expect any volume attachments to exist when upgrading from v1.4.x to v1.5.0. However, we could be
+	// walking the upgrade path again after a failure.
+	volumeAttachmentMap, err := upgradeutil.ListAndUpdateVolumeAttachmentsInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn VolumeAttachments during the Longhorn VolumeAttachment upgrade")
+	}
+
+	kubeVAMap := map[string][]storagev1.VolumeAttachment{}
+	for _, va := range kubeVAList.Items {
+		if va.Spec.Source.PersistentVolumeName != nil {
+			volName := *va.Spec.Source.PersistentVolumeName
+			kubeVAMap[volName] = append(kubeVAMap[volName], va)
+		}
+	}
+
+	smMap := map[string]longhorn.ShareManager{}
+	for _, sm := range smList.Items {
+		smMap[sm.Name] = sm
+	}
+
+	for _, v := range volumeList.Items {
+		if _, ok := volumeAttachmentMap[types.GetLHVolumeAttachmentNameFromVolumeName(v.Name)]; ok {
+			continue // We handled this one on a previous upgrade attempt.
+		}
+
+		va := longhorn.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   types.GetLHVolumeAttachmentNameFromVolumeName(v.Name),
+				Labels: types.GetVolumeLabels(v.Name),
+			},
+			Spec: longhorn.VolumeAttachmentSpec{
+				AttachmentTickets: generateVolumeAttachmentTickets(v, kubeVAMap, smMap),
+				Volume:            v.Name,
+			},
+		}
+		volumeAttachmentMap[va.Name] = &va
+	}
+
+	return nil
+}
+
+func generateVolumeAttachmentTickets(vol longhorn.Volume, kubeVAMap map[string][]storagev1.VolumeAttachment, smMap map[string]longhorn.ShareManager) map[string]*longhorn.AttachmentTicket {
+	attachmentTickets := make(map[string]*longhorn.AttachmentTicket)
+
+	kubeVAs := kubeVAMap[vol.Name]
+
+	for _, kubeVA := range kubeVAs {
+		if !kubeVA.DeletionTimestamp.IsZero() {
+			continue
+		}
+		ticketID := kubeVA.Name
+		attachmentTickets[ticketID] = &longhorn.AttachmentTicket{
+			ID:     ticketID,
+			Type:   longhorn.AttacherTypeCSIAttacher,
+			NodeID: kubeVA.Spec.NodeName,
+			Parameters: map[string]string{
+				longhorn.AttachmentParameterDisableFrontend: longhorn.FalseValue,
+			},
+		}
+	}
+
+	if sm, ok := smMap[vol.Name]; ok && sm.Status.State == longhorn.ShareManagerStateRunning {
+		ticketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeShareManagerController, sm.Name)
+		attachmentTickets[ticketID] = &longhorn.AttachmentTicket{
+			ID:     ticketID,
+			Type:   longhorn.AttacherTypeShareManagerController,
+			NodeID: sm.Status.OwnerID,
+			Parameters: map[string]string{
+				longhorn.AttachmentParameterDisableFrontend: longhorn.FalseValue,
+			},
+		}
+	}
+
+	if vol.Spec.NodeID != "" && len(attachmentTickets) == 0 {
+		ticketID := "longhorn-ui"
+		attachmentTickets[ticketID] = &longhorn.AttachmentTicket{
+			ID:     ticketID,
+			Type:   longhorn.AttacherTypeLonghornAPI,
+			NodeID: vol.Spec.NodeID,
+			Parameters: map[string]string{
+				longhorn.AttachmentParameterDisableFrontend: strconv.FormatBool(vol.Spec.DisableFrontend),
+			},
+		}
+	}
+
+	return attachmentTickets
+}
+
+func upgradeWebhookAndRecoveryService(namespace string, kubeClient *clientset.Clientset) error {
+	selectors := []string{"app=longhorn-conversion-webhook", "app=longhorn-admission-webhook", "app=longhorn-recovery-backend"}
+	propagation := metav1.DeletePropagationForeground
+
+	for _, selector := range selectors {
+		deployments, err := kubeClient.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return errors.Wrapf(err, upgradeLogPrefix+"failed to get deployment with label %v during the upgrade", selector)
+		}
+
+		for _, deployment := range deployments.Items {
+			err := kubeClient.AppsV1().Deployments(deployment.Namespace).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+			if err != nil {
+				return errors.Wrapf(err, upgradeLogPrefix+"failed to delete the deployment with label %v during the upgrade", selector)
+			}
+
+			err = util.WaitForResourceDeletion(kubeClient, deployment.Name, deployment.Namespace, selector, maxRetryForDeploymentDeletion, deploymentGetFunc)
+			if err != nil {
+				return errors.Wrapf(err, upgradeLogPrefix+"failed to wait for the deployment with label %v to be deleted during the upgrade", selector)
+			}
+			logrus.Infof("Deleted deployment %v with label %v during the upgrade", deployment.Name, selector)
+		}
+	}
+	return nil
+}
+
+func deploymentGetFunc(kubeClient *clientset.Clientset, name, namespace string) (runtime.Object, error) {
+	return kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade replica failed")
+	}()
+
+	replicaMap, err := upgradeutil.ListAndUpdateReplicasInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn replicas during the replica upgrade")
+	}
+
+	for _, r := range replicaMap {
+		if r.Spec.BackendStoreDriver == "" {
+			r.Spec.BackendStoreDriver = longhorn.BackendStoreDriverTypeV1
+		}
+	}
+
+	return nil
+}
+
+func upgradeEngines(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade engine failed")
+	}()
+
+	engineMap, err := upgradeutil.ListAndUpdateEnginesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn engines during the engine upgrade")
+	}
+
+	for _, e := range engineMap {
+		if e.Spec.BackendStoreDriver == "" {
+			e.Spec.BackendStoreDriver = longhorn.BackendStoreDriverTypeV1
+		}
+	}
+
+	return nil
+}
+
+func upgradeOrphans(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade orphan failed")
+	}()
+
+	orphanMap, err := upgradeutil.ListAndUpdateOrphansInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn orphans during the orphan upgrade")
+	}
+
+	for _, o := range orphanMap {
+		if o.Spec.Parameters == nil {
+			continue
+		}
+
+		if _, ok := o.Spec.Parameters[longhorn.OrphanDiskType]; !ok {
+			o.Spec.Parameters[longhorn.OrphanDiskType] = string(longhorn.DiskTypeFilesystem)
+		}
+	}
+
+	return nil
+}
+
+func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	return upgradeNodeStatus(namespace, lhClient, resourceMaps)
+}
+
+func upgradeNodeStatus(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade node failed")
+	}()
+
+	nodeMap, err := upgradeutil.ListAndUpdateNodesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn nodes during the node upgrade")
+	}
+
+	for _, n := range nodeMap {
+		if n.Status.DiskStatus != nil {
+			for name, disk := range n.Status.DiskStatus {
+				if disk.Type == "" {
+					disk.Type = longhorn.DiskTypeFilesystem
+					n.Status.DiskStatus[name] = disk
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func upgradeWebhookPDB(namespace string, kubeClient *clientset.Clientset) error {
+	webhookPDBs := []string{"longhorn-admission-webhook", "longhorn-conversion-webhook"}
+
+	for _, pdb := range webhookPDBs {
+		err := kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Delete(context.TODO(), pdb, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, upgradeLogPrefix+"failed to delete the pdb %v during the upgrade", pdb)
+		}
+	}
+
+	return nil
+}
+
+func upgradeCSIPlugin(namespace string, kubeClient *clientset.Clientset) error {
+	err := kubeClient.AppsV1().DaemonSets(namespace).Delete(context.TODO(), types.CSIPluginName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to delete the %v daemonset during the upgrade", types.CSIPluginName)
+	}
+	return nil
+}

--- a/upgrade/v151to152/upgrade.go
+++ b/upgrade/v151to152/upgrade.go
@@ -1,0 +1,110 @@
+package v151to152
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.5.1 to v1.5.2: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	// We will probably need to upgrade other resources as well. See upgradeVolumeAttachments or previous Longhorn
+	// versions for examples.
+	if err := upgradeVolumeAttachments(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	return deleteCSIServices(namespace, kubeClient)
+}
+
+func upgradeVolumeAttachments(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade VolumeAttachment failed")
+	}()
+
+	volumeAttachmentMap, err := upgradeutil.ListAndUpdateVolumeAttachmentsInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn VolumeAttachments during the Longhorn VolumeAttachment upgrade")
+	}
+
+	snapshotMap, err := upgradeutil.ListAndUpdateSnapshotsInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Snapshots during the Longhorn VolumeAttachment a upgrade")
+	}
+
+	ticketIDsForExistingSnapshotsMap := map[string]interface{}{}
+	for snapshotName := range snapshotMap {
+		ticketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeSnapshotController, snapshotName)
+		ticketIDsForExistingSnapshotsMap[ticketID] = nil
+	}
+
+	// Previous Longhorn versions may have created attachmentTickets for snapshots that no longer exist. Clean these up.
+	for _, volumeAttachment := range volumeAttachmentMap {
+		for ticketID, ticket := range volumeAttachment.Spec.AttachmentTickets {
+			if ticket.Type != longhorn.AttacherTypeSnapshotController {
+				continue
+			}
+			if _, ok := ticketIDsForExistingSnapshotsMap[ticketID]; !ok {
+				delete(volumeAttachment.Spec.AttachmentTickets, ticketID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func deleteCSIServices(namespace string, kubeClient *clientset.Clientset) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"delete CSI service failed")
+	}()
+
+	servicesToDelete := map[string]struct{}{
+		types.CSIAttacherName:    {},
+		types.CSIProvisionerName: {},
+		types.CSIResizerName:     {},
+		types.CSISnapshotterName: {},
+	}
+
+	servicesInCluster, err := kubeClient.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list all existing Longhorn services during the CSI service deletion")
+	}
+
+	for _, serviceInCluster := range servicesInCluster.Items {
+		if _, ok := servicesToDelete[serviceInCluster.Name]; !ok {
+			continue
+		}
+		if err = kubeClient.CoreV1().Services(namespace).Delete(context.TODO(), serviceInCluster.Name, metav1.DeleteOptions{}); err != nil {
+			// Best effort. Dummy services have no function and no finalizer, so we can proceed on failure.
+			logrus.Warnf("Deprecated CSI dummy service could not be deleted during upgrade: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	// Currently there are no statuses to upgrade. See UpgradeResources -> upgradeVolumes or previous Longhorn versions
+	// for examples.
+	return nil
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7539

#### What this PR does / why we need it:
- Add v140-to-v15x path back
-  Add a new flag `FlagUpgradeVersionCheck: "upgrade-version-check"`
    to accept the command to skip the upgrade path check.

#### Special notes for your reviewer:

#### Additional documentation or context
