### PR TITLE
fix(engineimage): update status `Incompatible` during upgrade.

### DIFF
--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -1097,6 +1097,8 @@ func UpdateResourcesStatus(namespace string, lhClient *lhclientset.Clientset, re
 		switch resourceKind {
 		case types.LonghornKindNode:
 			err = updateNodesStatus(namespace, lhClient, resourceMap.(map[string]*longhorn.Node))
+		case types.LonghornKindEngineImage:
+			err = updateEngineImageStatus(namespace, lhClient, resourceMap.(map[string]*longhorn.EngineImage))
 		default:
 			return fmt.Errorf("resource kind %v is not able to updated", resourceKind)
 		}
@@ -1123,6 +1125,24 @@ func updateNodesStatus(namespace string, lhClient *lhclientset.Clientset, nodes 
 			if _, err = lhClient.LonghornV1beta2().Nodes(namespace).UpdateStatus(context.TODO(), node, metav1.UpdateOptions{}); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func updateEngineImageStatus(namespace string, lhClient *lhclientset.Clientset, eis map[string]*longhorn.EngineImage) error {
+	existingEngineImageList, err := lhClient.LonghornV1beta2().EngineImages(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, existingEngineImage := range existingEngineImageList.Items {
+		ei, ok := eis[existingEngineImage.Name]
+		if !ok {
+			continue
+		}
+
+		if _, err = lhClient.LonghornV1beta2().EngineImages(namespace).UpdateStatus(context.TODO(), ei, metav1.UpdateOptions{}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/upgrade/v15xto160/upgrade.go
+++ b/upgrade/v15xto160/upgrade.go
@@ -44,16 +44,16 @@ func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeCli
 		return err
 	}
 
-	if err := upgradeEngineImages(namespace, lhClient, resourceMaps); err != nil {
-		return err
-	}
-
 	return deleteCSIServices(namespace, kubeClient)
 }
 
 func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
 	// Currently there are no statuses to upgrade. See UpgradeResources -> upgradeVolumes or previous Longhorn versions
 	// for examples.
+	if err := upgradeEngineImagesStatus(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -250,7 +250,7 @@ func upgradeVolumeAttachments(namespace string, lhClient *lhclientset.Clientset,
 	return nil
 }
 
-func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+func upgradeEngineImagesStatus(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade engine images failed")
 	}()
@@ -264,9 +264,7 @@ func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset, reso
 	}
 
 	for _, ei := range engineImages {
-		if ei.Status.State == longhorn.EngineImageStateIncompatible {
-			ei.Status.Incompatible = true
-		}
+		ei.Status.Incompatible = ei.Status.State == longhorn.EngineImageStateIncompatible
 	}
 
 	return nil


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7539, longhorn/longhorn#7683

#### What this PR does / why we need it:

`EngineImage.Status.Incompatible` will be updated properly.

#### Special notes for your reviewer:

#### Additional documentation or context
