### PR TITLE
fix: empty string of backup.status.size

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -970,6 +970,7 @@ spec:
                 description: The address of the replica that runs snapshot backup.
                 type: string
               size:
+                default: "0"
                 description: The snapshot size.
                 type: string
               snapshotCreatedAt:
@@ -998,6 +999,8 @@ spec:
               volumeSize:
                 description: The volume size.
                 type: string
+            required:
+            - size
             type: object
         type: object
     served: true

--- a/k8s/pkg/apis/longhorn/v1beta2/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/backup.go
@@ -84,7 +84,7 @@ type BackupStatus struct {
 	// +optional
 	BackupCreatedAt string `json:"backupCreatedAt"`
 	// The snapshot size.
-	// +optional
+	// +kubebuilder:default="0"
 	Size string `json:"size"`
 	// The labels of snapshot backup.
 	// +optional

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -31,6 +31,7 @@ import (
 	"github.com/longhorn/longhorn-manager/upgrade/v16xto170"
 	"github.com/longhorn/longhorn-manager/upgrade/v170to171"
 	"github.com/longhorn/longhorn-manager/upgrade/v17xto180"
+	"github.com/longhorn/longhorn-manager/upgrade/v18xto190"
 	"github.com/longhorn/longhorn-manager/upgrade/v1beta1"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -283,6 +284,12 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 			return err
 		}
 	}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.9.0") < 0 {
+		logrus.Info("Walking through the resource upgrade path v1.8.x to v1.9.0")
+		if err := v18xto190.UpgradeResources(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
 	if err := upgradeutil.UpdateResources(namespace, lhClient, resourceMaps); err != nil {
 		return err
 	}
@@ -313,6 +320,12 @@ func doResourceUpgrade(namespace string, lhClient *lhclientset.Clientset, kubeCl
 	if semver.Compare(lhVersionBeforeUpgrade, "v1.8.0") < 0 {
 		logrus.Info("Walking through the resource status upgrade path v1.7.x to v1.8.0")
 		if err := v17xto180.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	if semver.Compare(lhVersionBeforeUpgrade, "v1.9.0") < 0 {
+		logrus.Info("Walking through the resource status upgrade path v1.8.x to v1.9.0")
+		if err := v18xto190.UpgradeResourcesStatus(namespace, lhClient, kubeClient, resourceMaps); err != nil {
 			return err
 		}
 	}

--- a/upgrade/v18xto190/upgrade.go
+++ b/upgrade/v18xto190/upgrade.go
@@ -1,0 +1,51 @@
+package v18xto190
+
+import (
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clientset "k8s.io/client-go/kubernetes"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.8.x to v1.9.0: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	if resourceMaps == nil {
+		return errors.New("resourceMaps cannot be nil")
+	}
+
+	return nil
+}
+
+func UpgradeResourcesStatus(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	if resourceMaps == nil {
+		return errors.New("resourceMaps cannot be nil")
+	}
+	return upgradeBackupStatus(namespace, lhClient, resourceMaps)
+}
+
+func upgradeBackupStatus(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade backups failed")
+	}()
+
+	backupMap, err := upgradeutil.ListAndUpdateBackupsInProvidedCache(namespace, lhClient, resourceMaps)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list all existing Longhorn backups during the backup status upgrade")
+	}
+
+	for _, b := range backupMap {
+		if b.Status.Size == "" {
+			b.Status.Size = "0"
+		}
+	}
+	return nil
+}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10358

#### What this PR does / why we need it:

The data type of backup.status.size is string. If backup is failed and the size is not set to "0". The metrics collect will fail to parse it.

- The default value of backup.status.size should be "0"
- Update the existing backups with backup.status.size == "" to "0"

#### Special notes for your reviewer:

#### Additional documentation or context
