### PR TITLE
feat: add automatic storage_reserved calculation for block type disks

### DIFF
--- a/controller/kubernetes_node_controller.go
+++ b/controller/kubernetes_node_controller.go
@@ -304,10 +304,6 @@ func (knc *KubernetesNodeController) syncDefaultDisks(node *longhorn.Node) (err 
 		if err != nil {
 			return err
 		}
-		storageReservedPercentageForDefaultDisk, err := knc.ds.GetSettingAsInt(types.SettingNameStorageReservedPercentageForDefaultDisk)
-		if err != nil {
-			return err
-		}
 		disks, err = types.CreateDefaultDisk(dataPath, storageReservedPercentageForDefaultDisk)
 		if err != nil {
 			return err

--- a/controller/kubernetes_node_controller.go
+++ b/controller/kubernetes_node_controller.go
@@ -293,7 +293,10 @@ func (knc *KubernetesNodeController) syncDefaultDisks(node *longhorn.Node) (err 
 		return nil
 	}
 	val = strings.ToLower(val)
-
+	storageReservedPercentageForDefaultDisk, err := knc.ds.GetSettingAsInt(types.SettingNameStorageReservedPercentageForDefaultDisk)
+	if err != nil {
+		return err
+	}
 	disks := map[string]longhorn.DiskSpec{} // nolint: ineffassign,staticcheck
 	switch val {
 	case types.NodeCreateDefaultDiskLabelValueTrue:
@@ -314,7 +317,7 @@ func (knc *KubernetesNodeController) syncDefaultDisks(node *longhorn.Node) (err 
 		if !ok {
 			return nil
 		}
-		disks, err = types.CreateDisksFromAnnotation(annotation)
+		disks, err = types.CreateDisksFromAnnotation(annotation, storageReservedPercentageForDefaultDisk)
 		if err != nil {
 			knc.logger.WithError(err).Warnf("Failed to create disk from annotation, invalid annotation %v: %v", types.KubeNodeDefaultDiskConfigAnnotationKey, val)
 			return nil

--- a/types/types.go
+++ b/types/types.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	"unsafe"
 
 	lhns "github.com/longhorn/go-common-libs/ns"
 

--- a/types/types.go
+++ b/types/types.go
@@ -1044,9 +1044,9 @@ func CreateDisksFromAnnotation(annotation string, storageReservedPercentage int6
 				if err != nil {
 					return nil, fmt.Errorf("failed to open block device at %s: %w", disk.Path, err)
 				}
+				defer file.Close()
 				var size uint64
 				_, _, errno := unix.Syscall(unix.SYS_IOCTL, file.Fd(), 0x80081272, uintptr(unsafe.Pointer(&size)))
-				file.Close()
 				if errno != 0 {
 					return nil, fmt.Errorf("failed to get block device size for %s: errno=%v", disk.Path, errno)
 				}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/longhorn/longhorn/issues/9871 https://github.com/longhorn/longhorn/discussions/9797

#### What this PR does / why we need it:
This PR addresses a bug where the Storage Reserved value is incorrectly set to 0 during automatic disk registration when using Engine v2 block type.

#### Special notes for your reviewer:
To retrieve the total capacity of the block device, the implementation uses unix.Syscall.
If there is a more efficient or reliable approach to gather block device capacity, please provide your suggestions or feedback.

#### Additional documentation or context
