### PR TITLE
chore(vendor): update k8s.io/client-go to v0.32.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/cli-runtime v0.32.1
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.32.1
 	k8s.io/kubernetes v1.32.1
 	k8s.io/metrics v0.32.1
 	k8s.io/mount-utils v0.32.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1089,7 +1089,7 @@ k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics
 # k8s.io/cli-runtime v0.32.1 => k8s.io/cli-runtime v0.32.1
 ## explicit; go 1.23.0
 k8s.io/cli-runtime/pkg/printers
-# k8s.io/client-go v1.5.2 => k8s.io/client-go v0.32.1
+# k8s.io/client-go v0.32.1 => k8s.io/client-go v0.32.1
 ## explicit; go 1.23.0
 k8s.io/client-go/applyconfigurations
 k8s.io/client-go/applyconfigurations/admissionregistration/v1


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

longhorn/cli complains the v1.5.2 is incompatible.

https://github.com/longhorn/cli/pull/168

#### Special notes for your reviewer:

#### Additional documentation or context
