### PR TITLE
Fix bug uninstallation stuck if the MutatingWebhookConfigurations or ValidatingWebhookConfigurations already deleted

### DIFF
--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -939,27 +939,18 @@ func (c *UninstallController) deleteDeployment(deployment string) (bool, error) 
 }
 
 func (c *UninstallController) deleteWebhookConfiguration() error {
-	validatingCfg, err := c.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), types.ValidatingWebhookName, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if validatingCfg != nil {
-		if err := c.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), types.ValidatingWebhookName, metav1.DeleteOptions{}); err != nil {
-			return err
-		}
+	if err := c.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), types.ValidatingWebhookName, metav1.DeleteOptions{}); err == nil {
 		c.logger.Infof("Successfully clean up the validating webhook configuration %s", types.ValidatingWebhookName)
+	} else if !datastore.ErrorIsNotFound(err) {
+		return err
 	}
 
-	mutatingCfg, err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), types.MutatingWebhookName, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), types.MutatingWebhookName, metav1.DeleteOptions{}); err == nil {
+		c.logger.Infof("Successfully clean up the mutating webhook configuration %s", types.MutatingWebhookName)
+	} else if !datastore.ErrorIsNotFound(err) {
 		return err
 	}
-	if mutatingCfg != nil {
-		if err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), types.MutatingWebhookName, metav1.DeleteOptions{}); err != nil {
-			return err
-		}
-		c.logger.Infof("Successfully clean up the mutating webhook configuration %s", types.MutatingWebhookName)
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
The old code assumes that validatingCfg is nil when ValidatingWebhookConfigurations().Get() return error NotFound. This is an incorrect assumption, the validatingCfg is actually an empty non-nil object in this case and the old logic attempted to delete a non-exist object https://github.com/longhorn/longhorn-manager/blob/41d50c237d2f91b9acfc57cedb6fa0c18970d7e6/controller/uninstall_controller.go#L946C1-L951

longhorn/longhorn#7657
