### PR TITLE
feat(support-bundle): add support-bundle-node-collection-timeout setting

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1685,6 +1685,7 @@ func (info *ClusterInfo) collectSettings() error {
 		types.SettingNameStorageOverProvisioningPercentage:                        true,
 		types.SettingNameStorageReservedPercentageForDefaultDisk:                  true,
 		types.SettingNameSupportBundleFailedHistoryLimit:                          true,
+		types.SettingNameSupportBundleNodeCollectionTimeout:                       true,
 		types.SettingNameSystemManagedPodsImagePullPolicy:                         true,
 		types.SettingNameV1DataEngine:                                             true,
 		types.SettingNameV2DataEngine:                                             true,

--- a/controller/support_bundle_controller.go
+++ b/controller/support_bundle_controller.go
@@ -653,7 +653,12 @@ func (c *SupportBundleController) createSupportBundleManagerDeployment(supportBu
 	}
 	registrySecret := registrySecretSetting.Value
 
-	newSupportBundleManager, err := c.newSupportBundleManager(supportBundle, nodeSelector, imagePullPolicy, priorityClass, registrySecret)
+	nodeCollectionTimeoutMinute, err := c.ds.GetSettingAsInt(types.SettingNameSupportBundleNodeCollectionTimeout)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get support bundle node collection timeout setting before creating support bundle manager deployment")
+	}
+
+	newSupportBundleManager, err := c.newSupportBundleManager(supportBundle, nodeSelector, imagePullPolicy, priorityClass, registrySecret, nodeCollectionTimeoutMinute)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new support bundle manager")
 	}
@@ -661,7 +666,7 @@ func (c *SupportBundleController) createSupportBundleManagerDeployment(supportBu
 }
 
 func (c *SupportBundleController) newSupportBundleManager(supportBundle *longhorn.SupportBundle, nodeSelector map[string]string,
-	imagePullPolicy corev1.PullPolicy, priorityClass, registrySecret string) (*appsv1.Deployment, error) {
+	imagePullPolicy corev1.PullPolicy, priorityClass, registrySecret string, nodeCollectionTimeoutMinute int64) (*appsv1.Deployment, error) {
 
 	tolerationSetting, err := c.ds.GetSettingWithAutoFillingRO(types.SettingNameTaintToleration)
 	if err != nil {
@@ -759,6 +764,10 @@ func (c *SupportBundleController) newSupportBundleManager(supportBundle *longhor
 								{
 									Name:  "SUPPORT_BUNDLE_TAINT_TOLERATION",
 									Value: c.getTaintTolerationString(tolerationSetting),
+								},
+								{
+									Name:  "SUPPORT_BUNDLE_NODE_TIMEOUT",
+									Value: fmt.Sprintf("%dm", nodeCollectionTimeoutMinute),
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/types/setting.go
+++ b/types/setting.go
@@ -103,6 +103,7 @@ const (
 	SettingNameRecurringFailedJobsHistoryLimit                          = SettingName("recurring-failed-jobs-history-limit")
 	SettingNameRecurringJobMaxRetention                                 = SettingName("recurring-job-max-retention")
 	SettingNameSupportBundleFailedHistoryLimit                          = SettingName("support-bundle-failed-history-limit")
+	SettingNameSupportBundleNodeCollectionTimeout                       = SettingName("support-bundle-node-collection-timeout")
 	SettingNameDeletingConfirmationFlag                                 = SettingName("deleting-confirmation-flag")
 	SettingNameEngineReplicaTimeout                                     = SettingName("engine-replica-timeout")
 	SettingNameSnapshotDataIntegrity                                    = SettingName("snapshot-data-integrity")
@@ -187,6 +188,7 @@ var (
 		SettingNameRecurringFailedJobsHistoryLimit,
 		SettingNameRecurringJobMaxRetention,
 		SettingNameSupportBundleFailedHistoryLimit,
+		SettingNameSupportBundleNodeCollectionTimeout,
 		SettingNameDeletingConfirmationFlag,
 		SettingNameEngineReplicaTimeout,
 		SettingNameSnapshotDataIntegrity,
@@ -299,6 +301,7 @@ var (
 		SettingNameRecurringFailedJobsHistoryLimit:                          SettingDefinitionRecurringFailedJobsHistoryLimit,
 		SettingNameRecurringJobMaxRetention:                                 SettingDefinitionRecurringJobMaxRetention,
 		SettingNameSupportBundleFailedHistoryLimit:                          SettingDefinitionSupportBundleFailedHistoryLimit,
+		SettingNameSupportBundleNodeCollectionTimeout:                       SettingDefinitionSupportBundleNodeCollectionTimeout,
 		SettingNameDeletingConfirmationFlag:                                 SettingDefinitionDeletingConfirmationFlag,
 		SettingNameEngineReplicaTimeout:                                     SettingDefinitionEngineReplicaTimeout,
 		SettingNameSnapshotDataIntegrity:                                    SettingDefinitionSnapshotDataIntegrity,
@@ -1052,6 +1055,20 @@ var (
 		Required: false,
 		ReadOnly: false,
 		Default:  "1",
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+		},
+	}
+
+	SettingDefinitionSupportBundleNodeCollectionTimeout = SettingDefinition{
+		DisplayName: "Timeout for Support Bundle Node Collection",
+		Description: "In minutes. The timeout for collecting node bundles for support bundle generation. The default value is 30.\n\n" +
+			"When the timeout is reached, the support bundle generation will proceed without requiring the collection of node bundles. \n\n",
+		Category: SettingCategoryGeneral,
+		Type:     SettingTypeInt,
+		Required: true,
+		ReadOnly: false,
+		Default:  "30",
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: 0,
 		},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8623

#### What this PR does / why we need it:

Propose adding a setting that allows users to configure the node bundle collection timeout during support bundle generation.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/rancher/support-bundle-kit/pull/109
