### PR TITLE
fix(metrics): add rwx-volume-fast-failover to upgrade responder colle…

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1847,6 +1847,7 @@ func (info *ClusterInfo) collectSettings() error {
 		types.SettingNameReplicaDiskSoftAntiAffinity:                              true,
 		types.SettingNameRestoreConcurrentLimit:                                   true,
 		types.SettingNameRestoreVolumeRecurringJobs:                               true,
+		types.SettingNameRWXVolumeFastFailover:                                    true,
 		types.SettingNameSnapshotDataIntegrity:                                    true,
 		types.SettingNameSnapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true,
 		types.SettingNameStorageMinimalAvailablePercentage:                        true,


### PR DESCRIPTION
…ction

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/9347

#### What this PR does / why we need it:

Add setting `rwx-volume-fast-failover` to the list collected for upgrade responder, so we can assess its adoption.

#### Special notes for your reviewer:

#### Additional documentation or context
