### PR TITLE
feat: shift NFS default version to 4.2 for RWX mount.

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -251,7 +251,7 @@ func (ns *NodeServer) nodeStageSharedVolume(volumeID, shareEndpoint, targetPath 
 	export := fmt.Sprintf("%s:%s", server, exportPath)
 
 	defaultMountOptions := []string{
-		"vers=4.1",
+		"vers=4.2",
 		"noresvport",
 		//"sync",    // sync mode is prohibitively expensive on the client, so we allow for host defaults
 		//"intr",


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/longhorn/longhorn/issues/7638

#### What this PR does / why we need it:

NFS v4.2 is a better default option, with more capabilities than the current v4.1.  The user can still force v4.1 if necessary.

#### Special notes for your reviewer:

#### Additional documentation or context

Passes regression rwx tests.
