### PR TITLE
fix(csi): check if the backup target is available before creating a backup

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -296,6 +296,21 @@ func (s *Server) BackupListByBackupVolume(w http.ResponseWriter, req *http.Reque
 	return nil
 }
 
+func (s *Server) BackupListByVolume(w http.ResponseWriter, req *http.Request) error {
+	var input Volume
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+
+	bs, err := s.m.ListBackupsForVolumeNameSorted(input.Name)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list backups for volume '%s'", input.Name)
+	}
+	apiContext.Write(toBackupCollection(bs))
+	return nil
+}
+
 func (s *Server) backupListAll(apiContext *api.ApiContext) (*client.GenericCollection, error) {
 	bs, err := s.m.ListAllBackupsSorted()
 	if err != nil {

--- a/api/model.go
+++ b/api/model.go
@@ -928,6 +928,10 @@ func backupVolumeSchema(backupVolume *client.Schema) {
 		"backupList": {
 			Output: "backupListOutput",
 		},
+		"backupListByVolume": {
+			Input:  "volume",
+			Output: "backupListOutput",
+		},
 		"backupGet": {
 			Input:  "backupInput",
 			Output: "backup",
@@ -1887,10 +1891,11 @@ func toBackupVolumeResource(bv *longhorn.BackupVolume, apiContext *api.ApiContex
 		VolumeName:           bv.Spec.VolumeName,
 	}
 	b.Actions = map[string]string{
-		"backupList":       apiContext.UrlBuilder.ActionLink(b.Resource, "backupList"),
-		"backupGet":        apiContext.UrlBuilder.ActionLink(b.Resource, "backupGet"),
-		"backupDelete":     apiContext.UrlBuilder.ActionLink(b.Resource, "backupDelete"),
-		"backupVolumeSync": apiContext.UrlBuilder.ActionLink(b.Resource, "backupVolumeSync"),
+		"backupList":         apiContext.UrlBuilder.ActionLink(b.Resource, "backupList"),
+		"backupListByVolume": apiContext.UrlBuilder.ActionLink(b.Resource, "backupListByVolume"),
+		"backupGet":          apiContext.UrlBuilder.ActionLink(b.Resource, "backupGet"),
+		"backupDelete":       apiContext.UrlBuilder.ActionLink(b.Resource, "backupDelete"),
+		"backupVolumeSync":   apiContext.UrlBuilder.ActionLink(b.Resource, "backupVolumeSync"),
 	}
 	return b
 }

--- a/api/router.go
+++ b/api/router.go
@@ -138,10 +138,11 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/backupvolumes/{backupVolumeName}").Handler(f(schemas, s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupVolumeGet)))
 	r.Methods("DELETE").Path("/v1/backupvolumes/{backupVolumeName}").Handler(f(schemas, s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupVolumeDelete)))
 	backupActions := map[string]func(http.ResponseWriter, *http.Request) error{
-		"backupList":       s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupListByBackupVolume),
-		"backupGet":        s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupGet),
-		"backupDelete":     s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupDelete),
-		"backupVolumeSync": s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.SyncBackupVolume),
+		"backupList":         s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupListByBackupVolume),
+		"backupListByVolume": s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupListByVolume),
+		"backupGet":          s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupGet),
+		"backupDelete":       s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.BackupDelete),
+		"backupVolumeSync":   s.fwd.Handler(s.fwd.HandleProxyRequestByNodeID, s.fwd.GetHTTPAddressByNodeID(NodeHasDefaultEngineImage(s.m)), s.SyncBackupVolume),
 	}
 	for name, action := range backupActions {
 		r.Methods("POST").Path("/v1/backupvolumes/{backupVolumeName}").Queries("action", name).Handler(f(schemas, action))

--- a/client/generated_backup_volume.go
+++ b/client/generated_backup_volume.go
@@ -56,6 +56,8 @@ type BackupVolumeOperations interface {
 	ActionBackupGet(*BackupVolume, *BackupInput) (*Backup, error)
 
 	ActionBackupList(*BackupVolume) (*BackupListOutput, error)
+
+	ActionBackupListByVolume(*BackupVolume, *Volume) (*BackupListOutput, error)
 }
 
 func newBackupVolumeClient(rancherClient *RancherClient) *BackupVolumeClient {
@@ -131,6 +133,15 @@ func (c *BackupVolumeClient) ActionBackupList(resource *BackupVolume) (*BackupLi
 	resp := &BackupListOutput{}
 
 	err := c.rancherClient.doAction(BACKUP_VOLUME_TYPE, "backupList", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *BackupVolumeClient) ActionBackupListByVolume(resource *BackupVolume, input *Volume) (*BackupListOutput, error) {
+
+	resp := &BackupListOutput{}
+
+	err := c.rancherClient.doAction(BACKUP_VOLUME_TYPE, "backupListByVolume", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -835,6 +835,17 @@ func (cs *ControllerServer) createCSISnapshotTypeLonghornBackup(req *csi.CreateS
 		return nil, status.Errorf(codes.NotFound, "volume %s not found", csiVolumeName)
 	}
 
+	existBackupTarget, err := cs.apiClient.BackupTarget.ById(existVol.BackupTargetName)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if existBackupTarget == nil {
+		return nil, status.Errorf(codes.NotFound, "backup target %s not found", existVol.BackupTargetName)
+	}
+	if !existBackupTarget.Available {
+		return nil, status.Errorf(codes.Aborted, "backup target %s is not available", existVol.BackupTargetName)
+	}
+
 	var snapshotCR *longhornclient.SnapshotCR
 	snapshotCRs, err := cs.apiClient.Volume.ActionSnapshotCRList(existVol)
 	if err != nil {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -4615,6 +4615,35 @@ func (s *DataStore) CreateBackup(backup *longhorn.Backup, backupVolumeName strin
 	return ret.DeepCopy(), nil
 }
 
+func (s *DataStore) listBackupsWithVolNameRO(volName, btName string) ([]*longhorn.Backup, error) {
+	selector, err := getBackupVolumeSelector(volName)
+	if err != nil {
+		return nil, err
+	}
+	if btName != "" {
+		selector, err = getBackupVolumeWithBackupTargetSelector(btName, volName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s.backupLister.Backups(s.namespace).List(selector)
+}
+
+// ListBackupsWithVolumeNameRO returns an object contains all read-only backups in the cluster Backups CR
+// of a given volume name and a optional backup target name
+func (s *DataStore) ListBackupsWithVolumeNameRO(volumeName, backupTargetName string) (map[string]*longhorn.Backup, error) {
+	list, err := s.listBackupsWithVolNameRO(volumeName, backupTargetName)
+	if err != nil {
+		return nil, err
+	}
+
+	itemMap := map[string]*longhorn.Backup{}
+	for _, itemRO := range list {
+		itemMap[itemRO.Name] = itemRO
+	}
+	return itemMap, nil
+}
+
 func (s *DataStore) listBackupsWithBTAndVolNameRO(btName, volName string) ([]*longhorn.Backup, error) {
 	selector, err := getBackupVolumeWithBackupTargetSelector(btName, volName)
 	if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10501

#### What this PR does / why we need it:

- check if the backup target is available before starting the backup process.
- refactor the function 'getBackup' to fix that it keeps creating backups if the backup target is unavailable.
- add a new API `backupListByVolume` to list backups with the volume name (and backup target if it has.)

#### Special notes for your reviewer:

#### Additional documentation or context
Regression test: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8274/
