### PR TITLE
feat(backup): separate backup settings from default settings

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -331,6 +331,10 @@ func startManager(c *cli.Context) error {
 		return err
 	}
 
+	if err := clients.Datastore.CreateOrUpdateDefaultBackupTarget(); err != nil {
+		return err
+	}
+
 	if err := updateRegistrySecretName(m); err != nil {
 		return err
 	}

--- a/controller/kubernetes_configmap_controller.go
+++ b/controller/kubernetes_configmap_controller.go
@@ -211,6 +211,11 @@ func (kc *KubernetesConfigMapController) reconcile(namespace, cfmName string) er
 		if err := kc.ds.UpdateCustomizedSettings(nil); err != nil {
 			return errors.Wrap(err, "failed to update built-in settings with customized values")
 		}
+	// Users tries to update the default backup target with customized values using Helm at runtime.
+	case types.DefaultDefaultResourceConfigMapName:
+		if err := kc.ds.CreateOrUpdateDefaultBackupTarget(); err != nil {
+			return errors.Wrap(err, "failed to create or update default backup target with customized values")
+		}
 	}
 
 	return nil

--- a/types/types.go
+++ b/types/types.go
@@ -208,12 +208,13 @@ const (
 
 	DefaultDiskPrefix = "default-disk-"
 
-	DeprecatedProvisionerName          = "rancher.io/longhorn"
-	DepracatedDriverName               = "io.rancher.longhorn"
-	DefaultStorageClassConfigMapName   = "longhorn-storageclass"
-	DefaultDefaultSettingConfigMapName = "longhorn-default-setting"
-	DefaultStorageClassName            = "longhorn"
-	ControlPlaneName                   = "longhorn-manager"
+	DeprecatedProvisionerName           = "rancher.io/longhorn"
+	DepracatedDriverName                = "io.rancher.longhorn"
+	DefaultStorageClassConfigMapName    = "longhorn-storageclass"
+	DefaultDefaultSettingConfigMapName  = "longhorn-default-setting"
+	DefaultDefaultResourceConfigMapName = "longhorn-default-resource"
+	DefaultStorageClassName             = "longhorn"
+	ControlPlaneName                    = "longhorn-manager"
 
 	DefaultRecurringJobConcurrency = 10
 

--- a/util/util.go
+++ b/util/util.go
@@ -877,3 +877,16 @@ func GetDataEngineForDiskType(diskType longhorn.DiskType) longhorn.DataEngineTyp
 	return longhorn.DataEngineTypeV1
 
 }
+
+// GetDataContentFromYAML unmarshals the data content YAML data into a map
+func GetDataContentFromYAML(configMapYAMLData []byte) (map[string]string, error) {
+	customizedDataMap := map[string]string{}
+
+	if err := yaml.Unmarshal(configMapYAMLData, &customizedDataMap); err != nil {
+		logrus.WithError(err).Errorf("Failed to unmarshal customized data content from yaml data %v, will give up using them", string(configMapYAMLData))
+		customizedDataMap = map[string]string{}
+		return nil, err
+	}
+
+	return customizedDataMap, nil
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411, longhorn/longhorn#10089

#### What this PR does / why we need it:

Separate the default backup related settings from default settings into a new yaml file `default-backupstore-setting.yaml`. Check if ConfigMap `longhorn-default-backupstore-settings` changed to update the default backup target.

#### Special notes for your reviewer:

#### Additional documentation or context
