### PR TITLE
fix: backupTargetController.bsTimerMap should be protected by lock

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -904,7 +904,11 @@ func (bst *BackupStoreTimer) Start() {
 		}
 		return false, nil
 	}); err != nil {
-		log.WithError(err).Error("Failed to sync backup target")
+		if errors.Is(err, context.Canceled) {
+			log.WithError(err).Warnf("Backup store timer for backup target %v is stopped", bst.btName)
+		} else {
+			log.WithError(err).Errorf("Failed to sync backup target %v", bst.btName)
+		}
 	}
 
 	bst.logger.Info("Stopped backup store timer")

--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -102,7 +102,7 @@ func (m *DiskMonitor) Start() {
 		return false, nil
 	}); err != nil {
 		if errors.Is(err, context.Canceled) {
-			m.logger.WithError(err).Warning("Disk monitor is stopped")
+			m.logger.WithError(err).Warn("Disk monitor is stopped")
 		} else {
 			m.logger.WithError(err).Error("Failed to start disk monitor")
 		}

--- a/controller/monitor/environment_check_monitor.go
+++ b/controller/monitor/environment_check_monitor.go
@@ -87,7 +87,7 @@ func (m *EnvironmentCheckMonitor) Start() {
 		return false, nil
 	}); err != nil {
 		if errors.Is(err, context.Canceled) {
-			m.logger.WithError(err).Warning("Environment check monitor is stopped")
+			m.logger.WithError(err).Warn("Environment check monitor is stopped")
 		} else {
 			m.logger.WithError(err).Error("Failed to start environment check monitor")
 		}

--- a/controller/monitor/fake_environment_check_monitor.go
+++ b/controller/monitor/fake_environment_check_monitor.go
@@ -51,7 +51,7 @@ func (m *FakeEnvironmentCheckMonitor) Start() {
 		return false, nil
 	}); err != nil {
 		if errors.Is(err, context.Canceled) {
-			m.logger.WithError(err).Warning("Environment check monitor is stopped")
+			m.logger.WithError(err).Warn("Environment check monitor is stopped")
 		} else {
 			m.logger.WithError(err).Error("Failed to start environment check monitor")
 		}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10190

#### What this PR does / why we need it:

There are 5 workers in each controller, so the map bsTimerMap should be protected by lock.


#### Special notes for your reviewer:

#### Additional documentation or context
