### PR TITLE
docs: add unit to the backing image size description

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -564,7 +564,7 @@ spec:
               ownerID:
                 type: string
               realSize:
-                description: Real size of image, which may be smaller than the size 
+                description: Real size of image in bytes, which may be smaller than the size 
                   when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
                 format: int64
                 type: integer
@@ -574,7 +574,7 @@ spec:
               uuid:
                 type: string
               virtualSize:
-                description: Virtual size of image, which may be larger than physical
+                description: Virtual size of image in bytes, which may be larger than physical
                   size. Will be zero until known (e.g. while a backing image is uploading)
                 format: int64
                 type: integer

--- a/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backingimage.go
@@ -77,10 +77,10 @@ type BackingImageStatus struct {
 	UUID string `json:"uuid"`
 	// +optional
 	Size int64 `json:"size"`
-	// Virtual size of image, which may be larger than physical size. Will be zero until known (e.g. while a backing image is uploading)
+	// Virtual size of image in bytes, which may be larger than physical size. Will be zero until known (e.g. while a backing image is uploading)
 	// +optional
 	VirtualSize int64 `json:"virtualSize"`
-	// Real size of image, which may be smaller than the size when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+	// Real size of image in bytes, which may be smaller than the size when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
 	// +optional
 	RealSize int64 `json:"realSize"`
 	// +optional


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8757

add unit to the size field description in BackingImage