### PR TITLE
fix(setting): flooding error message

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -285,7 +285,7 @@ func (sc *SettingController) syncDangerZoneSettingsForManagedComponents(settingN
 		}
 
 		if !detached {
-			return errors.Errorf("failed to apply %v setting to Longhorn components when there are attached volumes. It will be eventually applied", settingName)
+			return &types.ErrorInvalidState{Reason: fmt.Sprintf("failed to apply %v setting to Longhorn components when there are attached volumes. It will be eventually applied", settingName)}
 		}
 
 		switch settingName {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7654

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/7649#issuecomment-1889282614

Move returning logs from `errors.Wrapf` to `types.ErrorInvalidState` when synchronizing the danger zone setting with volumes attached.

Move the log level from `Error` to `Trace`.

#### Special notes for your reviewer:

#### Additional documentation or context
