### PR TITLE
fix: handle backup with non-existing snapshot and fix recurring job to correctly handle pending backup 

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -656,7 +656,7 @@ func (job *Job) doRecurringBackup() (err error) {
 		case string(longhorn.BackupStateCompleted):
 			complete = true
 			job.logger.Infof("Completed creating backup %v", info.Id)
-		case string(longhorn.BackupStateNew), string(longhorn.BackupStateInProgress):
+		case string(longhorn.BackupStateNew), string(longhorn.BackupStatePending), string(longhorn.BackupStateInProgress):
 			job.logger.Infof("Creating backup %v, current progress %v", info.Id, info.Progress)
 		case string(longhorn.BackupStateError), string(longhorn.BackupStateUnknown):
 			return fmt.Errorf("failed to create backup %v: %v", info.Id, info.Error)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -820,8 +820,14 @@ func (bc *BackupController) checkMonitor(backup *longhorn.Backup, volume *longho
 
 	snapshot, err := bc.ds.GetSnapshotRO(backup.Spec.SnapshotName)
 	if err != nil {
-		backup.Status.State = longhorn.BackupStatePending
-		backup.Status.Messages[MessageTypeReconcileInfo] = fmt.Sprintf(FailedToGetSnapshotMessage, backup.Spec.SnapshotName)
+		if apierrors.IsNotFound(err) {
+			backup.Status.Error = fmt.Sprintf("Snapshot %v not found", backup.Spec.SnapshotName)
+			backup.Status.State = longhorn.BackupStateError
+			backup.Status.LastSyncedAt = metav1.Time{Time: time.Now().UTC()}
+		} else {
+			backup.Status.State = longhorn.BackupStatePending
+			backup.Status.Messages[MessageTypeReconcileInfo] = fmt.Sprintf(FailedToGetSnapshotMessage, backup.Spec.SnapshotName)
+		}
 		return nil, errors.Wrapf(err, "failed to get the snapshot %v before enabling backup monitor", backup.Spec.SnapshotName)
 	}
 	if snapshot != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/10090

This PR has 2 commits:
1. fix: recurring job should not fail on pending backup
2. fix: backup with non-existing snapshot should be marked as errored
    Right now, backup with non-existing snapshot is stuck in pending forever.
    This is not good because it will keep the volume in attached state
    forever.
    Moreover, snapshot doesn't exist is a non-recoverable error so
    the backup should be marked as errored

### Demo:

**Before the fix**

Deploying a backup with non-existing snapshot 
```yaml
apiVersion: longhorn.io/v1beta2
kind: Backup
metadata:
  name: test-backup
  namespace: longhorn-system
  labels:
    backup-volume: pvc-34e83a41-bb6a-4406-b9d9-91fe3a8fcfbc
spec:
  backupMode: incremental
  snapshotName: non-exist-snapshot-name
```
The backup will stuck in pending state forever 
```yaml
status:
  backupCreatedAt: ""
  compressionMethod: ""
  labels: null
  lastSyncedAt: null
  messages:
    info: Failed to get the Snapshot non-exist-snapshot-name
  newlyUploadDataSize: ""
  ownerID: phan-v710-pool2-sbk7f-7dc5x
  progress: 0
  reUploadedDataSize: ""
  replicaAddress: ""
  size: ""
  snapshotCreatedAt: ""
  snapshotName: ""
  state: Pending
```
and keep the volume in attached state:
```yaml
spec:
  attachmentTickets:
    backup-controller-test-backup:
      generation: 0
      id: backup-controller-test-backup
      nodeID: phan-v710-pool2-sbk7f-9jmsr
      parameters:
        disableFrontend: any
      type: backup-controller
  volume: pvc-34e83a41-bb6a-4406-b9d9-91fe3a8fcfbc
status:
  attachmentTicketStatuses:
    backup-controller-test-backup:
      conditions:
      - lastProbeTime: ""
        lastTransitionTime: "2025-01-08T06:52:10Z"
        message: ""
        reason: ""
        status: "True"
        type: Satisfied
      generation: 0
      id: backup-controller-test-backup
      satisfied: true
```

**After the fix**

The backup is marked as error and the volume is detached
