### PR TITLE
feat: move SettingNameV2DataEngineHugepageLimit to danger zone settings

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -1361,7 +1361,7 @@ var (
 	SettingDefinitionV2DataEngineHugepageLimit = SettingDefinition{
 		DisplayName: "Hugepage Size for V2 Data Engine",
 		Description: "Hugepage size in MiB for v2 data engine",
-		Category:    SettingCategoryV2DataEngine,
+		Category:    SettingCategoryDangerZone,
 		Type:        SettingTypeInt,
 		Required:    true,
 		ReadOnly:    true,


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7746

#### What this PR does / why we need it:

The huge page setting for v2 IM should belong to danger zone settings as CPU requests, as it's related to resource change. It should be eventually applied in the same as other dangerous settings.


#### Special notes for your reviewer:

#### Additional documentation or context
