### PR TITLE
fix(setting): do not delete the storage class set in the setting `default-longhorn-static-storage-class`

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -424,6 +424,23 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 		if v < 2 || v > 250 {
 			return fmt.Errorf("%s should be between 2 and 250", name)
 		}
+	case types.SettingNameDefaultLonghornStaticStorageClass:
+		definition, ok := types.GetSettingDefinition(types.SettingNameDefaultLonghornStaticStorageClass)
+		if !ok {
+			return fmt.Errorf("setting %v is not found", types.SettingNameDefaultLonghornStaticStorageClass)
+		}
+
+		if value == definition.Default {
+			return nil
+		}
+
+		_, err := s.GetStorageClassRO(value)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "cannot use a storage class %v that does not exist to set the setting %v", value, types.SettingNameDefaultLonghornStaticStorageClass)
+			}
+			return errors.Wrapf(err, "failed to get the storage class %v for setting %v", value, types.SettingNameDefaultLonghornStaticStorageClass)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9391

#### What this PR does / why we need it:

Delete the old storage class set in reconciling the `default-longhorn-static-storage-class` setting.
Create the storage with a label if the storage class named as the value of `default-longhorn-static-storage-class` setting does not exist.

#### Special notes for your reviewer:

#### Additional documentation or context
