### PR TITLE
fix: bug cannot use the disk which has failed replica

### DIFF
--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -1392,6 +1392,7 @@ func (s *TestSuite) TestFilterDisksWithMatchingReplicas(c *C) {
 		inputDiskUUIDs       []string
 		inputReplicas        map[string]*longhorn.Replica
 		diskSoftAntiAffinity bool
+		ignoreFailedReplicas bool
 
 		expectDiskUUIDs []string
 	}
@@ -1454,6 +1455,7 @@ func (s *TestSuite) TestFilterDisksWithMatchingReplicas(c *C) {
 		replica4.Name: replica4,
 	}
 	tc.diskSoftAntiAffinity = true
+	tc.ignoreFailedReplicas = false
 	tc.expectDiskUUIDs = []string{diskUUID5} // Only disk5 has no matching replica.
 	tests["only schedule to disk without matching replica"] = tc
 
@@ -1463,7 +1465,7 @@ func (s *TestSuite) TestFilterDisksWithMatchingReplicas(c *C) {
 		for _, UUID := range tc.inputDiskUUIDs {
 			inputDisks[UUID] = &Disk{}
 		}
-		outputDiskUUIDs := filterDisksWithMatchingReplicas(inputDisks, tc.inputReplicas, tc.diskSoftAntiAffinity)
+		outputDiskUUIDs := filterDisksWithMatchingReplicas(inputDisks, tc.inputReplicas, tc.diskSoftAntiAffinity, tc.ignoreFailedReplicas)
 		c.Assert(len(outputDiskUUIDs), Equals, len(tc.expectDiskUUIDs))
 		for _, UUID := range tc.expectDiskUUIDs {
 			_, ok := outputDiskUUIDs[UUID]


### PR DESCRIPTION
**Root cause:**

The root cause of the issue longhorn/longhorn#10210 with [the reproducing steps ](https://github.com/longhorn/longhorn/issues/10210#issuecomment-2594392777) is that when `Replica Disk Level Soft Anti-Affinity` is `false`, Longhorn never considers a disk which contains a failed replica as a valid candidate.

**Propose solution:**

We should not exclude the disk which has failed replica in 2 cases:
1. The caller is trying to reuse the failed replica, this disk is a valid candidate
2. The failed replica is no longer reusable, this disk is a valid candidate


**Test plan:** 

https://github.com/longhorn/longhorn/issues/10210#issuecomment-2600594553

longhorn/longhorn#10210


