### PR TITLE
fix: fix node readiness condition logic

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1978,10 +1978,10 @@ func isNodeOrDisksEvictionRequested(node *longhorn.Node) bool {
 	return false
 }
 
-func (nc *NodeController) setReadyAndSchedulableConditions(node *longhorn.Node, kubeNode *corev1.Node,
-	managerPods []*corev1.Pod) error {
-	nodeReady := nc.setReadyConditionForManagerPod(node, managerPods)
-	nodeReady = nodeReady && nc.setReadyConditionForKubeNode(node, kubeNode)
+func (nc *NodeController) setReadyAndSchedulableConditions(node *longhorn.Node, kubeNode *corev1.Node, managerPods []*corev1.Pod) error {
+	nodeReady := true
+	nodeReady = nc.setReadyConditionForManagerPod(node, managerPods, nodeReady)
+	nodeReady = nc.setReadyConditionForKubeNode(node, kubeNode, nodeReady)
 	if nodeReady {
 		// Only record true if we did not already record false.
 		node.Status.Conditions = types.SetConditionAndRecord(node.Status.Conditions,
@@ -2000,9 +2000,7 @@ func (nc *NodeController) setReadyAndSchedulableConditions(node *longhorn.Node, 
 	return nil
 }
 
-func (nc *NodeController) setReadyConditionForManagerPod(node *longhorn.Node,
-	managerPods []*corev1.Pod) (nodeReady bool) {
-	nodeReady = true
+func (nc *NodeController) setReadyConditionForManagerPod(node *longhorn.Node, managerPods []*corev1.Pod, nodeReady bool) bool {
 	nodeManagerFound := false
 	for _, pod := range managerPods {
 		if pod.Spec.NodeName == node.Name {
@@ -2032,11 +2030,10 @@ func (nc *NodeController) setReadyConditionForManagerPod(node *longhorn.Node,
 			fmt.Sprintf("Manager pod is missing: node %v has no manager pod running on it", node.Name),
 			nc.eventRecorder, node, corev1.EventTypeWarning)
 	}
-	return // nodeReady is already correctly set.
+	return nodeReady
 }
 
-func (nc *NodeController) setReadyConditionForKubeNode(node *longhorn.Node, kubeNode *corev1.Node) (nodeReady bool) {
-	nodeReady = true
+func (nc *NodeController) setReadyConditionForKubeNode(node *longhorn.Node, kubeNode *corev1.Node, nodeReady bool) bool {
 	kubeConditions := kubeNode.Status.Conditions
 	for _, con := range kubeConditions {
 		switch con.Type {
@@ -2071,7 +2068,7 @@ func (nc *NodeController) setReadyConditionForKubeNode(node *longhorn.Node, kube
 			}
 		}
 	}
-	return // nodeReady is already correctly set.
+	return nodeReady
 }
 
 // Update node condition based on DisableSchedulingOnCordonedNode setting and Kubernetes node status.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9616


#### What this PR does / why we need it:

The wrong logic is introduced in the refactor commit https://github.com/longhorn/longhorn-manager/pull/3138

#### Special notes for your reviewer:

#### Additional documentation or context
