### PR TITLE
feat(webhook): reject strict-local RWX volume creation

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -824,6 +824,13 @@ func ValidateDataLocalityAndReplicaCount(mode longhorn.DataLocality, count int) 
 	return nil
 }
 
+func ValidateDataLocalityAndAccessMode(locality longhorn.DataLocality, migratable bool, mode longhorn.AccessMode) error {
+	if mode == longhorn.AccessModeReadWriteMany && !migratable && locality == longhorn.DataLocalityStrictLocal {
+		return fmt.Errorf("access mode %v (migratable: %v) is incompatible with data locality %v mode", mode, migratable, longhorn.DataLocalityStrictLocal)
+	}
+	return nil
+}
+
 func ValidateReplicaAutoBalance(option longhorn.ReplicaAutoBalance) error {
 	switch option {
 	case longhorn.ReplicaAutoBalanceIgnored,

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -74,6 +74,10 @@ func (v *volumeValidator) Create(request *admission.Request, newObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "")
 	}
 
+	if err := types.ValidateDataLocalityAndAccessMode(volume.Spec.DataLocality, volume.Spec.Migratable, volume.Spec.AccessMode); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
 	if err := types.ValidateReplicaAutoBalance(volume.Spec.ReplicaAutoBalance); err != nil {
 		return werror.NewInvalidError(err.Error(), "")
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#6735

#### What this PR does / why we need it:

When the server node is down, the RWX NFS server is unable to create on another node because of the strict-local volume. Also, strict-local is for distributed application only. Distributed application means it has replication capability, so they will only RWO.

#### Special notes for your reviewer:

#### Additional documentation or context
