### PR TITLE
feat: add check for hugepages configuration

### DIFF
--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -10,6 +10,7 @@ const (
 	NodeConditionTypeRequiredPackages    = "RequiredPackages"
 	NodeConditionTypeNFSClientInstalled  = "NFSClientInstalled"
 	NodeConditionTypeSchedulable         = "Schedulable"
+	NodeConditionTypeHugePagesAvailable  = "HugePagesAvailable"
 )
 
 const (
@@ -29,6 +30,8 @@ const (
 	NodeConditionReasonNFSClientIsNotFound       = "NFSClientIsNotFound"
 	NodeConditionReasonNFSClientIsMisconfigured  = "NFSClientIsMisconfigured"
 	NodeConditionReasonKubernetesNodeCordoned    = "KubernetesNodeCordoned"
+	NodeConditionReasonHugePagesNotConfigured    = "HugePagesNotConfigured"
+	NodeConditionReasonInsufficientHugePages     = "InsufficientHugePages"
 )
 
 const (


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9983

#### What this PR does / why we need it:
This PR introduces a checkHugePages function to the Longhorn NodeController. The purpose of this function is to periodically verify the configuration and availability of HugePages (2Mi) on Kubernetes nodes.


#### Special notes for your reviewer:

#### Additional documentation or context
