### PR TITLE
feat: remove related snapshot when removing backup

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -131,6 +131,7 @@ const (
 	SettingNameV2DataEngineLogLevel                                     = SettingName("v2-data-engine-log-level")
 	SettingNameV2DataEngineLogFlags                                     = SettingName("v2-data-engine-log-flags")
 	SettingNameFreezeFilesystemForSnapshot                              = SettingName("freeze-filesystem-for-snapshot")
+	SettingNameAutoCleanupSnapshotWhenDeleteBackup                      = SettingName("auto-cleanup-when-delete-backup")
 )
 
 var (
@@ -218,6 +219,7 @@ var (
 		SettingNameAllowEmptyDiskSelectorVolume,
 		SettingNameDisableSnapshotPurge,
 		SettingNameFreezeFilesystemForSnapshot,
+		SettingNameAutoCleanupSnapshotWhenDeleteBackup,
 	}
 )
 
@@ -333,6 +335,7 @@ var (
 		SettingNameAllowEmptyDiskSelectorVolume:                             SettingDefinitionAllowEmptyDiskSelectorVolume,
 		SettingNameDisableSnapshotPurge:                                     SettingDefinitionDisableSnapshotPurge,
 		SettingNameFreezeFilesystemForSnapshot:                              SettingDefinitionFreezeFilesystemForSnapshot,
+		SettingNameAutoCleanupSnapshotWhenDeleteBackup:                      SettingDefinitionAutoCleanupSnapshotWhenDeleteBackup,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -1398,6 +1401,16 @@ var (
 		Required:    false,
 		ReadOnly:    false,
 		Default:     "",
+	}
+
+	SettingDefinitionAutoCleanupSnapshotWhenDeleteBackup = SettingDefinition{
+		DisplayName: "Automatically Cleanup Snapshot When Deleting Backup",
+		Description: "This setting enables Longhorn to automatically cleanup snapshots when removing backup.",
+		Category:    SettingCategorySnapshot,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "false",
 	}
 )
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/8365

#### What this PR does / why we need it:

When users create a Bakcup, LH automatically creates a related Snapshot. However, when users delete the Bakcup, LH doesn't cleanup the Snapshot. This occupies snapshot quota. We have snapshot space management now, so it's better to clean up related resources.

#### Test steps

Case 1: set `auto-cleanup-when-delete-backup` as `false`
1. Create a volume and setup backup target.
2. Mount the volume.
3. Create multiple backups.
4. Delete a backup and check related snapshot is not removed.

Case 2: set `auto-cleanup-when-delete-backup` as `true`
1. Create a volume and setup backup target.
2. Mount the volume.
3. Create multiple backups.
4. Delete a backup and check related snapshot is removed too.
