### PR TITLE
fix(volume): wrong scheduled condition

### DIFF
--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -132,6 +132,8 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	tc.expectVolume.Status.State = longhorn.VolumeStateCreating
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.Image
 	tc.expectVolume.Status.Robustness = longhorn.VolumeRobustnessFaulted
+	tc.expectVolume.Status.Conditions = setVolumeConditionWithoutTimestamp(tc.expectVolume.Status.Conditions,
+		longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusFalse, longhorn.VolumeConditionReasonReplicaSchedulingFailure, longhorn.ErrorReplicaSchedulePrecheckNewReplicaFailed)
 	testCases["volume create - replica creation failure"] = tc
 
 	// unable to create volume because no node to schedule

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -44,6 +44,7 @@ const (
 	ErrorReplicaScheduleEngineImageNotReady              = "none of the node candidates contains a ready engine image"
 	ErrorReplicaScheduleHardNodeAffinityNotSatisfied     = "hard affinity cannot be satisfied"
 	ErrorReplicaScheduleSchedulingFailed                 = "replica scheduling failed"
+	ErrorReplicaSchedulePrecheckNewReplicaFailed         = "precheck new replica failed"
 )
 
 type DiskType string


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#8867

#### What this PR does / why we need it:

- Set volume condition scheduled to false when failed at replica creation precheck.
- Add a condition to check if the Replica count equals or is greater then volume.Spec.NumberOfReplicas before set volume condition scheduled to true.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

- https://github.com/longhorn/longhorn-manager/pull/2918
