### PR TITLE
fix(log): fix v2-data-engine-log-level is not applied

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -273,7 +273,7 @@ func (sc *SettingController) syncNonDangerZoneSettingsForManagedComponents(setti
 		if err := sc.cleanupFailedSupportBundles(); err != nil {
 			return err
 		}
-	case types.SettingNameLogLevel, types.SettingNameV2DataEngineLogLevel:
+	case types.SettingNameLogLevel:
 		if err := sc.updateLogLevel(settingName); err != nil {
 			return err
 		}


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8865

#### What this PR does / why we need it:

updateLogLevel() is for logrus log level.
v2-data-engine-log-level will be applied in instance-manager controller.

#### Special notes for your reviewer:

#### Additional documentation or context
