### PR TITLE
fix: failed to cancel volume expansion after engine is already expanded successfully

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2026,7 +2026,7 @@ func (c *VolumeController) reconcileVolumeSize(v *longhorn.Volume, e *longhorn.E
 	if e == nil || rs == nil {
 		return nil
 	}
-	if e.Spec.VolumeSize == v.Spec.Size {
+	if e.Spec.VolumeSize == v.Spec.Size && e.Status.CurrentSize == v.Spec.Size {
 		return nil
 	}
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9466

#### What this PR does / why we need it:

When the volume has already been successfully expanded, if the cancellation is issued after completing the volume expansion, and the spec.size and status.currentSize of the volume and engine are as follows:

- v.spec.size: 21474836480
- e.spec.size: 21474836480
- e.status.currentSize: 22548578304

The check
```
if e.Spec.VolumeSize == v.Spec.Size {
    return nil
}
```
prevents v.Status.ExpansionRequired from becoming true, which hinders the cancellation of the expansion.

#### Special notes for your reviewer:

#### Additional documentation or context
