### PR TITLE
Explicitly set preserveUnknownFields to false

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1365,7 +1365,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: engines.longhorn.io
@@ -1378,6 +1377,7 @@ spec:
     shortNames:
     - lhe
     singular: engine
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -1736,7 +1736,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: instancemanagers.longhorn.io
@@ -1749,6 +1748,7 @@ spec:
     shortNames:
     - lhim
     singular: instancemanager
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2510,7 +2510,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: replicas.longhorn.io
@@ -2523,6 +2522,7 @@ spec:
     shortNames:
     - lhr
     singular: replica
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2749,7 +2749,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     longhorn-manager: ""
   name: settings.longhorn.io
@@ -2762,6 +2761,7 @@ spec:
     shortNames:
     - lhs
     singular: setting
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/k8s/patches/crd/preserveUnknownFields/engine.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/engine.yaml
@@ -6,6 +6,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: volumes.longhorn.io
+  name: engines.longhorn.io
 spec:
   preserveUnknownFields: false

--- a/k8s/patches/crd/preserveUnknownFields/engineimage.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/engineimage.yaml
@@ -1,3 +1,8 @@
+# This is one of seven CRDs that were originally apiextensions.k8s.io/v1beta1. If Longhorn and Kubernetes are upgraded
+# in a particular order from Longhorn v1.0.2- to the latest, preserveUnknownFields may remain true, even though the
+# default (and intended value) is false.
+# https://github.com/longhorn/longhorn/discussions/4198
+# https://github.com/longhorn/longhorn/issues/7887
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/k8s/patches/crd/preserveUnknownFields/instancemanager.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/instancemanager.yaml
@@ -6,6 +6,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: volumes.longhorn.io
+  name: instancemanagers.longhorn.io
 spec:
   preserveUnknownFields: false

--- a/k8s/patches/crd/preserveUnknownFields/node.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/node.yaml
@@ -1,3 +1,8 @@
+# This is one of seven CRDs that were originally apiextensions.k8s.io/v1beta1. If Longhorn and Kubernetes are upgraded
+# in a particular order from Longhorn v1.0.2- to the latest, preserveUnknownFields may remain true, even though the
+# default (and intended value) is false.
+# https://github.com/longhorn/longhorn/discussions/4198
+# https://github.com/longhorn/longhorn/issues/7887
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/k8s/patches/crd/preserveUnknownFields/replica.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/replica.yaml
@@ -6,6 +6,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: volumes.longhorn.io
+  name: replicas.longhorn.io
 spec:
   preserveUnknownFields: false

--- a/k8s/patches/crd/preserveUnknownFields/setting.yaml
+++ b/k8s/patches/crd/preserveUnknownFields/setting.yaml
@@ -6,6 +6,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: volumes.longhorn.io
+  name: settings.longhorn.io
 spec:
   preserveUnknownFields: false


### PR DESCRIPTION
Longhorn 7887

#### Which issue(s) this PR fixes:

longhorn/longhorn#7887

#### What this PR does / why we need it:

If Longhorn and Kubernetes are upgraded in a particular order from Longhorn `v1.0.2-` to the latest, `preserveUnknownFields` may remain `true`, even though the default (and intended value) is `false`. As a result, Kubernetes does not consider affected CRDs to have structural schemas, potentially resulting in unexpected behavior (including https://github.com/longhorn/longhorn/issues/7887).