### PR TITLE
fix: rely on pod informer to requeue while share manager is starting

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -909,13 +909,15 @@ func (c *ShareManagerController) syncShareManagerPod(sm *longhorn.ShareManager) 
 			allContainersReady = allContainersReady && st.Ready
 		}
 
-		if !allContainersReady {
-			c.enqueueShareManager(sm)
-		} else if sm.Status.State == longhorn.ShareManagerStateStarting {
-			sm.Status.State = longhorn.ShareManagerStateRunning
-		} else if sm.Status.State != longhorn.ShareManagerStateRunning {
-			sm.Status.State = longhorn.ShareManagerStateError
+		if allContainersReady {
+			if sm.Status.State == longhorn.ShareManagerStateStarting {
+				sm.Status.State = longhorn.ShareManagerStateRunning
+			}
+			if sm.Status.State != longhorn.ShareManagerStateRunning {
+				sm.Status.State = longhorn.ShareManagerStateError
+			}
 		}
+		// If !allContainersReady, we will sync again when the situation changes.
 	default:
 		log.Infof("Share manager pod %v in unexpected phase: %v, setting sharemanager to error state.", sm.Name, pod.Status.Phase)
 		sm.Status.State = longhorn.ShareManagerStateError


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#9086

#### What this PR does / why we need it:

My preferred solution. There is no reason to enqueue the share manager in hopes of catching the pod with containers ready. The share manager controller has a pod informer that will enqueue the share manager any time the pod status changes.

#### Additional documentation or context

Reduced number of reconciles with the following message to 34 on `master-head`. (Even this number is inflated, because it accounts for reconciles from all share manager controllers in the cluster. In the buggy case, the tens of thousands were additional reconciles from only the owner).

```
[longhorn-manager-mckzz longhorn-manager] time="2024-07-25T21:44:39Z" level=warning msg="=====> In syncShareManager with state starting" func="controller.(*ShareManagerController).syncShareManager" file="share_manager_controller.go:333" controller=longhorn-share-manager node=eweber-v126-worker-9c1451b4-6464j owner=eweber-v126-worker-9c1451b4-kgxdq shareManager=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8 state=starting volume=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8
[longhorn-manager-cxksx longhorn-manager] time="2024-07-25T21:44:39Z" level=warning msg="=====> In syncShareManager with state starting" func="controller.(*ShareManagerController).syncShareManager" file="share_manager_controller.go:333" controller=longhorn-share-manager node=eweber-v126-worker-9c1451b4-kgxdq owner=eweber-v126-worker-9c1451b4-kgxdq shareManager=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8 state=starting volume=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8
[longhorn-manager-sfwwt longhorn-manager] time="2024-07-25T21:44:39Z" level=warning msg="=====> In syncShareManager with state starting" func="controller.(*ShareManagerController).syncShareManager" file="share_manager_controller.go:333" controller=longhorn-share-manager node=eweber-v126-worker-9c1451b4-rw5hf owner=eweber-v126-worker-9c1451b4-kgxdq shareManager=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8 state=starting volume=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8
[longhorn-manager-mckzz longhorn-manager] time="2024-07-25T21:44:39Z" level=warning msg="=====> In syncShareManager with state starting" func="controller.(*ShareManagerController).syncShareManager" file="share_manager_controller.go:333" controller=longhorn-share-manager node=eweber-v126-worker-9c1451b4-6464j owner=eweber-v126-worker-9c1451b4-kgxdq shareManager=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8 state=starting volume=pvc-781870d7-26e5-4a11-907a-f51d12acb2e8
```