### PR TITLE
fix: change misleading error message to warning level

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -749,7 +749,7 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 			} else {
 				after, err := util.TimestampAfterTimestamp(transitionTime, r.Spec.LastHealthyAt)
 				if err != nil {
-					log.WithError(err).Errorf("Failed to check if replica %v transitioned to mode %v after it was last healthy", r.Name, mode)
+					log.WithError(err).Warnf("Failed to check if replica %v transitioned to mode %v after it was last healthy", r.Name, mode)
 				}
 				if after || err != nil {
 					r.Spec.LastHealthyAt = now


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9916

When new replicas are created, the following error messages are emitted in the longhorn-manager. Empty timestamp is expected in this case, so the error messages are misleading.


#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
