### PR TITLE
fix: backing image ha and encryption conflicts

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -532,7 +532,7 @@ func (bic *BackingImageController) handleBackingImageDataSource(bi *longhorn.Bac
 			if bi.Spec.SourceType == longhorn.BackingImageDataSourceTypeClone {
 				readyNode, readyDiskName, err = bic.findReadyNodeAndDiskForClone(bi)
 				if err != nil {
-					return nil
+					return err
 				}
 			}
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -5287,7 +5287,7 @@ func (s *DataStore) CanPutBackingImageOnDisk(backingImage *longhorn.BackingImage
 }
 
 func (s *DataStore) GetOneBackingImageReadyNodeDisk(backingImage *longhorn.BackingImage) (*longhorn.Node, string, error) {
-	for diskUUID := range backingImage.Spec.Disks {
+	for diskUUID := range backingImage.Spec.DiskFileSpecMap {
 		bimMap, err := s.ListBackingImageManagersByDiskUUID(diskUUID)
 		if err != nil {
 			return nil, "", errors.Wrapf(err, "failed to get backing image manager by disk uuid %v", diskUUID)


### PR DESCRIPTION
spec.disks has been deprecated
fix to use spec.diskSpecMap