### PR TITLE
fix: aggregate "*-dev-*" versions into single "dev" version

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1400,8 +1400,13 @@ func (sc *SettingController) CheckLatestAndStableLonghornVersions() (string, str
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get extra info for upgrade checker")
 	}
+
+	version := sc.version
+	if strings.Contains(version, "dev") {
+		version = "dev"
+	}
 	req := &CheckUpgradeRequest{
-		AppVersion:     sc.version,
+		AppVersion:     version,
 		ExtraTagInfo:   extraTagInfo,
 		ExtraFieldInfo: extraFieldInfo,
 	}


### PR DESCRIPTION
This will prevent the upgrade responder from having too many tags which can be a performance issue


longhorn/longhorn#9522


