### PR TITLE
chore: remove default CSI component images

### DIFF
--- a/app/driver.go
+++ b/app/driver.go
@@ -76,7 +76,6 @@ func DeployDriverCmd() cli.Command {
 				Name:   FlagCSIAttacherImage,
 				Usage:  "Specify CSI attacher image",
 				EnvVar: EnvCSIAttacherImage,
-				Value:  csi.DefaultCSIAttacherImage,
 			},
 			cli.IntFlag{
 				Name:   FlagCSIAttacherReplicaCount,
@@ -88,7 +87,6 @@ func DeployDriverCmd() cli.Command {
 				Name:   FlagCSIProvisionerImage,
 				Usage:  "Specify CSI provisioner image",
 				EnvVar: EnvCSIProvisionerImage,
-				Value:  csi.DefaultCSIProvisionerImage,
 			},
 			cli.IntFlag{
 				Name:   FlagCSIProvisionerReplicaCount,
@@ -100,7 +98,6 @@ func DeployDriverCmd() cli.Command {
 				Name:   FlagCSIResizerImage,
 				Usage:  "Specify CSI resizer image",
 				EnvVar: EnvCSIResizerImage,
-				Value:  csi.DefaultCSIResizerImage,
 			},
 			cli.IntFlag{
 				Name:   FlagCSIResizerReplicaCount,
@@ -112,7 +109,6 @@ func DeployDriverCmd() cli.Command {
 				Name:   FlagCSISnapshotterImage,
 				Usage:  "Specify CSI snapshotter image",
 				EnvVar: EnvCSISnapshotterImage,
-				Value:  csi.DefaultCSISnapshotterImage,
 			},
 			cli.IntFlag{
 				Name:   FlagCSISnapshotterReplicaCount,
@@ -124,13 +120,11 @@ func DeployDriverCmd() cli.Command {
 				Name:   FlagCSINodeDriverRegistrarImage,
 				Usage:  "Specify CSI node-driver-registrar image",
 				EnvVar: EnvCSINodeDriverRegistrarImage,
-				Value:  csi.DefaultCSINodeDriverRegistrarImage,
 			},
 			cli.StringFlag{
 				Name:   FlagCSILivenessProbeImage,
 				Usage:  "Specify CSI liveness probe image",
 				EnvVar: EnvCSILivenessProbeImage,
-				Value:  csi.DefaultCSILivenessProbeImage,
 			},
 			cli.StringFlag{
 				Name:  FlagKubeConfig,

--- a/app/driver.go
+++ b/app/driver.go
@@ -132,6 +132,10 @@ func DeployDriverCmd() cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) {
+			if err := validateFlags(c); err != nil {
+				logrus.Fatalf("Error validating flags: %v", err)
+			}
+
 			if err := deployDriver(c); err != nil {
 				logrus.Fatalf("Error deploying driver: %v", err)
 			}
@@ -139,15 +143,28 @@ func DeployDriverCmd() cli.Command {
 	}
 }
 
+func validateFlags(c *cli.Context) error {
+	for _, flag := range []string{
+		FlagManagerImage,
+		FlagManagerURL,
+		FlagCSIAttacherImage,
+		FlagCSIProvisionerImage,
+		FlagCSIResizerImage,
+		FlagCSISnapshotterImage,
+		FlagCSINodeDriverRegistrarImage,
+		FlagCSILivenessProbeImage,
+	} {
+		if c.String(flag) == "" {
+			return fmt.Errorf("%q cannot be empty", flag)
+		}
+	}
+
+	return nil
+}
+
 func deployDriver(c *cli.Context) error {
 	managerImage := c.String(FlagManagerImage)
-	if managerImage == "" {
-		return fmt.Errorf("require %v", FlagManagerImage)
-	}
 	managerURL := c.String(FlagManagerURL)
-	if managerURL == "" {
-		return fmt.Errorf("require %v", FlagManagerURL)
-	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", c.String(FlagKubeConfig))
 	if err != nil {

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -20,13 +20,6 @@ import (
 )
 
 const (
-	DefaultCSIAttacherImage            = "longhornio/csi-attacher:v4.4.2"
-	DefaultCSIProvisionerImage         = "longhornio/csi-provisioner:v3.6.2"
-	DefaultCSIResizerImage             = "longhornio/csi-resizer:v1.9.2"
-	DefaultCSISnapshotterImage         = "longhornio/csi-snapshotter:v6.3.2"
-	DefaultCSINodeDriverRegistrarImage = "longhornio/csi-node-driver-registrar:v2.9.2"
-	DefaultCSILivenessProbeImage       = "longhornio/livenessprobe:v2.12.0"
-
 	DefaultCSIAttacherReplicaCount    = 3
 	DefaultCSIProvisionerReplicaCount = 3
 	DefaultCSIResizerReplicaCount     = 3


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9580

#### What this PR does / why we need it:

- Remove the default CSI component images from the command flag.
- Validate the required command flags are not empty.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
