### PR TITLE
fix(log): reduce auto balancing logging noise for detached volumes

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2966,7 +2966,9 @@ func (c *VolumeController) getNodeCandidatesForAutoBalanceZone(v *longhorn.Volum
 	}
 
 	if v.Status.Robustness != longhorn.VolumeRobustnessHealthy {
-		log.Warnf("Failed to auto-balance volume in %s state", v.Status.Robustness)
+		if v.Status.State != longhorn.VolumeStateDetached { // Detached volumes are not "healthy". Hence, it would cause excessive logging periodically for detached volumes
+			log.Warnf("Failed to auto-balance volume in %s robustness and %s state", v.Status.Robustness, v.Status.State)
+		}
 		return candidateNames
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#10302

#### What this PR does / why we need it:

Reduce auto balancing logging noise for detached volumes. This might also be confusing and prompt people to investigate these messages are errors (they are warning) - at least I did

#### Special notes for your reviewer:

#### Additional documentation or context
