### PR TITLE
fix(expand): check volume size first

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -468,6 +468,15 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 
 	size = util.RoundUpSize(size)
 
+	if v.Spec.Size >= size {
+		logrus.Infof("Volume %v expansion is not allowable since current size %v >= %v", v.Name, v.Spec.Size, size)
+		return v, nil
+	}
+
+	if _, err := m.scheduler.CheckReplicasSizeExpansion(v, v.Spec.Size, size); err != nil {
+		return nil, err
+	}
+
 	kubernetesStatus := &v.Status.KubernetesStatus
 	if kubernetesStatus.PVCName != "" && kubernetesStatus.LastPVCRefAt == "" {
 		waitForPVCExpansion, size, err := m.checkAndExpandPVC(kubernetesStatus.Namespace, kubernetesStatus.PVCName, size)
@@ -481,15 +490,6 @@ func (m *VolumeManager) Expand(volumeName string, size int64) (v *longhorn.Volum
 		}
 
 		logrus.Infof("CSI plugin call to expand volume %v to size %v", v.Name, size)
-	}
-
-	if v.Spec.Size >= size {
-		logrus.Infof("Volume %v expansion is not necessary since current size %v >= %v", v.Name, v.Spec.Size, size)
-		return v, nil
-	}
-
-	if _, err := m.scheduler.CheckReplicasSizeExpansion(v, v.Spec.Size, size); err != nil {
-		return nil, err
 	}
 
 	previousSize := v.Spec.Size


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

https://github.com/longhorn/longhorn/issues/7841

#### What this PR does / why we need it:

Check if volume size can be scheduled by the replica scheduler before expading the pv/pvc size.

#### Special notes for your reviewer:

#### Additional documentation or context
