### PR TITLE
fix(recurring-job): avoid intermediate volume detachment during backup

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -495,17 +495,6 @@ func (job *Job) eventCreate(eventType, eventReason, message string) error {
 	return nil
 }
 
-func (job *Job) deleteSnapshots(names []string, volume *longhornclient.Volume, volumeAPI longhornclient.VolumeOperations) error {
-	for _, name := range names {
-		_, err := volumeAPI.ActionSnapshotDelete(volume, &longhornclient.SnapshotInput{Name: name})
-		if err != nil {
-			return err
-		}
-		job.logger.WithField("volume", volume.Name).Infof("Deleted snapshot %v", name)
-	}
-	return nil
-}
-
 func (job *Job) purgeSnapshots(volume *longhornclient.Volume, volumeAPI longhornclient.VolumeOperations) error {
 	// Trigger snapshot purge of the volume
 	if _, err := volumeAPI.ActionSnapshotPurge(volume); err != nil {
@@ -821,24 +810,6 @@ func (job *Job) GetSettingAsBool(name types.SettingName) (bool, error) {
 	}
 
 	return value, nil
-}
-
-// waitForVolumeState timeout in second
-func (job *Job) waitForVolumeState(state string, timeout int) (*longhornclient.Volume, error) {
-	volumeAPI := job.api.Volume
-	volumeName := job.volumeName
-
-	for i := 0; i < timeout; i++ {
-		volume, err := volumeAPI.ById(volumeName)
-		if err == nil {
-			if volume.State == state {
-				return volume, nil
-			}
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	return nil, fmt.Errorf("timeout waiting for volume %v to be in state %v", volumeName, state)
 }
 
 // handleAttachmentTicketCreation check and create attachment so that the source volume doesn't get detached during the job.

--- a/k8s/pkg/apis/longhorn/v1beta2/volumeattachment.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volumeattachment.go
@@ -52,6 +52,7 @@ const (
 	AttacherTypeVolumeExpansionController        = AttacherType("volume-expansion-controller")
 	AttacherTypeBackingImageDataSourceController = AttacherType("bim-ds-controller")
 	AttacherTypeVolumeRebuildingController       = AttacherType("volume-rebuilding-controller")
+	AttacherTypeRecurringJobApp                  = AttacherType("recurring-job-app")
 )
 
 const (


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7937

#### What this PR does / why we need it:

This was initially created to resolve the issue in longhorn/longhorn#7937, and @PhanLe1010 proposed an alternative [solution](https://github.com/longhorn/longhorn-manager/pull/2627) to tackle the problem.

However, Longhorn could still benefit by avoiding the unnecessary volume detachment during the recurring job backup. Currently, the recurring job runs the snapshot followed by the backup, resulting in an intermediate volume detachment.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context
