### PR TITLE
fix: add data engine option to restore backing image api

### DIFF
--- a/api/backupbackingimage.go
+++ b/api/backupbackingimage.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
+
+	"github.com/longhorn/longhorn-manager/types"
 )
 
 func (s *Server) backupBackingImageList(apiContext *api.ApiContext) (*client.GenericCollection, error) {
@@ -56,7 +57,7 @@ func (s *Server) BackupBackingImageRestore(w http.ResponseWriter, req *http.Requ
 	}
 
 	backupBackingImageName := mux.Vars(req)["name"]
-	if err := s.m.RestoreBackupBackingImage(backupBackingImageName, input.Secret, input.SecretNamespace); err != nil {
+	if err := s.m.RestoreBackupBackingImage(backupBackingImageName, input.Secret, input.SecretNamespace, input.DataEngine); err != nil {
 		return errors.Wrapf(err, "failed to restore backup backing image '%s'", backupBackingImageName)
 	}
 	return nil
@@ -71,8 +72,9 @@ func (s *Server) BackupBackingImageCreate(w http.ResponseWriter, req *http.Reque
 	}
 
 	backingImageName := mux.Vars(req)["name"]
-	if err := s.m.CreateBackupBackingImage(input.Name, backingImageName, input.BackupTargetName); err != nil {
-		return errors.Wrapf(err, "failed to create backup backing image '%s'", input.Name)
+	backupBackingImageName := types.GetBackupBackingImageNameFromBIName(backingImageName)
+	if err := s.m.CreateBackupBackingImage(backupBackingImageName, backingImageName, input.BackupTargetName); err != nil {
+		return errors.Wrapf(err, "failed to create backup backing image '%s'", backupBackingImageName)
 	}
 	return nil
 }

--- a/api/model.go
+++ b/api/model.go
@@ -295,6 +295,7 @@ type UpdateMinNumberOfCopiesInput struct {
 type BackingImageRestoreInput struct {
 	Secret          string `json:"secret"`
 	SecretNamespace string `json:"secretNamespace"`
+	DataEngine      string `json:"dataEngine"`
 }
 
 type AttachInput struct {

--- a/client/generated_backing_image_restore_input.go
+++ b/client/generated_backing_image_restore_input.go
@@ -7,6 +7,8 @@ const (
 type BackingImageRestoreInput struct {
 	Resource `yaml:"-"`
 
+	DataEngine string `json:"dataEngine,omitempty" yaml:"data_engine,omitempty"`
+
 	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
 
 	SecretNamespace string `json:"secretNamespace,omitempty" yaml:"secret_namespace,omitempty"`

--- a/controller/system_backup_controller.go
+++ b/controller/system_backup_controller.go
@@ -987,6 +987,10 @@ func (c *SystemBackupController) BackupBackingImage() (map[string]*longhorn.Back
 
 	backingImageBackups := make(map[string]*longhorn.BackupBackingImage, len(backingImages))
 	for _, backingImage := range backingImages {
+		// TODO: support backup backing image v2
+		if types.IsDataEngineV2(backingImage.Spec.DataEngine) {
+			continue
+		}
 		backupBackingImage, err := c.createBackingImageBackup(backingImage)
 		if err != nil {
 			return nil, err

--- a/manager/backupbackingimage.go
+++ b/manager/backupbackingimage.go
@@ -41,9 +41,9 @@ func (m *VolumeManager) DeleteBackupBackingImage(name string) error {
 	return m.ds.DeleteBackupBackingImage(name)
 }
 
-func (m *VolumeManager) RestoreBackupBackingImage(name string, secret, secretNamespace string) error {
-	if name == "" {
-		return fmt.Errorf("restore backing image name is not given")
+func (m *VolumeManager) RestoreBackupBackingImage(name, secret, secretNamespace, dataEngine string) error {
+	if name == "" || dataEngine == "" {
+		return fmt.Errorf("missing parameters for restoring backing image, name=%v dataEngine=%v", name, dataEngine)
 	}
 
 	bbi, err := m.ds.GetBackupBackingImageRO(name)
@@ -62,7 +62,7 @@ func (m *VolumeManager) RestoreBackupBackingImage(name string, secret, secretNam
 		return fmt.Errorf("backing image %v already exists", biName)
 	}
 
-	return m.restoreBackingImage(bbi.Spec.BackupTargetName, biName, secret, secretNamespace)
+	return m.restoreBackingImage(bbi.Spec.BackupTargetName, biName, secret, secretNamespace, dataEngine)
 }
 
 func (m *VolumeManager) CreateBackupBackingImage(name, backingImageName, backupTargetName string) error {


### PR DESCRIPTION
ref: 
- https://github.com/longhorn/longhorn/issues/6341
- https://github.com/longhorn/longhorn/issues/10023

Fix:
- generate UUID for backupBackingImage when backing up from UI  (cc @mantissahz )
    - To fix: https://github.com/longhorn/longhorn/issues/10023
- add `DataEngine` option in restoring backup backing image
- restore volume will check the existing backing image dataEngine or restore backupBackingImage with correct dataEngine

cc @derekbit @mantissahz @houhoucoop 