### PR TITLE
fix(upgrade): add sleep to allow event to flush before panic

### DIFF
--- a/app/post_upgrade.go
+++ b/app/post_upgrade.go
@@ -70,7 +70,11 @@ func postUpgrade(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create event broadcaster")
 	}
-	defer eventBroadcaster.Shutdown()
+	defer func() {
+		eventBroadcaster.Shutdown()
+		// Allow a little time for the event to flush, but not greatly delay response to the calling job.
+		time.Sleep(5 * time.Second)
+	}()
 
 	scheme := runtime.NewScheme()
 	if err := longhorn.SchemeBuilder.AddToScheme(scheme); err != nil {

--- a/app/pre_upgrade.go
+++ b/app/pre_upgrade.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -61,7 +63,11 @@ func preUpgrade(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create event broadcaster")
 	}
-	defer eventBroadcaster.Shutdown()
+	defer func() {
+		eventBroadcaster.Shutdown()
+		// Allow a little time for the event to flush, but not greatly delay response to the calling job.
+		time.Sleep(5 * time.Second)
+	}()
 
 	scheme := runtime.NewScheme()
 	if err := longhorn.SchemeBuilder.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9569

#### What this PR does / why we need it:

Add a sleep after Run() before panicking to let the queued event get flushed.  We thought that eventBroadcaster.Shutdown() would take care of that, and it did in some testing, but there is still a race and it does not work reliably.  QA found that while testing the feature and I did reproduce it - see the note in https://github.com/longhorn/longhorn/issues/9569#issuecomment-2425705470

#### Special notes for your reviewer:

This is the simplest fix.  We could do something more complicated, like calling Watch() on the events and waiting for it to appear, but there is no need to speed up the exit as soon as possible.  The upgrade will not go forward anyway.  The important thing is to guarantee the event can be found so the problem can be corrected.

#### Additional documentation or context
