### PR TITLE
Fix a typo in message about small XFS filesystem

### DIFF
--- a/manager/kubernetes.go
+++ b/manager/kubernetes.go
@@ -55,7 +55,7 @@ func (m *VolumeManager) PVCreate(name, pvName, fsType, secretNamespace, secretNa
 		fsType = "ext4"
 	}
 	if fsType == "xfs" && v.Spec.Size < util.MinimalVolumeSizeXFS {
-		return nil, fmt.Errorf("XFS filesystems with size %d, larger than %d, are not supported", v.Spec.Size,
+		return nil, fmt.Errorf("XFS filesystems with size %d, smaller than %d, are not supported", v.Spec.Size,
 			util.MinimalVolumeSizeXFS)
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8488

#### What this PR does / why we need it:

There is a typo in a log message that is confusing.
