### PR TITLE
fix(uninstall): ignore the error 'the object has been modified' when touching backup targets

### DIFF
--- a/controller/uninstall_controller.go
+++ b/controller/uninstall_controller.go
@@ -321,7 +321,7 @@ func (c *UninstallController) uninstall() error {
 			return err
 		} else if len(backupTargets) > 0 {
 			for _, bt := range backupTargets {
-				if _, err = c.ds.UpdateBackupTarget(bt); err != nil {
+				if _, err = c.ds.UpdateBackupTarget(bt); err != nil && !apierrors.IsConflict(errors.Cause(err)) {
 					return errors.Wrap(err, "failed to touch the backup target CR for API version migration")
 				}
 			}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#8784
