### PR TITLE
fix(logging): only log GET requests at debug level

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -254,15 +254,7 @@ func startManager(c *cli.Context) error {
 
 	server := api.NewServer(m, wsc)
 	router := http.Handler(api.NewRouter(server))
-	router = util.FilteredLoggingHandler(map[string]struct{}{
-		"/v1/apiversions":  {},
-		"/v1/schemas":      {},
-		"/v1/settings":     {},
-		"/v1/volumes":      {},
-		"/v1/nodes":        {},
-		"/v1/engineimages": {},
-		"/v1/events":       {},
-	}, os.Stdout, router)
+	router = util.FilteredLoggingHandler(os.Stdout, router)
 	router = handlers.ProxyHeaders(router)
 
 	listen := types.GetAPIServerAddressFromIP(currentIP)

--- a/util/util.go
+++ b/util/util.go
@@ -460,15 +460,13 @@ func RunAsync(wg *sync.WaitGroup, f func()) {
 }
 
 type filteredLoggingHandler struct {
-	filteredPaths  map[string]struct{}
 	handler        http.Handler
 	loggingHandler http.Handler
 }
 
-func FilteredLoggingHandler(filteredPaths map[string]struct{}, writer io.Writer, router http.Handler) http.Handler {
+func FilteredLoggingHandler(writer io.Writer, router http.Handler) http.Handler {
 
 	return filteredLoggingHandler{
-		filteredPaths:  filteredPaths,
 		handler:        router,
 		loggingHandler: handlers.CombinedLoggingHandler(writer, router),
 	}
@@ -477,7 +475,7 @@ func FilteredLoggingHandler(filteredPaths map[string]struct{}, writer io.Writer,
 func (h filteredLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
-		if _, exists := h.filteredPaths[req.URL.Path]; exists {
+		if logrus.GetLevel() < logrus.DebugLevel {
 			h.handler.ServeHTTP(w, req)
 			return
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Part of https://github.com/longhorn/longhorn/issues/6702

#### What this PR does / why we need it:

Suppress logging of incoming REST GET queries unless log level is debug or more.  They can overwhelm all other logging.

#### Special notes for your reviewer:

this should backport to 1.6 and 1.7.

#### Additional documentation or context
