### PR TITLE
feat: no need to truncate block-type disk's StorageAvailable value

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -810,10 +810,13 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 		diskStatus := diskStatusMap[diskName]
 
 		if diskStatus.DiskUUID == info.DiskUUID {
-			// on the default disks this will be updated constantly since there is always something generating new disk usage (logs, etc)
-			// We also don't need byte/block precisions for this instead we can round down to the next 10/100mb
-			const truncateTo = 100 * 1024 * 1024
-			usableStorage := (diskInfoMap[diskName].DiskStat.StorageAvailable / truncateTo) * truncateTo
+			usableStorage := diskInfoMap[diskName].DiskStat.StorageAvailable
+			if diskStatus.Type == longhorn.DiskTypeFilesystem {
+				// on the default disks this will be updated constantly since there is always something generating new disk usage (logs, etc)
+				// We also don't need byte/block precisions for this instead we can round down to the next 10/100mb
+				const truncateTo = 100 * 1024 * 1024
+				usableStorage = (diskInfoMap[diskName].DiskStat.StorageAvailable / truncateTo) * truncateTo
+			}
 			diskStatus.StorageAvailable = usableStorage
 			diskStatus.StorageMaximum = diskInfoMap[diskName].DiskStat.StorageMaximum
 			diskStatus.InstanceManagerName = diskInfoMap[diskName].InstanceManagerName


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10121

#### What this PR does / why we need it:

Unlink a filesyste-type disk that contains log, etc and other files, there is no need to truncate block-type disk's StorageAvailable value.

#### Special notes for your reviewer:

#### Additional documentation or context
