### PR TITLE
Don't emit a warning for normal snapshot delete operations

### DIFF
--- a/constant/events.go
+++ b/constant/events.go
@@ -62,7 +62,7 @@ const (
 	EventReasonReady    = "Ready"
 	EventReasonUploaded = "Uploaded"
 
-	EventReasonUpgrade = "Uppgrade"
+	EventReasonUpgrade = "Upgrade"
 
 	EventReasonRolloutSkippedFmt = "RolloutSkipped: %v %v"
 )

--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -31,6 +31,10 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
+const (
+	snapshotErrorLost = "lost track of the corresponding snapshot info inside volume engine"
+)
+
 type SnapshotController struct {
 	*baseController
 
@@ -474,9 +478,10 @@ func (sc *SnapshotController) reconcile(snapshotName string) (err error) {
 	snapshotInfo, ok := engine.Status.Snapshots[snapshot.Name]
 	if !ok {
 		if !requestCreateNewSnapshot || alreadyCreatedBefore {
-			// The snapshotInfo exists inside engine.Status.Snapshots before but disappears now.
-			// Mark snapshotCR as lost track of the corresponding snapshotInfo
-			snapshot.Status.Error = "lost track of the corresponding snapshot info inside volume engine"
+			// The snapshotInfo existed inside engine.Status.Snapshots before but is gone now. This often doesn't
+			// signify an actual problem (e.g. if the snapshot is deleted by the engine process itself during a purge),
+			// but the snapshot controller can't reconcile the status anymore. Add a message to the CR.
+			snapshot.Status.Error = snapshotErrorLost
 		}
 		// Newly created snapshotCR, wait for the snapshotInfo to be appeared inside engine.Status.Snapshot
 		snapshot.Status.ReadyToUse = false
@@ -562,13 +567,20 @@ func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snap
 
 func (sc *SnapshotController) generatingEventsForSnapshot(existingSnapshot, snapshot *longhorn.Snapshot) {
 	if !existingSnapshot.Status.MarkRemoved && snapshot.Status.MarkRemoved {
-		sc.eventRecorder.Event(snapshot, corev1.EventTypeWarning, constant.EventReasonDelete, "snapshot is marked as removed")
+		sc.eventRecorder.Event(snapshot, corev1.EventTypeNormal, constant.EventReasonDelete, "snapshot is marked as removed")
 	}
 	if snapshot.Spec.CreateSnapshot && existingSnapshot.Status.CreationTime == "" && snapshot.Status.CreationTime != "" {
 		sc.eventRecorder.Event(snapshot, corev1.EventTypeNormal, constant.EventReasonCreate, "successfully provisioned the snapshot")
 	}
 	if snapshot.Status.Error != "" && existingSnapshot.Status.Error != snapshot.Status.Error {
-		sc.eventRecorder.Eventf(snapshot, corev1.EventTypeWarning, constant.EventReasonFailed, "%v", snapshot.Status.Error)
+		if snapshot.Status.Error == snapshotErrorLost {
+			// There are probably scenarios when this is an actual problem, so we want to continue to emit the event.
+			// However, it most often occurs in scenarios like https://github.com/longhorn/longhorn/issues/4126, so we
+			// want to use EventTypeNormal instead of EventTypeWarning.
+			sc.eventRecorder.Event(snapshot, corev1.EventTypeNormal, constant.EventReasonDelete, "snapshot was removed from engine")
+		} else {
+			sc.eventRecorder.Eventf(snapshot, corev1.EventTypeWarning, constant.EventReasonFailed, "%v", snapshot.Status.Error)
+		}
 	}
 	if existingSnapshot.Status.ReadyToUse != snapshot.Status.ReadyToUse {
 		if snapshot.Status.ReadyToUse {

--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -22,6 +22,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/longhorn/longhorn-manager/constant"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
@@ -561,19 +562,19 @@ func (sc *SnapshotController) handleAttachmentTicketCreation(snap *longhorn.Snap
 
 func (sc *SnapshotController) generatingEventsForSnapshot(existingSnapshot, snapshot *longhorn.Snapshot) {
 	if !existingSnapshot.Status.MarkRemoved && snapshot.Status.MarkRemoved {
-		sc.eventRecorder.Event(snapshot, corev1.EventTypeWarning, "SnapshotDelete", "snapshot is marked as removed")
+		sc.eventRecorder.Event(snapshot, corev1.EventTypeWarning, constant.EventReasonDelete, "snapshot is marked as removed")
 	}
 	if snapshot.Spec.CreateSnapshot && existingSnapshot.Status.CreationTime == "" && snapshot.Status.CreationTime != "" {
-		sc.eventRecorder.Eventf(snapshot, corev1.EventTypeNormal, "SnapshotCreate", "successfully provisioned the snapshot")
+		sc.eventRecorder.Event(snapshot, corev1.EventTypeNormal, constant.EventReasonCreate, "successfully provisioned the snapshot")
 	}
 	if snapshot.Status.Error != "" && existingSnapshot.Status.Error != snapshot.Status.Error {
-		sc.eventRecorder.Eventf(snapshot, corev1.EventTypeWarning, "SnapshotError", "%v", snapshot.Status.Error)
+		sc.eventRecorder.Eventf(snapshot, corev1.EventTypeWarning, constant.EventReasonFailed, "%v", snapshot.Status.Error)
 	}
 	if existingSnapshot.Status.ReadyToUse != snapshot.Status.ReadyToUse {
 		if snapshot.Status.ReadyToUse {
-			sc.eventRecorder.Eventf(snapshot, corev1.EventTypeNormal, "SnapshotUpdate", "snapshot becomes ready to use")
+			sc.eventRecorder.Event(snapshot, corev1.EventTypeNormal, constant.EventReasonUpdate, "snapshot becomes ready to use")
 		} else {
-			sc.eventRecorder.Eventf(snapshot, corev1.EventTypeWarning, "SnapshotUpdate", "snapshot becomes not ready to use")
+			sc.eventRecorder.Event(snapshot, corev1.EventTypeWarning, constant.EventReasonUpdate, "snapshot becomes not ready to use")
 		}
 	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#4126

#### What this PR does / why we need it:

Before this PR, we would emit events with type Warning when scaling up a volume by two replicas, even though nothing was actually wrong. Check https://github.com/longhorn/longhorn/issues/4126#issuecomment-1158156580 for context. We emitted warnings in response to two occurrences:

1. The snapshot controller saw that a snapshot which was previously NOT marked as removed in the engine became marked as removed. There's really no reason for there to be a warning here. It is just normal behavior when we try to purge the snapshot behind `volume-head`.
2. The engine monitor removed a snapshot from the engine CR and then deleted the corresponding snapshot CR. If the snapshot controller reconciled between the two events, it noticed the snapshot was no longer in the engine CR and emitted the warning. The disappearance of the snapshot from the engine CR MIGHT be something that interests us in some situations, but in this reproduce, it is just the annoying result of a race. (It is a race because sometimes the snapshot controller reconciles after the snapshot CR deletion, and the snapshot controller doesn't notice anything at all.)

I made both of these Normal instead of Warning events.

#### Special notes for your reviewer:

I also did a bit of refactoring:

1. We should be pulling our EventReasons from `events.go` like other controllers do.
2. IMO, we don't need separate EventReasons from the generic "Create", "Delete". However, I'm open to push back on this. We can just use the names from before, except put them in `events.go`.

#### Additional documentation or context

Before:

```
0s          Normal    Degraded         volume/test                                                             volume test became degraded
0s          Normal    Degraded         volume/test                                                             volume test became degraded
0s          Normal    Degraded         volume/test                                                             volume test became degraded
0s          Normal    Start            replica/test-r-52aeda9f                                                 Starts test-r-52aeda9f
0s          Normal    Degraded         volume/test                                                             volume test became degraded
0s          Normal    Start            replica/test-r-c17d5510                                                 Starts test-r-c17d5510
0s          Normal    Rebuilding       engine/test-e-0                                                         Start rebuilding replica test-r-52aeda9f with Address 10.42.4.193:10000 for normal engine test-e-0 and volume test
0s          Normal    Rebuilt          engine/test-e-0                                                         Replica test-r-52aeda9f with Address 10.42.4.193:10000 has been rebuilt for volume test
0s          Normal    Rebuilt          engine/test-e-0                                                         Detected replica test-r-52aeda9f (10.42.4.193:10000) has been rebuilt
0s          Normal    Rebuilding       engine/test-e-0                                                         Start rebuilding replica test-r-c17d5510 with Address 10.42.3.3:10000 for normal engine test-e-0 and volume test
0s          Normal    Rebuilt          engine/test-e-0                                                         Replica test-r-c17d5510 with Address 10.42.3.3:10000 has been rebuilt for volume test
0s          Normal    Rebuilt          engine/test-e-0                                                         Detected replica test-r-c17d5510 (10.42.3.3:10000) has been rebuilt
0s          Normal    Healthy          volume/test                                                             volume test became healthy
0s          Warning   SnapshotError    snapshot/203c3089-ed00-4807-8a80-e60ddbdb69ec                           lost track of the corresponding snapshot info inside volume engine
0s          Warning   SnapshotDelete   snapshot/3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c                           snapshot is marked as removed


[longhorn-manager-nlm8h] time="2024-06-28T17:48:01Z" level=info msg="Creating snapshot CR for the snapshot 203c3089-ed00-4807-8a80-e60ddbdb69ec" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1289" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-nlm8h] time="2024-06-28T17:48:01Z" level=info msg="Deleting snapshot CR for the snapshot 203c3089-ed00-4807-8a80-e60ddbdb69ec" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1260" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-nlm8h] time="2024-06-28T17:48:01Z" level=info msg="Event(v1.ObjectReference{Kind:\"Snapshot\", Namespace:\"longhorn-system\", Name:\"203c3089-ed00-4807-8a80-e60ddbdb69ec\", UID:\"ffded971-95b7-4396-b1b3-34560f1414e0\", APIVersion:\"longhorn.io/v1beta2\", ResourceVersion:\"118806709\", FieldPath:\"\"}): type: 'Warning' reason: 'SnapshotError' lost track of the corresponding snapshot info inside volume engine" func="record.(*eventBroadcasterImpl).StartLogging.func1" file="event.go:377"
[longhorn-manager-nlm8h] time="2024-06-28T17:48:01Z" level=info msg="Creating snapshot CR for the snapshot 3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1289" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-nlm8h] time="2024-06-28T17:48:01Z" level=info msg="Event(v1.ObjectReference{Kind:\"Snapshot\", Namespace:\"longhorn-system\", Name:\"3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c\", UID:\"16498dbd-98d4-48ba-a22e-b290b1707fd9\", APIVersion:\"longhorn.io/v1beta2\", ResourceVersion:\"118806713\", FieldPath:\"\"}): type: 'Warning' reason: 'SnapshotDelete' snapshot is marked as removed" func="record.(*eventBroadcasterImpl).StartLogging.func1" file="event.go:377"
```

After:

```
0s          Normal    Degraded                 volume/test                                            volume test became degraded
0s          Normal    Start                    replica/test-r-94eba309                                Starts test-r-94eba309
0s          Normal    Rebuilding               engine/test-e-0                                        Start rebuilding replica test-r-94eba309 with Address 10.42.4.193:10000 for normal engine test-e-0 and volume test
0s          Normal    Rebuilt                  engine/test-e-0                                        Replica test-r-94eba309 with Address 10.42.4.193:10000 has been rebuilt for volume test
0s          Normal    Rebuilt                  engine/test-e-0                                        Detected replica test-r-94eba309 (10.42.4.193:10000) has been rebuilt
0s          Normal    Delete                   snapshot/3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c          snapshot was removed from engine
0s          Normal    Start                    replica/test-r-2b13045b                                Starts test-r-2b13045b
0s          Normal    Rebuilding               engine/test-e-0                                        Start rebuilding replica test-r-2b13045b with Address 10.42.3.3:10000 for normal engine test-e-0 and volume test
0s          Normal    Rebuilt                  engine/test-e-0                                        Replica test-r-2b13045b with Address 10.42.3.3:10000 has been rebuilt for volume test
0s          Normal    Rebuilt                  engine/test-e-0                                        Detected replica test-r-2b13045b (10.42.3.3:10000) has been rebuilt
0s          Normal    Healthy                  volume/test                                            volume test became healthy
0s          Normal    Delete                   snapshot/7440ff6e-ac5a-4f17-8779-bd0e4b4fc120          snapshot is marked as removed

[longhorn-manager-hvs2z] time="2024-06-28T19:04:28Z" level=info msg="Event(v1.ObjectReference{Kind:\"Snapshot\", Namespace:\"longhorn-system\", Name:\"3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c\", UID:\"16498dbd-98d4-48ba-a22e-b290b1707fd9\", APIVersion:\"longhorn.io/v1beta2\", ResourceVersion:\"118831048\", FieldPath:\"\"}): type: 'Normal' reason: 'Delete' snapshot was removed from engine" func="record.(*eventBroadcasterImpl).StartLogging.func1" file="event.go:377"
[longhorn-manager-hvs2z] time="2024-06-28T19:04:47Z" level=info msg="Deleting snapshot CR for the snapshot 3e7f6787-cb5a-458a-b7b0-a8dbc8001b9c" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1260" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-hvs2z] time="2024-06-28T19:04:47Z" level=info msg="Creating snapshot CR for the snapshot ef18f40d-4819-44bd-8474-8aa0e757e5ec" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1289" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-hvs2z] time="2024-06-28T19:04:47Z" level=info msg="Deleting snapshot CR for the snapshot ef18f40d-4819-44bd-8474-8aa0e757e5ec" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1260" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-hvs2z] time="2024-06-28T19:04:47Z" level=info msg="Creating snapshot CR for the snapshot 7440ff6e-ac5a-4f17-8779-bd0e4b4fc120" func="controller.(*EngineController).syncSnapshotCRs" file="engine_controller.go:1289" controller=longhorn-engine engine=test-e-0 node=eweber-v126-worker-9c1451b4-kgxdq
[longhorn-manager-hvs2z] time="2024-06-28T19:04:47Z" level=info msg="Event(v1.ObjectReference{Kind:\"Snapshot\", Namespace:\"longhorn-system\", Name:\"7440ff6e-ac5a-4f17-8779-bd0e4b4fc120\", UID:\"c6f9f5b8-1030-4fc5-8e03-5f3814875381\", APIVersion:\"longhorn.io/v1beta2\", ResourceVersion:\"118831180\", FieldPath:\"\"}): type: 'Normal' reason: 'Delete' snapshot is marked as removed" func="record.(*eventBroadcasterImpl).StartLogging.func1" file="event.go:377"
```