### PR TITLE
fix(disk): non-existing block device results in longhorn-manager to be in Crashloopbackoff state

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -2584,16 +2584,7 @@ func (s *DataStore) needDefaultDiskCreation(dataPath string) bool {
 	}
 
 	// Do not create default block-type disk if v2 data engine is disabled
-	ok, err := types.IsBlockDisk(dataPath)
-	if err != nil {
-		logrus.WithError(err).Errorf("Failed to check if the data path %v is block-type", dataPath)
-		return false
-	}
-	if ok {
-		return false
-	}
-
-	return true
+	return !types.IsPotentialBlockDisk(dataPath)
 }
 
 func (s *DataStore) GetNodeRO(name string) (*longhorn.Node, error) {


### PR DESCRIPTION





#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9073

#### What this PR does / why we need it:

Non-existing block device results in longhorn-manager pods to be in Crashloopbackoff state. When longhorn-manager pods are in Crashloopbackoff, users are unable to update the default-data-path setting.

#### Special notes for your reviewer:

#### Additional documentation or context
