### PR TITLE
csi: use ensureFolderPath rather than ensureMount for checking folder path

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -328,7 +328,7 @@ func (ns *NodeServer) nodePublishBlockVolume(volumeID, devicePath, targetPath st
 	log := ns.log.WithFields(logrus.Fields{"function": "nodePublishBlockVolume"})
 
 	// we ensure the parent directory exists and is valid
-	if _, err := ensureMountPoint(filepath.Dir(targetPath), mounter); err != nil {
+	if _, err := ensureDirectory(filepath.Dir(targetPath)); err != nil {
 		return status.Errorf(codes.Internal, errors.Wrapf(err, "failed to prepare mount point for block device %v", devicePath).Error())
 	}
 

--- a/csi/util.go
+++ b/csi/util.go
@@ -321,6 +321,29 @@ func ensureMountPoint(path string, mounter mount.Interface) (bool, error) {
 	return isMnt, err
 }
 
+// ensureDirectory checks if a folder exists at the specified path.
+// If not, it creates the folder and returns true, otherwise returns false.
+// If the path exists but is not a folder, it returns an error.
+func ensureDirectory(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(path, os.ModePerm)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	if fileInfo.IsDir() {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("path %v exists but is not a folder", path)
+}
+
 func unmount(path string, mounter mount.Interface) (err error) {
 	forceUnmounter, ok := mounter.(mount.MounterForceUnmounter)
 	if ok {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7784

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
