### PR TITLE
fix(backuptarget): cordoned node controller renders the backup target unusable

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -630,6 +630,12 @@ func (btc *BackupTargetController) isResponsibleFor(bt *longhorn.BackupTarget, d
 		return false, err
 	}
 
+	if instanceManager, err := btc.ds.GetDefaultInstanceManagerByNodeRO(btc.controllerID, ""); err != nil {
+		return false, err
+	} else if instanceManager == nil || instanceManager.Status.CurrentState != longhorn.InstanceManagerStateRunning {
+		return false, errors.New("failed to get default running instance manager")
+	}
+
 	isPreferredOwner := currentNodeEngineAvailable && isResponsible
 	continueToBeOwner := currentNodeEngineAvailable && btc.controllerID == bt.Status.OwnerID
 	requiresNewOwner := currentNodeEngineAvailable && !currentOwnerEngineAvailable


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#7619

#### What this PR does / why we need it:

If a backup target is picked up by a node that is cordoned before the installation of Longhorn, the controller will render the backup target unusable.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/7619#issuecomment-1886222822