### PR TITLE
fix: support red hat package validation to resolve unknown os event

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -974,6 +974,8 @@ func (nc *NodeController) syncPackagesInstalled(kubeNode *corev1.Node, node *lon
 		fallthrough
 	case strings.Contains(osImage, "fedora"):
 		fallthrough
+	case strings.Contains(osImage, "red hat"):
+		fallthrough
 	case strings.Contains(osImage, "rocky"):
 		fallthrough
 	case strings.Contains(osImage, "ol"):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/longhorn/longhorn/discussions/9823 https://github.com/longhorn/longhorn/issues/9829

#### What this PR does / why we need it:
- Added package validation logic for Red Hat Enterprise Linux (RHEL).

#### Special notes for your reviewer:

#### Additional documentation or context
