### PR TITLE
Fix bug engine.status.clonestatus is unnecessarily repeatedly updated

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -389,11 +389,20 @@ func (ec *EngineController) syncEngine(key string) (err error) {
 	}
 
 	// Clean up CloneStatus for later retry
-	if engine.Spec.RequestedDataSource == "" {
+	if engine.Spec.RequestedDataSource == "" && failedCloneBefore(engine) {
 		engine.Status.CloneStatus = nil
 	}
 
 	return nil
+}
+
+func failedCloneBefore(e *longhorn.Engine) bool {
+	for _, status := range e.Status.CloneStatus {
+		if status.State == engineapi.ProcessStateError {
+			return true
+		}
+	}
+	return false
 }
 
 func (ec *EngineController) enqueueEngine(obj interface{}) {


### PR DESCRIPTION
longhorn/longhorn#8952

The monitor update engine.Status.CloneStatus to a non-nil value and the PR https://github.com/longhorn/longhorn-manager/pull/2895 set it back to nil. They are fighting each other leading to unnecessarily repeatedly engine CR updates

