### PR TITLE
Disable uuid checks on XFS

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -211,6 +211,15 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
 	}
+	fsType := volumeCapability.GetMount().GetFsType()
+	if fsType == "" {
+		fsType = defaultFsType
+	}
+	if fsType == "xfs" {
+		// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+		// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+		mountOptions = append(mountOptions, "nouuid")
+	}
 	mountOptions = append(mountOptions, volumeCapability.GetMount().GetMountFlags()...)
 
 	if err := mounter.Mount(stagingTargetPath, targetPath, "", mountOptions); err != nil {
@@ -510,6 +519,11 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	fsType := volumeCapability.GetMount().GetFsType()
 	if fsType == "" {
 		fsType = defaultFsType
+	}
+	if fsType == "xfs" {
+		// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+		// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+		options = append(options, "nouuid")
 	}
 
 	formatMounter, ok := mounter.(*mount.SafeFormatAndMount)


### PR DESCRIPTION
longhorn/longhorn#2907


XFS does not allow to mount two volumes that have the same UUID on the same machine. This is problematic when using a cloned volume or a restored snapshot - the original volume and the new volume cannot be mounted on the same compute node.


This PR disables uuid checks on XFS same as other CSI providers:
1. https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1204/files
1. https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pull/570/files
1. https://github.com/topolvm/topolvm/pull/522/files
