### PR TITLE
Prevent unnecessary updates of instanceManager status

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1633,7 +1633,11 @@ func (m *InstanceManagerMonitor) updateInstanceMap(im *longhorn.InstanceManager,
 				replicaProcess[name] = process
 			}
 		}
-		if reflect.DeepEqual(im.Status.InstanceEngines, engineProcess) && reflect.DeepEqual(im.Status.InstanceReplicas, replicaProcess) {
+
+		// reflect.DeepEqual treats the two maps `var m1 map[string]process` and `m2 := map[string]process` as different maps.
+		// Therefore, to prevent unnecessary updates, we must check both that the length of the maps is zero and that the maps are identical.
+		if ((len(im.Status.InstanceEngines) == 0 && len(engineProcess) == 0) || reflect.DeepEqual(im.Status.InstanceEngines, engineProcess)) &&
+			((len(im.Status.InstanceReplicas) == 0 && len(replicaProcess) == 0) || reflect.DeepEqual(im.Status.InstanceReplicas, replicaProcess)) {
 			return false
 		}
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8420

#### What this PR does / why we need it:

reflect.DeepEqual treats the two maps `var m1 map[string]process` and `m2 := map[string]process` as different maps. Therefore, to prevent unnecessary updates, we must check both that the length of the maps is zero and that the maps are identical.

#### Special notes for your reviewer:

#### Additional documentation or context
