### PR TITLE
fix(datastore): skip disabled nodes in ValidateV2DataEngineEnabled

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -471,6 +471,11 @@ func (s *DataStore) ValidateV2DataEngineEnabled(dataEngineEnabled bool) (ims []*
 				continue
 			}
 
+			if val, ok := node.Labels[types.NodeDisableV2DataEngineLabelKey]; ok && val == types.NodeDisableV2DataEngineLabelKeyTrue {
+				// V2 data engine is disabled on this node, don't worry about hugepages
+				continue
+			}
+
 			if dataEngineEnabled {
 				capacity, ok := node.Status.Capacity["hugepages-2Mi"]
 				if !ok {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/9319

#### What this PR does / why we need it:
So we can enable the v2 data engine without needing to allocate hugepages on disabled nodes
