### PR TITLE
Fix(RWX):  long remount time when share manager pod restart

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -847,6 +847,7 @@ func (ns *NodeServer) getMounter(volume *longhornclient.Volume, volumeCapability
 		} else {
 			logrus.Warnf("Volume %v with unsupported filesystem %v, use default fs creation params", volume.Name, fsType)
 		}
+
 		return mounter, nil
 	}
 

--- a/csi/util.go
+++ b/csi/util.go
@@ -361,7 +361,7 @@ func unmount(path string, mounter mount.Interface) (err error) {
 	return err
 }
 
-// unnountAndCleanupMountPoint ensures all mount layers for the path are unmounted and the mount directory is removed
+// unmountAndCleanupMountPoint ensures all mount layers for the path are unmounted and the mount directory is removed
 func unmountAndCleanupMountPoint(path string, mounter mount.Interface) error {
 	// we just try to unmount since the path check would get stuck for nfs mounts
 	logrus.Infof("Trying to umount mount point %v", path)

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -792,6 +792,11 @@ func (s *DataStore) CreateKubernetesEndpoint(endpoint *corev1.Endpoints) (*corev
 	return s.kubeClient.CoreV1().Endpoints(endpoint.Namespace).Create(context.TODO(), endpoint, metav1.CreateOptions{})
 }
 
+// DeleteKubernetesEndpoint deletes the Kubernetes Endpoint of the given name in the Longhorn namespace.
+func (s *DataStore) DeleteKubernetesEndpoint(namespace, name string) error {
+	return s.kubeClient.CoreV1().Endpoints(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
 // UpdateKubernetesEndpoint updates the Kubernetes Endpoint of the given name in the Longhorn namespace.
 func (s *DataStore) UpdateKubernetesEndpoint(endpoint *corev1.Endpoints) (*corev1.Endpoints, error) {
 	return s.kubeClient.CoreV1().Endpoints(s.namespace).Update(context.TODO(), endpoint, metav1.UpdateOptions{})


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8999

#### What this PR does / why we need it:

This PR addressed a regression where remounting NFS volume hangs for an extended period before succeeding. The regression is a side effect from  https://github.com/longhorn/longhorn-manager/pull/2815, and the way the share manager's Service is cleaned up caused the remounting to hang after the share manager Pod restarts.

This PR proposes moving the responsibility of cleaning up the Service and Endpoint to the setting controller. This is a more logical fit since the setting controller handles the storage network change, which aligns better with the purpose of this cleanup process. This change should eliminate the race condition.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

- https://github.com/longhorn/longhorn/issues/8999#issuecomment-2228183416
