### PR TITLE
Refuse to create an XFS volume smaller than 300 MiB

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -168,6 +168,15 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "%v not a proper volume source", volumeSource)
 		}
+	} else {
+		// Refuse to create a NEW XFS volume smaller than 300 MiB, since mkfs.xfs will eventually fail in the node
+		// server. Don't refuse for clones/restores though, as they may have an existing filesystem.
+		for _, cap := range req.VolumeCapabilities {
+			if cap.GetMount().GetFsType() == "xfs" && reqVolSizeBytes < util.MinimalVolumeSizeXFS {
+				return nil, fmt.Errorf("XFS filesystems with size %d, smaller than %d, are not supported",
+					reqVolSizeBytes, util.MinimalVolumeSizeXFS)
+			}
+		}
 	}
 
 	existVol, err := cs.apiClient.Volume.ById(volumeID)

--- a/manager/kubernetes.go
+++ b/manager/kubernetes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -52,6 +53,10 @@ func (m *VolumeManager) PVCreate(name, pvName, fsType, secretNamespace, secretNa
 
 	if fsType == "" {
 		fsType = "ext4"
+	}
+	if fsType == "xfs" && v.Spec.Size < util.MinimalVolumeSizeXFS {
+		return nil, fmt.Errorf("XFS filesystems with size %d, larger than %d, are not supported", v.Spec.Size,
+			util.MinimalVolumeSizeXFS)
 	}
 
 	pv := datastore.NewPVManifestForVolume(v, pvName, storageClassName, fsType)

--- a/util/util.go
+++ b/util/util.go
@@ -71,8 +71,9 @@ const (
 
 	DiskConfigFile = "longhorn-disk.cfg"
 
-	SizeAlignment     = 2 * 1024 * 1024
-	MinimalVolumeSize = 10 * 1024 * 1024
+	SizeAlignment        = 2 * MiB
+	MinimalVolumeSize    = 10 * MiB
+	MinimalVolumeSizeXFS = 300 * MiB // See https://github.com/longhorn/longhorn/issues/8488
 
 	MaxExt4VolumeSize = 16 * TiB
 	MaxXfsVolumeSize  = 8*EiB - 1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8488

#### What this PR does / why we need it:

Prevent the creation of Longhorn PersistentVolumes with `fstype: xfs` smaller than `300 MiB`.