### PR TITLE
fix(csi): add node info to failed mount logging.

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -414,7 +414,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 								},
 								{
 									Name:             "host",
-									MountPath:        "/rootfs", // path is required for namespaced mounter
+									MountPath:        "/host",
 									MountPropagation: &MountPropagationBidirectional,
 								},
 								{

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -24,6 +24,8 @@ import (
 	"github.com/longhorn/longhorn-manager/csi/crypto"
 	"github.com/longhorn/longhorn-manager/datastore"
 
+	lhns "github.com/longhorn/go-common-libs/ns"
+
 	longhornclient "github.com/longhorn/longhorn-manager/client"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -280,6 +282,16 @@ func (ns *NodeServer) nodeStageSharedVolume(volumeID, shareEndpoint, targetPath 
 			if err == nil {
 				return nil
 			}
+			// Still failed.  Log with mounting node and kernel version for possible troubleshooting.  Don't step on actual mount error.
+			kernelRelease, err1 := lhns.GetKernelRelease()
+			if err1 != nil {
+				kernelRelease = err1.Error()
+			}
+			osDistro, err2 := lhns.GetOSDistro()
+			if err2 != nil {
+				osDistro = err2.Error()
+			}
+			log.WithError(err).Warnf("Failed to mount volume %v on node %s with kernel release %s, os distro %s", volumeID, ns.nodeID, kernelRelease, osDistro)
 		}
 		return status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/longhorn/longhorn/issues/7931

#### What this PR does / why we need it:

Log with kernel release and OS info when an NFS mount fails, to aid in troubleshooting.

#### Special notes for your reviewer:

#### Additional documentation or context
