### PR TITLE
fix(volume): request remount every 1 min when read only

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	controllerAgentName = "longhorn-kubernetes-pod-controller"
+
+	remountRequestDelayDuration = 5 * time.Second
 )
 
 type KubernetesPodController struct {
@@ -336,9 +338,13 @@ func (kc *KubernetesPodController) handlePodDeletionIfVolumeRequestRemount(pod *
 		}
 
 		timeNow := time.Now()
-		delayDuration := time.Duration(int64(5)) * time.Second
+		if podStartTime.Before(remountRequestedAt) {
+			if !timeNow.After(remountRequestedAt.Add(remountRequestDelayDuration)) {
+				kc.logger.Infof("Current time is not %v seconds after request remount, requeue the pod %v to handle it later", remountRequestDelayDuration.Seconds(), pod.GetName())
+				kc.enqueuePod(pod)
+				return nil
+			}
 
-		if podStartTime.Before(remountRequestedAt) && timeNow.After(remountRequestedAt.Add(delayDuration)) {
 			gracePeriod := int64(30)
 			err := kc.kubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.GetName(), metav1.DeleteOptions{
 				GracePeriodSeconds: &gracePeriod,
@@ -468,4 +474,14 @@ func (kc *KubernetesPodController) getAssociatedVolumes(pod *corev1.Pod) ([]*lon
 	}
 
 	return volumeList, nil
+}
+
+func (kc *KubernetesPodController) enqueuePod(obj interface{}) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+
+	kc.queue.Add(key)
 }


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7751

Pod controller reconcile pod every 30 secs.
We should not update request remount time too frequently or it might not delete the pod.
Because it checks if it is 5 secs after request remount time before deleting the pod.
