### PR TITLE
Update engine and volume size less frequently

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"golang.org/x/time/rate"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -61,6 +63,11 @@ var (
 
 	// restoreMaxInterval: deleting the backup of big size volume takes a long time for retain policy and restoring backups would be in backoff period.
 	restoreMaxInterval = 1 * time.Hour
+
+	// amount of time between actual size updates that do not exceed threshold during periods with stable writes
+	sizeUpdateLimit = 30 * time.Second
+	// number of consecutive actual size updates allowed during bursts
+	sizeUpdateBurst = 3
 )
 
 const (
@@ -120,6 +127,8 @@ type EngineMonitor struct {
 	restoringCounter         util.Counter
 	restoringCounterAcquired bool
 	restoringCounterMutex    *sync.Mutex
+
+	sizeUpdateLimiter *rate.Limiter
 }
 
 func NewEngineController(
@@ -744,6 +753,7 @@ func (ec *EngineController) startMonitoring(e *longhorn.Engine) {
 		proxyConnCounter:       ec.proxyConnCounter,
 		restoringCounter:       ec.restoringCounter,
 		restoringCounterMutex:  ec.restoringCounterMutex,
+		sizeUpdateLimiter:      rate.NewLimiter(rate.Every(sizeUpdateLimit), sizeUpdateBurst),
 	}
 
 	ec.engineMonitorMutex.Lock()
@@ -1049,9 +1059,20 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	removeInvalidEngineOpStatus(engine)
 
 	// Make sure the engine object is updated before engineapi calls.
-	if !reflect.DeepEqual(existingEngine.Status, engine.Status) {
+	needStatusUpdate, rateLimited := m.needStatusUpdate(existingEngine, engine)
+	if needStatusUpdate && (!rateLimited || m.sizeUpdateLimiter.Tokens() >= 1) {
 		if engine, err = m.ds.UpdateEngineStatus(engine); err != nil {
 			return err
+		}
+		if rateLimited {
+			// Normally we would operate a Limiter by first obtaining a token, then taking an action. Here, we do not
+			// want to obtain a token unless the update succeeds. Otherwise the next attempt at an update (probably in a
+			// few milliseconds), will not be allowed. We might be able to refactor the engine controller so that update
+			// retries happen here instead of at the caller, but it's fine to operate the Limiter this way, since there
+			// is only one thread that uses it.
+			if obtainedToken := m.sizeUpdateLimiter.Allow(); !obtainedToken {
+				m.logger.Warnf("BUG: Size update bypassed rate limiting")
+			}
 		}
 		existingEngine = engine.DeepCopy()
 	}
@@ -1105,7 +1126,9 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 			}
 		}
 
-		if !reflect.DeepEqual(existingEngine.Status, engine.Status) {
+		// Ignore size change here to maintain rate limiting. (If we wanted to update status based on a size change,
+		// we already did so above.)
+		if needStatusUpdateBesidesSize(&existingEngine.Status, &engine.Status) {
 			e, err := m.ds.UpdateEngineStatus(engine)
 			if err != nil {
 				m.logger.WithError(err).Warn("Engine Monitor: Failed to update engine status")
@@ -2214,4 +2237,76 @@ func shouldProceedToWaitAndRebuild(e *longhorn.Engine, replicaName, originalRepl
 	}
 
 	return true
+}
+
+// needStatusUpdate checks whether we should update the engine status and whether that update should be rate limited. We
+// return:
+// - false, false if no fields change
+// - true, false if any field besides the size of the volume-head snapshot changes
+// - true, false if the change in size of the volume-head snapshot exceeds a threshold
+// - true, true if the change in size of the volume-head does not exceed a threshold
+func (m *EngineMonitor) needStatusUpdate(existing, new *longhorn.Engine) (needStatusUpdate, rateLimited bool) {
+	if needStatusUpdateBesidesSize(&existing.Status, &new.Status) {
+		return true, false
+	}
+
+	// Existence was already verified in needStatusUpdateBesidesSize.
+	existingSnapshot := existing.Status.Snapshots[etypes.VolumeHeadName]
+	newSnapshot := new.Status.Snapshots[etypes.VolumeHeadName]
+
+	// Now, compare only the volume-head sizes.
+	var existingSizeInt, newSizeInt int64
+	var err error
+	if existingSizeInt, err = strconv.ParseInt(existingSnapshot.Size, 10, 64); err != nil {
+		m.logger.WithError(err).Warnf("Failed to parse %s size %v", etypes.VolumeHeadName, existingSnapshot.Size)
+		return false, false
+	}
+	if newSizeInt, err = strconv.ParseInt(newSnapshot.Size, 10, 64); err != nil {
+		m.logger.WithError(err).Warnf("Failed to parse %s size %v", etypes.VolumeHeadName, newSnapshot.Size)
+		return false, false
+	}
+	return needSizeUpdate(existingSizeInt, newSizeInt, new.Spec.VolumeSize)
+}
+
+// needStatusUpdateBesidesSize does half of the work of needStatusUpdate. It is broken out because only one caller
+// should consider the size of the volume-head snapshot when deciding whether to update. All other callers should not
+// consider a change in volume-head snapshot size a reason to update. If they do, they will circumvent rate limiting.
+func needStatusUpdateBesidesSize(existing, new *longhorn.EngineStatus) bool {
+	// If we don't have a volume-head snapshot in new and old status, just compare statuses directly.
+	existingSnapshot, existingSnapshotOK := existing.Snapshots[etypes.VolumeHeadName]
+	newSnapshot, newSnapshotOK := new.Snapshots[etypes.VolumeHeadName]
+	if !existingSnapshotOK || !newSnapshotOK {
+		return !reflect.DeepEqual(existing, new)
+	}
+
+	// Otherwise, compare without the size of volume-head.
+	existingSize := existingSnapshot.Size
+	existingSnapshot.Size = newSnapshot.Size
+	needUpdate := !reflect.DeepEqual(existing, new)
+	existingSnapshot.Size = existingSize
+	return needUpdate
+}
+
+// needSizeUpdate returns needSizeUpdate == true if the caller should attempt to update the engine status based on size
+// alone. In addition, it returns rateLimited == true if the change in size does not exceed a threshold.
+func needSizeUpdate(existingSize, newSize, nominalSize int64) (needSizeUpdate, rateLimited bool) {
+	if newSize == existingSize {
+		return false, false
+	}
+	if newSize-existingSize >= sizeThreshold(nominalSize) {
+		// We don't need a reservation to update sizes exceeding the threshold.
+		return true, false
+	}
+	return true, true
+}
+
+// sizeThreshold calculates the difference in size for which we will update status (regardless of rate limiting).
+func sizeThreshold(nominalSize int64) int64 {
+	if nominalSize <= 0 {
+		return 0
+	}
+	if nominalSize <= 100*util.GiB {
+		return nominalSize / 1024 // Update status for change > 1/1024 nominal size.
+	}
+	return 100 * util.MiB // Update status for any change > 100 MiB.
 }

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2250,9 +2250,11 @@ func (m *EngineMonitor) needStatusUpdate(existing, new *longhorn.Engine) (needSt
 		return true, false
 	}
 
-	// Existence was already verified in needStatusUpdateBesidesSize.
-	existingSnapshot := existing.Status.Snapshots[etypes.VolumeHeadName]
-	newSnapshot := new.Status.Snapshots[etypes.VolumeHeadName]
+	existingSnapshot, existingSnapshotOK := existing.Status.Snapshots[etypes.VolumeHeadName]
+	newSnapshot, newSnapshotOK := new.Status.Snapshots[etypes.VolumeHeadName]
+	if !existingSnapshotOK || !newSnapshotOK {
+		return false, false // We can't do anything that needStatusUpdateBesidesSize hasn't already.
+	}
 
 	// Now, compare only the volume-head sizes.
 	var existingSizeInt, newSizeInt int64

--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -1,0 +1,134 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	etypes "github.com/longhorn/longhorn-engine/pkg/types"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/util"
+)
+
+func TestNeedStatusUpdate(t *testing.T) {
+	assert := require.New(t)
+
+	newMonitor := func() *EngineMonitor {
+		logger := logrus.New()
+		logger.Out = io.Discard
+		return &EngineMonitor{
+			logger: logger,
+		}
+	}
+
+	newEngine := func(nominalSize, volumeHeadSize int64) *longhorn.Engine {
+		return &longhorn.Engine{
+			Spec: longhorn.EngineSpec{
+				InstanceSpec: longhorn.InstanceSpec{
+					VolumeSize: nominalSize,
+				},
+			},
+			Status: longhorn.EngineStatus{
+				Snapshots: map[string]*longhorn.SnapshotInfo{
+					etypes.VolumeHeadName: {
+						Size: strconv.FormatInt(volumeHeadSize, 10),
+					},
+				},
+			},
+		}
+	}
+
+	type testCase struct {
+		existingEngine         *longhorn.Engine
+		engine                 *longhorn.Engine
+		monitor                *EngineMonitor
+		expectNeedStatusUpdate bool
+		expectRateLimited      bool
+	}
+	tests := map[string]testCase{}
+
+	tc := testCase{
+		existingEngine:         newEngine(TestVolumeSize, TestVolumeSize/2),
+		engine:                 newEngine(TestVolumeSize, TestVolumeSize/2),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: false,
+		expectRateLimited:      false,
+	}
+	tests["no field changed"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(TestVolumeSize, TestVolumeSize/2),
+		engine:                 newEngine(TestVolumeSize, TestVolumeSize/2),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      false,
+	}
+	tc.existingEngine.Status.CurrentImage = TestEngineImageName
+	tc.engine.Status.CurrentImage = "different"
+	tests["arbitrary field changed"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(1*util.GiB, 512*util.MiB),
+		engine:                 newEngine(1*util.GiB, 512*util.MiB+1*util.MiB+1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      false,
+	}
+	tests["size update larger than threshold, 1 GiB volume"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(50*util.GiB, 25*util.GiB),
+		engine:                 newEngine(50*util.GiB, 25*util.GiB+50*util.MiB+1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      false,
+	}
+	tests["size update larger than threshold, 50 GiB volume"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(150*util.GiB, 75*util.GiB),
+		engine:                 newEngine(150*util.GiB, 75*util.GiB+100*util.MiB+1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      false,
+	}
+	tests["size update larger than threshold, 150 GiB volume"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(1*util.GiB, 512*util.MiB),
+		engine:                 newEngine(1*util.GiB, 512*util.MiB+1*util.MiB-1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      true,
+	}
+	tests["size update smaller than threshold, 1 GiB volume"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(50*util.GiB, 25*util.GiB),
+		engine:                 newEngine(50*util.GiB, 25*util.GiB+50*util.MiB-1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      true,
+	}
+	tests["size update smaller than threshold, 50 GiB volume"] = tc
+
+	tc = testCase{
+		existingEngine:         newEngine(150*util.GiB, 75*util.GiB),
+		engine:                 newEngine(150*util.GiB, 75*util.GiB+100*util.MiB-1),
+		monitor:                newMonitor(),
+		expectNeedStatusUpdate: true,
+		expectRateLimited:      true,
+	}
+	tests["size update smaller than threshold, 150 GiB volume"] = tc
+
+	for name, tc := range tests {
+		fmt.Printf("testing %v\n", name)
+		needStatusUpdate, rateLimited := tc.monitor.needStatusUpdate(tc.existingEngine, tc.engine)
+		assert.Equal(tc.expectNeedStatusUpdate, needStatusUpdate, "needStatusUpdate")
+		assert.Equal(tc.expectRateLimited, rateLimited, "rateLimited")
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8076

#### What this PR does / why we need it:

This is meant to be an improvement over the rejected https://github.com/longhorn/longhorn-manager/pull/2817. It adds a rate limiter to provide the following behavior:

- The rate limiter generally only allows "size-only updates" (updates to `engine.status.snapshots[volume-head].size` once every thirty seconds.
- For responsiveness to bursty writing, the rate limiter allows up to three "size-only updates" in quick succession. (The underlying implementation is a "token bucket", so this burstability can be rebuilt over time if no writes happen.)
- Size changes that exceed a heuristic threshold ignore rate limiting (otherwise, it might feel weird).
- Any status changes that aren't "size-only" ignore rate limiting.
- Size fields have "eventual" byte accuracy (they are not truncated).

If this approach is generally acceptable, we can tweak `sizeUpdateLimit`, `sizeUpdateBurst`, or the heuristic now or in the future to provide different tradeoffs between ETCD load and responsiveness.