### PR TITLE
Only need to force ignore xfs uuid in NodeStageVolume

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -211,15 +211,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
 	}
-	fsType := volumeCapability.GetMount().GetFsType()
-	if fsType == "" {
-		fsType = defaultFsType
-	}
-	if fsType == "xfs" {
-		// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
-		// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
-		mountOptions = append(mountOptions, "nouuid")
-	}
 	mountOptions = append(mountOptions, volumeCapability.GetMount().GetMountFlags()...)
 
 	if err := mounter.Mount(stagingTargetPath, targetPath, "", mountOptions); err != nil {


### PR DESCRIPTION
Like @shuo-wu mentioned in the US sync meeting, we don't need to do this NodePublishVolume because bind mount will preserve the mount options from NodeStageVolume

longhorn/longhorn#8796

