### PR TITLE
fix(daemon): validate webhook by its domain

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -24,7 +24,7 @@ import (
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/manager"
 	"github.com/longhorn/longhorn-manager/meta"
-	"github.com/longhorn/longhorn-manager/recovery_backend"
+	recoverybackend "github.com/longhorn/longhorn-manager/recovery_backend"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/upgrade"
 	"github.com/longhorn/longhorn-manager/util"
@@ -153,9 +153,15 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
+	// Conversion webhook needs to be started first since we use its port 9501 as readiness port.
+	// longhorn-manager pod becomes ready only when conversion webhook is running.
+	// The services in the longhorn-manager can then start to receive the requests.
 	webhookTypes := []string{types.WebhookTypeConversion, types.WebhookTypeAdmission}
 	for _, webhookType := range webhookTypes {
 		if err := webhook.StartWebhook(ctx, webhookType, clients); err != nil {
+			return err
+		}
+		if err := webhook.CheckWebhookServiceAvailability(webhookType); err != nil {
 			return err
 		}
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/util/client"
 	"github.com/longhorn/longhorn-manager/webhook/server"
 )
@@ -22,12 +23,12 @@ var (
 func StartWebhook(ctx context.Context, webhookType string, clients *client.Clients) error {
 	logrus.Infof("Starting longhorn %s webhook server", webhookType)
 
-	var webhookPort int
+	var webhookLocalEndpoint string
 	switch webhookType {
 	case types.WebhookTypeAdmission:
-		webhookPort = types.DefaultAdmissionWebhookPort
+		webhookLocalEndpoint = fmt.Sprintf("https://localhost:%d/v1/healthz", types.DefaultAdmissionWebhookPort)
 	case types.WebhookTypeConversion:
-		webhookPort = types.DefaultConversionWebhookPort
+		webhookLocalEndpoint = fmt.Sprintf("https://localhost:%d/v1/healthz", types.DefaultConversionWebhookPort)
 	default:
 		return fmt.Errorf("unexpected webhook server type %v", webhookType)
 	}
@@ -40,37 +41,65 @@ func StartWebhook(ctx context.Context, webhookType string, clients *client.Clien
 	}()
 
 	logrus.Infof("Waiting for %v webhook to become ready", webhookType)
+	if !isServiceAvailable(webhookLocalEndpoint, defaultStartTimeout) {
+		return fmt.Errorf("%v webhook is not ready on localhost after %v sec", webhookType, defaultStartTimeout)
+	}
+	logrus.Infof("Started longhorn %s webhook server on localhost", webhookType)
+	return nil
+}
+
+// CheckWebhookServiceAvailability check if the service is available.
+// The server on the host is ready does not mean the service is accessible.
+func CheckWebhookServiceAvailability(webhookType string) error {
+	webhookServiceEndpoint, err := getWebhookServiceEndpoint(webhookType)
+	if err != nil {
+		return err
+	}
+
+	if !isServiceAvailable(webhookServiceEndpoint, defaultStartTimeout) {
+		return fmt.Errorf("%v webhook service is not accessible after %v sec", webhookType, defaultStartTimeout)
+
+	}
+	logrus.Infof("%s webhook service is now accessible", webhookType)
+	return nil
+}
+
+func isServiceAvailable(endpoint string, timeout time.Duration) bool {
 	cli := http.Client{
 		Timeout: time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
-	webhookHealthEndpoint := fmt.Sprintf("https://localhost:%d/v1/healthz", webhookPort)
 	running := false
-	for start := time.Now(); time.Since(start) < defaultStartTimeout; {
-		resp, err := cli.Get(webhookHealthEndpoint)
+	for start := time.Now(); time.Since(start) < timeout; {
+		resp, err := cli.Get(endpoint)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to get webhook health endpoint %v", webhookHealthEndpoint)
+			logrus.WithError(err).Warnf("Failed to check endpoint %v", endpoint)
 		} else if resp.StatusCode == 200 {
-			logrus.Infof("Webhook %v is ready", webhookType)
 			running = true
 			break
 		} else {
 			bodyBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
-				logrus.Warnf("Webhook health endpoint return %d not 200: cannot read the body", resp.StatusCode)
+				logrus.Warnf("Endpoint return %d not 200: cannot read the body", resp.StatusCode)
 			}
 			bodyString := string(bodyBytes)
-			logrus.Warnf("Webhook health endpoint return %d not 200: %v", resp.StatusCode, bodyString)
+			logrus.Warnf("Endpoint return %d not 200: %v", resp.StatusCode, bodyString)
 		}
-
 		time.Sleep(2 * time.Second)
 	}
-	if !running {
-		return fmt.Errorf("%v webhook is not ready after %v sec", webhookType, defaultStartTimeout)
-	}
 
-	logrus.Warnf("Started longhorn %s webhook server", webhookType)
-	return nil
+	return running
+}
+
+func getWebhookServiceEndpoint(webhookType string) (string, error) {
+	switch webhookType {
+	case types.WebhookTypeAdmission:
+		return fmt.Sprintf("https://%v.%v.svc:%d/v1/healthz", types.AdmissionWebhookServiceName, util.GetNamespace(types.EnvPodNamespace), types.DefaultAdmissionWebhookPort), nil
+	case types.WebhookTypeConversion:
+		return fmt.Sprintf("https://%v.%v.svc:%d/v1/healthz", types.ConversionWebhookServiceName, util.GetNamespace(types.EnvPodNamespace), types.DefaultConversionWebhookPort), nil
+	default:
+		return "", fmt.Errorf("unexpected webhook server type %v", webhookType)
+	}
 }


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8005

The root cause is that we now have conversion-webhook(`:9501`), admission-webhook(`:9502`) in longhorn-manager
We set the readiness port to `9501`
The order of starting is as follow
1. conversion-webhook
2. admission-webhook
3. upgrade
4. ....


So there is a chance that the pod is not ready yet (readiness on `9501` hasn't succeeded) when the longhorn-manager starts to do the upgrade 
It then fails to call the webhook by endpoint because there is no longhorn-manager pod ready. 
```
Post \"https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/validaton?timeout=10s\"
````

This PR fix it by validating the endpoint works by testing the domain instead of local address before doing the upgrade.