### PR TITLE
v2 volume: fix the conflict of offline rebuilding and full restoration

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2960,6 +2960,10 @@ func (c *VolumeController) checkAndInitVolumeOfflineReplicaRebuilding(v *longhor
 		return nil
 	}
 
+	if v.Status.RestoreRequired {
+		return nil
+	}
+
 	switch v.Spec.OfflineReplicaRebuilding {
 	case longhorn.OfflineReplicaRebuildingIgnored:
 		offlineReplicaRebuilding, err := c.ds.GetSettingValueExisted(types.SettingNameOfflineReplicaRebuilding)


### PR DESCRIPTION
Longhorn 7597

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7597

#### What this PR does / why we need it:

v2 volume becomes faulted and detached after deleting one replica during full restoration.

#### Special notes for your reviewer:

#### Additional documentation or context
