### PR TITLE
fix(backingimage): set default min number of copies when upgrading

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -31,6 +31,8 @@ const (
 
 	// From `maximumChainLength` in longhorn-engine/pkg/replica/replica.go
 	MaxSnapshotNum = 250
+
+	DefaultMinNumberOfCopies = 3
 )
 
 type SettingType string
@@ -1463,7 +1465,7 @@ var (
 		Type:        SettingTypeInt,
 		Required:    true,
 		ReadOnly:    false,
-		Default:     "3",
+		Default:     strconv.Itoa(DefaultMinNumberOfCopies),
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: 1,
 		},

--- a/upgrade/v16xto170/upgrade.go
+++ b/upgrade/v16xto170/upgrade.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -131,6 +132,8 @@ func upgradeBackingImages(namespace string, lhClient *lhclientset.Clientset, res
 				delete(bi.Spec.Disks, diskUUID)
 			}
 		}
+		// set the default value for bi.Spec.MinNumberOfCopies
+		bi.Spec.MinNumberOfCopies = types.DefaultMinNumberOfCopies
 	}
 
 	return nil


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9352

When upgrading Longhorn to v1.7.x
The BackingImage will have minNumberOfCopies = 0
Need to set the default value in upgrade path.