### PR TITLE
Update the description of v2-data-engine setting

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -1177,7 +1177,6 @@ var (
 		DisplayName: "V2 Data Engine",
 		Description: "This setting allows users to activate v2 data engine which is based on SPDK. Currently, it is in the preview phase and should not be utilized in a production environment.\n\n" +
 			"  - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached volumes. \n\n" +
-			"  - When applying the setting, Longhorn will restart all instance-manager pods. \n\n" +
 			"  - When the V2 Data Engine is enabled, each instance-manager pod utilizes 1 CPU core. This high CPU usage is attributed to the spdk_tgt process running within each instance-manager pod. The spdk_tgt process is responsible for handling input/output (IO) operations and requires intensive polling. As a result, it consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations. \n\n",
 		Category: SettingCategoryDangerZone,
 		Type:     SettingTypeBool,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7655

#### What this PR does / why we need it:

v1 and v2 date engines are separate, so the warning `When applying the setting, Longhorn will restart all instance-manager pods.` is not required.

#### Special notes for your reviewer:

#### Additional documentation or context
