### PR TITLE
feat(metrics): Add recurring job label to backup metrics or empty value

### DIFF
--- a/metrics_collector/backup_collector.go
+++ b/metrics_collector/backup_collector.go
@@ -32,7 +32,7 @@ func NewBackupCollector(
 		Desc: prometheus.NewDesc(
 			prometheus.BuildFQName(longhornName, subsystemBackup, "actual_size_bytes"),
 			"Actual size of this backup",
-			[]string{volumeLabel, backupLabel},
+			[]string{volumeLabel, backupLabel, recurringJobLabel},
 			nil,
 		),
 		Type: prometheus.GaugeValue,
@@ -42,7 +42,7 @@ func NewBackupCollector(
 		Desc: prometheus.NewDesc(
 			prometheus.BuildFQName(longhornName, subsystemBackup, "state"),
 			"State of this backup",
-			[]string{volumeLabel, backupLabel},
+			[]string{volumeLabel, backupLabel, recurringJobLabel},
 			nil,
 		),
 		Type: prometheus.GaugeValue,
@@ -79,8 +79,9 @@ func (bc *BackupCollector) Collect(ch chan<- prometheus.Metric) {
 			if !ok {
 				bc.logger.WithError(err).Warn("Error get backup volume label")
 			}
-			ch <- prometheus.MustNewConstMetric(bc.sizeMetric.Desc, bc.sizeMetric.Type, size, backupVolumeName, backup.Name)
-			ch <- prometheus.MustNewConstMetric(bc.stateMetric.Desc, bc.stateMetric.Type, float64(getBackupStateValue(backup)), backupVolumeName, backup.Name)
+			backupRecurringJobName := backup.Labels[types.RecurringJobLabel]
+			ch <- prometheus.MustNewConstMetric(bc.sizeMetric.Desc, bc.sizeMetric.Type, size, backupVolumeName, backup.Name, backupRecurringJobName)
+			ch <- prometheus.MustNewConstMetric(bc.stateMetric.Desc, bc.stateMetric.Type, float64(getBackupStateValue(backup)), backupVolumeName, backup.Name, backupRecurringJobName)
 		}
 	}
 }

--- a/metrics_collector/types.go
+++ b/metrics_collector/types.go
@@ -34,6 +34,7 @@ const (
 	userCreatedLabel        = "user_created"
 	backingImageLabel       = "backing_image"
 	backupBackingImageLabel = "backup_backing_image"
+	recurringJobLabel       = "recurring_job"
 )
 
 type metricInfo struct {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue N/A

#### What this PR does / why we need it:

Monitoring on usage of Backup per recurring job so we can trace the type of backup applied by PVC

#### Special notes for your reviewer:

Tried to understand documentation here and on longhorn-tests, but I am thoroughly confused on how to test a simple code change without creating a new version.

`make`/`make test` and CI seems to work though.

#### Additional documentation or context

Our recurring jobs, to trace usage/granularity per PVC, so we can raise alarms on certain pods not being backed up enough etc...

```yaml
---
apiVersion: longhorn.io/v1beta1
kind: RecurringJob
metadata:
  name: backup-weekly
  namespace: longhorn-system
spec:
  cron: "@weekly"
  task: "backup"
  groups:
    - backup-weekly
    - backup-daily
    - backup-hourly
  retain: 12
---
apiVersion: longhorn.io/v1beta1
kind: RecurringJob
metadata:
  name: backup-daily
  namespace: longhorn-system
spec:
  cron: "@daily"
  task: "backup"
  groups:
    - backup-daily
    - backup-hourly
  retain: 7
---
apiVersion: longhorn.io/v1beta1
kind: RecurringJob
metadata:
  name: backup-hourly
  namespace: longhorn-system
spec:
  cron: "@hourly"
  task: "backup"
  groups:
    - backup-hourly
  retain: 24
```
