### PR TITLE
Delete default StorageClass if ConfigMap doesn't exist

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -344,21 +344,6 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							StartupProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.FromInt(DefaultCSILivenessProbePort),
-									},
-								},
-								InitialDelaySeconds: datastore.PodProbeInitialDelay,
-								TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
-								PeriodSeconds:       datastore.PodProbePeriodSeconds,
-								// Ensure we are allowed at least the maximum container restart backoff time (five
-								// minutes) in case the livenessprobe container is in CrashLoopBackoff. See
-								// https://github.com/longhorn/longhorn/issues/7116.
-								FailureThreshold: (300 + datastore.PodProbePeriodSeconds - 1) / datastore.PodProbePeriodSeconds,
-							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#4648

#### What this PR does / why we need it:

Deletes the default StorageClass if the longhorn-storageclass ConfigMap doesn't exist.

If a user doesn't want Longhorn to manage the default StorageClass, they can remove the ConfigMap from the cluster (or instruct Helm to never create it).

I ended up with this approach because we shouldn't use the finalizer pattern (in which we maintain a finalizer on the ConfigMap until we delete the StorageClass) because we don't want to set a finalizer on the user-created ConfigMap. However, it occurs to me that an owner reference pattern may be appropriate. (Set the owner reference on the StorageClass so that it is owned by the ConfigMap. When the ConfigMap is deleted, so is the StorageClass.) It's a little weird on the first upgrade if the user deletes the ConfigMap before the StorageClass gets an owner reference, but I'll experiment with it on Monday.