### PR TITLE
Performance optimisation: skipping checkLeasesAndEnqueueAnyStale if the setting SettingNameRWXVolumeFastFailover is not enabled

### DIFF
--- a/controller/share_manager_controller.go
+++ b/controller/share_manager_controller.go
@@ -223,6 +223,14 @@ func isShareManagerPod(obj interface{}) bool {
 }
 
 func (c *ShareManagerController) checkLeasesAndEnqueueAnyStale() error {
+	enabled, err := c.ds.GetSettingAsBool(types.SettingNameRWXVolumeFastFailover)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return nil
+	}
+
 	sms, err := c.ds.ListShareManagersRO()
 	if err != nil {
 		return err


### PR DESCRIPTION
Related to longhorn/longhorn#6205