### PR TITLE
fix: incorrect field name for backup target in printcolumn

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -19,7 +19,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The current state of the pod used to provision the backing image file from source
+    - description: The current state of the pod used to provision the backing image
+        file from source
       jsonPath: .status.currentState
       name: State
       type: string
@@ -41,7 +42,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BackingImageDataSource is where Longhorn stores backing image data source object.
+        description: BackingImageDataSource is where Longhorn stores backing image
+          data source object.
         properties:
           apiVersion:
             description: |-
@@ -74,7 +76,8 @@ spec:
       jsonPath: .spec.uuid
       name: UUID
       type: string
-    - description: The current state of the pod used to provision the backing image file from source
+    - description: The current state of the pod used to provision the backing image
+        file from source
       jsonPath: .status.currentState
       name: State
       type: string
@@ -100,7 +103,8 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: BackingImageDataSource is where Longhorn stores backing image data source object.
+        description: BackingImageDataSource is where Longhorn stores backing image
+          data source object.
         properties:
           apiVersion:
             description: |-
@@ -120,7 +124,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source
+            description: BackingImageDataSourceSpec defines the desired state of the
+              Longhorn backing image data source
             properties:
               checksum:
                 type: string
@@ -148,7 +153,8 @@ spec:
                 type: string
             type: object
           status:
-            description: BackingImageDataSourceStatus defines the observed state of the Longhorn backing image data source
+            description: BackingImageDataSourceStatus defines the observed state of
+              the Longhorn backing image data source
             properties:
               checksum:
                 type: string
@@ -225,7 +231,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BackingImageManager is where Longhorn stores backing image manager object.
+        description: BackingImageManager is where Longhorn stores backing image manager
+          object.
         properties:
           apiVersion:
             description: |-
@@ -280,7 +287,8 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: BackingImageManager is where Longhorn stores backing image manager object.
+        description: BackingImageManager is where Longhorn stores backing image manager
+          object.
         properties:
           apiVersion:
             description: |-
@@ -300,7 +308,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageManagerSpec defines the desired state of the Longhorn backing image manager
+            description: BackingImageManagerSpec defines the desired state of the
+              Longhorn backing image manager
             properties:
               backingImages:
                 additionalProperties:
@@ -316,7 +325,8 @@ spec:
                 type: string
             type: object
           status:
-            description: BackingImageManagerStatus defines the observed state of the Longhorn backing image manager
+            description: BackingImageManagerStatus defines the observed state of the
+              Longhorn backing image manager
             properties:
               apiMinVersion:
                 type: integer
@@ -481,7 +491,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackingImageSpec defines the desired state of the Longhorn backing image
+            description: BackingImageSpec defines the desired state of the Longhorn
+              backing image
             properties:
               checksum:
                 type: string
@@ -510,7 +521,8 @@ spec:
               disks:
                 additionalProperties:
                   type: string
-                description: Deprecated. We are now using DiskFileSpecMap to assign different spec to the file on different disks.
+                description: Deprecated. We are now using DiskFileSpecMap to assign
+                  different spec to the file on different disks.
                 type: object
               minNumberOfCopies:
                 type: integer
@@ -536,7 +548,8 @@ spec:
                 type: string
             type: object
           status:
-            description: BackingImageStatus defines the observed state of the Longhorn backing image status
+            description: BackingImageStatus defines the observed state of the Longhorn
+              backing image status
             properties:
               checksum:
                 type: string
@@ -567,7 +580,9 @@ spec:
               ownerID:
                 type: string
               realSize:
-                description: Real size of image in bytes, which may be smaller than the size when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+                description: Real size of image in bytes, which may be smaller than
+                  the size when the file is a sparse file. Will be zero until known
+                  (e.g. while a backing image is uploading)
                 format: int64
                 type: integer
               size:
@@ -581,7 +596,9 @@ spec:
                 description: It is pending -> in-progress -> ready/failed
                 type: string
               virtualSize:
-                description: Virtual size of image in bytes, which may be larger than physical size. Will be zero until known (e.g. while a backing image is uploading)
+                description: Virtual size of image in bytes, which may be larger than
+                  physical size. Will be zero until known (e.g. while a backing image
+                  is uploading)
                 format: int64
                 type: integer
             type: object
@@ -634,7 +651,8 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: BackupBackingImage is where Longhorn stores backing image backup object.
+        description: BackupBackingImage is where Longhorn stores backing image backup
+          object.
         properties:
           apiVersion:
             description: |-
@@ -654,7 +672,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupBackingImageSpec defines the desired state of the Longhorn backing image backup
+            description: BackupBackingImageSpec defines the desired state of the Longhorn
+              backing image backup
             properties:
               backingImage:
                 description: |-
@@ -671,7 +690,8 @@ spec:
                 description: The labels of backing image backup.
                 type: object
               syncRequestedAt:
-                description: The time to request run sync the remote backing image backup.
+                description: The time to request run sync the remote backing image
+                  backup.
                 format: date-time
                 nullable: true
                 type: string
@@ -685,7 +705,8 @@ spec:
             - userCreated
             type: object
           status:
-            description: BackupBackingImageStatus defines the observed state of the Longhorn backing image backup
+            description: BackupBackingImageStatus defines the observed state of the
+              Longhorn backing image backup
             properties:
               backingImage:
                 description: The backing image name.
@@ -709,21 +730,25 @@ spec:
                 nullable: true
                 type: object
               lastSyncedAt:
-                description: The last time that the backing image backup was synced with the remote backup target.
+                description: The last time that the backing image backup was synced
+                  with the remote backup target.
                 format: date-time
                 nullable: true
                 type: string
               managerAddress:
-                description: The address of the backing image manager that runs backing image backup.
+                description: The address of the backing image manager that runs backing
+                  image backup.
                 type: string
               messages:
                 additionalProperties:
                   type: string
-                description: The error messages when listing or inspecting backing image backup.
+                description: The error messages when listing or inspecting backing
+                  image backup.
                 nullable: true
                 type: object
               ownerID:
-                description: The node ID on which the controller is responsible to reconcile this CR.
+                description: The node ID on which the controller is responsible to
+                  reconcile this CR.
                 type: string
               progress:
                 description: The backing image backup progress.
@@ -839,7 +864,7 @@ spec:
       name: SnapshotCreatedAt
       type: string
     - description: The backup target name
-      jsonPath: .status.backupTarget
+      jsonPath: .status.backupTargetName
       name: BackupTarget
       type: string
     - description: The backup state
@@ -920,21 +945,24 @@ spec:
                 nullable: true
                 type: object
               lastSyncedAt:
-                description: The last time that the backup was synced with the remote backup target.
+                description: The last time that the backup was synced with the remote
+                  backup target.
                 format: date-time
                 nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
-                description: The error messages when calling longhorn engine on listing or inspecting backups.
+                description: The error messages when calling longhorn engine on listing
+                  or inspecting backups.
                 nullable: true
                 type: object
               newlyUploadDataSize:
                 description: Size in bytes of newly uploaded data
                 type: string
               ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup CR.
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup CR.
                 type: string
               progress:
                 description: The snapshot backup progress.
@@ -1108,7 +1136,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupTargetSpec defines the desired state of the Longhorn backup target
+            description: BackupTargetSpec defines the desired state of the Longhorn
+              backup target
             properties:
               backupTargetURL:
                 description: The backup target URL.
@@ -1117,7 +1146,8 @@ spec:
                 description: The backup target credential secret.
                 type: string
               pollInterval:
-                description: The interval that the cluster needs to run sync with the backup target.
+                description: The interval that the cluster needs to run sync with
+                  the backup target.
                 type: string
               syncRequestedAt:
                 description: The time to request run sync the remote backup target.
@@ -1126,10 +1156,12 @@ spec:
                 type: string
             type: object
           status:
-            description: BackupTargetStatus defines the observed state of the Longhorn backup target
+            description: BackupTargetStatus defines the observed state of the Longhorn
+              backup target
             properties:
               available:
-                description: Available indicates if the remote backup target is available or not.
+                description: Available indicates if the remote backup target is available
+                  or not.
                 type: boolean
               conditions:
                 description: Records the reason on why the backup target is unavailable.
@@ -1139,13 +1171,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -1159,12 +1194,14 @@ spec:
                 nullable: true
                 type: array
               lastSyncedAt:
-                description: The last time that the controller synced with the remote backup target.
+                description: The last time that the controller synced with the remote
+                  backup target.
                 format: date-time
                 nullable: true
                 type: string
               ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup target CR.
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup target CR.
                 type: string
             type: object
         type: object
@@ -1280,7 +1317,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupVolumeSpec defines the desired state of the Longhorn backup volume
+            description: BackupVolumeSpec defines the desired state of the Longhorn
+              backup volume
             properties:
               backupTargetName:
                 description: The backup target name that the backup volume was synced.
@@ -1296,7 +1334,8 @@ spec:
                 type: string
             type: object
           status:
-            description: BackupVolumeStatus defines the observed state of the Longhorn backup volume
+            description: BackupVolumeStatus defines the observed state of the Longhorn
+              backup volume
             properties:
               backingImageChecksum:
                 description: the backing image checksum.
@@ -1328,18 +1367,21 @@ spec:
                 nullable: true
                 type: string
               lastSyncedAt:
-                description: The last time that the backup volume was synced into the cluster.
+                description: The last time that the backup volume was synced into
+                  the cluster.
                 format: date-time
                 nullable: true
                 type: string
               messages:
                 additionalProperties:
                   type: string
-                description: The error messages when call longhorn engine on list or inspect backup volumes.
+                description: The error messages when call longhorn engine on list
+                  or inspect backup volumes.
                 nullable: true
                 type: object
               ownerID:
-                description: The node ID on which the controller is responsible to reconcile this backup volume CR.
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup volume CR.
                 type: string
               size:
                 description: The backup volume size.
@@ -1484,7 +1526,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: EngineImageSpec defines the desired state of the Longhorn engine image
+            description: EngineImageSpec defines the desired state of the Longhorn
+              engine image
             properties:
               image:
                 minLength: 1
@@ -1493,7 +1536,8 @@ spec:
             - image
             type: object
           status:
-            description: EngineImageStatus defines the observed state of the Longhorn engine image
+            description: EngineImageStatus defines the observed state of the Longhorn
+              engine image
             properties:
               buildDate:
                 type: string
@@ -1508,13 +1552,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -1788,13 +1835,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -2064,7 +2114,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstanceManagerSpec defines the desired state of the Longhorn instance manager
+            description: InstanceManagerSpec defines the desired state of the Longhorn
+              instance manager
             properties:
               dataEngine:
                 type: string
@@ -2088,12 +2139,36 @@ spec:
                 type: string
             type: object
           status:
-            description: InstanceManagerStatus defines the observed state of the Longhorn instance manager
+            description: InstanceManagerStatus defines the observed state of the Longhorn
+              instance manager
             properties:
               apiMinVersion:
                 type: integer
               apiVersion:
                 type: integer
+              backingImages:
+                additionalProperties:
+                  properties:
+                    currentChecksum:
+                      type: string
+                    diskUUID:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    progress:
+                      type: integer
+                    size:
+                      format: int64
+                      type: integer
+                    state:
+                      type: string
+                    uuid:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
               currentState:
                 type: string
               dataEngineStatus:
@@ -2260,28 +2335,6 @@ spec:
                 type: integer
               proxyApiVersion:
                 type: integer
-              backingImages:
-                additionalProperties:
-                  properties:
-                    currentChecksum:
-                      type: string
-                    diskUUID:
-                      type: string
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    progress:
-                      type: integer
-                    size:
-                      format: int64
-                      type: integer
-                    state:
-                      type: string
-                    uuid:
-                      type: string
-                  type: object
-                type: object
             type: object
         type: object
     served: true
@@ -2326,7 +2379,8 @@ spec:
       jsonPath: .status.conditions['Ready']['status']
       name: Ready
       type: string
-    - description: Indicate whether the user disabled/enabled replica scheduling for the node
+    - description: Indicate whether the user disabled/enabled replica scheduling for
+        the node
       jsonPath: .spec.allowScheduling
       name: AllowScheduling
       type: boolean
@@ -2373,7 +2427,8 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
-    - description: Indicate whether the user disabled/enabled replica scheduling for the node
+    - description: Indicate whether the user disabled/enabled replica scheduling for
+        the node
       jsonPath: .spec.allowScheduling
       name: AllowScheduling
       type: boolean
@@ -2463,13 +2518,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -2492,13 +2550,16 @@ spec:
                             description: Last time we probed the condition.
                             type: string
                           lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
+                            description: Last time the condition transitioned from
+                              one status to another.
                             type: string
                           message:
-                            description: Human-readable message indicating details about last transition.
+                            description: Human-readable message indicating details
+                              about last transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
                             description: |-
@@ -2617,10 +2678,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: OrphanSpec defines the desired state of the Longhorn orphaned data
+            description: OrphanSpec defines the desired state of the Longhorn orphaned
+              data
             properties:
               nodeID:
-                description: The node ID on which the controller is responsible to reconcile this orphan CR.
+                description: The node ID on which the controller is responsible to
+                  reconcile this orphan CR.
                 type: string
               orphanType:
                 description: |-
@@ -2634,7 +2697,8 @@ spec:
                 type: object
             type: object
           status:
-            description: OrphanStatus defines the observed state of the Longhorn orphaned data
+            description: OrphanStatus defines the observed state of the Longhorn orphaned
+              data
             properties:
               conditions:
                 items:
@@ -2643,13 +2707,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -2691,7 +2758,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Sets groupings to the jobs. When set to "default" group will be added to the volume label when no other job label exist in volume
+    - description: Sets groupings to the jobs. When set to "default" group will be
+        added to the volume label when no other job label exist in volume
       jsonPath: .spec.groups
       name: Groups
       type: string
@@ -2750,11 +2818,13 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: Sets groupings to the jobs. When set to "default" group will be added to the volume label when no other job label exist in volume
+    - description: Sets groupings to the jobs. When set to "default" group will be
+        added to the volume label when no other job label exist in volume
       jsonPath: .spec.groups
       name: Groups
       type: string
-    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup", "backup-force-create" or "filesystem-trim"
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup",
+        "snapshot-delete", "backup", "backup-force-create" or "filesystem-trim"
       jsonPath: .spec.task
       name: Task
       type: string
@@ -2800,7 +2870,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: RecurringJobSpec defines the desired state of the Longhorn recurring job
+            description: RecurringJobSpec defines the desired state of the Longhorn
+              recurring job
             properties:
               concurrency:
                 description: The concurrency of taking the snapshot/backup.
@@ -2846,13 +2917,15 @@ spec:
                 type: string
             type: object
           status:
-            description: RecurringJobStatus defines the observed state of the Longhorn recurring job
+            description: RecurringJobStatus defines the observed state of the Longhorn
+              recurring job
             properties:
               executionCount:
                 description: The number of jobs that have been triggered.
                 type: integer
               ownerID:
-                description: The owner ID which is responsible to reconcile this recurring job CR.
+                description: The owner ID which is responsible to reconcile this recurring
+                  job CR.
                 type: string
             type: object
         type: object
@@ -3084,7 +3157,8 @@ spec:
                 type: string
             type: object
           status:
-            description: ReplicaStatus defines the observed state of the Longhorn replica
+            description: ReplicaStatus defines the observed state of the Longhorn
+              replica
             properties:
               conditions:
                 items:
@@ -3093,13 +3167,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -3352,20 +3429,25 @@ spec:
           metadata:
             type: object
           spec:
-            description: ShareManagerSpec defines the desired state of the Longhorn share manager
+            description: ShareManagerSpec defines the desired state of the Longhorn
+              share manager
             properties:
               image:
-                description: Share manager image used for creating a share manager pod
+                description: Share manager image used for creating a share manager
+                  pod
                 type: string
             type: object
           status:
-            description: ShareManagerStatus defines the observed state of the Longhorn share manager
+            description: ShareManagerStatus defines the observed state of the Longhorn
+              share manager
             properties:
               endpoint:
-                description: NFS endpoint that can access the mounted filesystem of the volume
+                description: NFS endpoint that can access the mounted filesystem of
+                  the volume
                 type: string
               ownerID:
-                description: The node ID on which the controller is responsible to reconcile this share manager resource
+                description: The node ID on which the controller is responsible to
+                  reconcile this share manager resource
                 type: string
               state:
                 description: The state of the share manager resource
@@ -3405,11 +3487,13 @@ spec:
       jsonPath: .status.creationTime
       name: CreationTime
       type: string
-    - description: Indicates if the snapshot is ready to be used to restore/backup a volume
+    - description: Indicates if the snapshot is ready to be used to restore/backup
+        a volume
       jsonPath: .status.readyToUse
       name: ReadyToUse
       type: boolean
-    - description: Represents the minimum size of volume required to rehydrate from this snapshot
+    - description: Represents the minimum size of volume required to rehydrate from
+        this snapshot
       jsonPath: .status.restoreSize
       name: RestoreSize
       type: string
@@ -3563,7 +3647,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: SupportBundleSpec defines the desired state of the Longhorn SupportBundle
+            description: SupportBundleSpec defines the desired state of the Longhorn
+              SupportBundle
             properties:
               description:
                 description: A brief description of the issue
@@ -3579,7 +3664,8 @@ spec:
             - description
             type: object
           status:
-            description: SupportBundleStatus defines the observed state of the Longhorn SupportBundle
+            description: SupportBundleStatus defines the observed state of the Longhorn
+              SupportBundle
             properties:
               conditions:
                 items:
@@ -3588,13 +3674,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -3690,7 +3779,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: SystemBackupSpec defines the desired state of the Longhorn SystemBackup
+            description: SystemBackupSpec defines the desired state of the Longhorn
+              SystemBackup
             properties:
               volumeBackupPolicy:
                 description: |-
@@ -3700,7 +3790,8 @@ spec:
                 type: string
             type: object
           status:
-            description: SystemBackupStatus defines the observed state of the Longhorn SystemBackup
+            description: SystemBackupStatus defines the observed state of the Longhorn
+              SystemBackup
             properties:
               conditions:
                 items:
@@ -3709,13 +3800,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -3737,7 +3831,8 @@ spec:
                 nullable: true
                 type: string
               lastSyncedAt:
-                description: The last time that the system backup was synced into the cluster.
+                description: The last time that the system backup was synced into
+                  the cluster.
                 format: date-time
                 nullable: true
                 type: string
@@ -3745,7 +3840,8 @@ spec:
                 description: The saved manager image.
                 type: string
               ownerID:
-                description: The node ID of the responsible controller to reconcile this SystemBackup.
+                description: The node ID of the responsible controller to reconcile
+                  this SystemBackup.
                 type: string
               state:
                 description: The system backup state.
@@ -3811,7 +3907,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: SystemRestoreSpec defines the desired state of the Longhorn SystemRestore
+            description: SystemRestoreSpec defines the desired state of the Longhorn
+              SystemRestore
             properties:
               systemBackup:
                 description: The system backup name in the object store.
@@ -3820,7 +3917,8 @@ spec:
             - systemBackup
             type: object
           status:
-            description: SystemRestoreStatus defines the observed state of the Longhorn SystemRestore
+            description: SystemRestoreStatus defines the observed state of the Longhorn
+              SystemRestore
             properties:
               conditions:
                 items:
@@ -3829,13 +3927,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-
@@ -3849,7 +3950,8 @@ spec:
                 nullable: true
                 type: array
               ownerID:
-                description: The node ID of the responsible controller to reconcile this SystemRestore.
+                description: The node ID of the responsible controller to reconcile
+                  this SystemRestore.
                 type: string
               sourceURL:
                 description: The source system backup URL.
@@ -3890,7 +3992,8 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: VolumeAttachment stores attachment information of a Longhorn volume
+        description: VolumeAttachment stores attachment information of a Longhorn
+          volume
         properties:
           apiVersion:
             description: |-
@@ -3910,7 +4013,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: VolumeAttachmentSpec defines the desired state of Longhorn VolumeAttachment
+            description: VolumeAttachmentSpec defines the desired state of Longhorn
+              VolumeAttachment
             properties:
               attachmentTickets:
                 additionalProperties:
@@ -3922,7 +4026,8 @@ spec:
                       format: int64
                       type: integer
                     id:
-                      description: The unique ID of this attachment. Used to differentiate different attachments of the same volume.
+                      description: The unique ID of this attachment. Used to differentiate
+                        different attachments of the same volume.
                       type: string
                     nodeID:
                       description: The node that this attachment is requesting
@@ -3943,7 +4048,8 @@ spec:
             - volume
             type: object
           status:
-            description: VolumeAttachmentStatus defines the observed state of Longhorn VolumeAttachment
+            description: VolumeAttachmentStatus defines the observed state of Longhorn
+              VolumeAttachment
             properties:
               attachmentTicketStatuses:
                 additionalProperties:
@@ -3956,13 +4062,16 @@ spec:
                             description: Last time we probed the condition.
                             type: string
                           lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
+                            description: Last time the condition transitioned from
+                              one status to another.
                             type: string
                           message:
-                            description: Human-readable message indicating details about last transition.
+                            description: Human-readable message indicating details
+                              about last transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
                             description: |-
@@ -3982,10 +4091,12 @@ spec:
                       format: int64
                       type: integer
                     id:
-                      description: The unique ID of this attachment. Used to differentiate different attachments of the same volume.
+                      description: The unique ID of this attachment. Used to differentiate
+                        different attachments of the same volume.
                       type: string
                     satisfied:
-                      description: Indicate whether this attachment ticket has been satisfied
+                      description: Indicate whether this attachment ticket has been
+                        satisfied
                       type: boolean
                   required:
                   - conditions
@@ -4186,7 +4297,8 @@ spec:
                 description: 'Deprecated: Replaced by field `image`.'
                 type: string
               freezeFilesystemForSnapshot:
-                description: Setting that freezes the filesystem on the root partition before a snapshot is created.
+                description: Setting that freezes the filesystem on the root partition
+                  before a snapshot is created.
                 enum:
                 - ignored
                 - enabled
@@ -4225,21 +4337,24 @@ spec:
                 - best-effort
                 type: string
               replicaDiskSoftAntiAffinity:
-                description: Replica disk soft anti affinity of the volume. Set enabled to allow replicas to be scheduled in the same disk.
+                description: Replica disk soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled in the same disk.
                 enum:
                 - ignored
                 - enabled
                 - disabled
                 type: string
               replicaSoftAntiAffinity:
-                description: Replica soft anti affinity of the volume. Set enabled to allow replicas to be scheduled on the same node.
+                description: Replica soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled on the same node.
                 enum:
                 - ignored
                 - enabled
                 - disabled
                 type: string
               replicaZoneSoftAntiAffinity:
-                description: Replica zone soft anti affinity of the volume. Set enabled to allow replicas to be scheduled in the same zone.
+                description: Replica zone soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled in the same zone.
                 enum:
                 - ignored
                 - enabled
@@ -4303,13 +4418,16 @@ spec:
                       description: Last time we probed the condition.
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: |-

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -132,7 +132,7 @@ type BackupStatus struct {
 // +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.status.snapshotName`,description="The snapshot name"
 // +kubebuilder:printcolumn:name="SnapshotSize",type=string,JSONPath=`.status.size`,description="The snapshot size"
 // +kubebuilder:printcolumn:name="SnapshotCreatedAt",type=string,JSONPath=`.status.snapshotCreatedAt`,description="The snapshot creation time"
-// +kubebuilder:printcolumn:name="BackupTarget",type=string,JSONPath=`.status.backupTarget`,description="The backup target name"
+// +kubebuilder:printcolumn:name="BackupTarget",type=string,JSONPath=`.status.backupTargetName`,description="The backup target name"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The backup state"
 // +kubebuilder:printcolumn:name="LastSyncedAt",type=string,JSONPath=`.status.lastSyncedAt`,description="The backup last synced time"
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10191

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
