### PR TITLE
fix(crypto): execute cryptsetup in the host namespace again

### DIFF
--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -76,7 +76,7 @@ func VolumeMapper(volume string) string {
 // EncryptVolume encrypts provided device with LUKS.
 func EncryptVolume(devicePath, passphrase string, cryptoParams *EncryptParams) error {
 	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
-	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.ProcDirectory, namespaces)
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func OpenVolume(volume, devicePath, passphrase string) error {
 	}
 
 	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
-	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.ProcDirectory, namespaces)
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func OpenVolume(volume, devicePath, passphrase string) error {
 // CloseVolume closes encrypted volume so it can be detached.
 func CloseVolume(volume string) error {
 	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
-	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.ProcDirectory, namespaces)
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func ResizeEncryptoDevice(volume, passphrase string) error {
 	}
 
 	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
-	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.ProcDirectory, namespaces)
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func DeviceEncryptionStatus(devicePath string) (mappedDevice, mapper string, err
 	}
 
 	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
-	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.ProcDirectory, namespaces)
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
 	if err != nil {
 		return devicePath, "", err
 	}

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -420,6 +420,12 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									MountPath: "/dev",
 								},
 								{
+									// The plugin must be able to switch to the host's namespaces in order to execute
+									// cryptsetup commands for encrypted devices.
+									Name:      "host-proc",
+									MountPath: "/host/proc",
+								},
+								{
 									Name:      "host-sys",
 									MountPath: "/sys",
 								},
@@ -473,6 +479,14 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/dev",
+								},
+							},
+						},
+						{
+							Name: "host-proc",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/proc",
 								},
 							},
 						},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#9000

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/9000#issuecomment-2228720946

#### Special notes for your reviewer:

- `examples/block/crypto` works with this PR (from https://github.com/longhorn/longhorn/issues/9000#issuecomment-2227888212).
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7224 - PASSED
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7225 - PASSED
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7226 - PASSED
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7228/ - PASSED
- I also set up a storage network and tried some basic attach/detach operations and everything worked.

@c3y1huang, can you foresee any issues with Talos / container optimized distros?
