### PR TITLE
feat(backup): delete backup in the backupstore asynchronously

### DIFF
--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -323,7 +323,7 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 		backupLabelMap := map[string]string{}
 
 		backupURL := backupstore.EncodeBackupURL(backupName, backupVolumeName, backupTargetClient.URL)
-		if backupInfo, err := backupTargetClient.BackupGet(backupURL, backupTargetClient.Credential); err != nil {
+		if backupInfo, err := backupTargetClient.BackupGet(backupURL, backupTargetClient.Credential); err != nil && !types.ErrorIsNotFound(err) {
 			log.WithError(err).WithFields(logrus.Fields{
 				"backup":       backupName,
 				"backupvolume": backupVolumeName,

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -271,9 +271,6 @@ func parseBackupConfig(output string) (*Backup, error) {
 func (btc *BackupTargetClient) BackupGet(backupConfigURL string, credential map[string]string) (*Backup, error) {
 	output, err := btc.ExecuteEngineBinary("backup", "inspect", backupConfigURL)
 	if err != nil {
-		if types.ErrorIsNotFound(err) {
-			return nil, nil
-		}
 		return nil, errors.Wrapf(err, "error getting backup config %s", backupConfigURL)
 	}
 	return parseBackupConfig(output)
@@ -302,6 +299,7 @@ func (btc *BackupTargetClient) BackupConfigMetaGet(url string, credential map[st
 
 // BackupDelete deletes the backup from the remote backup target
 func (btc *BackupTargetClient) BackupDelete(backupURL string, credential map[string]string) error {
+	logrus.Infof("Start deleting backup %s", backupURL)
 	_, err := btc.ExecuteEngineBinaryWithoutTimeout("backup", "rm", backupURL)
 	if err != nil {
 		if types.ErrorIsNotFound(err) {

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -5,14 +5,17 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type BackupState string
 
 const (
-	// non-final state
+	// Non-final state
 	BackupStateNew        = BackupState("")
 	BackupStatePending    = BackupState("Pending")
 	BackupStateInProgress = BackupState("InProgress")
-	// final state
+	// Final state
 	BackupStateCompleted = BackupState("Completed")
 	BackupStateError     = BackupState("Error")
 	BackupStateUnknown   = BackupState("Unknown")
+	// Deleting is also considered as final state
+	// as it only happens when the backup is being deleting and has deletion timestamp
+	BackupStateDeleting = BackupState("Deleting")
 )
 
 type BackupCompressionMethod string

--- a/types/types.go
+++ b/types/types.go
@@ -757,6 +757,10 @@ func ErrorIsNotFound(err error) bool {
 	return strings.Contains(err.Error(), "cannot find")
 }
 
+func ErrorIsInProgress(err error) bool {
+	return strings.Contains(err.Error(), "in progress")
+}
+
 func ErrorIsStopped(err error) bool {
 	return strings.Contains(err.Error(), "is stopped")
 }


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8746

follow LEP to implement: https://github.com/longhorn/longhorn/pull/9152

- Make backup deletion asynchronous
- Add Deleting state to Backup
    - Add deleting in-memory map to allow go routine to pass the command failure to the controller.
    - Add backoff to delay deletion command execution. 
    - When the Backup is being deleted it should follow the following diagram
- Disallow backup creation when there is any backup being deleted.

```
# Normal Case
Completed => Deleting 
=> finalizer removed (CR isgone)

# Command failure Case
Completed => Deleting 
=> Error (found the error message in the map) 
=> Deleting (Retry the command) => finalizer removed (CR isgone)

# Controller crashes
Completed => Deleting 
=> Error (failed to find the record in the map)
=> Deleting (Retry the command) => finalizer removed (CR isgone)
```

