### PR TITLE
fix:  remove checks of deprecated volume status PendingNodeID.  Also …

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -33,7 +33,6 @@ func isTargetVolumeOfCloning(v *longhorn.Volume) bool {
 func isVolumeFullyDetached(vol *longhorn.Volume) bool {
 	return vol.Spec.NodeID == "" &&
 		vol.Spec.MigrationNodeID == "" &&
-		vol.Status.PendingNodeID == "" &&
 		vol.Status.State == longhorn.VolumeStateDetached
 }
 

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -931,7 +931,6 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.State = longhorn.VolumeStateDetached
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.Image
 	tc.expectVolume.Status.CurrentNodeID = ""
-	tc.expectVolume.Status.PendingNodeID = ""
 	tc.expectVolume.Status.Robustness = longhorn.VolumeRobustnessUnknown
 	tc.expectVolume.Status.RemountRequestedAt = getTestNow()
 
@@ -961,7 +960,6 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc = generateVolumeTestCaseTemplate()
 	tc.volume.Spec.NodeID = ""
 	tc.volume.Status.CurrentNodeID = ""
-	tc.volume.Status.PendingNodeID = TestNode1
 	tc.volume.Status.State = longhorn.VolumeStateDetaching
 	for _, e := range tc.engines {
 		e.Spec.NodeID = ""

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1079,8 +1079,7 @@ func GetNewCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.En
 			oldEngineName = e.Name
 		}
 		if (v.Spec.NodeID != "" && v.Spec.NodeID == e.Spec.NodeID) ||
-			(v.Status.CurrentNodeID != "" && v.Status.CurrentNodeID == e.Spec.NodeID) ||
-			(v.Status.PendingNodeID != "" && v.Status.PendingNodeID == e.Spec.NodeID) {
+			(v.Status.CurrentNodeID != "" && v.Status.CurrentNodeID == e.Spec.NodeID) {
 			if currentEngine != nil {
 				return nil, nil, fmt.Errorf("BUG: found the second new active engine %v besides %v", e.Name, currentEngine.Name)
 			}

--- a/upgrade/v14xto150/upgrade.go
+++ b/upgrade/v14xto150/upgrade.go
@@ -121,6 +121,9 @@ func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset, resourceM
 		if v.Spec.OfflineReplicaRebuilding == "" {
 			v.Spec.OfflineReplicaRebuilding = longhorn.OfflineReplicaRebuildingDisabled
 		}
+		if v.Status.PendingNodeID != "" {
+			v.Status.PendingNodeID = ""
+		}
 	}
 
 	return nil


### PR DESCRIPTION
…clear field on upgrade.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7994

#### What this PR does / why we need it:

Volume Status field PendingNodeID was deprecated in v1.5.  Don't let an un-cleared residual value derail attachments.

#### Special notes for your reviewer:

#### Additional documentation or context
