### PR TITLE
fix: fix backing image metrics support

### DIFF
--- a/metrics_collector/backing_image_collector.go
+++ b/metrics_collector/backing_image_collector.go
@@ -96,8 +96,8 @@ func (bc *BackingImageCollector) getDiskNodeMap() (map[string]string, error) {
 	}
 
 	for _, node := range nodeList {
-		for diskID := range node.Spec.Disks {
-			diskNodeMap[diskID] = node.Name
+		for _, status := range node.Status.DiskStatus {
+			diskNodeMap[status.DiskUUID] = node.Name
 		}
 	}
 


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7563

Fix a bug in backing image metrics support
should get the diskUUID instead of diskName


Test results
```
longhorn-manager-8hs5s:/ # curl -sSL http://10.96.75.66:9500/metrics | grep "parrot"
longhorn_backing_image_actual_size_bytes{backing_image="parrot",disk="ca203ce8-2cad-4cd1-92a7-542851f50518",node="kworker1"} 3.3554432e+07
longhorn_backing_image_state{backing_image="parrot",disk="ca203ce8-2cad-4cd1-92a7-542851f50518",node="kworker1"} 4

longhorn_backup_backing_image_actual_size_bytes{backup_backing_image="parrot"} 3.3554432e+07
longhorn_backup_backing_image_state{backup_backing_image="parrot"} 3
```