### PR TITLE
fix(backup): do not get backing image custom resource

### DIFF
--- a/webhook/resources/backupbackingimage/validator.go
+++ b/webhook/resources/backupbackingimage/validator.go
@@ -45,11 +45,11 @@ func (bbi *backupBackingImageValidator) Create(request *admission.Request, newOb
 	backingImageName := backupBackingImage.Spec.BackingImage
 
 	backingImage, err := bbi.ds.GetBackingImageRO(backingImageName)
-	if err != nil {
+	if err != nil && !datastore.ErrorIsNotFound(err) {
 		return werror.NewInvalidError(fmt.Sprintf("failed to get the backing image %v for backup: %v", backingImageName, err), "")
 	}
 	// TODO: support backup for v2 data engine in the future
-	if types.IsDataEngineV2(backingImage.Spec.DataEngine) {
+	if backingImage != nil && types.IsDataEngineV2(backingImage.Spec.DataEngine) {
 		return werror.NewInvalidError(fmt.Sprintf("backing image %v uses v2 data engine which doesn't support backup operations", backingImageName), "")
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #ref longhorn/longhorn#10026, longhorn/longhorn#6341

#### What this PR does / why we need it:

Do not get the backing image custom resource if the backup backing image is synchronized from the remote backup target because the backing image might not exist.

#### Special notes for your reviewer:

#### Additional documentation or context
