### PR TITLE
Update engine and volume size less frequently

### DIFF
--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/longhorn/longhorn-manager/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateSnapshotSize(t *testing.T) {
+	assert := require.New(t)
+
+	type testCase struct {
+		nominalSize               int64
+		sizeBase                  int64
+		sizeSmallerThanTruncation int64
+		sizeLargerThanTruncation  int64
+	}
+	tests := map[string]testCase{}
+
+	// We only detect changes of 1 MiB for 1 GiB volumes.
+	tc := testCase{}
+	tc.nominalSize = 1 * util.GiB
+	tc.sizeBase = 500 * util.MiB
+	tc.sizeSmallerThanTruncation = tc.sizeBase + 500*util.KiB
+	tc.sizeLargerThanTruncation = tc.sizeBase + 1*util.MiB
+	tests["1 GB nominal size"] = tc
+
+	// We only detect changes of 10 MiB for 10 GiB volumes.
+	tc = testCase{}
+	tc.nominalSize = 10 * util.GiB
+	tc.sizeBase = 5 * util.GiB
+	tc.sizeSmallerThanTruncation = tc.sizeBase + 5*util.MiB
+	tc.sizeLargerThanTruncation = tc.sizeBase + 10*util.MiB
+	tests["10 GB nominal size"] = tc
+
+	// We only detect changes of 100 MiB for 100 GiB volumes.
+	tc = testCase{}
+	tc.nominalSize = 100 * util.GiB
+	tc.sizeBase = 50 * util.GiB
+	tc.sizeSmallerThanTruncation = tc.sizeBase + 50*util.MiB
+	tc.sizeLargerThanTruncation = tc.sizeBase + 100*util.MiB
+	tests["100 GB nominal size"] = tc
+
+	// We only detect changes of 100 MiB for > 100 GiB volumes.
+	tc = testCase{}
+	tc.nominalSize = 1 * util.TiB
+	tc.sizeBase = 500 * util.GiB
+	tc.sizeSmallerThanTruncation = tc.sizeBase + 50*util.MiB
+	tc.sizeLargerThanTruncation = tc.sizeBase + 100*util.MiB
+	tests["> 100 GB nominal size"] = tc
+
+	for name, tc := range tests {
+		fmt.Printf("testing %v\n", name)
+		assert.Equal(tc.sizeBase, truncateSnapshotSize(tc.sizeSmallerThanTruncation, tc.nominalSize))
+		assert.Less(tc.sizeBase, truncateSnapshotSize(tc.sizeLargerThanTruncation, tc.nominalSize))
+	}
+
+	// Really just ensure there is no panic. We don't expect any truncation.
+	fmt.Printf("testing 0 GB nominal size\n")
+	assert.Equal(truncateSnapshotSize(5*util.GiB, 0), int64(5*util.GiB))
+	assert.Equal(truncateSnapshotSize(5*util.TiB, 0), int64(5*util.TiB))
+}

--- a/k8s/pkg/apis/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engine.go
@@ -109,6 +109,7 @@ type SnapshotInfo struct {
 	// +optional
 	Created string `json:"created"`
 	// +optional
+	// Actual size in bytes. May be truncated for volume-head to reduce API server churn.
 	Size string `json:"size"`
 	// +optional
 	// +nullable

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -342,6 +342,7 @@ type VolumeStatus struct {
 	// +optional
 	IsStandby bool `json:"isStandby"`
 	// +optional
+	// Actual size in bytes. May be truncated to reduce API server churn.
 	ActualSize int64 `json:"actualSize"`
 	// +optional
 	LastDegradedAt string `json:"lastDegradedAt"`


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8076

#### What this PR does / why we need it:

Update the size of the volume-head snapshot in the engine CR less frequently. As a result, also update the actualSize in the volume CR less frequently.

I basically stole the method for "truncating" from the below.

https://github.com/longhorn/longhorn-manager/blob/4e8fb0ab239559f5bfa6a711ca9b82ceba6b33f1/controller/node_controller.go#L850-L852

I didn't want to use a fixed size of `100 MiB` for the truncation because I want the user to still be able to see the size of small volumes increasing under light write activity. See the code comments and tests for the heuristic I chose. I'm certainly open to discussion on whether it is the right one.
