### PR TITLE
fix(upgrade): block live upgrade of strict-local

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -515,7 +515,8 @@ func (ic *EngineImageController) canDoOfflineEngineImageUpgrade(v *longhorn.Volu
 //  3. Volume is not a DR volume AND
 //  4. Volume is not expanding AND
 //  5. Volume is not migrating AND
-//  6. The current volume's engine image is compatible with the new engine image
+//  6. Volume is not strict-local AND
+//  7. The current volume's engine image is compatible with the new engine image
 func (ic *EngineImageController) canDoLiveEngineImageUpgrade(v *longhorn.Volume, newEngineImageResource *longhorn.EngineImage) bool {
 	if v.Status.State != longhorn.VolumeStateAttached {
 		return false
@@ -530,6 +531,9 @@ func (ic *EngineImageController) canDoLiveEngineImageUpgrade(v *longhorn.Volume,
 		return false
 	}
 	if util.IsVolumeMigrating(v) {
+		return false
+	}
+	if v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
 		return false
 	}
 	oldEngineImageResource, err := ic.ds.GetEngineImage(types.GetEngineImageChecksumName(v.Status.CurrentImage))

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -808,6 +808,10 @@ func (m *VolumeManager) EngineUpgrade(volumeName, image string) (v *longhorn.Vol
 		return nil, fmt.Errorf("cannot do live upgrade for a unhealthy volume %v", v.Name)
 	}
 
+	if v.Status.State == longhorn.VolumeStateAttached && v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
+		return nil, fmt.Errorf("cannot do live upgrade for an attached strict-local volume %v", v.Name)
+	}
+
 	oldImage := v.Spec.Image
 	v.Spec.Image = image
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/9389

#### What this PR does / why we need it:

Stopgap to prevent live engine upgrade on attached strict-local volumes.

#### Special notes for your reviewer:

#### Additional documentation or context
