### PR TITLE
fix(pre-upgrade): don't call environmentCheck without necessary bind mounts

### DIFF
--- a/app/pre_upgrade.go
+++ b/app/pre_upgrade.go
@@ -56,9 +56,5 @@ func preUpgrade(c *cli.Context) error {
 		return err
 	}
 
-	if err := environmentCheck(); err != nil {
-		return errors.Wrap(err, "failed to check environment, please make sure you have iscsiadm/open-iscsi installed on the host")
-	}
-
 	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/8974

#### Additional documentation or context

I think this is the right fix, but I may be missing some context. Feel free to open a different PR if the fix should be different @mantissahz.