### PR TITLE
fix(manager): add detailed message when deleting pdb is not allowed (backport #3045)

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -940,14 +940,14 @@ func formatInstanceMessage(im *longhorn.InstanceManager) string {
 		}
 	}
 
-	if len(im.Status.Instances) > 0 {
+	if len(im.Status.Instances) > 0 { // nolint: staticcheck
 		if ieFormated {
-			msg = fmt.Sprintf("%v Instances count %v", msg, len(im.Status.Instances))
+			msg = fmt.Sprintf("%v Instances count %v", msg, len(im.Status.Instances)) // nolint: staticcheck
 		} else {
-			msg = fmt.Sprintf("Instances count %v", len(im.Status.Instances))
+			msg = fmt.Sprintf("Instances count %v", len(im.Status.Instances)) // nolint: staticcheck
 		}
 		i := 0
-		for k := range im.Status.Instances {
+		for k := range im.Status.Instances { // nolint: staticcheck
 			msg = msg + " " + k
 			if i++; i >= ITERATE_NAME_LIMIT {
 				break


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue # https://github.com/longhorn/longhorn/issues/9183
btw: https://github.com/longhorn/longhorn/issues/5910

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
Test log of manual attached volume when drain node
```
time="2024-08-05T18:48:14Z" level=info msg="Node instance-manager-68cd2514dd3f6d59b95cbd865d5b08f7 is marked unschedulable but removing harv2 PDB is blocked: some volumes are still attached " func="controller.(*InstanceManagerController).syncInstanceManagerPDB" file="instance_manager_controller.go:730" controller=longhorn-instance-manager node=harv2
```

This is a manual backport to replace https://github.com/longhorn/longhorn-manager/pull/3098, which has conflicts and I have no rights to push to/on-top-of it.