### PR TITLE
fix: fix nil pointer if the record in the status but not in the spec

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1637,7 +1637,7 @@ func (nc *NodeController) syncBackingImageEvictionRequested(node *longhorn.Node)
 			}
 		} else {
 			for _, backingImage := range diskBackingImageMap[diskUUID] {
-				if backingImage.Spec.DiskFileSpecMap[diskUUID].EvictionRequested {
+				if diskFileSpec, ok := backingImage.Spec.DiskFileSpecMap[diskUUID]; ok && diskFileSpec.EvictionRequested {
 					// if it is previously set to true, cancel the eviction request
 					backingImage.Spec.DiskFileSpecMap[diskUUID].EvictionRequested = false
 					backingImagesToSync = append(backingImagesToSync, backingImageToSync{backingImage, diskUUID, false})


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10464


There is a chance that the disk in the spec is deleted first, but the status is not reflected yet
Then when the node/disk is eviction requested, the lookup map is build from the status
And since we are going to check and update the spec.evictionRequested, It will hit the nil pointer issue.

disk is deleted from the spec means it is going to be deleted, we don't need to update/check the evictionRequested in this case.
skip it if it is not in the spec.