### PR TITLE
feat(system-backup): support backup backing image

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -465,6 +465,27 @@ func newBackup(name string) *longhorn.Backup {
 	}
 }
 
+func newBackupBackingImage(name string) *longhorn.BackupBackingImage {
+	return &longhorn.BackupBackingImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: TestNamespace,
+		},
+	}
+}
+
+func newBackingIamge(name string, sourceType longhorn.BackingImageDataSourceType) *longhorn.BackingImage {
+	return &longhorn.BackingImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: TestNamespace,
+		},
+		Spec: longhorn.BackingImageSpec{
+			SourceType: sourceType,
+		},
+	}
+}
+
 func newKubernetesNode(name string, readyStatus, diskPressureStatus, memoryStatus, pidStatus, networkStatus, kubeletStatus corev1.ConditionStatus) *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controller/system_restore_controller_test.go
+++ b/controller/system_restore_controller_test.go
@@ -371,6 +371,41 @@ func fakeSystemRolloutBackups(fakeObjs map[string]*longhorn.Backup, c *C, inform
 	}
 }
 
+func fakeSystemRolloutBackupBackingImages(fakeObjs map[string]*longhorn.BackupBackingImage, c *C, informerFactory lhinformers.SharedInformerFactory, client *lhfake.Clientset) {
+	indexer := informerFactory.Longhorn().V1beta2().BackupBackingImages().Informer().GetIndexer()
+
+	clientInterface := client.LonghornV1beta2().BackupBackingImages(TestNamespace)
+
+	exists, err := clientInterface.List(context.TODO(), metav1.ListOptions{})
+	c.Assert(err, IsNil)
+
+	for _, exist := range exists.Items {
+		exist, err := clientInterface.Get(context.TODO(), exist.Name, metav1.GetOptions{})
+		c.Assert(err, IsNil)
+
+		err = clientInterface.Delete(context.TODO(), exist.Name, metav1.DeleteOptions{})
+		c.Assert(err, IsNil)
+
+		err = indexer.Delete(exist)
+		c.Assert(err, IsNil)
+	}
+
+	for k, fakeObj := range fakeObjs {
+		name := string(k)
+		if strings.HasSuffix(name, TestIgnoreSuffix) {
+			continue
+		}
+
+		backupBackingImage := newBackupBackingImage(name)
+		backupBackingImage.Status = fakeObj.Status
+		exist, err := clientInterface.Create(context.TODO(), backupBackingImage, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		err = indexer.Add(exist)
+		c.Assert(err, IsNil)
+	}
+}
+
 func fakeSystemRolloutDaemonSets(fakeObjs map[SystemRolloutCRName]*appsv1.DaemonSet, c *C, informerFactory informers.SharedInformerFactory, client *fake.Clientset) {
 	indexer := informerFactory.Apps().V1().DaemonSets().Informer().GetIndexer()
 
@@ -678,6 +713,40 @@ func fakeSystemRolloutVolumes(fakeObjs map[SystemRolloutCRName]*longhorn.Volume,
 		volume := newVolume(name, fakeObj.Spec.NumberOfReplicas)
 		volume.Status = fakeObj.Status
 		exist, err := clientInterface.Create(context.TODO(), volume, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		err = indexer.Add(exist)
+		c.Assert(err, IsNil)
+	}
+}
+
+func fakeSystemRolloutBackingImages(fakeObjs map[SystemRolloutCRName]*longhorn.BackingImage, c *C, informerFactory lhinformers.SharedInformerFactory, client *lhfake.Clientset) {
+	indexer := informerFactory.Longhorn().V1beta2().BackingImages().Informer().GetIndexer()
+
+	clientInterface := client.LonghornV1beta2().BackingImages(TestNamespace)
+
+	exists, err := clientInterface.List(context.TODO(), metav1.ListOptions{})
+	c.Assert(err, IsNil)
+
+	for _, exist := range exists.Items {
+		exist, err := clientInterface.Get(context.TODO(), exist.Name, metav1.GetOptions{})
+		c.Assert(err, IsNil)
+
+		err = clientInterface.Delete(context.TODO(), exist.Name, metav1.DeleteOptions{})
+		c.Assert(err, IsNil)
+
+		err = indexer.Delete(exist)
+		c.Assert(err, IsNil)
+	}
+
+	for k, fakeObj := range fakeObjs {
+		name := string(k)
+		if strings.HasSuffix(name, TestIgnoreSuffix) {
+			continue
+		}
+
+		backingImage := newBackingIamge(name, fakeObj.Spec.SourceType)
+		exist, err := clientInterface.Create(context.TODO(), backingImage, metav1.CreateOptions{})
 		c.Assert(err, IsNil)
 
 		err = indexer.Add(exist)

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -33,6 +33,9 @@ var (
 
 	// VolumeBackupTimeout is the timeout for volume backups
 	VolumeBackupTimeout = 24 * time.Hour
+
+	// BackingImageBackupTimeout is the timeout for backing image backups
+	BackingImageBackupTimeout = 24 * time.Hour
 )
 
 // DataStore object

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1936,6 +1936,7 @@ func (s *DataStore) ListBackingImages() (map[string]*longhorn.BackingImage, erro
 	return itemMap, nil
 }
 
+// ListBackingImagesRO returns object includes all BackingImage in namespace
 func (s *DataStore) ListBackingImagesRO() ([]*longhorn.BackingImage, error) {
 	return s.backingImageLister.BackingImages(s.namespace).List(labels.Everything())
 }

--- a/datastore/uncached.go
+++ b/datastore/uncached.go
@@ -392,3 +392,12 @@ func (s *DataStore) GetConfigMapWithoutCache(namespace, name string) (*corev1.Co
 func (s *DataStore) GetLonghornSnapshotUncached(name string) (*longhorn.Snapshot, error) {
 	return s.lhClient.LonghornV1beta2().Snapshots(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
+
+// GetAllBackingImages returns an uncached list of BackingImage in Longhorn
+// namespace directly from the API server.
+// Using cached informers should be preferred but current lister doesn't have a
+// field selector.
+// Direct retrieval from the API server should only be used for one-shot tasks.
+func (s *DataStore) GetAllLonghornBackingImages() (runtime.Object, error) {
+	return s.lhClient.LonghornV1beta2().BackingImages(s.namespace).List(context.TODO(), metav1.ListOptions{})
+}

--- a/k8s/pkg/apis/longhorn/v1beta2/systembackup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/systembackup.go
@@ -5,14 +5,15 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type SystemBackupState string
 
 const (
-	SystemBackupStateDeleting     = SystemBackupState("Deleting")
-	SystemBackupStateError        = SystemBackupState("Error")
-	SystemBackupStateGenerating   = SystemBackupState("Generating")
-	SystemBackupStateNone         = SystemBackupState("")
-	SystemBackupStateReady        = SystemBackupState("Ready")
-	SystemBackupStateSyncing      = SystemBackupState("Syncing")
-	SystemBackupStateUploading    = SystemBackupState("Uploading")
-	SystemBackupStateVolumeBackup = SystemBackupState("CreatingVolumeBackups")
+	SystemBackupStateDeleting           = SystemBackupState("Deleting")
+	SystemBackupStateError              = SystemBackupState("Error")
+	SystemBackupStateGenerating         = SystemBackupState("Generating")
+	SystemBackupStateNone               = SystemBackupState("")
+	SystemBackupStateReady              = SystemBackupState("Ready")
+	SystemBackupStateSyncing            = SystemBackupState("Syncing")
+	SystemBackupStateUploading          = SystemBackupState("Uploading")
+	SystemBackupStateVolumeBackup       = SystemBackupState("CreatingVolumeBackups")
+	SystemBackupStateBackingImageBackup = SystemBackupState("CreatingBackingImageBackups")
 
 	SystemBackupConditionTypeError = "Error"
 

--- a/types/types.go
+++ b/types/types.go
@@ -47,6 +47,7 @@ const (
 	LonghornKindRecurringJobList = "RecurringJobList"
 	LonghornKindSettingList      = "SettingList"
 	LonghornKindVolumeList       = "VolumeList"
+	LonghornKindBackingImageList = "BackingImageList"
 
 	KubernetesKindClusterRole           = "ClusterRole"
 	KubernetesKindClusterRoleBinding    = "ClusterRoleBinding"


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/5085

1. Backup all BackingImages after backing up Volumes and their yaml when taking system-backup
    - **`After backing up Volumes`: Because now we already backup BackingImage when backing up Volumes**, In this stage, we only backup those BackingImages not being used.
3. Restore BackingImages before restoring Volumes, so the Volumes with BackingImages can restore successfully.
    - **`Before restoring Volumes`: Because Volume with BackingImage creation will fail if there is no BackingImage in the cluster**
    - If the BackingImage already exists, update the tag `last-skipped-system-restored` and `last-skipped-system-restored-at`
    - If the BackingImage does not exist, restore it by creating `restore` type BackingImage
        - use `Checksum:   restore.Status.Checksum,` to verify the BackingImage (checksum from the yaml system-backup stored)
        -  update the tag `last-system-restored` and `last-system-restored-at`