### PR TITLE
Fix(trim): extend the timeout

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -749,7 +749,7 @@ func TrimFilesystem(volumeName string, encryptedDevice bool) error {
 		return err
 	}
 
-	_, err = nsexec.Execute(nil, lhtypes.BinaryFstrim, []string{validMountpoint}, lhtypes.ExecuteDefaultTimeout)
+	_, err = nsexec.Execute(nil, lhtypes.BinaryFstrim, []string{validMountpoint}, time.Hour)
 	if err != nil {
 		return errors.Wrapf(err, "cannot find volume %v mount info on host", volumeName)
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6868

#### What this PR does / why we need it:

Propose extending the execution timeout for the `fstrim` command to 1 hour for v1.7.0. In the future release, we can work on enhancements such as running sync or making the timeout configurable.

#### Special notes for your reviewer:

I've not been able to reproduce the timeout issue as mentioned in the issue. In my environment, the `fstrim` completes quickly, However, my test data size is relatively small (100G). cc @longhorn/qa 

#### Additional documentation or context

`None`