### PR TITLE
fix: fix volume not ready for workload condition

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1491,8 +1491,16 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 		}
 	}
 
+	allReplicaScheduled := true
+	if len(vrs) == 0 {
+		allReplicaScheduled = false
+	}
 	replicas := []Replica{}
 	for _, r := range vrs {
+		if r.Spec.NodeID == "" {
+			allReplicaScheduled = false
+		}
+
 		mode := ""
 		if ve != nil && ve.Status.ReplicaModeMap != nil {
 			mode = string(ve.Status.ReplicaModeMap[r.Name])
@@ -1568,7 +1576,7 @@ func toVolumeResource(v *longhorn.Volume, ves []*longhorn.Engine, vrs []*longhor
 	isCloningDesired := types.IsDataFromVolume(v.Spec.DataSource)
 	isCloningCompleted := v.Status.CloneStatus.State == longhorn.VolumeCloneStateCompleted
 	if (v.Spec.NodeID == "" && v.Status.State != longhorn.VolumeStateDetached) ||
-		(v.Status.State == longhorn.VolumeStateDetached && scheduledCondition.Status != longhorn.ConditionStatusTrue) ||
+		(v.Status.State == longhorn.VolumeStateDetached && (scheduledCondition.Status != longhorn.ConditionStatusTrue && !allReplicaScheduled)) ||
 		v.Status.Robustness == longhorn.VolumeRobustnessFaulted ||
 		v.Status.RestoreRequired ||
 		(isCloningDesired && !isCloningCompleted) {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9938

Currently there is a chance that when the volume is detached and the `len(rs) != numOfReplicas`, the `scheduledCondition` won't be set back to True even all the current replicas are scheduled.

This can happen when 
1. Volume with 2 replica (A & B) has best-effort locality and attached to node-X
2. The new replica-X can't be scheduled to the node-X due to node is cordoned. Volume `scheduledCondition` is False
3. Another replica-A on node-A becomes faulted because the node-A is also cordoned and the instance-manager is deleted somehow.
4. replica-A will be deleted due to stale time.
5. replica-X will be deleted when the volume is detached due to `replica.Spec.RebuildRetryCount = scheduler.FailedReplicaMaxRetryCount`
6. now the volume is detached and since `len(rs) != numOfReplicas`, the `scheduledCondition` will always be False

We should consider it is ready for workload in api when all the current replicas are still scheduled.