### PR TITLE
controller: Check backup volume sync time before activation

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3184,6 +3184,11 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 			return err
 		}
 		if bv != nil {
+			if !bv.Status.LastSyncedAt.IsZero() &&
+				bv.Spec.SyncRequestedAt.After(bv.Status.LastSyncedAt.Time) {
+				log.Infof("Restore/DR volume needs to wait for backup volume %s update", bvName)
+				return nil
+			}
 			if bv.Status.LastBackupName != "" {
 				// If the backup CR does not exist, the Longhorn system may be still syncing up the info with the remote backup target.
 				// If the backup is removed already, the backup volume should receive the notification and update bv.Status.LastBackupName.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Longhorn/longhorn#7946


#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
