### PR TITLE
Fix typo in TestTimestampAfterTimestamp case name

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -194,7 +194,7 @@ func TestTimestampAfterTimestamp(t *testing.T) {
 		"timestamp1BadFormat": {"2024-01-02T18:37Z", "2024-01-02T18:16:37Z", false, true},
 		"timestamp2BadFormat": {"2024-01-02T18:16:37Z", "2024-01-02T18:37Z", false, true},
 		"timestamp1After":     {"2024-01-02T18:17:37Z", "2024-01-02T18:16:37Z", true, false},
-		"timestamp2NotAfter":  {"2024-01-02T18:16:37Z", "2024-01-02T18:17:37Z", false, false},
+		"timestamp1NotAfter":  {"2024-01-02T18:16:37Z", "2024-01-02T18:17:37Z", false, false},
 		"sameTime":            {"2024-01-02T18:16:37Z", "2024-01-02T18:16:37Z", false, false},
 	}
 


### PR DESCRIPTION
Longhorn 7425

#### Which issue(s) this PR fixes:

longhorn/longhorn#7425

#### What this PR does / why we need it:

Fixes a small (nonfunctional) typo in https://github.com/longhorn/longhorn-manager/pull/2432.

I am making this change in the backports of https://github.com/longhorn/longhorn-manager/pull/2432, so we do not need to backport this one.