### PR TITLE
feat(env-check): check NFS default protocal version

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -112,6 +112,8 @@ const (
 	TestKernelVersion        = "6.2.0-32-generic"
 	TestKernelConfigDIR      = "/host/boot"
 	TestKernelConfigFilePath = TestKernelConfigDIR + "/config-" + TestKernelVersion
+	TestSystemEtcDIR         = "/host/etc"
+	TestNFSMountConfigPath   = TestSystemEtcDIR + "/nfsmount.conf"
 )
 
 var (

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -1945,25 +1945,36 @@ func (s *NodeControllerSuite) TestSyncInstanceManagers(c *C) {
 	}
 }
 
-func (s *NodeControllerSuite) TestKubeNodeKernelModulesCondition(c *C) {
+func (s *NodeControllerSuite) TestKubeNodeNFSCapabilityCondition(c *C) {
 	var err error
 
-	// Create a temporary Kernel config file
+	// Create a mock kernel config file
 	err = os.MkdirAll(TestKernelConfigDIR, 0755)
 	c.Assert(err, IsNil)
-	tmpKernelConfigFile, err := os.Create(TestKernelConfigFilePath)
-	c.Assert(err, IsNil)
-	defer tmpKernelConfigFile.Close()
-	defer os.Remove(TestKernelConfigFilePath)
+	defer os.RemoveAll(TestKernelConfigFilePath)
 
-	// Write some fake content to the temporary file
-	fakeFileContent := `CONFIG_DM_CRYPT=y
+	// The content of the mock kernel config
+	mockKernelConfigContent := `CONFIG_DM_CRYPT=y
 CONFIG_NFS_V4=m
 CONFIG_NFS_V4_1=m
 CONFIG_NFS_V4_2=y`
 
-	_, err = tmpKernelConfigFile.Write([]byte(fakeFileContent))
+	genKernelConfig := func(content string) {
+		err = os.WriteFile(TestKernelConfigFilePath, []byte(content), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	// Create a mock NFS mount config file
+	err = os.MkdirAll(TestSystemEtcDIR, 0755)
 	c.Assert(err, IsNil)
+	defer os.RemoveAll(TestSystemEtcDIR)
+
+	// The content of the mock NFS mount config
+	genNFSMountConf := func(nfsVer string) {
+		data := fmt.Sprintf("[ NFSMount_Global_Options ]\nDefaultvers=%s\n", nfsVer)
+		err := os.WriteFile(TestNFSMountConfigPath, []byte(data), 0644)
+		c.Assert(err, IsNil)
+	}
 
 	fixture := &NodeControllerFixture{
 		lhNodes: map[string]*longhorn.Node{
@@ -2005,43 +2016,140 @@ CONFIG_NFS_V4_2=y`
 		},
 	}
 
-	expectation := &NodeControllerExpectation{
-		nodeStatus: map[string]*longhorn.NodeStatus{
-			TestNode1: {
-				Conditions: []longhorn.Condition{
-					newNodeCondition(longhorn.NodeConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeReady, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeMountPropagation, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeRequiredPackages, longhorn.ConditionStatusFalse, longhorn.NodeConditionReasonUnknownOS),
-					newNodeCondition(longhorn.NodeConditionTypeMultipathd, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeKernelModulesLoaded, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeNFSClientInstalled, longhorn.ConditionStatusTrue, ""),
-				},
+	s.initTest(c, fixture)
+
+	type nfsConfigCases struct {
+		setup                 func()
+		expectConditionStatus longhorn.ConditionStatus
+		expectConditionReason string
+	}
+	testCases := map[string]nfsConfigCases{
+		"it is acceptable when nfsmount.conf is not present": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				_, err := os.Stat(TestNFSMountConfigPath)
+				c.Assert(os.IsNotExist(err), Equals, true)
 			},
-			TestNode2: {
-				Conditions: []longhorn.Condition{
-					newNodeCondition(longhorn.NodeConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
-					newNodeCondition(longhorn.NodeConditionTypeReady, longhorn.ConditionStatusTrue, ""),
-				},
+			longhorn.ConditionStatusTrue,
+			"",
+		},
+		"it is acceptable when default NFS version set to 4": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("4")
 			},
+			longhorn.ConditionStatusTrue,
+			"",
+		},
+		"it is acceptable when default NFS version set to 4.0": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("4.0")
+			},
+			longhorn.ConditionStatusTrue,
+			"",
+		},
+		"it is acceptable when default NFS version set to 4.1": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("4.1")
+			},
+			longhorn.ConditionStatusTrue,
+			"",
+		},
+		"it is acceptable when default NFS version set to 4.2": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("4.2")
+			},
+			longhorn.ConditionStatusTrue,
+			"",
+		},
+		"it is not acceptable when no kernel module enabled for NFS": {
+			func() {
+				genKernelConfig("CONFIG_DM_CRYPT=y")
+				genNFSMountConf("4.3")
+			},
+			longhorn.ConditionStatusFalse,
+			longhorn.NodeConditionReasonNFSClientIsNotFound,
+		},
+		"it is not acceptable when default NFS version newer than 4.2": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("4.3")
+			},
+			longhorn.ConditionStatusFalse,
+			longhorn.NodeConditionReasonNFSClientIsMisconfigured,
+		},
+		"it is not acceptable when default NFS version older then 4": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("3")
+			},
+			longhorn.ConditionStatusFalse,
+			longhorn.NodeConditionReasonNFSClientIsMisconfigured,
+		},
+		"it is not acceptable when default NFS version illegal value": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("???")
+			},
+			longhorn.ConditionStatusFalse,
+			longhorn.NodeConditionReasonNFSClientIsMisconfigured,
+		},
+		"it is not acceptable when default NFS version empty value": {
+			func() {
+				genKernelConfig(mockKernelConfigContent)
+				genNFSMountConf("")
+			},
+			longhorn.ConditionStatusFalse,
+			longhorn.NodeConditionReasonNFSClientIsMisconfigured,
 		},
 	}
 
-	s.initTest(c, fixture)
+	for testName, testCase := range testCases {
+		fmt.Printf("testing %v", testName)
+		func(setup func(), expectConditionStatus longhorn.ConditionStatus, expectConditionReason string) {
+			setup()
+			defer os.Remove(TestNFSMountConfigPath)
 
-	for _, node := range fixture.lhNodes {
-		if s.controller.controllerID == node.Name {
-			err = s.controller.diskMonitor.RunOnce()
-			c.Assert(err, IsNil)
-		}
+			expectation := &NodeControllerExpectation{
+				nodeStatus: map[string]*longhorn.NodeStatus{
+					TestNode1: {
+						Conditions: []longhorn.Condition{
+							newNodeCondition(longhorn.NodeConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeReady, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeMountPropagation, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeRequiredPackages, longhorn.ConditionStatusFalse, longhorn.NodeConditionReasonUnknownOS),
+							newNodeCondition(longhorn.NodeConditionTypeMultipathd, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeKernelModulesLoaded, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeNFSClientInstalled, expectConditionStatus, expectConditionReason),
+						},
+					},
+					TestNode2: {
+						Conditions: []longhorn.Condition{
+							newNodeCondition(longhorn.NodeConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
+							newNodeCondition(longhorn.NodeConditionTypeReady, longhorn.ConditionStatusTrue, ""),
+						},
+					},
+				},
+			}
 
-		err = s.controller.syncNode(getKey(node, c))
-		c.Assert(err, IsNil)
+			for _, node := range fixture.lhNodes {
+				if s.controller.controllerID == node.Name {
+					err = s.controller.diskMonitor.RunOnce()
+					c.Assert(err, IsNil)
+				}
 
-		n, err := s.lhClient.LonghornV1beta2().Nodes(TestNamespace).Get(context.TODO(), node.Name, metav1.GetOptions{})
-		c.Assert(err, IsNil)
+				err = s.controller.syncNode(getKey(node, c))
+				c.Assert(err, IsNil)
 
-		s.checkNodeConditions(c, expectation, n)
+				n, err := s.lhClient.LonghornV1beta2().Nodes(TestNamespace).Get(context.TODO(), node.Name, metav1.GetOptions{})
+				c.Assert(err, IsNil)
+
+				s.checkNodeConditions(c, expectation, n)
+			}
+		}(testCase.setup, testCase.expectConditionStatus, testCase.expectConditionReason)
 	}
 }
 

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -27,6 +27,7 @@ const (
 	NodeConditionReasonPackagesNotInstalled      = "PackagesNotInstalled"
 	NodeConditionReasonCheckKernelConfigFailed   = "CheckKernelConfigFailed"
 	NodeConditionReasonNFSClientIsNotFound       = "NFSClientIsNotFound"
+	NodeConditionReasonNFSClientIsMisconfigured  = "NFSClientIsMisconfigured"
 	NodeConditionReasonKubernetesNodeCordoned    = "KubernetesNodeCordoned"
 )
 

--- a/vendor/github.com/longhorn/go-common-libs/nfs/nfs.go
+++ b/vendor/github.com/longhorn/go-common-libs/nfs/nfs.go
@@ -1,0 +1,97 @@
+package nfs
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/longhorn/go-common-libs/types"
+)
+
+const (
+	nfsmountGlobalSection  = "NFSMount_Global_Options"
+	nfsmountDefaultVersion = "Defaultvers"
+)
+
+// GetSystemDefaultNFSVersion reads the system default NFS version. This config can be overridden by nfsmount.conf under
+// configDir. If configDir is empty, it will be /etc by default. If the nfsmount.conf is absent, or the default
+// version is not overridden in the configuration file, a wrapped ErrNotConfigured error will be returned. It is possible
+// for the caller to tell if the configuration is overridden by errors.Is(err, types.ErrNotConfigured).
+func GetSystemDefaultNFSVersion(configDir string) (major, minor int, err error) {
+	if configDir == "" {
+		configDir = types.SysEtcDirectory
+	}
+
+	configMap, err := getSystemNFSMountConfigMap(configDir)
+	if os.IsNotExist(err) {
+		return 0, 0, fmt.Errorf("system default NFS version is not overridden under %q: %w", configDir, types.ErrNotConfigured)
+	} else if err != nil {
+		return 0, 0, err
+	}
+	if globalSection, ok := configMap[nfsmountGlobalSection]; ok {
+		if configured, ok := globalSection[nfsmountDefaultVersion]; ok {
+			majorStr, minorStr, _ := strings.Cut(configured, ".")
+			major, err := strconv.Atoi(majorStr)
+			if err != nil {
+				return 0, 0, errors.Wrapf(err, "invalid NFS major version %q", configured)
+			}
+
+			minor := 0
+			if minorStr != "" {
+				minor, err = strconv.Atoi(minorStr)
+				if err != nil {
+					return 0, 0, errors.Wrapf(err, "invalid NFS minor version %q", configured)
+				}
+			}
+			return major, minor, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("system default NFS version is not overridden under %q: %w", configDir, types.ErrNotConfigured)
+}
+
+// getSystemNFSMountConfigMap reads the nfsmount.conf under configDir. The returned result is in
+// map[section]map[key]value structure, and the global options is result["NFSMount_Global_Options"]. Refer to man page
+// for more detail: man 5 nfsmount.conf
+func getSystemNFSMountConfigMap(configDir string) (map[string]map[string]string, error) {
+	configFilePath := filepath.Join(configDir, types.NFSMountFileName)
+	configFile, err := os.Open(configFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer configFile.Close()
+
+	configMap := make(map[string]map[string]string)
+	scanner := bufio.NewScanner(configFile)
+	var section = ""
+	var sectionMap map[string]string
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			section = strings.TrimSpace(strings.Trim(line, "[]"))
+			continue
+		}
+		if sectionMap = configMap[section]; sectionMap == nil {
+			sectionMap = make(map[string]string)
+			configMap[section] = sectionMap
+		}
+		if key, val, isParsable := strings.Cut(line, "="); isParsable {
+			sectionMap[strings.TrimSpace(key)] = strings.TrimSpace(val)
+		} else {
+			return nil, fmt.Errorf("invalid key-value pair: '%s'", line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return configMap, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,6 +251,7 @@ github.com/longhorn/go-common-libs/backup
 github.com/longhorn/go-common-libs/exec
 github.com/longhorn/go-common-libs/io
 github.com/longhorn/go-common-libs/longhorn
+github.com/longhorn/go-common-libs/nfs
 github.com/longhorn/go-common-libs/ns
 github.com/longhorn/go-common-libs/proc
 github.com/longhorn/go-common-libs/sync


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9830

#### What this PR does / why we need it:

Though the node supports NFSv4, the NFS client picks the protocol version by `Defaultvers` defined in host's `/etc/nfsmount.conf`. This may cause problem while using backup-related features.

#### Special notes for your reviewer:

#### Additional documentation or context
