### PR TITLE
fix: don't build longhorn-manager twice before packaging

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -9,7 +9,8 @@ TAG=${TAG:-${IMAGE_TAG_PREFIX}}
 REPO=${REPO:-longhornio}
 IMAGE=${IMAGE:-${REPO}/longhorn-manager:${TAG}}
 
-if [ ! -e ./bin/longhorn-manager ]; then
+if [ ! -e ./bin/longhorn-manager-amd64 ] || [ ! -e ./bin/longhorn-manager-arm64 ]; then
+    echo "Building longhorn-manager binary before packaging"
     ./scripts/build
 fi
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8744

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
