### PR TITLE
chore(backup): clarify deletion log message

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -496,7 +496,7 @@ func (btc *BackupTargetController) syncBackupVolume(backupStoreBackupVolumeNames
 	// and delete the BackupVolume CR in the cluster
 	backupVolumesToDelete := clusterBackupVolumesSet.Difference(backupStoreBackupVolumes)
 	if count := backupVolumesToDelete.Len(); count > 0 {
-		log.Infof("Found %d backup volumes in the backup target that do not exist in the backup target and need to be deleted", count)
+		log.Infof("Found %d backup volumes in the backup target that do not exist in the cluster and need to be deleted from the cluster", count)
 	}
 	for backupVolumeName := range backupVolumesToDelete {
 		log.WithField("backupVolume", backupVolumeName).Info("Deleting backup volume from cluster")

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -351,7 +351,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 	// and delete the Backup CR in the cluster
 	backupsToDelete := clustersSet.Difference(backupStoreBackups)
 	if count := backupsToDelete.Len(); count > 0 {
-		log.Infof("Found %d backups in the backup target that do not exist in the backup target and need to be deleted", count)
+		log.Infof("Found %d backups in the backup target that do not exist in the cluster and need to be deleted from the cluster", count)
 	}
 	for backupName := range backupsToDelete {
 		if err = bvc.ds.DeleteBackup(backupName); err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

No particular linked issue. I saw the following logged when I configured a backup target in my cluster and I was quite confused.

```
[longhorn-manager-qwx8h longhorn-manager] time="2024-07-24T14:47:28Z" level=info msg="Found 1 backup volumes in the backup target that do not exist in the backup target and need to be deleted" func="controller.
```

The repeated mention of "backup target" doesn't make sense, and I was worried that backups were being deleted from the target itself, which I would not expect. (That is not the case, so the log can be clarified.)