### PR TITLE
Allow maxSnapshotSize to change from 0 to 250 while upgrading

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1262,6 +1262,12 @@ func (c *VolumeController) syncVolumeSnapshotSetting(v *longhorn.Volume, es map[
 	if es == nil && rs == nil {
 		return nil
 	}
+	// The webhook ONLY allows volume.spec.snapshotMaxCount to be modified during a migration if a Longhorn upgrade is
+	// changing the value from 0 (unset) to 250 (the maximum). To be safe, don't apply the change to engines or replicas
+	// until the migration is complete.
+	if util.IsVolumeMigrating(v) {
+		return nil
+	}
 
 	for _, e := range es {
 		e.Spec.SnapshotMaxCount = v.Spec.SnapshotMaxCount


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7833

#### What this PR does / why we need it:

@roger-ryao discovered that https://github.com/longhorn/longhorn-manager/pull/2564 was ineffective when upgrading from `v1.5.x` to `v1.6.x+`. In fact, the inclusion of https://github.com/longhorn/longhorn/issues/6563 in `v1.6.x` makes it impossible to upgrade Longhorn from `v1.5.x` to `v1.6.x+` while a volume is migrating at all. This is something I didn't notice in my original testing. Thanks @roger-ryao!

This PR:

1. Allows the `volume.spec.snapshotMaxCount` to be changed on a migrating volume ONLY if is from 0 (coming from `v1.5.x`) to `250` (as the upgrade logic does).
2. Waits to propagate that change to engines and replicas until migration is complete.

I updated the test steps at https://github.com/longhorn/longhorn-manager/pull/2558#issuecomment-1932296348 to account for the change.