### PR TITLE
fix: do not panic when looking up BackupVolume of non-existing Volume

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -317,7 +317,7 @@ func (s *Server) BackupGet(w http.ResponseWriter, req *http.Request) error {
 	}
 	backupVolumeName := mux.Vars(req)["backupVolumeName"]
 
-	backup, err := s.m.GetBackup(input.Name, backupVolumeName)
+	backup, err := s.m.GetBackup(input.Name)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get backup '%v' of volume '%v'", input.Name, backupVolumeName)
 	}
@@ -344,13 +344,13 @@ func (s *Server) BackupDelete(w http.ResponseWriter, req *http.Request) error {
 
 	backupVolumeName := mux.Vars(req)["backupVolumeName"]
 
-	backup, err := s.m.GetBackup(input.Name, backupVolumeName)
+	backup, err := s.m.GetBackup(input.Name)
 	if err != nil {
 		logrus.WithError(err).Warnf("failed to get backup '%v' of volume '%v'", input.Name, backupVolumeName)
 	}
 
 	if backup != nil {
-		if err := s.m.DeleteBackup(input.Name, backupVolumeName); err != nil {
+		if err := s.m.DeleteBackup(input.Name); err != nil {
 			return errors.Wrapf(err, "failed to delete backup '%v' of volume '%v'", input.Name, backupVolumeName)
 		}
 	}

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -527,10 +527,10 @@ func (m *VolumeManager) ListBackupsForBackupVolumeSorted(backupVolumeName string
 	return backups, nil
 }
 
-func (m *VolumeManager) GetBackup(backupName, volumeName string) (*longhorn.Backup, error) {
+func (m *VolumeManager) GetBackup(backupName string) (*longhorn.Backup, error) {
 	return m.ds.GetBackupRO(backupName)
 }
 
-func (m *VolumeManager) DeleteBackup(backupName, volumeName string) error {
+func (m *VolumeManager) DeleteBackup(backupName string) error {
 	return m.ds.DeleteBackup(backupName)
 }


### PR DESCRIPTION
1. One Volume can have multiple BackupVolumes, need to check all BackupVolumes when finding backups
2. It is totally valid to look up BackupVolumes of non-existing Volume. A deleted Volume can still have Backups in the cluster. Do not panic

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/longhorn/longhorn/issues/10303

#### Special notes for your reviewer:

Putting this PR as draft. Need @mantissahz to help to review the multiple backup target logic 