### PR TITLE
fix: fix recurring job recreate issue

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3842,6 +3842,9 @@ func (c *VolumeController) restoreVolumeRecurringJobs(v *longhorn.Volume) error 
 		if job.JobSpec.Labels == nil {
 			job.JobSpec.Labels = map[string]string{}
 		}
+		if job.JobSpec.Parameters == nil {
+			job.JobSpec.Parameters = map[string]string{}
+		}
 		if jobName, err = createRecurringJobNotExist(log, c.ds, v, jobName, &job); err != nil {
 			return err
 		}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8874

fix recurring job recreating even the job already exists issue
`reflect.DeepEqual` considers `nil` and `map[]` are different, need to init the map struct before comparing