### PR TITLE
Export GOPATH for code generators

### DIFF
--- a/k8s/generate_code.sh
+++ b/k8s/generate_code.sh
@@ -55,6 +55,8 @@ if ! command -v kustomize > /dev/null; then
 	popd
 fi
 
+# The generators use GOPATH when locating boilerplate.go.txt, so it must be made available in the child shell.
+export GOPATH
 bash ${GOPATH}/src/k8s.io/code-generator/generate-groups.sh \
   deepcopy,client,lister,informer \
   ${OUTPUT_DIR} \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

#### What this PR does / why we need it:

We ensure GOPATH is set in `generate_code.sh`.

https://github.com/longhorn/longhorn-manager/blob/4b2a8db4c5a58c430455105e4e513ea273c4d046/k8s/generate_code.sh#L20-L27

However, we do not export it.

Later we execute the code generators in a child shell, which does not have access to the set GOPATH variable.

https://github.com/longhorn/longhorn-manager/blob/4b2a8db4c5a58c430455105e4e513ea273c4d046/k8s/generate_code.sh#L60-L65

The code generators (e.g. `deepcopy-gen`) look in the environment for GOPATH in order to find `boilerplate.go.txt`. Unless it was explicitly exported by the user, the code generators can't use it and default to `./`.

https://github.com/kubernetes/code-generator/blob/c3277d42784bc6492e21dee0e0ed900901ac0299/cmd/deepcopy-gen/main.go#L62-L64

#### Additional documentation or context

Before this change:

```
eweber@laptop:~/go/src/github.com/longhorn/longhorn-manager> k8s/generate_code.sh 
Generating deepcopy funcs
F0215 10:51:41.674040   26366 deepcopy.go:131] Failed loading boilerplate: open k8s.io/code-generator/hack/boilerplate.go.txt: no such file or directory
```

After this change:

```
eweber@laptop:~/go/src/github.com/longhorn/longhorn-manager> k8s/generate_code.sh 
Generating deepcopy funcs
Generating clientset for longhorn:v1beta1,v1beta2 at github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset
Generating listers for longhorn:v1beta1,v1beta2 at github.com/longhorn/longhorn-manager/k8s/pkg/client/listers
Generating informers for longhorn:v1beta1,v1beta2 at github.com/longhorn/longhorn-manager/k8s/pkg/client/informers
Generating CRD
~/go/src/github.com/longhorn/longhorn-manager/crds ~/go/src/github.com/longhorn/longhorn-manager
~/go/src/github.com/longhorn/longhorn-manager
```