### PR TITLE
fix(scheduler): integer divided by zero panic

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2618,6 +2618,10 @@ func (c *VolumeController) checkReplicaDiskPressuredSchedulableCandidates(volume
 			continue
 		}
 
+		if types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeSchedulable).Status != longhorn.ConditionStatusTrue {
+			continue
+		}
+
 		diskInfo, err := c.scheduler.GetDiskSchedulingInfo(diskSpec, diskStatus)
 		if err != nil {
 			log.WithError(err).Debugf("Failed to get disk scheduling info for disk %v on node %v", diskName, nodeCandidate.Name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10502

#### What this PR does / why we need it:

Fix `Panic: runtime error: integer divide by zero` during `IsSchedulableToDiskConsiderDiskPressure()`.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
