### PR TITLE
fix: should find the volume name of a pv from pv.Spec.CSI.VolumeHandle

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -634,7 +634,7 @@ func (kc *KubernetesPodController) getAssociatedVolumes(pod *corev1.Pod) ([]*lon
 		}
 
 		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == types.LonghornDriverName {
-			vol, err := kc.ds.GetVolume(pv.GetName())
+			vol, err := kc.ds.GetVolume(pv.Spec.CSI.VolumeHandle)
 			if datastore.ErrorIsNotFound(err) {
 				log.WithError(err).Warn("Cannot auto-delete Pod when the associated Volume is not found")
 				continue


### PR DESCRIPTION
pv is not always the same as pv.Spec.CSI.VolumeHandle and pv.Spec.CSI.VolumeHandle is always the same as longhorn volume name

longhorn/longhorn#10314

More details is at https://github.com/longhorn/longhorn/issues/10314#issuecomment-2632648534

