### PR TITLE
feat(backup): delete snapshot immediately  after backup completed

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -137,6 +137,7 @@ const (
 	SettingNameV2DataEngineFastReplicaRebuilding                        = SettingName("v2-data-engine-fast-replica-rebuilding")
 	SettingNameFreezeFilesystemForSnapshot                              = SettingName("freeze-filesystem-for-snapshot")
 	SettingNameAutoCleanupSnapshotWhenDeleteBackup                      = SettingName("auto-cleanup-when-delete-backup")
+	SettingNameAutoCleanupSnapshotAfterOnDemandBackupCompleted          = SettingName("auto-cleanup-snapshot-after-on-demand-backup-completed")
 	SettingNameDefaultMinNumberOfBackingImageCopies                     = SettingName("default-min-number-of-backing-image-copies")
 	SettingNameBackupExecutionTimeout                                   = SettingName("backup-execution-timeout")
 	SettingNameRWXVolumeFastFailover                                    = SettingName("rwx-volume-fast-failover")
@@ -236,6 +237,7 @@ var (
 		SettingNameDisableSnapshotPurge,
 		SettingNameFreezeFilesystemForSnapshot,
 		SettingNameAutoCleanupSnapshotWhenDeleteBackup,
+		SettingNameAutoCleanupSnapshotAfterOnDemandBackupCompleted,
 		SettingNameDefaultMinNumberOfBackingImageCopies,
 		SettingNameBackupExecutionTimeout,
 		SettingNameRWXVolumeFastFailover,
@@ -357,6 +359,7 @@ var (
 		SettingNameDisableSnapshotPurge:                                     SettingDefinitionDisableSnapshotPurge,
 		SettingNameFreezeFilesystemForSnapshot:                              SettingDefinitionFreezeFilesystemForSnapshot,
 		SettingNameAutoCleanupSnapshotWhenDeleteBackup:                      SettingDefinitionAutoCleanupSnapshotWhenDeleteBackup,
+		SettingNameAutoCleanupSnapshotAfterOnDemandBackupCompleted:          SettingDefinitionAutoCleanupSnapshotAfterOnDemandBackupCompleted,
 		SettingNameDefaultMinNumberOfBackingImageCopies:                     SettingDefinitionDefaultMinNumberOfBackingImageCopies,
 		SettingNameBackupExecutionTimeout:                                   SettingDefinitionBackupExecutionTimeout,
 		SettingNameRWXVolumeFastFailover:                                    SettingDefinitionRWXVolumeFastFailover,
@@ -1473,6 +1476,16 @@ var (
 	SettingDefinitionAutoCleanupSnapshotWhenDeleteBackup = SettingDefinition{
 		DisplayName: "Automatically Cleanup Snapshot When Deleting Backup",
 		Description: "This setting enables Longhorn to automatically cleanup snapshots when removing backup.",
+		Category:    SettingCategorySnapshot,
+		Type:        SettingTypeBool,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "false",
+	}
+
+	SettingDefinitionAutoCleanupSnapshotAfterOnDemandBackupCompleted = SettingDefinition{
+		DisplayName: "Automatically Cleanup Snapshot After On-Demand Backup Completed",
+		Description: "This setting allows users to trigger automatically delete the backup snapshot after the on-demand backup is completed.",
 		Category:    SettingCategorySnapshot,
 		Type:        SettingTypeBool,
 		Required:    true,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9213

#### What this PR does / why we need it:

- Introduce a new boolean field `Spec.CleanupBackupSnasphot` to check if it needs to delete the snapshot after the backup is completed when doing a recurring job.
- Introduce a new field `Spec.CleanupSnapshot` to specify the backup will delete the snapshot after the backup is completed.

#### Special notes for your reviewer:

#### Additional documentation or context
