### PR TITLE
[MANUALLY BACKPORT v1.4.x ] fix: mount the whole host to engine im

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1152,12 +1152,9 @@ func (imc *InstanceManagerController) createEngineManagerPodSpec(im *longhorn.In
 	}
 	podSpec.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
 		{
-			MountPath: "/host/dev",
-			Name:      "dev",
-		},
-		{
-			MountPath: "/host/proc",
-			Name:      "proc",
+			MountPath:        "/host",
+			Name:             "host",
+			MountPropagation: &hostToContainer,
 		},
 		{
 			MountPath:        types.EngineBinaryDirectoryInContainer,
@@ -1175,18 +1172,10 @@ func (imc *InstanceManagerController) createEngineManagerPodSpec(im *longhorn.In
 	}
 	podSpec.Spec.Volumes = []v1.Volume{
 		{
-			Name: "dev",
+			Name: "host",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: "/dev",
-				},
-			},
-		},
-		{
-			Name: "proc",
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
-					Path: "/proc",
+					Path: "/",
 				},
 			},
 		},


### PR DESCRIPTION
ref:
https://github.com/longhorn/longhorn/issues/7501
https://github.com/longhorn/longhorn/issues/7730

To allow engine instance manager to inspect mount point, we need to mount the whole host to the pod
After v1.5.x, engine/replica instance manager become one, and it mount the whole host to the pod as well.