### PR TITLE
Fix minor issues with ReplicaTransitionTimeMap

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -894,7 +894,11 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 
 		currentReplicaModeMap[replica] = r.Mode
 
-		if engine.Status.ReplicaModeMap != nil {
+		if engine.Status.ReplicaModeMap == nil {
+			// We are constructing the ReplicaModeMap for the first time. Construct the ReplicaTransitionTimeMap
+			// alongside it.
+			currentReplicaTransitionTimeMap[replica] = util.Now()
+		} else {
 			if r.Mode != engine.Status.ReplicaModeMap[replica] {
 				switch r.Mode {
 				case longhorn.ReplicaModeERR:

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -287,6 +287,13 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 			return err
 		}
 	}
+	// When lhVersionBeforeUpgrade < v1.7.0, it is v1.6.x. The `CheckUpgradePathSupported` method would have failed us out earlier if it was not v1.6.x.
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.7.0") < 0 {
+		logrus.Info("Walking through the resource status upgrade path v1.6.x to v1.7.0")
+		if err := v16xto170.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
 	if err := upgradeutil.UpdateResourcesStatus(namespace, lhClient, resourceMaps); err != nil {
 		return err
 	}

--- a/upgrade/v16xto170/upgrade.go
+++ b/upgrade/v16xto170/upgrade.go
@@ -70,6 +70,9 @@ func upgradeEngineStatus(namespace string, lhClient *lhclientset.Clientset, reso
 	}
 
 	for _, e := range engineMap {
+		if e.Status.ReplicaTransitionTimeMap == nil {
+			e.Status.ReplicaTransitionTimeMap = map[string]string{}
+		}
 		for replicaName := range e.Status.ReplicaModeMap {
 			// We don't have any historical information to rely on. Starting at the time of the upgrade.
 			if _, ok := e.Status.ReplicaTransitionTimeMap[replicaName]; !ok {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8114

#### What this PR does / why we need it:

Further testing of https://github.com/longhorn/longhorn-manager/pull/2685 shows two issues:

- ReplicaTransitionTimeMap was only created if ReplicaModeMap previously existed. This didn't really impact functionality (as we quickly created it on a followup reconciliation) but it led to erroneous log messages like `"BUG: Replica %v is in mode %v but transition time was not recorded"`.
- Update logic was added, but never triggered. Again, this didn't really affect functionality (as the volume and engine controllers quickly filled in the missing fields after upgrade), but it was confusing.