### PR TITLE
If the volume is faulted, we don't need to have RWX fast failover.

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -1297,7 +1297,7 @@ func (c *ShareManagerController) createLeaseManifest(sm *longhorn.ShareManager) 
 	holderIdentity := ""
 	leaseDurationSeconds := int32(shareManagerLeaseDurationSeconds)
 	leaseTransitions := int32(0)
-	zeroTime := time.Now()
+	zeroTime := time.Time{}
 
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1828,7 +1828,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			}
 
 			if v.Status.State != longhorn.VolumeStateAttached || nodeDeleted {
-				msg := fmt.Sprintf("Replica %v is marked as failed since the volume %v is not attached because the instance manager is unable to launch the replica", r.Name, v.Name)
+				msg := fmt.Sprintf("Replica %v is marked as failed because the volume %v is not attached and the instance manager is unable to launch the replica", r.Name, v.Name)
 				if nodeDeleted {
 					msg = fmt.Sprintf("Replica %v is marked as failed since the node %v is deleted.", r.Name, r.Spec.NodeID)
 				}


### PR DESCRIPTION
If the volume is faulted, we don't need to have RWX fast failover.
If shareManager is delinquent, clear both delinquent and stale state.
If we don't do that, the volume will get stuck in the auto-savage loop.

See https://github.com/longhorn/longhorn/issues/9089

New statemachine

![lease_cr_statemachine](https://github.com/user-attachments/assets/3daeafd8-40ca-4f23-80c7-acfed664a5de)




