### PR TITLE
fix(typo): add intended word to make comment less confusing

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -447,8 +447,8 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 								},
 								{
 									// The plugin must be able to switch to the host's namespaces in order to execute
-									// cryptsetup commands for encrypted devices to mount RWX volumes when not using a
-									// storage network.
+									// cryptsetup commands for encrypted devices and to mount RWX volumes when not using
+									// a storage network.
 									Name:      "host-proc",
 									MountPath: "/host/proc",
 								},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Related to work done for longhorn/longhorn#9223.

#### What this PR does / why we need it:

I noticed a typo in a comment. It made it more difficult to understand.

#### Additional documentation or context

Should be backported to `v1.7.x` as well, but should not gate any release activities, etc.