### PR TITLE
fix(uninstall): deleting failed backups when uninstalling

### DIFF
--- a/controller/system_backup_controller_test.go
+++ b/controller/system_backup_controller_test.go
@@ -285,7 +285,9 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 			systemBackupController.UploadSystemBackup(systemBackup, archievePath, tempDir, backupTargetClient)
 
 		default:
-			err = systemBackupController.reconcile(tc.systemBackupName, backupTargetClient, nil)
+			defaultBackupTarget, err := lhClient.LonghornV1beta2().BackupTargets(TestNamespace).Get(context.TODO(), types.DefaultBackupTargetName, metav1.GetOptions{})
+			c.Assert(err, IsNil)
+			err = systemBackupController.reconcile(tc.systemBackupName, backupTargetClient, defaultBackupTarget)
 			if tc.expectError {
 				c.Assert(err, NotNil)
 			} else {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4485,7 +4485,7 @@ func (s *DataStore) GetBackupVolumeByBackupTargetAndVolumeRO(backupTargetName, v
 		return nil, err
 	}
 
-	if len(list) >= 2 {
+	if len(list) > 1 {
 		return nil, fmt.Errorf("datastore: found more than one backup volume with backup target %v and volume %v", backupTargetName, volumeName)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,7 @@ const (
 	LonghornKindRecurringJob        = "RecurringJob"
 	LonghornKindSetting             = "Setting"
 	LonghornKindSupportBundle       = "SupportBundle"
+	LonghornKindSystemBackup        = "SystemBackup"
 	LonghornKindSystemRestore       = "SystemRestore"
 	LonghornKindOrphan              = "Orphan"
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10104


#### What this PR does / why we need it:

Deleting failed backups failed when uninstalling because failed backups will not update the backup target name in the `Status`.

Clean up system backups when deleting the default backup target. Add OwnerReferences with default backup target into system backups.

#### Special notes for your reviewer:

#### Additional documentation or context
