### PR TITLE
feat(env-check): remove dependency of system package manager from node env checker

### DIFF
--- a/controller/monitor/environment_check_monitor.go
+++ b/controller/monitor/environment_check_monitor.go
@@ -221,9 +221,7 @@ func (m *EnvironmentCheckMonitor) syncPackagesInstalled(kubeNode *corev1.Node, n
 		packageProbeExecutables["sys-fs/cryptsetup"] = "cryptsetup"
 		packageProbeExecutables["sys-fs/lvm2"] = "dmsetup"
 	default:
-		collectedData.conditions = types.SetCondition(collectedData.conditions, longhorn.NodeConditionTypeRequiredPackages, longhorn.ConditionStatusFalse,
-			string(longhorn.NodeConditionReasonUnknownOS),
-			fmt.Sprintf("Unable to verify the required packages because the OS image '%v' is unknown to the Longhorn system. Please ensure the required packages are installed.", osImage))
+		// unsupported host platform, skip environment check condition
 		return
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10019

#### What this PR does / why we need it:

Instead of reading the system package database, check the executables needed by the system, to eliminate the system management tool chain issue.

#### Special notes for your reviewer:

#### Additional documentation or context
