### PR TITLE
fix(expansion): Prevent oversize PVC expansion requests

### DIFF
--- a/webhook/resources/persistentvolumeclaim/validator.go
+++ b/webhook/resources/persistentvolumeclaim/validator.go
@@ -1,0 +1,98 @@
+package persistentvolumeclaim
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/scheduler"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+type pvcValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &pvcValidator{ds: ds}
+}
+
+func (v *pvcValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "persistentvolumeclaims",
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   corev1.SchemeGroupVersion.Group,
+		APIVersion: corev1.SchemeGroupVersion.Version,
+		ObjectType: &corev1.PersistentVolumeClaim{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *pvcValidator) Update(request *admission.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	oldPVC, ok := oldObj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return werror.NewInvalidError(fmt.Sprintf("invalid old object: expected *corev1.PersistentVolumeClaim, got %T", oldObj), "")
+	}
+
+	newPVC, ok := newObj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return werror.NewInvalidError(fmt.Sprintf("invalid new object: expected *corev1.PersistentVolumeClaim, got %T", newObj), "")
+	}
+
+	// Handle only PVC size expansion.
+	oldSize := oldPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	newSize := newPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	if oldSize == newSize {
+		// Size has not changed; no further validation needed.
+		return nil
+	}
+
+	pv, err := v.ds.GetPersistentVolumeRO(newPVC.Spec.VolumeName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	// Skip validation if the PV is not a Longhorn volume.
+	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != types.LonghornDriverName {
+		return nil
+	}
+
+	volume, err := v.ds.GetVolumeRO(pv.Spec.CSI.VolumeHandle)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	return v.validateExpansionSize(oldPVC, newPVC, volume)
+}
+
+func (v *pvcValidator) validateExpansionSize(oldPVC *corev1.PersistentVolumeClaim, newPVC *corev1.PersistentVolumeClaim, volume *longhorn.Volume) error {
+	oldSize := oldPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	oldSizeInt64, ok := oldSize.AsInt64()
+	if !ok {
+		return werror.NewInternalError(fmt.Sprintf("unable to convert old size '%v' to int64", oldSize))
+	}
+
+	newSize := newPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	newSizeInt64, ok := newSize.AsInt64()
+	if !ok {
+		return werror.NewInternalError(fmt.Sprintf("unable to convert new size '%v' to int64", newSize))
+	}
+
+	replicaScheduler := scheduler.NewReplicaScheduler(v.ds)
+	if _, err := replicaScheduler.CheckReplicasSizeExpansion(volume, oldSizeInt64, newSizeInt64); err != nil {
+		return werror.NewForbiddenError(err.Error())
+	}
+
+	return nil
+}

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/instancemanager"
 	"github.com/longhorn/longhorn-manager/webhook/resources/node"
 	"github.com/longhorn/longhorn-manager/webhook/resources/orphan"
+	"github.com/longhorn/longhorn-manager/webhook/resources/persistentvolumeclaim"
 	"github.com/longhorn/longhorn-manager/webhook/resources/recurringjob"
 	"github.com/longhorn/longhorn-manager/webhook/resources/replica"
 	"github.com/longhorn/longhorn-manager/webhook/resources/setting"
@@ -47,6 +48,7 @@ func Validation(ds *datastore.DataStore) (http.Handler, []admission.Resource, er
 		engine.NewValidator(ds),
 		replica.NewValidator(ds),
 		instancemanager.NewValidator(ds),
+		persistentvolumeclaim.NewValidator(ds),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6633

#### What this PR does / why we need it:

Introduce a PVC admission validator to prevent PVC expansion requests that exceed the storage maximum size.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
