### PR TITLE
fix: fix the false alarm while stopping syncing backup status

### DIFF
--- a/engineapi/backup_monitor.go
+++ b/engineapi/backup_monitor.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -209,7 +210,11 @@ func (m *BackupMonitor) linerTimer() {
 		m.syncCallBack(currentBackupStatus)
 		return false, nil
 	}); err != nil {
-		m.logger.WithError(err).Error("Failed to sync backup status")
+		if errors.Is(err, context.Canceled) {
+			m.logger.WithError(err).Warn("Sync backup status canceled")
+		} else {
+			m.logger.WithError(err).Error("Failed to sync backup status")
+		}
 	}
 }
 


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10301

#### What this PR does / why we need it:

Use warning-level messages for context cancellation.

#### Special notes for your reviewer:

#### Additional documentation or context
