### PR TITLE
feat(backupbackingimage): add parameters to backup backing image create proto

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -185,6 +185,8 @@ type BackupBackingImage struct {
 	Labels            map[string]string    `json:"labels"`
 	Messages          map[string]string    `json:"messages"`
 	CompressionMethod string               `json:"compressionMethod"`
+	Secret            string               `json:"secret"`
+	SecretNamespace   string               `json:"secretNamespace"`
 }
 
 type Setting struct {
@@ -1873,6 +1875,8 @@ func toBackupBackingImageResource(bbi *longhorn.BackupBackingImage, apiContext *
 		Labels:            bbi.Status.Labels,
 		Messages:          bbi.Status.Messages,
 		CompressionMethod: string(bbi.Status.CompressionMethod),
+		Secret:            bbi.Status.Secret,
+		SecretNamespace:   bbi.Status.SecretNamespace,
 	}
 
 	backupBackingImage.Actions = map[string]string{

--- a/client/generated_backup_backing_image.go
+++ b/client/generated_backup_backing_image.go
@@ -21,6 +21,10 @@ type BackupBackingImage struct {
 
 	Progress int64 `json:"progress,omitempty" yaml:"progress,omitempty"`
 
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+
+	SecretNamespace string `json:"secretNamespace,omitempty" yaml:"secretNamespace,omitempty"`
+
 	Size int64 `json:"size,omitempty" yaml:"size,omitempty"`
 
 	State string `json:"state,omitempty" yaml:"state,omitempty"`

--- a/controller/backup_backing_image_controller.go
+++ b/controller/backup_backing_image_controller.go
@@ -332,6 +332,8 @@ func (bc *BackupBackingImageController) reconcile(backupBackingImageName string)
 	bbi.Status.Checksum = backupBackingImageInfo.Checksum
 	bbi.Status.Size = backupBackingImageInfo.Size
 	bbi.Status.Labels = backupBackingImageInfo.Labels
+	bbi.Status.Secret = backupBackingImageInfo.Secret
+	bbi.Status.SecretNamespace = backupBackingImageInfo.SecretNamespace
 	bbi.Status.CompressionMethod = longhorn.BackupCompressionMethod(backupBackingImageInfo.CompressionMethod)
 	bbi.Status.LastSyncedAt = syncTime
 	return nil

--- a/engineapi/backing_image_manager.go
+++ b/engineapi/backing_image_manager.go
@@ -145,12 +145,12 @@ func (c *BackingImageManagerClient) VersionGet() (int, int, error) {
 	return output.BackingImageManagerAPIMinVersion, output.BackingImageManagerAPIVersion, nil
 }
 
-func (c *BackingImageManagerClient) BackupCreate(name, uuid, checksum, backupTargetURL string, labels, credential map[string]string, compressionMethod string, concurrentLimit int) error {
+func (c *BackingImageManagerClient) BackupCreate(name, uuid, checksum, backupTargetURL string, labels, credential map[string]string, compressionMethod string, concurrentLimit int, parameters map[string]string) error {
 
 	if err := CheckBackingImageManagerCompatibility(c.apiMinVersion, c.apiVersion); err != nil {
 		return err
 	}
-	return c.grpcClient.BackupCreate(name, uuid, checksum, backupTargetURL, labels, credential, compressionMethod, concurrentLimit)
+	return c.grpcClient.BackupCreate(name, uuid, checksum, backupTargetURL, labels, credential, compressionMethod, concurrentLimit, parameters)
 }
 
 func (c *BackingImageManagerClient) BackupStatus(name string) (*longhorn.BackupBackingImageStatus, error) {

--- a/go.mod
+++ b/go.mod
@@ -60,12 +60,12 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jinzhu/copier v0.4.0
 	github.com/kubernetes-csi/csi-lib-utils v0.19.0
-	github.com/longhorn/backing-image-manager v1.7.0-dev.0.20240823042906-1ae3d5073f60
+	github.com/longhorn/backing-image-manager v1.8.0-dev-20240825.0.20240828064910-e0449cbedcae
 	github.com/longhorn/backupstore v0.0.0-20240907142840-c1268343d512
 	github.com/longhorn/go-common-libs v0.0.0-20240907130740-7060fefb5bda
 	github.com/longhorn/go-iscsi-helper v0.0.0-20240907143006-2d71415d9bd3
 	github.com/longhorn/go-spdk-helper v0.0.0-20240907134443-f2c9f3529ef6
-	github.com/longhorn/longhorn-engine v1.7.0-dev.0.20240824053610-9d2b194f765f
+	github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f
 	github.com/longhorn/longhorn-instance-manager v1.8.0-dev-20240825.0.20240828024302-1bdcacd93207
 	github.com/longhorn/longhorn-share-manager v1.7.0-rc1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
-github.com/longhorn/backing-image-manager v1.7.0-dev.0.20240823042906-1ae3d5073f60 h1:iZrC1Xq2k9fUVFkeZrD6X6UxaPZNr3jBZ5tyo+Efbhg=
-github.com/longhorn/backing-image-manager v1.7.0-dev.0.20240823042906-1ae3d5073f60/go.mod h1:uRo+kg+oA0+5jcFtBcajOzAv6pXjy7gKUgwMEndn698=
+github.com/longhorn/backing-image-manager v1.8.0-dev-20240825.0.20240828064910-e0449cbedcae h1:fPsMlEy7I7Qx2EbuTGOjVkfkwAjCkTatFIeF3+fz8l4=
+github.com/longhorn/backing-image-manager v1.8.0-dev-20240825.0.20240828064910-e0449cbedcae/go.mod h1:3IoBX6MkcjJefcwZNSoprmc/GgFfrTYYK44KtzaxI3g=
 github.com/longhorn/backupstore v0.0.0-20240907142840-c1268343d512 h1:zrGVZZTClL0isTJf11rbELdAmDi5SME3ItJqAl+s6jU=
 github.com/longhorn/backupstore v0.0.0-20240907142840-c1268343d512/go.mod h1:3gjQWnKXqJSxAE6rpM5mrCcbRJyLKXHqgzxyyaLgLSo=
 github.com/longhorn/go-common-libs v0.0.0-20240907130740-7060fefb5bda h1:+jlHExQsoeb5B8Avl5tc/mX0rDvPDUhTDVbDitvl5vE=
@@ -167,8 +167,8 @@ github.com/longhorn/go-iscsi-helper v0.0.0-20240907143006-2d71415d9bd3 h1:PWXUT0
 github.com/longhorn/go-iscsi-helper v0.0.0-20240907143006-2d71415d9bd3/go.mod h1:3f/GmbvwXLWGAnCT1Bj0bb373wd4T48/uZJREbDr//g=
 github.com/longhorn/go-spdk-helper v0.0.0-20240907134443-f2c9f3529ef6 h1:9H2GjbvERQuS0HFiXJlZBmFWBduQhl0Nw7Znj/yV6LE=
 github.com/longhorn/go-spdk-helper v0.0.0-20240907134443-f2c9f3529ef6/go.mod h1:Hxn5CTNfYCx1EEQ5YLOSnsI65H9CJAXHioqXx6xx1D0=
-github.com/longhorn/longhorn-engine v1.7.0-dev.0.20240824053610-9d2b194f765f h1:Nsal/5akxiEyoBL+M0NOXiV5R96ACEgC64rK5w0VKcY=
-github.com/longhorn/longhorn-engine v1.7.0-dev.0.20240824053610-9d2b194f765f/go.mod h1:E1ec7ub7SNGvASDtiFHL1dXX4bhEQiroBixD2GGeRbQ=
+github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f h1:d6UjaruyQFXMoCPYmcf9SfP1svCokONAHblpjJ6XXcc=
+github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f/go.mod h1:WxnRZefYEMqrTn4H189DTqIPeKEAknNlmQjoAOk9K38=
 github.com/longhorn/longhorn-instance-manager v1.8.0-dev-20240825.0.20240828024302-1bdcacd93207 h1:07e35ywxlYhF2yFgYko6Ni6tL4NyjeZU7eSm5pOvF6o=
 github.com/longhorn/longhorn-instance-manager v1.8.0-dev-20240825.0.20240828024302-1bdcacd93207/go.mod h1:D6ciWSaUShhjZGK3V/IHgO0o1XOOmdIRUSGX59GDjiY=
 github.com/longhorn/longhorn-share-manager v1.7.0-rc1 h1:LsSkSajhG8tCfORKKfwK+8XHVrT/8rI9DRWb7fuoVls=

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -712,6 +712,12 @@ spec:
               progress:
                 description: The backing image backup progress.
                 type: integer
+              secret:
+                description: Record the secret if this backup backing image is encrypted
+                type: string
+              secretNamespace:
+                description: Record the secret namespace if this backup backing image is encrypted
+                type: string
               size:
                 description: The backing image size.
                 format: int64

--- a/k8s/pkg/apis/longhorn/v1beta2/backupbackingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backupbackingimage.go
@@ -64,6 +64,12 @@ type BackupBackingImageStatus struct {
 	// Compression method
 	// +optional
 	CompressionMethod BackupCompressionMethod `json:"compressionMethod"`
+	// Record the secret if this backup backing image is encrypted
+	// +optional
+	Secret string `json:"secret"`
+	// Record the secret namespace if this backup backing image is encrypted
+	// +optional
+	SecretNamespace string `json:"secretNamespace"`
 }
 
 // +genclient

--- a/vendor/github.com/longhorn/backing-image-manager/pkg/client/manager_client.go
+++ b/vendor/github.com/longhorn/backing-image-manager/pkg/client/manager_client.go
@@ -240,7 +240,7 @@ func (cli *BackingImageManagerClient) Watch() (*api.BackingImageStream, error) {
 	return api.NewBackingImageStream(conn, cancel, stream), nil
 }
 
-func (cli *BackingImageManagerClient) BackupCreate(name, uuid, checksum, backupTargetURL string, labels, credential map[string]string, compressionMethod string, concurrentLimit int) error {
+func (cli *BackingImageManagerClient) BackupCreate(name, uuid, checksum, backupTargetURL string, labels, credential map[string]string, compressionMethod string, concurrentLimit int, parameters map[string]string) error {
 	if name == "" || uuid == "" || checksum == "" {
 		return fmt.Errorf("failed to create backup backing image: missing required parameter")
 	}
@@ -269,6 +269,7 @@ func (cli *BackingImageManagerClient) BackupCreate(name, uuid, checksum, backupT
 		Credential:        credential,
 		CompressionMethod: compressionMethod,
 		ConcurrentLimit:   int32(concurrentLimit),
+		Parameters:        parameters,
 	})
 	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/kylelemons/godebug/diff
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/longhorn/backing-image-manager v1.7.0-dev.0.20240823042906-1ae3d5073f60
+# github.com/longhorn/backing-image-manager v1.8.0-dev-20240825.0.20240828064910-e0449cbedcae
 ## explicit; go 1.22.2
 github.com/longhorn/backing-image-manager/api
 github.com/longhorn/backing-image-manager/pkg/client
@@ -271,7 +271,7 @@ github.com/longhorn/go-iscsi-helper/util
 # github.com/longhorn/go-spdk-helper v0.0.0-20240907134443-f2c9f3529ef6
 ## explicit; go 1.22.0
 github.com/longhorn/go-spdk-helper/pkg/types
-# github.com/longhorn/longhorn-engine v1.7.0-dev.0.20240824053610-9d2b194f765f
+# github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f
 ## explicit; go 1.22.2
 github.com/longhorn/longhorn-engine/pkg/interceptor
 github.com/longhorn/longhorn-engine/pkg/meta


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8884

update
- `backupBackingImage` status CRD to add `secret` and `secretNamespace`
- pass the `secret` and `secretNamespace` to `backing-image-manager` through grpc using `parameters`
- update `backupBackingImage` api model to pass the `secret` and `secretNamespace` to UI
