### PR TITLE
feat(metrics): add volume filesystem read only state metrics

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -5556,3 +5556,23 @@ func (s *DataStore) GetOneBackingImageReadyNodeDisk(backingImage *longhorn.Backi
 
 	return nil, "", fmt.Errorf("failed to find one ready backing image %v", backingImage.Name)
 }
+
+func (s *DataStore) IsPVMountOptionReadOnly(volume *longhorn.Volume) (bool, error) {
+	kubeStatus := volume.Status.KubernetesStatus
+	if kubeStatus.PVName == "" {
+		return false, nil
+	}
+
+	pv, err := s.GetPersistentVolumeRO(kubeStatus.PVName)
+	if err != nil {
+		return false, err
+	}
+	if pv != nil {
+		for _, opt := range pv.Spec.MountOptions {
+			if opt == "ro" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8508

Export the metrics in the following form
- metric name: `longhorn_volume_file_system_read_only`
- type: gauge
- if the volume becomes read-only, it has metric value 1 with the corresponding labels
    - So you know which volume is in read-only mode now
    - You can sum up the metrics to see how many volumes are in read-only mode now 
```
# HELP longhorn_volume_file_system_read_only Volume whose mount point is in read-only mode
# TYPE longhorn_volume_file_system_read_only gauge
longhorn_volume_file_system_read_only{node="kworker1",pvc="nginx",pvc_namespace="default",volume="pvc-3a7a208b-c8c9-46a9-b2ce-4c5f740c8673"} 1
```

Note:
If Longhorn remounts the mount point to read-write successfully, the metrics will be cleaned up.
The metric is either 1 or no record for each volume