### PR TITLE
fix(volume-controller): mark volume as scheduled when no more replicas to replenish

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1773,7 +1773,8 @@ func (c *VolumeController) reconcileVolumeCondition(v *longhorn.Volume, e *longh
 	}
 
 	failureMessage := ""
-	if scheduled && len(rs) >= v.Spec.NumberOfReplicas {
+	replenishCount, _ := c.getReplenishReplicasCount(v, rs, e)
+	if scheduled && replenishCount == 0 {
 		v.Status.Conditions = types.SetCondition(v.Status.Conditions,
 			longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusTrue, "", "")
 	} else if v.Status.CurrentNodeID == "" {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8872

#### What this PR does / why we need it:

Before marking the volume as scheduled, we need to check the replica replenish count. Otherwise, the controller might accidentally mark it as scheduled when the replica count is correct, but new replicas are actually expected and are being blocked by the pre-check.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
