### PR TITLE
Cancel migration when the old node is down

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -18,7 +18,7 @@ func hasReplicaEvictionRequested(rs map[string]*longhorn.Replica) bool {
 	return false
 }
 
-func (vc *VolumeController) isVolumeUpgrading(v *longhorn.Volume) bool {
+func isVolumeUpgrading(v *longhorn.Volume) bool {
 	return v.Status.CurrentImage != v.Spec.Image
 }
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -971,7 +971,7 @@ func (c *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*lo
 	}
 
 	// give a chance to delete new replicas failed when upgrading volume and waiting for IM-r starting
-	if c.isVolumeUpgrading(v) {
+	if isVolumeUpgrading(v) {
 		return nil
 	}
 
@@ -990,7 +990,7 @@ func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, r
 	// See comments for isSafeAsLastReplica for an explanation of why we call getSafeAsLastReplicaCount instead of
 	// getHealthyAndActiveReplicaCount here.
 	safeAsLastReplicaCount := getSafeAsLastReplicaCount(rs)
-	cleanupLeftoverReplicas := !c.isVolumeUpgrading(v) && !util.IsVolumeMigrating(v)
+	cleanupLeftoverReplicas := !isVolumeUpgrading(v) && !util.IsVolumeMigrating(v)
 	log := getLoggerForVolume(c.logger, v)
 
 	for _, r := range rs {
@@ -1836,7 +1836,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			}
 		} else {
 			// wait for IM is starting when volume is upgrading
-			if c.isVolumeUpgrading(v) {
+			if isVolumeUpgrading(v) {
 				continue
 			}
 
@@ -2786,7 +2786,7 @@ func (c *VolumeController) upgradeEngineForVolume(v *longhorn.Volume, es map[str
 		"volumeDesiredEngineImage": v.Spec.Image,
 	})
 
-	if !c.isVolumeUpgrading(v) {
+	if !isVolumeUpgrading(v) {
 		// it must be a rollback
 		if e.Spec.Image != v.Spec.Image {
 			e.Spec.Image = v.Spec.Image
@@ -3746,7 +3746,7 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 	}
 
 	// cannot process migrate when upgrading
-	if c.isVolumeUpgrading(v) {
+	if isVolumeUpgrading(v) {
 		log.Warn("Skip the migration processing since the volume is being upgraded")
 		return nil
 	}
@@ -3761,11 +3761,11 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 		// in the case of a confirmation we need to switch the v.Status.CurrentNodeID to v.Spec.NodeID
 		// so that currentEngine becomes the migration engine
 		if v.Status.CurrentNodeID != v.Spec.NodeID {
-			log.Infof("volume migration complete switching current node id from %v to %v", v.Status.CurrentNodeID, v.Spec.NodeID)
+			log.Infof("Volume migration complete switching current node id from %v to %v", v.Status.CurrentNodeID, v.Spec.NodeID)
 			v.Status.CurrentNodeID = v.Spec.NodeID
 		}
 
-		// The latest current engine is based on the multiple node related fields of the volume basides all engine desired node ID,
+		// The latest current engine is based on the multiple node related fields of the volume besides all engine desired node ID,
 		// If the new engine matches, it means a migration confirmation then it's time to remove the old engine.
 		// If the old engine matches, it means a migration rollback hence cleaning up the migration engine is required.
 		//


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#3401

#### What this PR does / why we need it:

According to my analysis at https://github.com/longhorn/longhorn/issues/3401#issuecomment-2148015598, we cannot roll back a migration from `oldNode` to `newNode` while `oldNode` is down primarily because NO `processMigration` code can run while a volume's robustness is unknown. In other words, typically, we must wait for a volume to be attached and running before taking migration steps.

In this issue, however, `oldNode` is down. It may take a long time to come back, or it may never come back. We want to allow the migration from `oldNode` to be canceled so that the migration engine and replicas can be cleaned up. (Long running migrations can cause unexpected issues, so it's better to end them if we can.)

In this PR, we delay checking the volume's robustness until AFTER we check for the special case that `oldNode` is down. If `oldNode` is down, we cancel the migration and clean up the extra resources.