### PR TITLE
Revert "Add a startup probe to the longhorn-csi-plugin container"

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -24,7 +24,7 @@ const (
 	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.9.2"
 	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v6.3.2"
 	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.9.2"
-	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.11.0"
+	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.12.0"
 
 	DefaultCSIAttacherReplicaCount    = 3
 	DefaultCSIProvisionerReplicaCount = 3

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -344,21 +344,6 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							StartupProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.FromInt(DefaultCSILivenessProbePort),
-									},
-								},
-								InitialDelaySeconds: datastore.PodProbeInitialDelay,
-								TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
-								PeriodSeconds:       datastore.PodProbePeriodSeconds,
-								// Ensure we are allowed at least the maximum container restart backoff time (five
-								// minutes) in case the livenessprobe container is in CrashLoopBackoff. See
-								// https://github.com/longhorn/longhorn/issues/7116.
-								FailureThreshold: (300 + datastore.PodProbePeriodSeconds - 1) / datastore.PodProbePeriodSeconds,
-							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7428

#### What this PR does / why we need it:

This reverts commit fe405e668ca9619acb08e00f953881a3f8f21148. We no longer need these changes because livenessprobe was fixed upstream. 

https://github.com/kubernetes-csi/livenessprobe/issues/236