### PR TITLE
fix: fix system restore PV and PVC stuck beause of backing image and volume

### DIFF
--- a/controller/system_rollout_controller.go
+++ b/controller/system_rollout_controller.go
@@ -435,19 +435,17 @@ func (c *SystemRolloutController) systemRollout() error {
 
 		wg := &sync.WaitGroup{}
 		restoreFns := map[string]func() error{
-			types.KubernetesKindServiceList:               c.restoreService,
-			types.KubernetesKindServiceAccountList:        c.restoreServiceAccounts,
-			types.KubernetesKindClusterRoleList:           c.restoreClusterRoles,
-			types.KubernetesKindClusterRoleBindingList:    c.restoreClusterRoleBindings,
-			types.KubernetesKindRoleList:                  c.restoreRoles,
-			types.KubernetesKindRoleBindingList:           c.restoreRoleBindings,
-			types.KubernetesKindStorageClassList:          c.restoreStorageClasses,
-			types.KubernetesKindConfigMapList:             c.restoreConfigMaps,
-			types.KubernetesKindDeploymentList:            c.restoreDeployments,
-			types.LonghornKindBackingImageList:            c.restoreBackingIamges,
-			types.KubernetesKindPersistentVolumeList:      c.restorePersistentVolumes,
-			types.KubernetesKindPersistentVolumeClaimList: c.restorePersistentVolumeClaims,
-			types.LonghornKindRecurringJobList:            c.restoreRecurringJobs,
+			types.KubernetesKindServiceList:            c.restoreService,
+			types.KubernetesKindServiceAccountList:     c.restoreServiceAccounts,
+			types.KubernetesKindClusterRoleList:        c.restoreClusterRoles,
+			types.KubernetesKindClusterRoleBindingList: c.restoreClusterRoleBindings,
+			types.KubernetesKindRoleList:               c.restoreRoles,
+			types.KubernetesKindRoleBindingList:        c.restoreRoleBindings,
+			types.KubernetesKindStorageClassList:       c.restoreStorageClasses,
+			types.KubernetesKindConfigMapList:          c.restoreConfigMaps,
+			types.KubernetesKindDeploymentList:         c.restoreDeployments,
+			types.LonghornKindBackingImageList:         c.restoreBackingIamges,
+			types.LonghornKindRecurringJobList:         c.restoreRecurringJobs,
 		}
 		wg.Add(len(restoreFns))
 		for k, v := range restoreFns {
@@ -459,8 +457,11 @@ func (c *SystemRolloutController) systemRollout() error {
 		}
 		wg.Wait()
 
-		// Need to wait until backingimages are restored, so the volumes with backingimages can be restored.
+		// Need to wait until backing images are restored, so the volumes with backingimages won't be rejected by webhook when restoring.
+		// PV/PVC restoration depends on Volume, so move them after volume restoration.
 		c.restore(types.LonghornKindVolumeList, c.restoreVolumes, log)
+		c.restore(types.KubernetesKindPersistentVolumeList, c.restorePersistentVolumes, log)
+		c.restore(types.KubernetesKindPersistentVolumeClaimList, c.restorePersistentVolumeClaims, log)
 
 		if len(c.cacheErrors) == 0 {
 			c.updateSystemRolloutRecord(record,

--- a/webhook/admission/admission.go
+++ b/webhook/admission/admission.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	AdmissionTypeValidation = "validaton"
+	AdmissionTypeValidation = "validation"
 	AdmissionTypeMutation   = "mutation"
 )
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/8601

#### What this PR does / why we need it:
During the system restore
Volume depends on BackingImage, our webhook rejects the Volume creation if the BackingImage is not in the cluster
=> move the volume restoration out of the parallel restoration

And since PV depends on Volume
=> So we also need to move PV,PVC restoration after Volume restoration

cc @c3y1huang 