### PR TITLE
fix(env-check): remove monitor initial pending to fix disk mismatch problem

### DIFF
--- a/controller/monitor/fake_disk_monitor.go
+++ b/controller/monitor/fake_disk_monitor.go
@@ -21,10 +21,10 @@ const (
 	TestOrphanedReplicaDirectoryName = "test-volume-r-000000000"
 )
 
-func NewFakeDiskMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, nodeName string, syncCallback func(key string)) (*DiskMonitor, error) {
+func NewFakeDiskMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, nodeName string, syncCallback func(key string)) (DiskMonitor, error) {
 	ctx, quit := context.WithCancel(context.Background())
 
-	m := &DiskMonitor{
+	m := &diskMonitorImpl{
 		baseMonitor: newBaseMonitor(ctx, quit, logger, ds, DiskMonitorSyncPeriod),
 
 		nodeName:        nodeName,

--- a/controller/monitor/monitor.go
+++ b/controller/monitor/monitor.go
@@ -9,11 +9,11 @@ import (
 	"github.com/longhorn/longhorn-manager/datastore"
 )
 
-type Monitor interface {
+type Monitor[CollectedDataType any] interface {
 	Start()
 	Stop()
 	UpdateConfiguration(map[string]interface{}) error
-	GetCollectedData() (interface{}, error)
+	GetCollectedData() (CollectedDataType, error)
 	RunOnce() error
 }
 


### PR DESCRIPTION
EDIT: change to draft since the initial waiting is expected for while disk mismatch really happens.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10098

#### What this PR does / why we need it:

Trigger the initial disk status collecting right after the disk monitor get created, to eliminate disk mismatching errors, which blocks the rest node sync logic.

#### Special notes for your reviewer:

#### Additional documentation or context
