### PR TITLE
fix(backup): correct mismatch action name of volume API

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1103,7 +1103,7 @@ func volumeSchema(volume *client.Schema) {
 			Input: "UpdateFreezeFilesystemForSnapshotInput",
 		},
 
-		"updateBackupTarget": {
+		"updateBackupTargetName": {
 			Input: "UpdateBackupTargetInput",
 		},
 
@@ -1680,7 +1680,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["updateReplicaZoneSoftAntiAffinity"] = struct{}{}
 			actions["updateReplicaDiskSoftAntiAffinity"] = struct{}{}
 			actions["updateFreezeFilesystemForSnapshot"] = struct{}{}
-			actions["updateBackupTarget"] = struct{}{}
+			actions["updateBackupTargetName"] = struct{}{}
 			actions["recurringJobAdd"] = struct{}{}
 			actions["recurringJobDelete"] = struct{}{}
 			actions["recurringJobList"] = struct{}{}
@@ -1712,7 +1712,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 			actions["updateReplicaZoneSoftAntiAffinity"] = struct{}{}
 			actions["updateReplicaDiskSoftAntiAffinity"] = struct{}{}
 			actions["updateFreezeFilesystemForSnapshot"] = struct{}{}
-			actions["updateBackupTarget"] = struct{}{}
+			actions["updateBackupTargetName"] = struct{}{}
 			actions["pvCreate"] = struct{}{}
 			actions["pvcCreate"] = struct{}{}
 			actions["cancelExpansion"] = struct{}{}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411

#### What this PR does / why we need it:

Modify the name of the action `updateBackupTargetName` of volume in the api/router.go to `updateBackupTarget` to match the name in api/model.go.

#### Special notes for your reviewer:

#### Additional documentation or context
