### PR TITLE
Always clean up FailedToScheduleReplica with wrong HardNodeAffinity

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1030,7 +1030,7 @@ func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, r
 
 func (c *VolumeController) cleanupFailedToScheduleReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) (err error) {
 	healthyCount := getHealthyAndActiveReplicaCount(rs)
-	var replicaToCleanUp *longhorn.Replica
+	var replicasToCleanUp []*longhorn.Replica
 
 	if hasReplicaEvictionRequested(rs) {
 		return nil
@@ -1042,21 +1042,19 @@ func (c *VolumeController) cleanupFailedToScheduleReplicas(v *longhorn.Volume, r
 			// immediately. It is better to replenish a new replica without HardNodeAffinity so we can avoid corner
 			// cases like https://github.com/longhorn/longhorn/issues/8522.
 			if isDataLocalityDisabled(v) && r.Spec.HardNodeAffinity != "" {
-				replicaToCleanUp = r
-				break
+				replicasToCleanUp = append(replicasToCleanUp, r)
 			}
 			// Otherwise, only clean up failed to schedule replicas when there are enough existing healthy ones.
 			if healthyCount >= v.Spec.NumberOfReplicas && r.Spec.HardNodeAffinity != v.Status.CurrentNodeID {
-				replicaToCleanUp = r
-				break
+				replicasToCleanUp = append(replicasToCleanUp, r)
 			}
 		}
 	}
 
-	if replicaToCleanUp != nil {
-		logrus.Infof("Cleaning up failed to scheduled replica %v", replicaToCleanUp.Name)
-		if err := c.deleteReplica(replicaToCleanUp, rs); err != nil {
-			return errors.Wrapf(err, "failed to cleanup failed to scheduled replica %v", replicaToCleanUp.Name)
+	for _, r := range replicasToCleanUp {
+		logrus.Infof("Cleaning up failed-to-schedule replica %v", r.Name)
+		if err := c.deleteReplica(r, rs); err != nil {
+			return errors.Wrapf(err, "failed to clean up failed-to-schedule replica %v", r.Name)
 		}
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8522

#### What this PR does / why we need it:

Delete a failed to schedule replica with HardNodeAffinity if DataLocality is disabled.

Previously, we would only do this if there were enough healthy replicas, but it led to the "deadlock" in longhorn/longhorn#8522 where we would not schedule more replicas until we deleted the failed to schedule one, but we would not delete the failed to schedule one until there were enough healthy ones.

#### Special notes for your reviewer:

I experimented with changing the behavior of this function even more, but there were some weird side effects. I think it is better to keep it working almost exactly as it did before. I did, however, rearrange a bit.