### PR TITLE
fix(monitor): remove the close of monitors

### DIFF
--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -136,7 +136,6 @@ func (m *DiskMonitor) GetCollectedData() (interface{}, error) {
 func (m *DiskMonitor) run(value interface{}) error {
 	node, err := m.ds.GetNode(m.nodeName)
 	if err != nil {
-		logrus.WithError(err).Errorf("Failed to get longhorn node %v", m.nodeName)
 		return errors.Wrapf(err, "failed to get longhorn node %v", m.nodeName)
 	}
 

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -375,22 +375,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 
 	if node.DeletionTimestamp != nil {
 		nc.eventRecorder.Eventf(node, corev1.EventTypeWarning, constant.EventReasonDelete, "Deleting node %v", node.Name)
-
-		if nc.diskMonitor != nil {
-			nc.diskMonitor.Stop()
-			nc.diskMonitor = nil
-		}
-
-		if nc.environmentCheckMonitor != nil {
-			nc.environmentCheckMonitor.Stop()
-			nc.environmentCheckMonitor = nil
-		}
-
-		if nc.snapshotMonitor != nil {
-			nc.snapshotMonitor.Stop()
-			nc.snapshotMonitor = nil
-		}
-
 		return nc.ds.RemoveFinalizerForNode(node)
 	}
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10035

#### What this PR does / why we need it:

No need to close the monitors after deleting a node resource. If a node is gone, monitor will return error and won't continue the following tasks.

e2e
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/2295/console

#### Special notes for your reviewer:

#### Additional documentation or context
