### PR TITLE
Revert "fix(webhook): disable tsl 1.0 and 1.1 on webhook service"

### DIFF
--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -32,17 +31,6 @@ var (
 	matchPolicyExact = admissionregv1.Exact // nolint: unused
 
 	sideEffectClassNone = admissionregv1.SideEffectClassNone
-)
-
-var (
-	whiteListedCiphers = []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-	}
 )
 
 type WebhookServer struct {
@@ -190,10 +178,6 @@ func (s *WebhookServer) runAdmissionWebhookListenAndServe(handler http.Handler, 
 				tlsName,
 			},
 			FilterCN: dynamiclistener.OnlyAllow(tlsName),
-			TLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS12,
-				CipherSuites: whiteListedCiphers,
-			},
 		},
 	})
 }
@@ -253,10 +237,6 @@ func (s *WebhookServer) runConversionWebhookListenAndServe(handler http.Handler,
 				tlsName,
 			},
 			FilterCN: dynamiclistener.OnlyAllow(tlsName),
-			TLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS12,
-				CipherSuites: whiteListedCiphers,
-			},
 		},
 	})
 }


### PR DESCRIPTION
Reverts longhorn/longhorn-manager#2770

Change the fix to upgrading the golang version in v1.6.x