### PR TITLE
Fix `rpc error: code = Canceled desc = context canceled` when falling back to non-TLS client

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -446,8 +446,7 @@ func (ec *EngineController) CreateInstance(obj interface{}) (*longhorn.InstanceP
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, err
 	}
@@ -593,8 +592,7 @@ func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return err
 	}
@@ -684,8 +682,7 @@ func (ec *EngineController) GetInstance(obj interface{}) (*longhorn.InstanceProc
 			return nil, err
 		}
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, err
 	}
@@ -705,8 +702,7 @@ func (ec *EngineController) LogInstance(ctx context.Context, obj interface{}) (*
 		return nil, nil, err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2037,8 +2033,7 @@ func (ec *EngineController) UpgradeEngineInstance(e *longhorn.Engine, log *logru
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return err
 	}

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -84,8 +84,7 @@ type InstanceManagerMonitor struct {
 }
 
 func updateInstanceManagerVersion(im *longhorn.InstanceManager) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	cli, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	cli, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return err
 	}
@@ -1369,8 +1368,7 @@ func (imc *InstanceManagerController) startMonitoring(im *longhorn.InstanceManag
 	}
 
 	// TODO: #2441 refactor this when we do the resource monitoring refactor
-	ctx, cancel := context.WithCancel(context.Background())
-	client, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	client, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to initialize im client to %v before monitoring", im.Name)
 		return

--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -171,7 +171,7 @@ func (m *NodeMonitor) getRunningInstanceManagerRO(dataEngine longhorn.DataEngine
 	return nil, fmt.Errorf("unknown data engine %v", dataEngine)
 }
 
-func (m *NodeMonitor) newDiskServiceClients(ctx context.Context, ctxCancel context.CancelFunc, node *longhorn.Node) map[longhorn.DataEngineType]*DiskServiceClient {
+func (m *NodeMonitor) newDiskServiceClients(node *longhorn.Node) map[longhorn.DataEngineType]*DiskServiceClient {
 	clients := map[longhorn.DataEngineType]*DiskServiceClient{}
 
 	dataEngines := m.ds.GetDataEngines()
@@ -187,7 +187,7 @@ func (m *NodeMonitor) newDiskServiceClients(ctx context.Context, ctxCancel conte
 
 		im, err := m.getRunningInstanceManagerRO(dataEngine)
 		if err == nil {
-			client, err = engineapi.NewDiskServiceClient(ctx, ctxCancel, im, m.logger)
+			client, err = engineapi.NewDiskServiceClient(im, m.logger)
 		}
 
 		clients[dataEngine] = &DiskServiceClient{
@@ -211,8 +211,7 @@ func (m *NodeMonitor) closeDiskServiceClients(clients map[longhorn.DataEngineTyp
 func (m *NodeMonitor) collectDiskData(node *longhorn.Node) map[string]*CollectedDiskInfo {
 	diskInfoMap := make(map[string]*CollectedDiskInfo, 0)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	diskServiceClients := m.newDiskServiceClients(ctx, cancel, node)
+	diskServiceClients := m.newDiskServiceClients(node)
 	defer func() {
 		m.closeDiskServiceClients(diskServiceClients)
 	}()

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -1502,8 +1501,7 @@ func (nc *NodeController) deleteDisk(node *longhorn.Node, diskType longhorn.Disk
 		return errors.Wrapf(err, "failed to get default engine instance manager")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	diskServiceClient, err := engineapi.NewDiskServiceClient(ctx, cancel, im, nc.logger)
+	diskServiceClient, err := engineapi.NewDiskServiceClient(im, nc.logger)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create disk service client")
 	}

--- a/controller/orphan_controller.go
+++ b/controller/orphan_controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -341,8 +340,7 @@ func (oc *OrphanController) DeleteSpdkReplicaInstance(diskName, diskUUID, replic
 		return errors.Wrapf(err, "failed to get instance manager for node %v for deleting SPDK replica instance  %v", oc.controllerID, replicaInstanceName)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewDiskServiceClient(ctx, cancel, im, oc.logger)
+	c, err := engineapi.NewDiskServiceClient(im, oc.logger)
 	if err != nil {
 		return err
 	}

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -344,8 +344,7 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, err
 	}
@@ -541,8 +540,7 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return err
 	}
@@ -665,8 +663,7 @@ func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstancePro
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, err
 	}
@@ -697,8 +694,7 @@ func (rc *ReplicaController) LogInstance(ctx context.Context, obj interface{}) (
 		return nil, nil, err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	c, err := engineapi.NewInstanceManagerClient(ctx, cancel, im)
+	c, err := engineapi.NewInstanceManagerClient(im)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engineapi/disk_service.go
+++ b/engineapi/disk_service.go
@@ -13,7 +13,7 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
-func NewDiskServiceClient(ctx context.Context, ctxCancel context.CancelFunc, im *longhorn.InstanceManager, logger logrus.FieldLogger) (c *DiskService, err error) {
+func NewDiskServiceClient(im *longhorn.InstanceManager, logger logrus.FieldLogger) (c *DiskService, err error) {
 	defer func() {
 		err = errors.Wrap(err, "failed to get disk service client")
 	}()
@@ -30,8 +30,9 @@ func NewDiskServiceClient(ctx context.Context, ctxCancel context.CancelFunc, im 
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	endpoint := "tcp://" + imutil.GetURL(im.Status.IP, InstanceManagerDiskServiceDefaultPort)
-	client, err := imclient.NewDiskServiceClient(ctx, ctxCancel, endpoint, nil)
+	client, err := imclient.NewDiskServiceClient(ctx, cancel, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/engineapi/proxy.go
+++ b/engineapi/proxy.go
@@ -87,6 +87,7 @@ func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogge
 		defer func() {
 			if err != nil && proxyClient != nil {
 				proxyClient.Close()
+				proxyClient = nil
 			}
 		}()
 
@@ -115,6 +116,7 @@ func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogge
 	defer func() {
 		if err != nil && proxyClient != nil {
 			proxyClient.Close()
+			proxyClient = nil
 		}
 	}()
 	if err != nil {


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7040

#### What this PR does / why we need it:

If TLS connection is broken, cancel() of ctx will be called. Then, it causes the fallback to non-TLS runs into the error `rpc error: code = Canceled desc = context canceled`.


#### Special notes for your reviewer:

#### Additional documentation or context
