### PR TITLE
fix(webhook): disable tsl 1.0 and 1.1 on webhook service

### DIFF
--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -31,6 +32,17 @@ var (
 	matchPolicyExact = admissionregv1.Exact // nolint: unused
 
 	sideEffectClassNone = admissionregv1.SideEffectClassNone
+)
+
+var (
+	whiteListedCiphers = []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	}
 )
 
 type WebhookServer struct {
@@ -178,6 +190,10 @@ func (s *WebhookServer) runAdmissionWebhookListenAndServe(handler http.Handler, 
 				tlsName,
 			},
 			FilterCN: dynamiclistener.OnlyAllow(tlsName),
+			TLSConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				CipherSuites: whiteListedCiphers,
+			},
 		},
 	})
 }
@@ -237,6 +253,10 @@ func (s *WebhookServer) runConversionWebhookListenAndServe(handler http.Handler,
 				tlsName,
 			},
 			FilterCN: dynamiclistener.OnlyAllow(tlsName),
+			TLSConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				CipherSuites: whiteListedCiphers,
+			},
 		},
 	})
 }


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8387

Follow the same implementation in [Harvester](https://github.com/harvester/harvester/blob/68c52fa87b44906b7915e81fb674fb73c1d41951/pkg/server/types.go#L165-L175) to disable tls 1.0 and 1.1 on webhook service

