### PR TITLE
feat(docker-volume): remove volume from dockerfile, no compliant with CIS benchmark

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -20,6 +20,5 @@ RUN zypper -n ref && \
 RUN zypper -n install iputils iproute2 nfs-client cifs-utils bind-utils e2fsprogs xfsprogs zip unzip && \
     rm -rf /var/cache/zypp/*
 
-VOLUME /usr/local/sbin
 EXPOSE 9500
 CMD ["launch-manager"]


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
 
[Issue#8780](https://github.com/longhorn/longhorn/issues/8780)

#### What this PR does / why we need it:

This remove volume /usr/local/bin define in dockerfile. In my case, longhorn-manager gets the permission denied error because the noexec option is propagated to the container automatically. in fact, my /var/ volume, used by containerd, has `noexec` option, with this option longhorn-manager is not allow to start because this option not allow the execution of executable binaries in the mounted filesystem

#### Special notes for your reviewer:

is this volume really used ?

#### Additional documentation or context
