### PR TITLE
fix: use engineCLIAPIVersion for snapshot max count & size

### DIFF
--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -313,6 +313,9 @@ func getBinaryAndArgsForEngineProcessCreation(e *longhorn.Engine,
 
 	if engineCLIAPIVersion >= 9 {
 		args = append([]string{"--engine-instance-name", e.Name}, args...)
+	}
+
+	if engineCLIAPIVersion >= 10 {
 		args = append(args, "--snapshot-max-count", strconv.Itoa(e.Spec.SnapshotMaxCount))
 		args = append(args, "--snapshot-max-size", strconv.FormatInt(e.Spec.SnapshotMaxSize, 10))
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/7642

#### What this PR does / why we need it:

Only append snapshot max count and size if `engineCLIAPIVersion` is larger than `10`.

#### Special notes for your reviewer:

#### Additional documentation or context
