### PR TITLE
fix(live upgrade): newly live upgraded engine doesn't respect the disableRevCounter setting

### DIFF
--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -728,6 +728,10 @@ func (c *InstanceManagerClient) engineInstanceUpgrade(req *EngineInstanceUpgrade
 		args = append(args, "--replica", GetBackendReplicaURL(addr))
 	}
 
+	if req.Engine.Spec.RevisionCounterDisabled {
+		args = append(args, "--disableRevCounter")
+	}
+
 	if req.EngineCLIAPIVersion >= 6 {
 		args = append(args,
 			"--size", strconv.FormatInt(req.Engine.Spec.VolumeSize, 10),


### PR DESCRIPTION
We forget to set disableRevCounter for the newly live upgraded engine. As a result, the newly live upgraded engine always has disableRevCounter as `false` even if the volume has disableRevCounter as `true`.

This mismatch prevents the volume from successfully rebuilding a new replica.

longhorn/longhorn#9331
