### PR TITLE
feat(backup): add option validation for backup creation

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -140,6 +140,7 @@ type BackupVolume struct {
 	BackingImageName     string            `json:"backingImageName"`
 	BackingImageChecksum string            `json:"backingImageChecksum"`
 	StorageClassName     string            `json:"storageClassName"`
+	BackupTimes          int64             `json:"backupTimes"`
 }
 
 type Backup struct {
@@ -1742,6 +1743,7 @@ func toBackupVolumeResource(bv *longhorn.BackupVolume, apiContext *api.ApiContex
 		BackingImageName:     bv.Status.BackingImageName,
 		BackingImageChecksum: bv.Status.BackingImageChecksum,
 		StorageClassName:     bv.Status.StorageClassName,
+		BackupTimes:          bv.Status.BackupTimes,
 	}
 	b.Actions = map[string]string{
 		"backupList":   apiContext.UrlBuilder.ActionLink(b.Resource, "backupList"),

--- a/client/generated_backup_volume.go
+++ b/client/generated_backup_volume.go
@@ -28,6 +28,8 @@ type BackupVolume struct {
 	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 
 	StorageClassName string `json:"storageClassName,omitempty" yaml:"storage_class_name,omitempty"`
+
+	BackupTimes int64 `json:"backupTimes,omitempty" yaml:"backup_times,omitempty"`
 }
 
 type BackupVolumeCollection struct {

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -408,6 +408,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	backupVolume.Status.BackingImageChecksum = backupVolumeInfo.BackingImageChecksum
 	backupVolume.Status.StorageClassName = backupVolumeInfo.StorageClassName
 	backupVolume.Status.LastSyncedAt = syncTime
+	backupVolume.Status.BackupTimes = backupVolumeInfo.BackupTimes
 	return nil
 }
 

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -162,6 +162,7 @@ type BackupVolume struct {
 	BackingImageName     string             `json:"backingImageName"`
 	BackingImageChecksum string             `json:"backingImageChecksum"`
 	StorageClassName     string             `json:"storageClassName"`
+	BackupTimes          int64              `json:"backupTimes"`
 }
 
 type Backup struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/longhorn/longhorn-manager
 go 1.21
 
 replace (
+	github.com/longhorn/backupstore v0.0.0-20240219094812-3a87ee02df77 => github.com/ChanYiLin/backupstore v0.0.0-20240321072722-823fe2cd73ef
 	k8s.io/api => k8s.io/api v0.28.5
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.5
 	k8s.io/apimachinery => k8s.io/apimachinery v0.28.5

--- a/go.sum
+++ b/go.sum
@@ -605,6 +605,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/ChanYiLin/backupstore v0.0.0-20240321072722-823fe2cd73ef h1:qoykZ7hwdDo36NyEYw+Azebq0dmBghOaayPtEBHwjTA=
+github.com/ChanYiLin/backupstore v0.0.0-20240321072722-823fe2cd73ef/go.mod h1:4cbJWtlrD2cGTQxQLtdlPTYopiJiusXH7CpOBrn/s3k=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
@@ -1045,14 +1047,10 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/longhorn/backing-image-manager v1.6.0 h1:Jmlc8+W63l0VZoVhPwNLniAk+eBC4CNaadoqpqA51KE=
 github.com/longhorn/backing-image-manager v1.6.0/go.mod h1:IH0mgbK+Dr13xkY+LhDaufyd9YIpiKqYo1AeRLFYGrk=
-github.com/longhorn/backupstore v0.0.0-20240219094812-3a87ee02df77 h1:iJRq59kA22f9HIjFtY/lz5rKCorZJrrYXju70XoWdmE=
-github.com/longhorn/backupstore v0.0.0-20240219094812-3a87ee02df77/go.mod h1:4cbJWtlrD2cGTQxQLtdlPTYopiJiusXH7CpOBrn/s3k=
 github.com/longhorn/go-common-libs v0.0.0-20240307063052-6e77996eda29 h1:tyzIDCMjQGQzhqAtdJaeEMAaNUZJD/sHERXp+tYc+ms=
 github.com/longhorn/go-common-libs v0.0.0-20240307063052-6e77996eda29/go.mod h1:ePLGb2r/PJBUIVoVhLOt4bLOeu0S72ZB+fWDWwC8H28=
 github.com/longhorn/go-iscsi-helper v0.0.0-20240308033847-bc3aab599425 h1:koSD52H0VkzJAh3OIZCdgQ9mqoRXklkeuhqmuwQ1WzU=
 github.com/longhorn/go-iscsi-helper v0.0.0-20240308033847-bc3aab599425/go.mod h1:2aM6KBix3Khd56I4rihOBOOPOm0/YvYMjtr1KNclQsI=
-github.com/longhorn/go-spdk-helper v0.0.0-20240301101140-6eb6aa5fc09d h1:vajqcFlGHmyQcqhBbGMRo33GNcrKMgNY8ca87rGuKnU=
-github.com/longhorn/go-spdk-helper v0.0.0-20240301101140-6eb6aa5fc09d/go.mod h1:Zv0UpwuqZpijy5/vSW2PvR8zVPBX8CJPF3XeZAuc4Ek=
 github.com/longhorn/go-spdk-helper v0.0.0-20240308030201-9b252d6f7250 h1:bc9BtfvSuXvmztYiBCebvPWPxakbiCWBvydbeqat+Ek=
 github.com/longhorn/go-spdk-helper v0.0.0-20240308030201-9b252d6f7250/go.mod h1:re2QHb6FUU9G/CL3AnXDbzFjLNPwmweBvnTfeVpkZ1E=
 github.com/longhorn/longhorn-engine v1.6.0 h1:6CH2vvwCgFBIGW4TegcI79CL1Ego1nvLZIC3ioRjjdM=
@@ -2231,8 +2229,6 @@ k8s.io/mount-utils v0.28.5/go.mod h1:ceMAZ+Nzlk8zOwN205YXXGJRGmf1o0/XIwsKnG44p0I
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCfRziVtos3ofG/sQ=
-k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0gQBEuevE/AaBsHY=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1111,6 +1111,10 @@ spec:
               backingImageName:
                 description: The backing image name.
                 type: string
+              backupTimes:
+                description: The number of backups that have been created.
+                format: int64
+                type: integer
               createdAt:
                 description: The backup volume creation time.
                 type: string

--- a/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backupvolume.go
@@ -55,6 +55,9 @@ type BackupVolumeStatus struct {
 	// +optional
 	// +nullable
 	LastSyncedAt metav1.Time `json:"lastSyncedAt"`
+	// The number of backups that have been created.
+	// +optional
+	BackupTimes int64 `json:"backupTimes"`
 }
 
 // +genclient

--- a/vendor/github.com/longhorn/backupstore/backupstore.go
+++ b/vendor/github.com/longhorn/backupstore/backupstore.go
@@ -23,6 +23,7 @@ type Volume struct {
 	CompressionMethod    string `json:",string"`
 	StorageClassName     string `json:",string"`
 	DataEngine           string `json:",string"`
+	BackupTimes          int64  `json:",string"`
 }
 
 type Snapshot struct {
@@ -73,6 +74,9 @@ func addVolume(driver BackupStoreDriver, volume *Volume) error {
 	if !util.ValidateName(volume.Name) {
 		return fmt.Errorf("invalid volume name %v", volume.Name)
 	}
+
+	// first time create backup volume means first time create backup on this backupstore
+	volume.BackupTimes = 0
 
 	if err := saveVolume(driver, volume); err != nil {
 		log.WithError(err).Errorf("Failed to add volume %v", volume.Name)

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -175,7 +175,7 @@ func CreateDeltaBlockBackup(backupName string, config *DeltaBackupConfig) (isInc
 	}
 
 	backupRequest := &backupRequest{}
-	if volume.LastBackupName != "" {
+	if volume.LastBackupName != "" && !isFullBackup(config) {
 		lastBackupName := volume.LastBackupName
 		var backup, err = loadBackup(bsDriver, lastBackupName, volume.Name)
 		if err != nil {
@@ -207,6 +207,9 @@ func CreateDeltaBlockBackup(backupName string, config *DeltaBackupConfig) (isInc
 			backupRequest.lastBackup = backup
 		}
 	}
+
+	logrus.Infof("[DEBUG] isFullBackup(config): %v", isFullBackup(config))
+	logrus.Infof("[DEBUG] backupRequest.lastBackup: %v", backupRequest.lastBackup)
 
 	log.WithFields(logrus.Fields{
 		LogFieldReason:       LogReasonStart,
@@ -368,7 +371,7 @@ func backupBlock(bsDriver BackupStoreDriver, config *DeltaBackupConfig,
 	}()
 
 	blkFile := getBlockFilePath(volume.Name, checksum)
-	if bsDriver.FileExists(blkFile) {
+	if bsDriver.FileExists(blkFile) && !isFullBackup(config) {
 		log.Debugf("Found existing block matching at %v", blkFile)
 		return nil
 	}
@@ -554,6 +557,7 @@ func performBackup(bsDriver BackupStoreDriver, config *DeltaBackupConfig, delta 
 	volume.CompressionMethod = config.Volume.CompressionMethod
 	volume.StorageClassName = config.Volume.StorageClassName
 	volume.DataEngine = config.Volume.DataEngine
+	volume.BackupTimes = volume.BackupTimes + 1
 
 	if err := saveVolume(bsDriver, volume); err != nil {
 		return progress.progress, "", err
@@ -1302,4 +1306,13 @@ func getBlockNamesForVolume(driver BackupStoreDriver, volumeName string) ([]stri
 	}
 
 	return util.ExtractNames(names, "", BLK_SUFFIX), nil
+}
+
+func isFullBackup(config *DeltaBackupConfig) bool {
+	if config.Labels != nil {
+		if backupMode, exist := config.Labels[types.GetLonghornLabelKey(types.LonghornBackupOptionBackupMode)]; exist {
+			return backupMode == types.LonghornBackupModeFull
+		}
+	}
+	return false
 }

--- a/vendor/github.com/longhorn/backupstore/types/types.go
+++ b/vendor/github.com/longhorn/backupstore/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 type ProgressState string
 
 const (
@@ -29,6 +31,16 @@ const (
 	NOProxy    = "NO_PROXY"
 
 	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
+
+	LonghornLabelKeyPrefix = "longhorn.io"
+)
+
+const (
+	LonghornBackupOptionBackupMode = "backup-mode"
+	LonghornBackupModeFull         = "full"
+	LonghornBackupModeIncremental  = "incremental"
+
+	LonghornBackupOptionFullBackupInterval = "full-backup-interval"
 )
 
 type Mapping struct {
@@ -65,3 +77,7 @@ const (
 const (
 	ErrorMsgRestoreCancelled = "backup restoration is cancelled"
 )
+
+func GetLonghornLabelKey(name string) string {
+	return fmt.Sprintf("%s/%s", LonghornLabelKeyPrefix, name)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/longhorn/backing-image-manager/pkg/meta
 github.com/longhorn/backing-image-manager/pkg/rpc
 github.com/longhorn/backing-image-manager/pkg/types
 github.com/longhorn/backing-image-manager/pkg/util
-# github.com/longhorn/backupstore v0.0.0-20240219094812-3a87ee02df77
+# github.com/longhorn/backupstore v0.0.0-20240219094812-3a87ee02df77 => github.com/ChanYiLin/backupstore v0.0.0-20240321072722-823fe2cd73ef
 ## explicit; go 1.21
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/backupbackingimage

--- a/webhook/resources/backup/validator.go
+++ b/webhook/resources/backup/validator.go
@@ -1,10 +1,17 @@
 package backup
 
 import (
-	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"fmt"
+	"strings"
 
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	btypes "github.com/longhorn/backupstore/types"
 	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -27,4 +34,43 @@ func (b *backupValidator) Resource() admission.Resource {
 		ObjectType:     &longhorn.Backup{},
 		OperationTypes: []admissionregv1.OperationType{},
 	}
+}
+
+func (b *backupValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	backup, ok := newObj.(*longhorn.Backup)
+	if !ok {
+		return werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.Backup", newObj), "")
+	}
+
+	if backup.Spec.Labels != nil {
+		for key, value := range backup.Spec.Labels {
+			if !strings.HasPrefix(key, types.LonghornLabelKeyPrefix) {
+				continue
+			}
+			if err := validateBackupOption(key, value); err != nil {
+				return werror.NewInvalidError(err.Error(), "")
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func validateBackupOption(label, value string) error {
+	option := label[strings.LastIndex(label, "/")+1:]
+
+	switch option {
+	case btypes.LonghornBackupOptionBackupMode:
+		if value != btypes.LonghornBackupModeFull &&
+			value != btypes.LonghornBackupModeIncremental {
+			return fmt.Errorf("%v:%v is not a valid option", label, value)
+		}
+	case types.LonghornLabelVolumeAccessMode:
+		return nil
+	default:
+		return fmt.Errorf("%v:%v is not a valid option", label, value)
+	}
+
+	return nil
 }


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7070

backupstore: If the backup has the option `backupmodea: full`, it will pretend there is no last backup, and backup all the blocks of the current volume.

longhorn-manager: We need to validate the option of the Backup to check if there is any typo in the option.