### PR TITLE
fix(backup): enqueue volumes with correct names

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -464,6 +464,15 @@ func newStorageClass(name, provisioner string) *storagev1.StorageClass {
 	}
 }
 
+func newSnapshot(name string) *longhorn.Snapshot {
+	return &longhorn.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: TestNamespace,
+		},
+	}
+}
+
 func newBackup(name string) *longhorn.Backup {
 	return &longhorn.Backup{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411, longhorn/longhorn#10057

#### What this PR does / why we need it:

In `enqueueVolumesForBackupVolume` of volume controller, it needs to use BackupVolume.Spec.VolumeName` to get volume CR instead of `BackupVolume.Name`.

#### Special notes for your reviewer:

#### Additional documentation or context
Run test cases:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7981
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7986 
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7995
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8001
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8012
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8013
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8014
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8015