### PR TITLE
Recognize pods that use Longhorn generic ephemeral volumes

### DIFF
--- a/controller/kubernetes_pv_controller.go
+++ b/controller/kubernetes_pv_controller.go
@@ -434,6 +434,12 @@ func (kc *KubernetesPVController) getAssociatedPods(ks *longhorn.KubernetesStatu
 			if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == ks.PVCName {
 				return true
 			}
+			// Generic ephemeral volumes have an Ephemeral section instead of a PersistentVolumeClaim section. The name
+			// of the PersistentVolumeClaim associated with a generic ephemeral volume is deterministic:
+			// https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#persistentvolumeclaim-naming.
+			if v.Ephemeral != nil && fmt.Sprintf("%s-%s", pod.Name, v.Name) == ks.PVCName {
+				return true
+			}
 		}
 		return false
 	})


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fixes the root cause of longhorn/longhorn#8198.

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn-manager/pull/2494 only allowed NodePublishVolume calls to proceed if a Longhorn volume's `status.kubernetesStatus.workloadsStatus` contained a pending workload. However, Longhorn's Kubernetes PV controller does not recognize workloads that use generic ephemeral volumes. As a result, NodePublishVolume calls fail for generic ephemeral volumes. https://github.com/longhorn/longhorn-manager/pull/2659 happened to mitigate this behavior, but the root cause remains.

This PR modifies Longhorn's Kubernetes PV controller so that it can detect workloads that use generic ephemeral volumes.