### PR TITLE
fix: pv volume-scheduling-error not consistent with volume condition

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1750,6 +1750,11 @@ func (c *VolumeController) reconcileVolumeCondition(v *longhorn.Volume, e *longh
 	}
 
 	failureMessage := ""
+
+	if len(rs) != v.Spec.NumberOfReplicas {
+		scheduled = false
+	}
+
 	replenishCount, _ := c.getReplenishReplicasCount(v, rs, e)
 	if scheduled && replenishCount == 0 {
 		v.Status.Conditions = types.SetCondition(v.Status.Conditions,
@@ -1782,6 +1787,10 @@ func (c *VolumeController) reconcileVolumeCondition(v *longhorn.Volume, e *longh
 		failureMessage = aggregatedReplicaScheduledError.Join()
 		scheduledCondition := types.GetCondition(v.Status.Conditions, longhorn.VolumeConditionTypeScheduled)
 		if scheduledCondition.Status == longhorn.ConditionStatusFalse {
+			if scheduledCondition.Reason == longhorn.VolumeConditionReasonReplicaSchedulingFailure &&
+				scheduledCondition.Message != "" {
+				failureMessage = scheduledCondition.Message
+			}
 			v.Status.Conditions = types.SetCondition(v.Status.Conditions,
 				longhorn.VolumeConditionTypeScheduled, longhorn.ConditionStatusFalse,
 				scheduledCondition.Reason, failureMessage)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9514

#### What this PR does / why we need it:

Update PV volume-scheduling-error annotation when the replica schedule precheck fails.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
