### PR TITLE
fix: clear fast-failover status when node goes not ready

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1480,7 +1480,7 @@ func (c *VolumeController) handleDelinquentAndStaleStateForFaultedRWXVolume(v *l
 	if !isRegularRWXVolume(v) {
 		return nil
 	}
-	return c.ds.ClearDelinquentAndStaleStateIfVolumeIsDelinquent(v.Name)
+	return c.ds.ClearDelinquentAndStaleStateIfVolumeIsDelinquent(v.Name, "")
 }
 
 func (c *VolumeController) requestRemountIfFileSystemReadOnly(v *longhorn.Volume, e *longhorn.Engine) {

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -287,7 +287,7 @@ func (s *DataStore) UpdateLease(lease *coordinationv1.Lease) (*coordinationv1.Le
 	return s.kubeClient.CoordinationV1().Leases(s.namespace).Update(context.TODO(), lease, metav1.UpdateOptions{})
 }
 
-func (s *DataStore) ClearDelinquentAndStaleStateIfVolumeIsDelinquent(volumeName string) (err error) {
+func (s *DataStore) ClearDelinquentAndStaleStateIfVolumeIsDelinquent(volumeName string, nodeName string) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "failed to ClearDelinquentAndStaleStateIfVolumeIsDelinquent")
 	}()
@@ -304,6 +304,10 @@ func (s *DataStore) ClearDelinquentAndStaleStateIfVolumeIsDelinquent(volumeName 
 	if holder == "" {
 		// Empty holder means not delinquent.
 		// Ref: IsRWXVolumeDelinquent() function
+		return nil
+	}
+	if nodeName != "" && nodeName != holder {
+		// If a node is specified, only clear state for it.
 		return nil
 	}
 	if !(lease.Spec.AcquireTime).IsZero() {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/longhorn/longhorn/issues/9093

#### What this PR does / why we need it:

Do a fail-safe clearing of RWX fast-failover status still pending on a node that is NotReady.  If it hasn't already happened, it is too late for fast failover, so let the normal IsNodeDownOrDeleted logic take over.

#### Special notes for your reviewer:

#### Additional documentation or context
