### PR TITLE
fix: workload pod will be able to move to new node when backup operation is taking a long time

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -602,12 +602,8 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 
 	return cs.unpublishVolume(volume, nodeID, attachmentID, func() error {
 		checkVolumeUnpublished := func(vol *longhornclient.Volume) bool {
-			isRegularRWXVolume := vol.AccessMode == string(longhorn.AccessModeReadWriteMany) && !vol.Migratable
 			_, ok := vol.VolumeAttachment.Attachments[attachmentID]
-			if isRegularRWXVolume {
-				return !ok
-			}
-			return !ok && !isVolumeAvailableOn(vol, nodeID)
+			return !ok
 		}
 
 		if !cs.waitForVolumeState(volumeID, "volume unpublished", checkVolumeUnpublished, false, true) {


### PR DESCRIPTION
Reverting the commit
https://github.com/longhorn/longhorn-manager/commit/473b6d4b29c16e42ddb5019769396a33d76d9d2c because I cannot see the reason why we need to refuse the csi detachment when the volume is currently attached for operation such as backup/snapshot

Futher more, reading the design decision at
https://github.com/longhorn/longhorn/issues/8735#issuecomment-2177309258, I think we don't really need that commit
(https://github.com/longhorn/longhorn-manager/commit/473b6d4b29c16e42ddb5019769396a33d76d9d2c)

longhorn/longhorn#10171


