### PR TITLE
Record instance-manager name for a block disksin `node.spec.diskStatus`

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/longhorn/longhorn-manager/util"
 
 	"github.com/longhorn/longhorn-manager/controller/monitor"
+
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
@@ -783,6 +784,7 @@ func (nc *NodeController) findNotReadyAndReadyDiskMaps(node *longhorn.Node, coll
 					monitor.NewDiskInfo(diskInfo.DiskName, diskInfo.DiskUUID, diskInfo.Path, diskInfo.DiskDriver,
 						diskInfo.NodeOrDiskEvicted, diskInfo.DiskStat,
 						diskInfo.OrphanedReplicaDirectoryNames,
+						diskInfo.InstanceManagerName,
 						string(longhorn.DiskConditionReasonDiskFilesystemChanged), errorMessage)
 				continue
 			}
@@ -803,6 +805,7 @@ func (nc *NodeController) findNotReadyAndReadyDiskMaps(node *longhorn.Node, coll
 				notReadyDiskInfoMap[diskID][diskName] =
 					monitor.NewDiskInfo(diskInfo.DiskName, diskInfo.DiskUUID, diskInfo.Path, diskInfo.DiskDriver, diskInfo.NodeOrDiskEvicted, diskInfo.DiskStat,
 						diskInfo.OrphanedReplicaDirectoryNames,
+						diskInfo.InstanceManagerName,
 						string(longhorn.DiskConditionReasonDiskFilesystemChanged),
 						fmt.Sprintf("Disk %v(%v) on node %v is not ready: disk has same file system ID %v as other disks %+v",
 							diskName, diskInfoMap[diskName].Path, node.Name, diskID, monitor.GetDiskNamesFromDiskMap(diskInfoMap)))
@@ -850,6 +853,7 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 			usableStorage := (diskInfoMap[diskName].DiskStat.StorageAvailable / truncateTo) * truncateTo
 			diskStatus.StorageAvailable = usableStorage
 			diskStatus.StorageMaximum = diskInfoMap[diskName].DiskStat.StorageMaximum
+			diskStatus.InstanceManagerName = diskInfoMap[diskName].InstanceManagerName
 			diskStatusMap[diskName].Conditions = types.SetConditionAndRecord(diskStatusMap[diskName].Conditions,
 				longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue,
 				"", fmt.Sprintf("Disk %v(%v) on node %v is ready", diskName, diskInfoMap[diskName].Path, node.Name),

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"strings"
 
-	monitor "github.com/longhorn/longhorn-manager/controller/monitor"
-	"github.com/longhorn/longhorn-manager/datastore"
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
-	"github.com/longhorn/longhorn-manager/types"
-	"github.com/longhorn/longhorn-manager/util"
 	"github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +17,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
 
-	. "gopkg.in/check.v1"
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
+	monitor "github.com/longhorn/longhorn-manager/controller/monitor"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
 const (
@@ -473,12 +475,13 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
 	node1.Status.DiskStatus = map[string]*longhorn.DiskStatus{
 		TestDiskID1: {
-			StorageScheduled: 0,
-			StorageAvailable: 0,
-			Type:             longhorn.DiskTypeFilesystem,
-			FSType:           TestDiskPathFSType,
-			DiskPath:         TestDefaultDataPath,
-			DiskName:         TestDiskID1,
+			StorageScheduled:    0,
+			StorageAvailable:    0,
+			Type:                longhorn.DiskTypeFilesystem,
+			FSType:              TestDiskPathFSType,
+			DiskPath:            TestDefaultDataPath,
+			DiskName:            TestDiskID1,
+			InstanceManagerName: TestInstanceManagerName,
 		},
 	}
 	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
@@ -489,10 +492,11 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 			Conditions: []longhorn.Condition{
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusUnknown, ""),
 			},
-			Type:     longhorn.DiskTypeFilesystem,
-			FSType:   TestDiskPathFSType,
-			DiskPath: TestDefaultDataPath,
-			DiskName: TestDiskID1,
+			Type:                longhorn.DiskTypeFilesystem,
+			FSType:              TestDiskPathFSType,
+			DiskPath:            TestDefaultDataPath,
+			DiskName:            TestDiskID1,
+			InstanceManagerName: TestInstanceManagerName,
 		},
 	}
 
@@ -561,11 +565,12 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 						ScheduledReplica: map[string]int64{
 							fixture.lhReplicas[0].Name: fixture.lhReplicas[0].Spec.VolumeSize,
 						},
-						DiskName: TestDiskID1,
-						DiskUUID: TestDiskID1,
-						Type:     longhorn.DiskTypeFilesystem,
-						FSType:   TestDiskPathFSType,
-						DiskPath: TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						DiskUUID:            TestDiskID1,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -581,10 +586,11 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 						Conditions: []longhorn.Condition{
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusUnknown, ""),
 						},
-						Type:     longhorn.DiskTypeFilesystem,
-						FSType:   TestDiskPathFSType,
-						DiskPath: TestDefaultDataPath,
-						DiskName: TestDiskID1,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -639,12 +645,13 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
 	node2.Status.DiskStatus = map[string]*longhorn.DiskStatus{
 		TestDiskID1: {
-			StorageScheduled: 0,
-			StorageAvailable: 0,
-			Type:             longhorn.DiskTypeFilesystem,
-			FSType:           TestDiskPathFSType,
-			DiskPath:         TestDefaultDataPath,
-			DiskName:         TestDiskID1,
+			StorageScheduled:    0,
+			StorageAvailable:    0,
+			Type:                longhorn.DiskTypeFilesystem,
+			FSType:              TestDiskPathFSType,
+			DiskPath:            TestDefaultDataPath,
+			DiskName:            TestDiskID1,
+			InstanceManagerName: TestInstanceManagerName,
 		},
 	}
 
@@ -704,12 +711,13 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusFalse, string(longhorn.DiskConditionReasonDiskPressure)),
 							newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue, ""),
 						},
-						ScheduledReplica: map[string]int64{},
-						DiskName:         TestDiskID1,
-						DiskUUID:         TestDiskID1,
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
+						ScheduledReplica:    map[string]int64{},
+						DiskName:            TestDiskID1,
+						DiskUUID:            TestDiskID1,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -720,12 +728,13 @@ func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {
 				},
 				DiskStatus: map[string]*longhorn.DiskStatus{
 					TestDiskID1: {
-						StorageScheduled: 0,
-						StorageAvailable: 0,
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
-						DiskName:         TestDiskID1,
+						StorageScheduled:    0,
+						StorageAvailable:    0,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -778,23 +787,25 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 				newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
 				newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue, ""),
 			},
-			DiskName: TestDiskID1,
-			DiskUUID: "new-uuid",
-			Type:     longhorn.DiskTypeFilesystem,
-			FSType:   TestDiskPathFSType,
-			DiskPath: TestDefaultDataPath,
+			DiskName:            TestDiskID1,
+			DiskUUID:            "new-uuid",
+			Type:                longhorn.DiskTypeFilesystem,
+			FSType:              TestDiskPathFSType,
+			DiskPath:            TestDefaultDataPath,
+			InstanceManagerName: TestInstanceManagerName,
 		},
 	}
 
 	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
 	node2.Status.DiskStatus = map[string]*longhorn.DiskStatus{
 		TestDiskID1: {
-			DiskName:         TestDiskID1,
-			StorageScheduled: 0,
-			StorageAvailable: 0,
-			Type:             longhorn.DiskTypeFilesystem,
-			FSType:           TestDiskPathFSType,
-			DiskPath:         TestDefaultDataPath,
+			DiskName:            TestDiskID1,
+			StorageScheduled:    0,
+			StorageAvailable:    0,
+			Type:                longhorn.DiskTypeFilesystem,
+			FSType:              TestDiskPathFSType,
+			DiskPath:            TestDefaultDataPath,
+			InstanceManagerName: TestInstanceManagerName,
 		},
 	}
 
@@ -854,12 +865,13 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusFalse, string(longhorn.DiskConditionReasonDiskNotReady)),
 							newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusFalse, string(longhorn.DiskConditionReasonDiskFilesystemChanged)),
 						},
-						ScheduledReplica: map[string]int64{},
-						DiskName:         TestDiskID1,
-						DiskUUID:         "new-uuid",
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
+						ScheduledReplica:    map[string]int64{},
+						DiskName:            TestDiskID1,
+						DiskUUID:            "new-uuid",
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -870,12 +882,13 @@ func (s *NodeControllerSuite) TestDisableDiskOnFilesystemChange(c *C) {
 				},
 				DiskStatus: map[string]*longhorn.DiskStatus{
 					TestDiskID1: {
-						DiskName:         TestDiskID1,
-						StorageScheduled: 0,
-						StorageAvailable: 0,
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						StorageScheduled:    0,
+						StorageAvailable:    0,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -977,12 +990,13 @@ func (s *NodeControllerSuite) TestCreateDefaultInstanceManager(c *C) {
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusFalse, string(longhorn.DiskConditionReasonDiskPressure)),
 							newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue, ""),
 						},
-						DiskName:         TestDiskID1,
-						ScheduledReplica: map[string]int64{},
-						DiskUUID:         TestDiskID1,
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						ScheduledReplica:    map[string]int64{},
+						DiskUUID:            TestDiskID1,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},
@@ -1116,12 +1130,13 @@ func (s *NodeControllerSuite) TestCleanupRedundantInstanceManagers(c *C) {
 							newNodeCondition(longhorn.DiskConditionTypeSchedulable, longhorn.ConditionStatusFalse, string(longhorn.DiskConditionReasonDiskPressure)),
 							newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue, ""),
 						},
-						ScheduledReplica: map[string]int64{},
-						DiskName:         TestDiskID1,
-						DiskUUID:         TestDiskID1,
-						Type:             longhorn.DiskTypeFilesystem,
-						FSType:           TestDiskPathFSType,
-						DiskPath:         TestDefaultDataPath,
+						DiskName:            TestDiskID1,
+						ScheduledReplica:    map[string]int64{},
+						DiskUUID:            TestDiskID1,
+						Type:                longhorn.DiskTypeFilesystem,
+						FSType:              TestDiskPathFSType,
+						DiskPath:            TestDefaultDataPath,
+						InstanceManagerName: TestInstanceManagerName,
 					},
 				},
 			},

--- a/engineapi/disk_service.go
+++ b/engineapi/disk_service.go
@@ -38,14 +38,16 @@ func NewDiskServiceClient(im *longhorn.InstanceManager, logger logrus.FieldLogge
 	}
 
 	return &DiskService{
-		logger:     logger,
-		grpcClient: client,
+		logger:              logger,
+		grpcClient:          client,
+		instanceManagerName: im.Name,
 	}, nil
 }
 
 type DiskService struct {
-	logger     logrus.FieldLogger
-	grpcClient *imclient.DiskServiceClient
+	logger              logrus.FieldLogger
+	grpcClient          *imclient.DiskServiceClient
+	instanceManagerName string
 }
 
 func (s *DiskService) Close() {
@@ -77,4 +79,8 @@ func (s *DiskService) DiskReplicaInstanceList(diskType, diskName, diskDriver str
 
 func (s *DiskService) DiskReplicaInstanceDelete(diskType, diskName, diskUUID, diskDriver, replciaInstanceName string) error {
 	return s.grpcClient.DiskReplicaInstanceDelete(diskType, diskName, diskUUID, diskDriver, replciaInstanceName)
+}
+
+func (s *DiskService) GetInstanceManagerName() string {
+	return s.instanceManagerName
 }

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2226,6 +2226,8 @@ spec:
                       type: string
                     filesystemType:
                       type: string
+                    instanceManagerName:
+                      type: string
                     scheduledReplica:
                       additionalProperties:
                         format: int64

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -112,6 +112,8 @@ type DiskStatus struct {
 	DiskDriver DiskDriver `json:"diskDriver"`
 	// +optional
 	FSType string `json:"filesystemType"`
+	// +optional
+	InstanceManagerName string `json:"instanceManagerName"`
 }
 
 // NodeSpec defines the desired state of the Longhorn node


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8458

#### What this PR does / why we need it:

A block-type disk can only be managed by a specific spdk_tgt within an instance manager. The commit is intended to record the name of the instance manager associated with that disk.
On the other hand, for a filesystem-type disk, any instance manager can access it. Therefore, the recorded instance manager for a filesystem-type disk is always the default instance manager.

#### Special notes for your reviewer:

#### Additional documentation or context
