### PR TITLE
fix(networking): cleanup service/endpoint if needed

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -359,14 +359,6 @@ func (sc *SettingController) syncDangerZoneSettingsForManagedComponents(settingN
 					return &types.ErrorInvalidState{Reason: fmt.Sprintf("failed to apply %v setting to Longhorn components when there are attached volumes. It will be eventually applied", types.SettingNameStorageNetworkForRWXVolumeEnabled)}
 				}
 
-				// Perform cleanup of the share manager Service
-				// This is to allow the creation of the correct Service
-				// and Endpoint when switching between cluster network
-				// and storage network.
-				if err := sc.cleanupShareManagerServiceAndEndpoints(); err != nil {
-					return err
-				}
-
 				return nil
 			}
 
@@ -936,38 +928,6 @@ func (sc *SettingController) updateKubernetesClusterAutoscalerEnabled() error {
 		}
 		dp.Spec.Template.Annotations = anno
 		if _, err := sc.ds.UpdateDeployment(dp); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (sc *SettingController) cleanupShareManagerServiceAndEndpoints() error {
-	var err error
-	defer func() {
-		if err != nil {
-			err = errors.Wrapf(err, "failed to cleanup share manager service and endpoints for %s setting update", types.SettingNameStorageNetworkForRWXVolumeEnabled)
-		}
-	}()
-
-	shareManagers, err := sc.ds.ListShareManagers()
-	if err != nil {
-		return err
-	}
-
-	for _, shareManager := range shareManagers {
-		log := sc.logger.WithField("shareManager", shareManager.Name)
-
-		log.WithField("service", shareManager.Name).Infof("Deleting Service for %v setting update", types.SettingNameStorageNetworkForRWXVolumeEnabled)
-		err := sc.ds.DeleteService(shareManager.Namespace, shareManager.Name)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-
-		log.WithField("endpoint", shareManager.Name).Infof("Deleting Endpoint for %v setting update", types.SettingNameStorageNetworkForRWXVolumeEnabled)
-		err = sc.ds.DeleteKubernetesEndpoint(shareManager.Namespace, shareManager.Name)
-		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -619,6 +619,14 @@ func (s *DataStore) GetSettingExactRO(sName types.SettingName) (*longhorn.Settin
 	return resultRO, nil
 }
 
+func (s *DataStore) GetSettingApplied(sName types.SettingName) (bool, error) {
+	resultRO, err := s.getSettingRO(string(sName))
+	if err != nil {
+		return false, err
+	}
+	return resultRO.Status.Applied, nil
+}
+
 // GetSetting will automatically fill the non-existing setting if it's a valid
 // setting name.
 // The function will not return nil for *longhorn.Setting when error is nil


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9272

#### What this PR does / why we need it:
We meet a corner case that the service/endpoint would not be cleanup. That will cause the service keep the ClusterIP `None`. With this config, the endpoint of sharemanager would not be correct, so the CSI driver cannot perform the mountpoint well.

We would like to have a checking mechanism to know if the service/endpoint did not cleanup. Then we will cleanup the service/endpoint to ensure the correct endpoint.

#### Special notes for your reviewer:

#### Additional documentation or context
