### PR TITLE
fix(backup): only delete backups' resources when synchronization

### DIFF
--- a/controller/backup_backing_image_controller.go
+++ b/controller/backup_backing_image_controller.go
@@ -214,7 +214,11 @@ func (bc *BackupBackingImageController) reconcile(backupBackingImageName string)
 
 	// Examine DeletionTimestamp to determine if object is under deletion
 	if !bbi.DeletionTimestamp.IsZero() {
-		if backupTarget.Spec.BackupTargetURL != "" {
+		needsCleanupRemoteData, err := checkIfRemoteDataCleanupIsNeeded(bbi, backupTarget)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if it needs to delete remote backup backing image data")
+		}
+		if needsCleanupRemoteData {
 			backupTargetClient, err := newBackupTargetClientFromDefaultEngineImage(bc.ds, backupTarget)
 			if err != nil {
 				log.WithError(err).Warn("Failed to init backup target clients")

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -280,8 +280,12 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 			return err
 		}
 
-		if backupTarget.Spec.BackupTargetURL != "" &&
-			backupVolume != nil && backupVolume.DeletionTimestamp == nil {
+		needsCleanupRemoteData, err := checkIfRemoteDataCleanupIsNeeded(backup, backupTarget)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if it needs to delete remote backup data")
+		}
+
+		if needsCleanupRemoteData && backupVolume != nil && backupVolume.DeletionTimestamp == nil {
 			backupTargetClient, err := newBackupTargetClientFromDefaultEngineImage(bc.ds, backupTarget)
 			if err != nil {
 				log.WithError(err).Warn("Failed to init backup target clients")

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -506,9 +506,12 @@ func (btc *BackupTargetController) syncBackupVolume(backupStoreBackupVolumeNames
 		log.Infof("Found %d backup volumes in the backup target that do not exist in the cluster and need to be deleted from the cluster", count)
 	}
 	for backupVolumeName := range backupVolumesToDelete {
-		log.WithField("backupVolume", backupVolumeName).Info("Deleting backup volume from cluster")
+		log.WithField("backupVolume", backupVolumeName).Info("Deleting BackupVolume not exist in backupstore")
+		if err = datastore.AddBackupVolumeDeleteCustomResourceOnlyLabel(btc.ds, backupVolumeName); err != nil {
+			return errors.Wrapf(err, "failed to add label delete-custom-resource-only to Backupvolume %s", backupVolumeName)
+		}
 		if err = btc.ds.DeleteBackupVolume(backupVolumeName); err != nil {
-			return errors.Wrapf(err, "failed to delete backup volume %s from cluster", backupVolumeName)
+			return errors.Wrapf(err, "failed to delete BackupVolume %s not exist in backupstore", backupVolumeName)
 		}
 	}
 
@@ -561,9 +564,12 @@ func (btc *BackupTargetController) syncBackupBackingImage(backupStoreBackingImag
 		log.Infof("Found %d backup backing images in the cluster that do not exist in the backup target and need to be deleted", count)
 	}
 	for backupBackingImageName := range backupBackingImagesToDelete {
-		log.WithField("backupBackingImage", backupBackingImageName).Info("Deleting backup backing image from cluster")
+		log.WithField("backupBackingImage", backupBackingImageName).Info("Deleting BackupBackingImage not exist in backupstore")
+		if err = datastore.AddBackupBackingImageDeleteCustomResourceOnlyLabel(btc.ds, backupBackingImageName); err != nil {
+			return errors.Wrapf(err, "failed to add label delete-custom-resource-only to BackupBackingImage %s", backupBackingImageName)
+		}
 		if err = btc.ds.DeleteBackupBackingImage(backupBackingImageName); err != nil {
-			return errors.Wrapf(err, "failed to delete backup backing image %s from cluster", backupBackingImageName)
+			return errors.Wrapf(err, "failed to delete BackupBackingImage %s not exist in backupstore", backupBackingImageName)
 		}
 	}
 
@@ -617,6 +623,9 @@ func (btc *BackupTargetController) syncSystemBackup(backupStoreSystemBackups sys
 	delSystemBackupsInCluster := clusterReadySystemBackupNames.Difference(backupstoreSystemBackupNames)
 	for name := range delSystemBackupsInCluster {
 		log.WithField("systemBackup", name).Info("Deleting SystemBackup not exist in backupstore")
+		if err = datastore.AddSystemBackupDeleteCustomResourceOnlyLabel(btc.ds, name); err != nil {
+			return errors.Wrapf(err, "failed to add label delete-custom-resource-only to SystemBackup %v", name)
+		}
 		if err = btc.ds.DeleteSystemBackup(name); err != nil {
 			return errors.Wrapf(err, "failed to delete SystemBackup %v not exist in backupstore", name)
 		}
@@ -666,6 +675,10 @@ func (btc *BackupTargetController) cleanupBackupVolumes() error {
 
 	var errs []string
 	for backupVolumeName := range clusterBackupVolumes {
+		if err = datastore.AddBackupVolumeDeleteCustomResourceOnlyLabel(btc.ds, backupVolumeName); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
 		if err = btc.ds.DeleteBackupVolume(backupVolumeName); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, err.Error())
 			continue
@@ -686,6 +699,10 @@ func (btc *BackupTargetController) cleanupBackupBackingImages() error {
 
 	var errs []string
 	for backupBackingImageName := range clusterBackupBackingImages {
+		if err = datastore.AddBackupBackingImageDeleteCustomResourceOnlyLabel(btc.ds, backupBackingImageName); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
 		if err = btc.ds.DeleteBackupBackingImage(backupBackingImageName); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, err.Error())
 			continue
@@ -706,6 +723,10 @@ func (btc *BackupTargetController) cleanupSystemBackups() error {
 
 	var errs []string
 	for systemBackup := range systemBackups {
+		if err = datastore.AddSystemBackupDeleteCustomResourceOnlyLabel(btc.ds, systemBackup); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
 		if err = btc.ds.DeleteSystemBackup(systemBackup); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, err.Error())
 			continue

--- a/controller/system_backup_controller_test.go
+++ b/controller/system_backup_controller_test.go
@@ -278,7 +278,7 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 			systemBackupController.UploadSystemBackup(systemBackup, archievePath, tempDir, backupTargetClient)
 
 		default:
-			err = systemBackupController.reconcile(tc.systemBackupName, backupTargetClient)
+			err = systemBackupController.reconcile(tc.systemBackupName, backupTargetClient, nil)
 			if tc.expectError {
 				c.Assert(err, NotNil)
 			} else {

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -1,9 +1,14 @@
 package controller
 
 import (
-	"github.com/longhorn/longhorn-manager/types"
 	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -89,4 +94,16 @@ func isRegularRWXVolume(v *longhorn.Volume) bool {
 		return false
 	}
 	return v.Spec.AccessMode == longhorn.AccessModeReadWriteMany && !v.Spec.Migratable
+}
+
+func checkIfRemoteDataCleanupIsNeeded(obj runtime.Object, bt *longhorn.BackupTarget) (bool, error) {
+	if obj == nil || bt == nil {
+		return false, nil
+	}
+	exists, err := datastore.IsLabelLonghornDeleteCustomResourceOnlyExisting(obj)
+	if err != nil {
+		return false, err
+	}
+
+	return !exists && bt.Spec.BackupTargetURL != "", nil
 }

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3255,6 +3255,121 @@ func labelBackupVolume(backupVolumeName string, obj k8sruntime.Object) error {
 	return nil
 }
 
+// labelLonghornDeleteCustomResourceOnly labels the object with the label `longhorn.io/delete-custom-resource-only: true`
+func labelLonghornDeleteCustomResourceOnly(obj k8sruntime.Object) error {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	labels := metadata.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[types.GetLonghornLabelKey(types.DeleteCustomResourceOnly)] = "true"
+	metadata.SetLabels(labels)
+	return nil
+}
+
+// IsLabelLonghornDeleteCustomResourceOnlyExisting check if the object label `longhorn.io/delete-custom-resource-only` exists
+func IsLabelLonghornDeleteCustomResourceOnlyExisting(obj k8sruntime.Object) (bool, error) {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	labels := metadata.GetLabels()
+	if labels == nil {
+		return false, nil
+	}
+	_, ok := labels[types.GetLonghornLabelKey(types.DeleteCustomResourceOnly)]
+	return ok, nil
+}
+
+// AddBackupVolumeDeleteCustomResourceOnlyLabel adds the label `longhorn.io/delete-custom-resource-only: true` to the BackupVolume
+func AddBackupVolumeDeleteCustomResourceOnlyLabel(ds *DataStore, backupVolumeName string) error {
+	bv, err := ds.GetBackupVolume(backupVolumeName)
+	if err != nil {
+		return err
+	}
+	if exists, err := IsLabelLonghornDeleteCustomResourceOnlyExisting(bv); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if err := labelLonghornDeleteCustomResourceOnly(bv); err != nil {
+		return err
+	}
+	if _, err = ds.UpdateBackupVolume(bv); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddBackupDeleteCustomResourceOnlyLabel adds the label `longhorn.io/delete-custom-resource-only: true` to the Backup
+func AddBackupDeleteCustomResourceOnlyLabel(ds *DataStore, backupName string) error {
+	backup, err := ds.GetBackup(backupName)
+	if err != nil {
+		return err
+	}
+	if exists, err := IsLabelLonghornDeleteCustomResourceOnlyExisting(backup); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if err := labelLonghornDeleteCustomResourceOnly(backup); err != nil {
+		return err
+	}
+	if _, err = ds.UpdateBackup(backup); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddBackupBackingImageDeleteCustomResourceOnlyLabel adds the label `longhorn.io/delete-custom-resource-only: true` to the BackupBackingImage
+func AddBackupBackingImageDeleteCustomResourceOnlyLabel(ds *DataStore, backupBackingImageName string) error {
+	bbi, err := ds.GetBackupBackingImage(backupBackingImageName)
+	if err != nil {
+		return err
+	}
+	if exists, err := IsLabelLonghornDeleteCustomResourceOnlyExisting(bbi); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if err := labelLonghornDeleteCustomResourceOnly(bbi); err != nil {
+		return err
+	}
+	if _, err = ds.UpdateBackupBackingImage(bbi); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddSystemBackupDeleteCustomResourceOnlyLabel adds the label `longhorn.io/delete-custom-resource-only: true` to the SystemBackup
+func AddSystemBackupDeleteCustomResourceOnlyLabel(ds *DataStore, systemBackupName string) error {
+	sb, err := ds.GetSystemBackup(systemBackupName)
+	if err != nil {
+		return err
+	}
+	if exists, err := IsLabelLonghornDeleteCustomResourceOnlyExisting(sb); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if err := labelLonghornDeleteCustomResourceOnly(sb); err != nil {
+		return err
+	}
+	if _, err = ds.UpdateSystemBackup(sb); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func FixupRecurringJob(v *longhorn.Volume) error {
 	if err := labelRecurringJobDefault(v); err != nil {
 		return err

--- a/types/types.go
+++ b/types/types.go
@@ -128,6 +128,8 @@ const (
 	ConfigMapResourceVersionKey = "configmap-resource-version"
 	UpdateSettingFromLonghorn   = "update-setting-from-longhorn"
 
+	DeleteCustomResourceOnly = "delete-custom-resource-only"
+
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"
 	KubernetesStatefulSet = "StatefulSet"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9530

#### What this PR does / why we need it:

Only delete backups' resources (BackupVolume, BackupBackingImage, SystemBackup, and Backup) when synchronization.

Add the label `DeleteCustomResourceOnly`, and delete remote backup data when deleting the corresponding backup resource in the cluster and the label does not exist.

#### Special notes for your reviewer:

#### Additional documentation or context
