### PR TITLE
Track replica mode transition times with replicaTransitionTimeMap

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -348,6 +348,7 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 		if engine.Status.CurrentState != longhorn.InstanceStateRunning {
 			engine.Status.Endpoint = ""
 			engine.Status.ReplicaModeMap = nil
+			engine.Status.ReplicaTransitionTimeMap = nil
 		}
 		return nil
 	}
@@ -875,6 +876,7 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	}
 
 	currentReplicaModeMap := map[string]longhorn.ReplicaMode{}
+	currentReplicaTransitionTimeMap := map[string]string{}
 	for url, r := range replicaURLModeMap {
 		addr := engineapi.GetAddressFromBackendReplicaURL(url)
 		replica, exists := addressReplicaMap[addr]
@@ -897,17 +899,29 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 				switch r.Mode {
 				case longhorn.ReplicaModeERR:
 					m.eventRecorder.Eventf(engine, corev1.EventTypeWarning, constant.EventReasonFaulted, "Detected replica %v (%v) in error", replica, addr)
+					currentReplicaTransitionTimeMap[replica] = util.Now()
 				case longhorn.ReplicaModeWO:
 					m.eventRecorder.Eventf(engine, corev1.EventTypeNormal, constant.EventReasonRebuilding, "Detected rebuilding replica %v (%v)", replica, addr)
+					currentReplicaTransitionTimeMap[replica] = util.Now()
 				case longhorn.ReplicaModeRW:
 					m.eventRecorder.Eventf(engine, corev1.EventTypeNormal, constant.EventReasonRebuilt, "Detected replica %v (%v) has been rebuilt", replica, addr)
+					currentReplicaTransitionTimeMap[replica] = util.Now()
 				default:
 					m.logger.Errorf("Invalid engine replica mode %v", r.Mode)
+				}
+			} else {
+				oldTime, ok := engine.Status.ReplicaTransitionTimeMap[replica]
+				if !ok {
+					m.logger.Errorf("BUG: Replica %v (%v) was previously in mode %v but transition time was not recorded", replica, addr, engine.Status.ReplicaModeMap[replica])
+					currentReplicaTransitionTimeMap[replica] = util.Now()
+				} else {
+					currentReplicaTransitionTimeMap[replica] = oldTime
 				}
 			}
 		}
 	}
 	engine.Status.ReplicaModeMap = currentReplicaModeMap
+	engine.Status.ReplicaTransitionTimeMap = currentReplicaTransitionTimeMap
 
 	snapshots, err := engineClientProxy.SnapshotList(engine)
 	if err != nil {
@@ -2017,6 +2031,7 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine, log *logrus.Entry) (err 
 	e.Status.CurrentReplicaAddressMap = e.Spec.UpgradedReplicaAddressMap
 	// reset ReplicaModeMap to reflect the new replicas
 	e.Status.ReplicaModeMap = nil
+	e.Status.ReplicaTransitionTimeMap = nil
 	e.Status.RestoreStatus = nil
 	e.Status.RebuildStatus = nil
 	return nil

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -722,7 +722,18 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 				r.Spec.RebuildRetryCount = 0
 			}
 			// Set LastHealthyAt to record the last time this replica became RW in an engine.
-			r.Spec.LastHealthyAt = now
+			if transitionTime, ok := e.Status.ReplicaTransitionTimeMap[rName]; !ok {
+				log.Errorf("BUG: Replica %v is in mode %v but transition time was not recorded", r.Name, mode)
+				r.Spec.LastHealthyAt = now
+			} else {
+				after, err := util.TimestampAfterTimestamp(transitionTime, r.Spec.LastHealthyAt)
+				if err != nil {
+					log.Errorf("Failed to check if replica %v transitioned to mode %v after it was last healthy", r.Name, mode)
+				}
+				if after || err != nil {
+					r.Spec.LastHealthyAt = now
+				}
+			}
 			healthyCount++
 		}
 	}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3049,6 +3049,7 @@ func (s *DataStore) ResetMonitoringEngineStatus(e *longhorn.Engine) (*longhorn.E
 	e.Status.Endpoint = ""
 	e.Status.LastRestoredBackup = ""
 	e.Status.ReplicaModeMap = nil
+	e.Status.ReplicaTransitionTimeMap = nil
 	e.Status.RestoreStatus = nil
 	e.Status.PurgeStatus = nil
 	e.Status.RebuildStatus = nil

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1653,6 +1653,11 @@ spec:
                   type: string
                 nullable: true
                 type: object
+              replicaTransitionTimeMap:
+                additionalProperties:
+                  type: string
+                description: ReplicaTransitionTimeMap records the time a replica in ReplicaModeMap transitions from one mode to another (or from not being in the ReplicaModeMap to being in it). This information is sometimes required by other controllers (e.g. the volume controller uses it to determine the correct value for replica.Spec.lastHealthyAt).
+                type: object
               restoreStatus:
                 additionalProperties:
                   properties:
@@ -2643,20 +2648,20 @@ spec:
               evictionRequested:
                 type: boolean
               failedAt:
-                description: FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason. FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage.
+                description: FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason. FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage. FailedAt may be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller acknowledges the change.
                 type: string
               hardNodeAffinity:
                 type: string
               healthyAt:
-                description: HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have useful (though possibly stale) data. HealthyAt is cleared before a rebuild.
+                description: HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have useful (though possibly stale) data. HealthyAt is cleared before a rebuild. HealthyAt may be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller acknowledges the change.
                 type: string
               image:
                 type: string
               lastFailedAt:
-                description: LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared. LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to LastHealthyAt to help prevent dangerous replica deletion in some corner cases.
+                description: LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared. LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to LastHealthyAt to help prevent dangerous replica deletion in some corner cases. LastFailedAt may be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller acknowledges the change.
                 type: string
               lastHealthyAt:
-                description: LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases.
+                description: LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases. LastHealthyAt may be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller acknowledges the change.
                 type: string
               logRequested:
                 type: boolean

--- a/k8s/pkg/apis/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engine.go
@@ -158,6 +158,11 @@ type EngineStatus struct {
 	// +nullable
 	ReplicaModeMap map[string]ReplicaMode `json:"replicaModeMap"`
 	// +optional
+	// ReplicaTransitionTimeMap records the time a replica in ReplicaModeMap transitions from one mode to another (or
+	// from not being in the ReplicaModeMap to being in it). This information is sometimes required by other controllers
+	// (e.g. the volume controller uses it to determine the correct value for replica.Spec.lastHealthyAt).
+	ReplicaTransitionTimeMap map[string]string `json:"replicaTransitionTimeMap"`
+	// +optional
 	Endpoint string `json:"endpoint"`
 	// +optional
 	LastRestoredBackup string `json:"lastRestoredBackup"`

--- a/k8s/pkg/apis/longhorn/v1beta2/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/replica.go
@@ -27,25 +27,33 @@ type ReplicaSpec struct {
 	// +optional
 	// HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt
 	// indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have
-	// useful (though possibly stale) data. HealthyAt is cleared before a rebuild.
+	// useful (though possibly stale) data. HealthyAt is cleared before a rebuild. HealthyAt may be later than the
+	// corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+	// acknowledges the change.
 	HealthyAt string `json:"healthyAt"`
 	// +optional
 	// LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is
 	// never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a
 	// replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be
-	// compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases.
+	// compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases. LastHealthyAt may be
+	// later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+	// controller acknowledges the change.
 	LastHealthyAt string `json:"lastHealthyAt"`
 	// +optional
 	// FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason.
 	// FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful
 	// (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can
-	// be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage.
+	// be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage. FailedAt may
+	// be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+	// controller acknowledges the change.
 	FailedAt string `json:"failedAt"`
 	// +optional
 	// LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared.
 	// LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with
 	// LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to
-	// LastHealthyAt to help prevent dangerous replica deletion in some corner cases.
+	// LastHealthyAt to help prevent dangerous replica deletion in some corner cases. LastFailedAt may be later than the
+	// corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+	// acknowledges the change.
 	LastFailedAt string `json:"lastFailedAt"`
 	// +optional
 	DiskID string `json:"diskID"`

--- a/k8s/pkg/apis/longhorn/v1beta2/zz_generated.deepcopy.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/zz_generated.deepcopy.go
@@ -1184,6 +1184,13 @@ func (in *EngineStatus) DeepCopyInto(out *EngineStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.ReplicaTransitionTimeMap != nil {
+		in, out := &in.ReplicaTransitionTimeMap, &out.ReplicaTransitionTimeMap
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.BackupStatus != nil {
 		in, out := &in.BackupStatus, &out.BackupStatus
 		*out = make(map[string]*EngineBackupStatus, len(*in))

--- a/upgrade/v16xto170/upgrade.go
+++ b/upgrade/v16xto170/upgrade.go
@@ -8,6 +8,7 @@ import (
 
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+	"github.com/longhorn/longhorn-manager/util"
 )
 
 const (
@@ -21,9 +22,9 @@ func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeCli
 }
 
 func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
-	// Currently there are no statuses to upgrade. See UpgradeResources -> upgradeVolumes or previous Longhorn versions
-	// for examples.
-	return nil
+	// We will probably need to upgrade other resource status as well. See upgradeEngineStatus or previous Longhorn
+	// versions for examples.
+	return upgradeEngineStatus(namespace, lhClient, resourceMaps)
 }
 
 func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
@@ -49,6 +50,31 @@ func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset, resource
 			// There is no way for us to know the right time for Spec.LastFailedAt if the replica isn't currently
 			// failed. Start updating it after the upgrade.
 			r.Spec.LastFailedAt = r.Spec.FailedAt
+		}
+	}
+
+	return nil
+}
+
+func upgradeEngineStatus(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade engines failed")
+	}()
+
+	engineMap, err := upgradeutil.ListAndUpdateEnginesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn engines during the engine status upgrade")
+	}
+
+	for _, e := range engineMap {
+		for replicaName := range e.Status.ReplicaModeMap {
+			// We don't have any historical information to rely on. Starting at the time of the upgrade.
+			if _, ok := e.Status.ReplicaTransitionTimeMap[replicaName]; !ok {
+				e.Status.ReplicaTransitionTimeMap[replicaName] = util.Now()
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8114

#### What this PR does / why we need it:

When I added the below line of code in longhorn-manager, it was my intention for it to only update `lastHealthyAt` when a replica transitioned from some other mode to RW. However, it actually updates `lastHealthyAt` every time a replica reconciles as long as that replica is RW (whether it is transitioning or not).

https://github.com/ejweber/longhorn-manager/blob/e8f7d17d58b8897012ca9acbdbba97314beceedc/controller/volume_controller.go#L725

This bad behavior did not disrupt the purpose of the `lastHealthyAt` field in that PR (to allow Longhorn to verify that a replica had been healthy at some point since its last failure). However:

- It does not match the intended purpose of the field: to record the last time the replica became RW (not any arbitrary time we have confirmed it to be RW).
- It is causing an unexpectedly high number of PUTs to the Kubernetes API server.

Before this PR, `lastHealthyAt` is updated to the current time once every 30 seconds (the volume controller resync period) even if nothing is happening.

```
# Three replicas for one volume.

eweber@laptop:~/longhorn> kl get replica -oyaml -w | grep lastHealthyAt
  lastHealthyAt: "2024-03-08T20:13:34Z"
  lastHealthyAt: "2024-03-08T20:13:34Z"
  lastHealthyAt: "2024-03-08T20:13:34Z"
  lastHealthyAt: "2024-03-08T20:14:30Z"
  lastHealthyAt: "2024-03-08T20:14:30Z"
  lastHealthyAt: "2024-03-08T20:14:30Z"
  lastHealthyAt: "2024-03-08T20:15:00Z"
  lastHealthyAt: "2024-03-08T20:15:00Z"
  lastHealthyAt: "2024-03-08T20:15:00Z"
  lastHealthyAt: "2024-03-08T20:15:30Z"
  lastHealthyAt: "2024-03-08T20:15:30Z"
  lastHealthyAt: "2024-03-08T20:15:30Z"
```

This Prometheus query shows three PUTs to replicas.longhorn.io every 30 seconds, matching the `kubectl watch`.

![image](https://github.com/longhorn/longhorn-manager/assets/24213029/cee9a549-89ed-4081-8d99-c79022888c1d)

After this PR, `lastHealthyAt` is never updated unnecessarily. 

```
eweber@laptop:~/longhorn> kl get replica -oyaml -w | grep lastHealthyAt
  lastHealthyAt: "2024-03-08T20:27:06Z"
  lastHealthyAt: "2024-03-08T20:27:06Z"
  lastHealthyAt: "2024-03-08T20:27:06Z"

# Output stops after the initial GET.
```

The same Prometheus query shows the three PUTs every 30 seconds go away.

![image](https://github.com/longhorn/longhorn-manager/assets/24213029/26aaa873-e234-45a4-a0d9-6e93e7e0e0d9)


#### Additional documentation or context

I did not want to add an extra field to fix this bug. Unfortunately, there aren't any good alternatives in my opinion:

- As it stands, the volume controller does not have enough information to determine whether `lastHealthyAt` should be modified or not. When looking at the `engine.status.replicaModeMap`, it can see that a replica is currently RW, but it has no way of knowing whether this has just happened or it happened a long time ago.
- The only component that DOES know a replica is transitioning from one mode to another is the engine controller (and more specifically, the engine monitor).
- I considered allowing the engine monitor to directly update the `replica.spec.lastHealthyAt`, but:
  - There is no precedent for doing this (the engine monitor doesn't even currently have access to the replica object).
  - This seems to be a violation of the engine monitor's purpose (which should only be to update the engine status).
  - The engine monitor may be repeatedly unable to update one of the associated replica objects, slowing its ability to update the engine status.
- I considered changing the type of `engine.status.replicaModeMap` so we could store time information in it directly. (See below for one idea.) However, changing the type of CRD fields seems like a recipe for disaster.

```go
// Idea for changing the replicaModeMap that we should not use.

type ReplicaModeMap map[string]ReplicaModeStruct

type ReplicaModeStruct struct {
    ReplicaMode
    transitionTime string
}
```