### PR TITLE
[BACKPORT v1.7.x] fix(backingimage): set default min number of copies of backing image

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -29,6 +29,7 @@ import (
 	"github.com/longhorn/longhorn-manager/upgrade/v151to152"
 	"github.com/longhorn/longhorn-manager/upgrade/v15xto160"
 	"github.com/longhorn/longhorn-manager/upgrade/v16xto170"
+	"github.com/longhorn/longhorn-manager/upgrade/v170to171"
 	"github.com/longhorn/longhorn-manager/upgrade/v1beta1"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -265,6 +266,12 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.7.0") < 0 {
 		logrus.Info("Walking through the resource upgrade path v1.6.x to v1.7.0")
 		if err := v16xto170.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.7.1") < 0 {
+		logrus.Info("Walking through the resource upgrade path v1.7.0 to v1.7.1")
+		if err := v170to171.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
 			return err
 		}
 	}

--- a/upgrade/v170to171/upgrade.go
+++ b/upgrade/v170to171/upgrade.go
@@ -1,0 +1,49 @@
+package v170to171
+
+import (
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.7.0 to v1.7.1: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	return upgradeBackingImages(namespace, lhClient, resourceMaps)
+}
+
+func upgradeBackingImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backing image failed")
+	}()
+
+	backingImageMap, err := upgradeutil.ListAndUpdateBackingImagesInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn backing images during the backing image upgrade")
+	}
+
+	for _, bi := range backingImageMap {
+		if bi.Spec.MinNumberOfCopies == 0 {
+			bi.Spec.MinNumberOfCopies = types.DefaultMinNumberOfCopies
+		}
+	}
+
+	return nil
+}
+
+func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	// Currently there are no statuses to upgrade. See UpgradeResources -> upgradeVolumes or previous Longhorn versions
+	// for examples.
+	return nil
+}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9352

add upgrade path
1.7.0 -> 1.7.1