### PR TITLE
Fix bug we initiate a backup when the volume has started detaching

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -531,8 +531,9 @@ func (bc *BackupController) VerifyAttachment(backup *longhorn.Backup, volumeName
 	}
 
 	attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeBackupController, backup.Name)
+	isVolumeStillDesiredToAttachToSameNodeAsAttachmentTicket := vol.Spec.NodeID == longhorn.GetNodeIdOfAttachmentTicket(attachmentTicketID, va)
 
-	return longhorn.IsAttachmentTicketSatisfied(attachmentTicketID, va), nil
+	return isVolumeStillDesiredToAttachToSameNodeAsAttachmentTicket && longhorn.IsAttachmentTicketSatisfied(attachmentTicketID, va), nil
 }
 
 func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineImage string) (bool, error) {

--- a/k8s/pkg/apis/longhorn/v1beta2/volumeattachment.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volumeattachment.go
@@ -123,6 +123,18 @@ func GetAttachmentTicketID(attacherType AttacherType, id string) string {
 	return retID
 }
 
+func GetNodeIdOfAttachmentTicket(attachmentID string, va *VolumeAttachment) string {
+	if va == nil {
+		return ""
+	}
+	attachmentTicket, ok := va.Spec.AttachmentTickets[attachmentID]
+	if !ok {
+		return ""
+	}
+
+	return attachmentTicket.NodeID
+}
+
 func IsAttachmentTicketSatisfied(attachmentID string, va *VolumeAttachment) bool {
 	if va == nil {
 		return false


### PR DESCRIPTION
When the volume.Spec.NodeID is different than the node ID of the backup VA ticket, we should not initiate a backup as the volume is going to detach soon

longhorn/longhorn#7937

This PR is going to replace the approach at the PR https://github.com/longhorn/longhorn-manager/pull/2627. After discussed with @ejweber and @james-munson , we think that this approach is better because:
1. The other approach only touches the logic for the VA ticket of RWO non-migratible volume. It still leaves the logic for the RWX and mitigrable volume the same as we cannot compare the volume.Spec.NodeID with the node ID of these VA tickets. They are most likely to be different
1. It is fundamentally still correct that when the volume start detaching (but not finish detaching yet) the VA ticket can set to satisfied because at this exact moment the volume is still attached. VA controller can set reset the VA ticket to satisfied:false when the volume finish detaching. It is the responsibility of the client (backup controller in this case) to check and make sure that the volume.Spec.NodeID is still the desired one

