### PR TITLE
fix(volume-controller): rNames shadowed in cleanupAutoBalancedReplicas

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1147,8 +1147,10 @@ func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, e *lo
 			_, rNames, _ = c.getReplicaCountForAutoBalanceBestEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone)
 		}
 	}
+
+	var err error
 	if len(rNames) == 0 {
-		rNames, err := c.getPreferredReplicaCandidatesForDeletion(rs)
+		rNames, err = c.getPreferredReplicaCandidatesForDeletion(rs)
 		if err != nil {
 			return false, err
 		}
@@ -1158,7 +1160,7 @@ func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, e *lo
 		log.Infof("Found replica deletion candidates %v with best-effort", rNames)
 	}
 
-	rNames, err := c.getSortedReplicasByAscendingStorageAvailable(rNames, rs)
+	rNames, err = c.getSortedReplicasByAscendingStorageAvailable(rNames, rs)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#4105

#### What this PR does / why we need it:

The `rNames` variable is declared inside the if statement, which shadows the outer `rNames` variable. Hence it has no effect on the outer variable.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

- https://github.com/longhorn/longhorn/issues/4105#issuecomment-2216989458
- https://github.com/longhorn/longhorn-manager/pull/2547/commits/3518ab56cda494cd45da43077e20c31d79f20c9a
