### PR TITLE
Make InstanceProcessStatus.Conditions nullable

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1865,6 +1865,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -1907,6 +1908,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string
@@ -1949,6 +1951,7 @@ spec:
                         conditions:
                           additionalProperties:
                             type: boolean
+                          nullable: true
                           type: object
                         endpoint:
                           type: string

--- a/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
@@ -124,6 +124,7 @@ type InstanceProcessStatus struct {
 	// +optional
 	ErrorMsg string `json:"errorMsg"`
 	//+optional
+	//+nullable
 	Conditions map[string]bool `json:"conditions"`
 	// +optional
 	Listen string `json:"listen"`


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7887

#### What this PR does / why we need it:

Make the InstanceProcessStatus.Conditions CRD field nullable (like the other status CRD fields that are maps). See the linked issue for context.
