### PR TITLE
fix(rwx): revert default NFS version to 4.1 for RWX volume mounts 

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -251,7 +251,7 @@ func (ns *NodeServer) nodeStageSharedVolume(volumeID, shareEndpoint, targetPath 
 	export := fmt.Sprintf("%s:%s", server, exportPath)
 
 	defaultMountOptions := []string{
-		"vers=4.2",
+		"vers=4.1",
 		"noresvport",
 		//"sync",    // sync mode is prohibitively expensive on the client, so we allow for host defaults
 		//"intr",


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7741

#### What this PR does / why we need it:
This reverts the change in default RWX mount options to use NFS v4.2, and sets it back to v4.1.  The default can still be overridden using parameter nfsOptions in the volume's storage class, and that will remain the preferred way to use v4.2.

#### Special notes for your reviewer:
Passed `rwx` regression tests: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6055/

This will need to be backported to 1.4.5, 1.5.4, and 1.60, since the original change was.

#### Additional documentation or context
