### PR TITLE
Lh8650 make backup wait for snapshot

### DIFF
--- a/engineapi/backup_monitor.go
+++ b/engineapi/backup_monitor.go
@@ -72,7 +72,7 @@ func NewBackupMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, backup
 	}
 
 	// Call engine API snapshot backup
-	if backup.Status.State == longhorn.BackupStateNew {
+	if backup.Status.State == longhorn.BackupStateNew || backup.Status.State == longhorn.BackupStatePending {
 		// volumeRecurringJobInfo could be "".
 		volumeRecurringJobInfo, err := m.getVolumeRecurringJobInfos(ds, volume)
 		if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
ref: https://github.com/longhorn/longhorn/issues/8650

Backup might failed because  the snapshot is not created yet.
We should prevent the Backup from triggering before the snapshot is found.

~~Introduce new state to the Backup CR: preparing~~
Reuse the status: `Pending`
and add some information to the Messages when the Backup is still waiting for the snapshot or engine.

When the backup starts
the message and the state will be override by the monitor

~~Note:~~
~~`Pending` state has been used for another purpose~~
