### PR TITLE
controller: Fix issue that regular restore volume won't be detached

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3158,7 +3158,7 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 	// 3) The restore/DR volume is
 	//   3.1) it's state `Healthy`;
 	//   3.2) or it's state `Degraded` with all the scheduled replica included in the engine
-	if v.Spec.FromBackup == "" || !v.Status.IsStandby {
+	if v.Spec.FromBackup == "" {
 		return nil
 	}
 	isPurging := false
@@ -3173,24 +3173,26 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 		return nil
 	}
 
-	// Make sure the backup volume is up-to-date and the latest backup is restored
-	_, bvName, _, err := backupstore.DecodeBackupURL(v.Spec.FromBackup)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get backup name from volume %s backup URL %v", v.Name, v.Spec.FromBackup)
-	}
-	bv, err := c.ds.GetBackupVolumeRO(bvName)
-	if err != nil {
-		return err
-	}
-	if !bv.Status.LastSyncedAt.IsZero() &&
-		bv.Spec.SyncRequestedAt.After(bv.Status.LastSyncedAt.Time) {
-		log.Infof("Restore/DR volume needs to wait for backup volume %s update", bvName)
-		return nil
-	}
-	if e.Status.LastRestoredBackup != bv.Status.LastBackupName {
-		log.Infof("Restore/DR volume needs to restore the latest backup %s, and the current restored backup is %s", bv.Status.LastBackupName, e.Status.LastRestoredBackup)
-		c.enqueueVolume(v)
-		return nil
+	if v.Status.IsStandby {
+		// For DR volume, make sure the backup volume is up-to-date and the latest backup is restored
+		_, bvName, _, err := backupstore.DecodeBackupURL(v.Spec.FromBackup)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get backup name from volume %s backup URL %v", v.Name, v.Spec.FromBackup)
+		}
+		bv, err := c.ds.GetBackupVolumeRO(bvName)
+		if err != nil {
+			return err
+		}
+		if !bv.Status.LastSyncedAt.IsZero() &&
+			bv.Spec.SyncRequestedAt.After(bv.Status.LastSyncedAt.Time) {
+			log.Infof("Restore/DR volume needs to wait for backup volume %s update", bvName)
+			return nil
+		}
+		if e.Status.LastRestoredBackup != bv.Status.LastBackupName {
+			log.Infof("Restore/DR volume needs to restore the latest backup %s, and the current restored backup is %s", bv.Status.LastBackupName, e.Status.LastRestoredBackup)
+			c.enqueueVolume(v)
+			return nil
+		}
 	}
 
 	allScheduledReplicasIncluded, err := c.checkAllScheduledReplicasIncluded(v, e, rs)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/7945

This fixes the regression introduced by https://github.com/longhorn/longhorn-manager/pull/2611

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
