### PR TITLE
fix(encrypt): close encrypted volume if it is opened

### DIFF
--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -145,6 +145,16 @@ func ResizeEncryptoDevice(volume, passphrase string) error {
 	return err
 }
 
+// IsDeviceMappedToNullPath determines if encrypted device is already open at a null path. The command 'cryptsetup status [crypted_device]' show "device:  (null)"
+func IsDeviceMappedToNullPath(device string) (bool, error) {
+	devPath, mappedFile, err := DeviceEncryptionStatus(device)
+	if err != nil {
+		return false, err
+	}
+
+	return mappedFile != "" && strings.Compare(devPath, "(null)") == 0, nil
+}
+
 // IsDeviceOpen determines if encrypted device is already open.
 func IsDeviceOpen(device string) (bool, error) {
 	_, mappedFile, err := DeviceEncryptionStatus(device)

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -487,6 +487,18 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		cryptoDevice := crypto.VolumeMapper(volumeID)
 		log.Infof("Volume %s requires crypto device %s", volumeID, cryptoDevice)
 
+		// check if the crypto device is open at the null path.
+		// this will happen if the crypto device is not closed properly and a new attaching request is made on the same node.
+		// reference issue: https://github.com/longhorn/longhorn/issues/9385
+		if mappedToNullPath, err := crypto.IsDeviceMappedToNullPath(cryptoDevice); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to check if the crypto device %s for volume %s is mapped to the null path: %v", cryptoDevice, volumeID, err.Error())
+		} else if mappedToNullPath {
+			log.Warnf("Closing active crypto device %s for volume %s since the volume is not closed properly before", cryptoDevice, volumeID)
+			if err := crypto.CloseVolume(volumeID); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to close active crypto device %s for volume %s: %v ", cryptoDevice, volumeID, err.Error())
+			}
+		}
+
 		if err := crypto.OpenVolume(volumeID, devicePath, passphrase); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9385

#### What this PR does / why we need it:

In the normal process of attaching a volume via CSI, the encrypted volume should be closed or inactivated before Longhorn attempts to open it.

#### Special notes for your reviewer:

#### Additional documentation or context
Full regression test:
~https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7529~
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7538/