### PR TITLE
fix(system-backup): handle snapshot of last backup removed

### DIFF
--- a/controller/system_backup_controller.go
+++ b/controller/system_backup_controller.go
@@ -915,11 +915,19 @@ func (c *SystemBackupController) isVolumeBackupUpToDate(volume *longhorn.Volume,
 	// Retrieve last backup and its snapshot.
 	lastBackup, err := c.ds.GetBackup(volume.Status.LastBackup)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Warnf("Last Backup %v not found for volume %v", volume.Status.LastBackup, volume.Name)
+			return false, nil
+		}
 		return false, err
 	}
 
 	lastBackupSnapshot, err := c.ds.GetSnapshot(lastBackup.Status.SnapshotName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Warnf("Snapshot %v not found for backup %v", lastBackup.Status.SnapshotName, lastBackup.Name)
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10215

#### What this PR does / why we need it:

The snapshot of the last backup of the volume might be removed. Therefore, volume backup will not be up to date and needs to create a new backup.

#### Special notes for your reviewer:

#### Additional documentation or context
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8300/ - passed