### PR TITLE
fix(v2): clean up v2 resources on instancemanager pod pre-stop

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1444,6 +1444,13 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			podSpec.Spec.Containers[0].Resources.Limits = corev1.ResourceList{}
 		}
 		podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName("hugepages-2Mi")] = resource.MustParse(fmt.Sprintf("%vMi", hugepage))
+
+		podSpec.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"instance-manager-v2-prestop"},
+				}},
+		}
 	} else {
 		podSpec.Spec.Containers[0].Args = []string{
 			"instance-manager", "--debug", "daemon", "--listen", fmt.Sprintf("0.0.0.0:%d", engineapi.InstanceManagerProcessManagerServiceDefaultPort),


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9959

#### What this PR does / why we need it:

Introduce pre-stop script to the instance manager pod lifecycle.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
