### PR TITLE
Fix a race condition in volumeattachment controller

### DIFF
--- a/controller/volume_attachment_controller.go
+++ b/controller/volume_attachment_controller.go
@@ -813,7 +813,7 @@ func (vac *VolumeAttachmentController) updateStatusForDesiredAttachingAttachment
 		return
 	}
 
-	if vol.Status.CurrentNodeID == attachmentTicket.NodeID && vol.Status.State == longhorn.VolumeStateAttached {
+	if vol.Spec.NodeID == attachmentTicket.NodeID && vol.Status.CurrentNodeID == attachmentTicket.NodeID && vol.Status.State == longhorn.VolumeStateAttached {
 		if !verifyAttachmentParameters(attachmentTicket.Parameters, vol) {
 			attachmentTicketStatus.Satisfied = false
 			cond := types.GetCondition(attachmentTicketStatus.Conditions, longhorn.AttachmentStatusConditionTypeSatisfied)


### PR DESCRIPTION
The race condition is that we sometimes mark the volumeattachment ticket as satisfied even though the volume has empty spec.NodeID and has started the detaching process.

More context is at https://github.com/longhorn/longhorn/issues/7937#issuecomment-1958604698

longhorn/longhorn#7937
