### PR TITLE
ci: automatically relate a backport PR to the backport issue

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,0 +1,63 @@
+name: Link-Backport-PR-Issue
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - master
+      - "v*"
+
+jobs:
+  check-backport:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check if PR is a backport
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ "backport #" ]]; then
+            echo "BACKPORT=true" >> $GITHUB_ENV
+          else
+            echo "BACKPORT=false" >> $GITHUB_ENV
+          fi
+
+      - name: Extract backport branch and issue number
+        if: env.BACKPORT == 'true'
+        run: |
+          # Extract branch from the target branch of the PR
+          BRANCH=$(echo "${{ github.event.pull_request.base.ref }}")
+          BRANCH=${BRANCH%.x}   # Remove the '.x' suffix
+          BRANCH=$(echo "${BRANCH}" | sed 's/\./\\./g')   # Escape periods
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+          # Extract issue number from the PR description
+          ORIGINAL_ISSUE_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oE 'issues/[0-9]+' | cut -d'/' -f2)
+          echo "ORIGINAL_ISSUE_NUMBER=$ORIGINAL_ISSUE_NUMBER" >> $GITHUB_ENV
+
+      - name: Get the original issue
+        if: env.BACKPORT == 'true'
+        id: original-issue
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/longhorn/longhorn/issues/${{ env.ORIGINAL_ISSUE_NUMBER }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: URL encode the original issue title
+        if: env.BACKPORT == 'true'
+        run: echo "ORIGINAL_ISSUE_TITLE=$(node -e 'console.log(encodeURIComponent("${{ fromJson(steps.original-issue.outputs.data).title  }}"))')" >> $GITHUB_ENV
+
+      - name: Find corresponding backport issue number
+        if: env.BACKPORT == 'true'
+        run: |
+          BACKPORT_ISSUE_NUMBER=$(curl -s "https://api.github.com/search/issues?q=repo:longhorn/longhorn+is:open+is:issue+in:title+${{ env.BRANCH }}+${{ env.ORIGINAL_ISSUE_TITLE }}" | jq .items[0].number)
+          echo "BACKPORT_ISSUE_NUMBER=$BACKPORT_ISSUE_NUMBER" >> $GITHUB_ENV
+
+      - name: Link the PR with the corresponding backport issue
+        if: env.BACKPORT == 'true'
+        run: |
+          # Relate the pull request to the backport issue
+          gh issue comment --repo longhorn/longhorn ${{ env.BACKPORT_ISSUE_NUMBER }} --body "Related PR: ${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8002

#### What this PR does / why we need it:

automatically relate a backport PR to the backport issue

#### Special notes for your reviewer:

#### Additional documentation or context
