### PR TITLE
fix: attempt to delete processes from instance-managers in unknown state

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -534,16 +534,9 @@ func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {
 		return err
 	}
 
-	// For a RWX volume, the node down, for example, caused by kubelet restart, leads to share-manager pod deletion/recreation
-	// and volume detachment/attachment.
-	// Then, the newly created share-manager pod blindly mounts the longhorn volume inside /dev/longhorn/<pvc-name> and exports it.
-	// To avoid mounting a dead and orphaned volume, try to clean up the engine instance as well as the orphaned iscsi device
-	// regardless of the instance-manager status.
-	if !isRWXVolume {
-		if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
-			log.Infof("Skipping deleting engine %v since instance manager is in %v state", e.Name, im.Status.CurrentState)
-			return nil
-		}
+	if shouldSkip, skipReason := shouldSkipEngineDeletion(im.Status.CurrentState, isRWXVolume); shouldSkip {
+		log.Infof("Skipping deleting engine %v since %s", e.Name, skipReason)
+		return nil
 	}
 
 	isDelinquent, err := ec.ds.IsNodeDelinquent(im.Spec.NodeID, e.Spec.VolumeName)
@@ -556,28 +549,11 @@ func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {
 	defer func() {
 		if err != nil {
 			log.WithError(err).Warnf("Failed to delete engine %v", e.Name)
-		}
-		if isRWXVolume && (im.Status.CurrentState != longhorn.InstanceManagerStateRunning || isDelinquent) {
-			// Try the best to delete engine instance.
-			// To prevent that the volume is stuck at detaching state, ignore the error when volume is
-			// a RWX volume and the instance manager is not running or the RWX volume is currently delinquent.
-			//
-			// If the engine instance of a RWX volume is not deleted successfully:
-			// If a RWX volume is on node A and the network of this node is partitioned,
-			// the owner of the share manager (SM) is transferred to node B. The engine instance and
-			// the block device (/dev/longhorn/pvc-xxx) on the node A become orphaned.
-			// If the network of the node A gets back to normal, the SM can be shifted back to node A.
-			// After shifting to node A, the first reattachment fail due to the IO error resulting from the
-			// orphaned engine instance and block device. Then, the detachment will trigger the teardown of the
-			// problematic engine instance and block device. The next reattachment then will succeed.
-			if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
-				log.Warnf("Ignored the failure of deleting engine %v because im.Status.CurrentState is %v", e.Name, im.Status.CurrentState)
+			if canIgnore, ignoreReason := canIgnoreEngineDeletionFailure(im.Status.CurrentState, isRWXVolume,
+				isDelinquent); canIgnore {
+				log.Warnf("Ignored the failure to delete engine %v because %s", e.Name, ignoreReason)
+				err = nil
 			}
-			if isDelinquent {
-				log.Warnf("Ignored the failure of deleting engine %v because the RWX volume is currently delinquent", e.Name)
-			}
-
-			err = nil
 		}
 	}()
 
@@ -2405,4 +2381,54 @@ func sizeThreshold(nominalSize int64) int64 {
 		return nominalSize / 1024 // Update status for change > 1/1024 nominal size.
 	}
 	return 100 * util.MiB // Update status for any change > 100 MiB.
+}
+
+func shouldSkipEngineDeletion(imState longhorn.InstanceManagerState, isRWXVolume bool) (canSkip bool, reason string) {
+	// For a RWX volume, the node down, for example, caused by kubelet restart, leads to share-manager pod
+	// deletion/recreation and volume detachment/attachment. Then, the newly created share-manager pod blindly mounts
+	// the longhorn volume inside /dev/longhorn/<pvc-name> and exports it. To avoid mounting a dead and orphaned volume,
+	// try to clean up the engine instance as well as the orphaned iscsi device regardless of the instance-manager
+	// status.
+	if isRWXVolume {
+		return false, ""
+	}
+
+	// If the instance manager is in an unknown state, we should at least attempt instance deletion.
+	if imState == longhorn.InstanceManagerStateRunning || imState == longhorn.InstanceManagerStateUnknown {
+		return false, ""
+	}
+
+	return true, fmt.Sprintf("instance manager is in %v state", imState)
+}
+
+func canIgnoreEngineDeletionFailure(imState longhorn.InstanceManagerState, isRWXVolume, isDelinquent bool) (canIgnore bool, reason string) {
+	// Instance deletion is always best effort for an unknown instance manager.
+	if imState == longhorn.InstanceManagerStateUnknown {
+		return true, fmt.Sprintf("instance manager is in %v state", imState)
+	}
+
+	// The remaining reasons apply only to RWX volumes.
+	if !isRWXVolume {
+		return false, ""
+	}
+
+	// Try the best to delete engine instance.
+	// To prevent that the volume is stuck at detaching state, ignore the error when volume is a RWX volume and the
+	// instance manager is not running or the RWX volume is currently delinquent.
+	//
+	// If the engine instance of a RWX volume is not deleted successfully: If a RWX volume is on node A and the network
+	// of this node is partitioned, the owner of the share manager (SM) is transferred to node B. The engine instance
+	// and the block device (/dev/longhorn/pvc-xxx) on the node A become orphaned. If the network of the node A gets
+	// back to normal, the SM can be shifted back to node A. After shifting to node A, the first reattachment fail due
+	// to the IO error resulting from the orphaned engine instance and block device. Then, the detachment will trigger
+	// the teardown of the problematic engine instance and block device. The next reattachment then will succeed.
+	if imState != longhorn.InstanceManagerStateRunning {
+		return true, fmt.Sprintf("instance manager is in %v state for the RWX volume", imState)
+	}
+
+	if isDelinquent {
+		return true, "the RWX volume is delinquent"
+	}
+
+	return false, ""
 }

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -456,7 +456,7 @@ func (ec *EngineController) CreateInstance(obj interface{}) (*longhorn.InstanceP
 		return nil, err
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +578,7 @@ func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {
 		return nil
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, true)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (ec *EngineController) GetInstance(obj interface{}) (*longhorn.InstanceProc
 			return nil, err
 		}
 	}
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +633,7 @@ func (ec *EngineController) LogInstance(ctx context.Context, obj interface{}) (*
 		return nil, nil, err
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2130,7 +2130,7 @@ func (ec *EngineController) UpgradeEngineInstance(e *longhorn.Engine, log *logru
 		return err
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return err
 	}

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -83,7 +83,7 @@ type InstanceManagerMonitor struct {
 }
 
 func updateInstanceManagerVersion(im *longhorn.InstanceManager) error {
-	cli, err := engineapi.NewInstanceManagerClient(im)
+	cli, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func (imc *InstanceManagerController) syncLogSettingsToInstanceManagerPod(im *lo
 		return nil
 	}
 
-	client, err := engineapi.NewInstanceManagerClient(im)
+	client, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create instance manager client for %v", im.Name)
 	}
@@ -1579,7 +1579,7 @@ func (imc *InstanceManagerController) startMonitoring(im *longhorn.InstanceManag
 	}
 
 	// TODO: #2441 refactor this when we do the resource monitoring refactor
-	client, err := engineapi.NewInstanceManagerClient(im)
+	client, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to initialize im client to %v before monitoring", im.Name)
 		return

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -543,7 +543,8 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) (err error) {
 		}
 	}
 
-	if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
+	if shouldSkip, skipReason := shouldSkipReplicaDeletion(im.Status.CurrentState); shouldSkip {
+		log.Infof("Skipping deleting replica %v since %s", r.Name, skipReason)
 		return nil
 	}
 
@@ -555,14 +556,15 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) (err error) {
 	defer func() {
 		if err != nil {
 			log.WithError(err).Warnf("Failed to delete replica process %v", r.Name)
-			if isDelinquent {
-				log.Warnf("Ignored the failure of deleting replica process %v because the RWX volume is currently delinquent", r.Name)
+			if canIgnore, ignoreReason := canIgnoreReplicaDeletionFailure(im.Status.CurrentState,
+				isDelinquent); canIgnore {
+				log.Warnf("Ignored the failure to delete replica process %v because %s", r.Name, ignoreReason)
 				err = nil
 			}
 		}
 	}()
 
-	c, err := engineapi.NewInstanceManagerClient(im, false)
+	c, err := engineapi.NewInstanceManagerClient(im, true)
 	if err != nil {
 		return err
 	}
@@ -887,4 +889,26 @@ func hasMatchingReplica(replica *longhorn.Replica, replicas map[string]*longhorn
 		}
 	}
 	return false
+}
+
+func shouldSkipReplicaDeletion(imState longhorn.InstanceManagerState) (canSkip bool, reason string) {
+	// If the instance manager is in an unknown state, we should at least attempt instance deletion.
+	if imState == longhorn.InstanceManagerStateRunning || imState == longhorn.InstanceManagerStateUnknown {
+		return false, ""
+	}
+
+	return true, fmt.Sprintf("instance manager is in %v state", imState)
+}
+
+func canIgnoreReplicaDeletionFailure(imState longhorn.InstanceManagerState, isDelinquent bool) (canIgnore bool, reason string) {
+	// Instance deletion is always best effort for an unknown instance manager.
+	if imState == longhorn.InstanceManagerStateUnknown {
+		return true, fmt.Sprintf("instance manager is in %v state", imState)
+	}
+
+	if isDelinquent {
+		return true, "the RWX volume is delinquent"
+	}
+
+	return false, ""
 }

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -357,7 +357,7 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		return nil, err
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +562,7 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) (err error) {
 		}
 	}()
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return err
 	}
@@ -628,7 +628,7 @@ func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstancePro
 		}
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +659,7 @@ func (rc *ReplicaController) LogInstance(ctx context.Context, obj interface{}) (
 		return nil, nil, err
 	}
 
-	c, err := engineapi.NewInstanceManagerClient(im)
+	c, err := engineapi.NewInstanceManagerClient(im, false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#6552

#### What this PR does / why we need it:

See https://github.com/longhorn/longhorn/issues/6552#issuecomment-2319177183 for context. It may be possible to delete engine and replica processes from an instance-manager even when the instance-manager's state is unknown. Doing so prevents the processes from becoming orphans if the instance-manager eventually recovers from the unknown state.

This PR is looking good in some local testing, but I want to put it through a few more paces before review.