### PR TITLE
fix(replica-scheduling): power off replica node should not rebuild new replica on same node

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2241,7 +2241,14 @@ func (c *VolumeController) replenishReplicas(v *longhorn.Volume, e *longhorn.Eng
 			c.enqueueVolumeAfter(v, c.backoff.Get(reusableFailedReplica.Name))
 		}
 		if checkBackDuration := c.scheduler.RequireNewReplica(rs, v, hardNodeAffinity); checkBackDuration == 0 {
-			if err := c.createReplica(v, e, rs, hardNodeAffinity, !newVolume); err != nil {
+			newReplica := c.newReplica(v, e, hardNodeAffinity)
+
+			if err := c.precheckCreateReplica(newReplica, rs, v); err != nil {
+				log.WithError(err).Warnf("Unable to create new replica %v", newReplica.Name)
+				continue
+			}
+
+			if err := c.createReplica(newReplica, v, rs, !newVolume); err != nil {
 				return err
 			}
 		} else {
@@ -3320,11 +3327,8 @@ func (c *VolumeController) createEngine(v *longhorn.Volume, currentEngineName st
 	return c.ds.CreateEngine(engine)
 }
 
-func (c *VolumeController) createReplica(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica,
-	hardNodeAffinity string, isRebuildingReplica bool) error {
-	log := getLoggerForVolume(c.logger, v)
-
-	replica := &longhorn.Replica{
+func (c *VolumeController) newReplica(v *longhorn.Volume, e *longhorn.Engine, hardNodeAffinity string) *longhorn.Replica {
+	return &longhorn.Replica{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            types.GenerateReplicaNameForVolume(v.Name),
 			OwnerReferences: datastore.GetOwnerReferencesForVolume(v),
@@ -3347,6 +3351,24 @@ func (c *VolumeController) createReplica(v *longhorn.Volume, e *longhorn.Engine,
 			SnapshotMaxSize:                  v.Spec.SnapshotMaxSize,
 		},
 	}
+}
+
+func (c *VolumeController) precheckCreateReplica(replica *longhorn.Replica, replicas map[string]*longhorn.Replica, volume *longhorn.Volume) error {
+	diskCandidates, _, err := c.scheduler.FindDiskCandidates(replica, replicas, volume)
+	if err != nil {
+		return err
+	}
+
+	if len(diskCandidates) == 0 {
+		return errors.Errorf("No available disk candidates to create a new replica of size %v", replica.Spec.VolumeSize)
+	}
+
+	return nil
+}
+
+func (c *VolumeController) createReplica(replica *longhorn.Replica, v *longhorn.Volume, rs map[string]*longhorn.Replica, isRebuildingReplica bool) error {
+	log := getLoggerForVolume(c.logger, v)
+
 	if isRebuildingReplica {
 		// TODO: reuse failed replica for replica rebuilding of SPDK volumes
 		if types.IsDataEngineV2(v.Spec.DataEngine) {
@@ -3360,6 +3382,11 @@ func (c *VolumeController) createReplica(v *longhorn.Volume, e *longhorn.Engine,
 		// Prevent this new replica from being reused after rebuilding failure.
 		replica.Spec.RebuildRetryCount = scheduler.FailedReplicaMaxRetryCount
 	}
+
+	log.WithFields(logrus.Fields{
+		"replica":          replica.Name,
+		"hardNodeAffinity": replica.Spec.HardNodeAffinity,
+	}).Info("Creating new Replica")
 
 	replica, err := c.ds.CreateReplica(replica)
 	if err != nil {

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -119,8 +119,9 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		tc.nodes[i].Spec.AllowScheduling = false
 	}
 	tc.copyCurrentToExpect()
-	// replicas and engine object would still be created
+	// replica object would not be created
 	tc.replicas = nil
+	// engine object would still be created
 	tc.engines = nil
 	for _, r := range tc.expectReplicas {
 		r.Spec.NodeID = ""
@@ -128,6 +129,28 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 		r.Spec.DiskPath = ""
 		r.Spec.DataDirectoryName = ""
 	}
+	tc.expectVolume.Status.State = longhorn.VolumeStateCreating
+	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.Image
+	tc.expectVolume.Status.Robustness = longhorn.VolumeRobustnessFaulted
+	testCases["volume create - replica creation failure"] = tc
+
+	// unable to create volume because no node to schedule
+	tc = generateVolumeTestCaseTemplate()
+	for i := range tc.nodes {
+		tc.nodes[i].Spec.AllowScheduling = false
+	}
+	tc.copyCurrentToExpect()
+	// engine object would still be created
+	tc.engines = nil
+	for _, r := range tc.expectReplicas {
+		r.Spec.NodeID = ""
+		r.Spec.DiskID = ""
+		r.Spec.DiskPath = ""
+		r.Spec.DataDirectoryName = ""
+	}
+	// replica object is already created
+	tc.replicas = tc.expectReplicas
+
 	tc.expectVolume.Status.State = longhorn.VolumeStateCreating
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.Image
 	tc.expectVolume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.expectVolume.Status.Conditions,

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3253,6 +3253,41 @@ func CheckInstanceManagerType(im *longhorn.InstanceManager) (longhorn.InstanceMa
 	return longhorn.InstanceManagerType(""), fmt.Errorf("unknown type %v for instance manager %v", imType, im.Name)
 }
 
+// CheckInstanceManagerReadiness checks if the InstanceManager is running on the
+// specified set of nodes.
+//
+// Parameters:
+//   - dataEngine: the data engine type.
+//   - nodes: the list of node names.
+//
+// Returns:
+// - Boolean indicating if all InstanceManagers are running on the nodes.
+// - Error for any errors encountered.
+func (s *DataStore) CheckInstanceManagersReadiness(dataEngine longhorn.DataEngineType, nodes ...string) (isReady bool, err error) {
+	for _, node := range nodes {
+		instanceManager, err := s.GetDefaultInstanceManagerByNodeRO(node, dataEngine)
+		if err != nil {
+			return false, err
+		}
+
+		isRunning := instanceManager.Status.CurrentState == longhorn.InstanceManagerStateRunning
+		notDeleted := instanceManager.DeletionTimestamp == nil
+		if !isRunning && notDeleted {
+			logrus.WithFields(
+				logrus.Fields{
+					"currentState":    instanceManager.Status.CurrentState,
+					"dataEngine":      dataEngine,
+					"instanceManager": instanceManager.Name,
+					"node":            node,
+				},
+			).Errorf("CheckInstanceManagerReadiness: instance manager is not running")
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 // ListInstanceManagersBySelectorRO gets a list of InstanceManager by labels for
 // the given namespace,
 // the list contains direct references to the internal cache objects and should not be mutated.

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -63,7 +63,34 @@ func (rcs *ReplicaScheduler) ScheduleReplica(replica *longhorn.Replica, replicas
 		return nil, nil, nil
 	}
 
-	// get all hosts
+	diskCandidates, multiError, err := rcs.FindDiskCandidates(replica, replicas, volume)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// there's no disk that fit for current replica
+	if len(diskCandidates) == 0 {
+		logrus.Errorf("There's no available disk for replica %v, size %v", replica.ObjectMeta.Name, replica.Spec.VolumeSize)
+		return nil, multiError, nil
+	}
+
+	rcs.scheduleReplicaToDisk(replica, diskCandidates)
+
+	return replica, nil, nil
+}
+
+// FindDiskCandidates identifies suitable disks on eligible nodes for the replica.
+//
+// Parameters:
+// - replica: The replica for which to find disk candidates.
+// - replicas: The map of existing replicas.
+// - volume: The volume associated with the replica.
+//
+// Returns:
+// - Map of disk candidates (disk UUID to Disk).
+// - MultiError for non-fatal errors encountered.
+// - Error for any fatal errors encountered.
+func (rcs *ReplicaScheduler) FindDiskCandidates(replica *longhorn.Replica, replicas map[string]*longhorn.Replica, volume *longhorn.Volume) (map[string]*Disk, util.MultiError, error) {
 	nodesInfo, err := rcs.getNodeInfo()
 	if err != nil {
 		return nil, nil, err
@@ -95,17 +122,7 @@ func (rcs *ReplicaScheduler) ScheduleReplica(replica *longhorn.Replica, replicas
 	}
 
 	diskCandidates, multiError := rcs.getDiskCandidates(nodeCandidates, nodeDisksMap, replicas, volume, true, false)
-
-	// there's no disk that fit for current replica
-	if len(diskCandidates) == 0 {
-		logrus.Errorf("There's no available disk for replica %v, size %v", replica.ObjectMeta.Name, replica.Spec.VolumeSize)
-		return nil, multiError, nil
-	}
-
-	// schedule replica to disk
-	rcs.scheduleReplicaToDisk(replica, diskCandidates)
-
-	return replica, nil, nil
+	return diskCandidates, multiError, nil
 }
 
 func (rcs *ReplicaScheduler) getNodeCandidates(nodesInfo map[string]*longhorn.Node, schedulingReplica *longhorn.Replica) (nodeCandidates map[string]*longhorn.Node, multiError util.MultiError) {
@@ -135,8 +152,15 @@ func (rcs *ReplicaScheduler) getNodeCandidates(nodesInfo map[string]*longhorn.No
 			}
 		}
 
-		if isReady, _ := rcs.ds.CheckDataEngineImageReadiness(schedulingReplica.Spec.Image, schedulingReplica.Spec.DataEngine, node.Name); isReady {
+		log := logrus.WithField("node", node.Name)
+
+		if isReady, err := rcs.ds.CheckDataEngineImageReadiness(schedulingReplica.Spec.Image, schedulingReplica.Spec.DataEngine, node.Name); isReady {
 			nodeCandidates[node.Name] = node
+		} else {
+			if err != nil {
+				log = log.WithError(err)
+			}
+			log.Debugf("Excluding node in node candidates because data engine image on node is not ready")
 		}
 	}
 
@@ -670,7 +694,7 @@ func (rcs *ReplicaScheduler) isFailedReplicaReusable(r *longhorn.Replica, v *lon
 
 	im, err := rcs.ds.GetInstanceManagerByInstanceRO(r)
 	if err != nil {
-		logrus.Errorf("failed to get instance manager when checking replica %v is reusable: %v", r.Name, err)
+		logrus.Errorf("Failed to get instance manager when checking replica %v is reusable: %v", r.Name, err)
 		return false, nil
 	}
 	if im.DeletionTimestamp != nil || im.Status.CurrentState != longhorn.InstanceManagerStateRunning {

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -34,8 +34,9 @@ const (
 	TestNode2     = "test-node-name-2"
 	TestNode3     = "test-node-name-3"
 
-	TestOwnerID1    = TestNode1
-	TestEngineImage = "longhorn-engine:latest"
+	TestOwnerID1             = TestNode1
+	TestEngineImage          = "longhorn-engine:latest"
+	TestInstanceManagerImage = "longhorn-instance-manager:latest"
 
 	TestVolumeName         = "test-volume"
 	TestVolumeSize         = 1073741824
@@ -106,6 +107,24 @@ func newNode(name, namespace, zone string, allowScheduling bool, status longhorn
 				newCondition(longhorn.NodeConditionTypeReady, status),
 			},
 			Zone: zone,
+		},
+	}
+}
+
+func newInstanceManager(nodeName string) *longhorn.InstanceManager {
+	return &longhorn.InstanceManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance-manager-" + util.RandomID(),
+			Namespace: TestNamespace,
+			Labels:    types.GetInstanceManagerLabels(nodeName, TestInstanceManagerImage, longhorn.InstanceManagerTypeAllInOne, longhorn.DataEngineTypeV1),
+		},
+		Spec: longhorn.InstanceManagerSpec{
+			Image:  TestInstanceManagerImage,
+			NodeID: nodeName,
+			Type:   longhorn.InstanceManagerTypeAllInOne,
+		},
+		Status: longhorn.InstanceManagerStatus{
+			CurrentState: longhorn.InstanceManagerStateRunning,
 		},
 	}
 }
@@ -1147,6 +1166,7 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
 		nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
 		eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
 		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
 		pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 
@@ -1172,6 +1192,15 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		c.Assert(ei, NotNil)
 		err = eiIndexer.Add(ei)
 		c.Assert(err, IsNil)
+		// Create instance manager
+		for _, node := range tc.nodes {
+			fakeInstanceManager := newInstanceManager(node.Name)
+			im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), fakeInstanceManager, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(im, NotNil)
+			err = imIndexer.Add(im)
+			c.Assert(err, IsNil)
+		}
 		// create volume
 		volume, err := lhClient.LonghornV1beta2().Volumes(TestNamespace).Create(context.TODO(), tc.volume, metav1.CreateOptions{})
 		c.Assert(err, IsNil)
@@ -1291,6 +1320,13 @@ func generateFailedReplicaTestCase(
 }
 
 func setSettings(tc *ReplicaSchedulerTestCase, lhClient *lhfake.Clientset, sIndexer cache.Indexer, c *C) {
+	// Set default-instance-manager-image setting
+	s := initSettings(string(types.SettingNameDefaultInstanceManagerImage), TestInstanceManagerImage)
+	setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = sIndexer.Add(setting)
+	c.Assert(err, IsNil)
+
 	// Set storage over-provisioning percentage settings
 	if tc.storageOverProvisioningPercentage != "" && tc.storageMinimalAvailablePercentage != "" {
 		s := initSettings(string(types.SettingNameStorageOverProvisioningPercentage), tc.storageOverProvisioningPercentage)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#1992

#### What this PR does / why we need it:

- Before creating a new Replica CR, verify the availability of suitable nodes with sufficient disk to accommodate the replica. This prevents creating Replicas that cannot be scheduled.
- During node disk candidate selection, exclude nodes where the InstanceManager is not in a running state. This prevents creating redundant Replica CRs on nodes that haven't fully recovered after a power down.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
