### PR TITLE
fix: extend im pod liveness probe failure timeout

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1479,10 +1479,10 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 				},
 			},
 		},
-		InitialDelaySeconds: datastore.PodProbeInitialDelay,
-		TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
-		PeriodSeconds:       datastore.PodProbePeriodSeconds,
-		FailureThreshold:    datastore.PodLivenessProbeFailureThreshold,
+		InitialDelaySeconds: datastore.IMPodProbeInitialDelay,
+		TimeoutSeconds:      datastore.IMPodProbeTimeoutSeconds,
+		PeriodSeconds:       datastore.IMPodProbePeriodSeconds,
+		FailureThreshold:    datastore.IMPodLivenessProbeFailureThreshold,
 	}
 
 	// Set environment variables

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -43,6 +43,11 @@ const (
 	PodProbeTimeoutSeconds           = PodProbePeriodSeconds - 1
 	PodProbePeriodSeconds            = 5
 	PodLivenessProbeFailureThreshold = 3
+
+	IMPodProbeInitialDelay             = 3
+	IMPodProbeTimeoutSeconds           = IMPodProbePeriodSeconds - 1
+	IMPodProbePeriodSeconds            = 5
+	IMPodLivenessProbeFailureThreshold = 6
 )
 
 func labelMapToLabelSelector(labels map[string]string) (labels.Selector, error) {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9851

Extend the liveness probe failure timeout.

Period: every 30 seconds
Timeout: every 29 seconds if command not response
FailureThreshold: 3 times failure in a row.