### PR TITLE
feat(k8s): deprecates v1beta1

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -70,7 +70,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -262,7 +262,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -453,7 +453,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -854,7 +854,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1099,7 +1099,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1287,7 +1287,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1496,7 +1496,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -1699,7 +1699,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2094,7 +2094,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2448,7 +2448,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -2846,7 +2846,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3042,7 +3042,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3314,7 +3314,7 @@ spec:
         required:
         - value
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -3433,7 +3433,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -4238,7 +4238,7 @@ spec:
           status:
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -39,6 +39,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageDataSource is deprecated;
+      use longhorn.io/v1beta2 BackingImageDataSource instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -228,6 +231,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImageManager is deprecated; use
+      longhorn.io/v1beta2 BackingImageManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -417,6 +423,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2
+      BackingImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -815,6 +824,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2
+      Backup instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1057,6 +1069,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2
+      BackupTarget instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1242,6 +1257,9 @@ spec:
       jsonPath: .status.lastSyncedAt
       name: LastSyncedAt
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2
+      BackupVolume instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1448,6 +1466,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2
+      EngineImage instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1648,6 +1669,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2
+      Engine instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2040,6 +2064,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2
+      InstanceManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2391,6 +2418,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2
+      Node instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2786,6 +2816,9 @@ spec:
       jsonPath: .spec.labels
       name: Labels
       type: string
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2
+      RecurringJob instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -2979,6 +3012,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2
+      Replica instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3248,6 +3284,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2
+      Setting instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -3364,6 +3403,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2
+      ShareManager instead
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -4166,6 +4208,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2
+      Volume instead
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -63,6 +63,8 @@ type BackingImageStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbi
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2 BackingImage instead"
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="The backing image name"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimage.go
@@ -62,6 +62,7 @@ type BackingImageStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbi
+// +kubebuilder:unservedversion
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2 BackingImage instead"

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
@@ -40,6 +40,8 @@ type BackingImageDataSourceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbids
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImageDataSource is deprecated; use longhorn.io/v1beta2 BackingImageDataSource instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the pod used to provision the backing image file from source"
 // +kubebuilder:printcolumn:name="SourceType",type=string,JSONPath=`.spec.sourceType`,description="The data source type"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeID`,description="The node the backing image file will be prepared on"

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagedatasource.go
@@ -40,6 +40,7 @@ type BackingImageDataSourceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbids
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImageDataSource is deprecated; use longhorn.io/v1beta2 BackingImageDataSource instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the pod used to provision the backing image file from source"

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
@@ -54,6 +54,7 @@ type BackingImageManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbim
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImageManager is deprecated; use longhorn.io/v1beta2 BackingImageManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the manager"

--- a/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backingimagemanager.go
@@ -54,6 +54,8 @@ type BackingImageManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbim
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackingImageManager is deprecated; use longhorn.io/v1beta2 BackingImageManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the manager"
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="The image the manager pod will use"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeID`,description="The node the manager is on"

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -66,6 +66,8 @@ type BackupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhb
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2 Backup instead"
 // +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.status.snapshotName`,description="The snapshot name"
 // +kubebuilder:printcolumn:name="SnapshotSize",type=string,JSONPath=`.status.size`,description="The snapshot size"
 // +kubebuilder:printcolumn:name="SnapshotCreatedAt",type=string,JSONPath=`.status.snapshotCreatedAt`,description="The snapshot creation time"

--- a/k8s/pkg/apis/longhorn/v1beta1/backup.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backup.go
@@ -66,6 +66,7 @@ type BackupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhb
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2 Backup instead"
 // +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.status.snapshotName`,description="The snapshot name"

--- a/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
@@ -45,6 +45,8 @@ type BackupTargetStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbt
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2 BackupTarget instead"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.backupTargetURL`,description="The backup target URL"
 // +kubebuilder:printcolumn:name="Credential",type=string,JSONPath=`.spec.credentialSecret`,description="The backup target credential secret"
 // +kubebuilder:printcolumn:name="LastBackupAt",type=string,JSONPath=`.spec.pollInterval`,description="The backup target poll interval"

--- a/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backuptarget.go
@@ -45,6 +45,7 @@ type BackupTargetStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbt
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2 BackupTarget instead"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.backupTargetURL`,description="The backup target URL"

--- a/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
@@ -40,6 +40,7 @@ type BackupVolumeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbv
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2 BackupVolume instead"
 // +kubebuilder:printcolumn:name="CreatedAt",type=string,JSONPath=`.status.createdAt`,description="The backup volume creation time"

--- a/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/backupvolume.go
@@ -40,6 +40,8 @@ type BackupVolumeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhbv
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2 BackupVolume instead"
 // +kubebuilder:printcolumn:name="CreatedAt",type=string,JSONPath=`.status.createdAt`,description="The backup volume creation time"
 // +kubebuilder:printcolumn:name="LastBackupName",type=string,JSONPath=`.status.lastBackupName`,description="The backup volume last backup name"
 // +kubebuilder:printcolumn:name="LastBackupAt",type=string,JSONPath=`.status.lastBackupAt`,description="The backup volume last backup time"

--- a/k8s/pkg/apis/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engine.go
@@ -103,6 +103,7 @@ type EngineStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhe
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2 Engine instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the engine"

--- a/k8s/pkg/apis/longhorn/v1beta1/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engine.go
@@ -103,6 +103,8 @@ type EngineStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhe
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2 Engine instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the engine"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeID`,description="The node that the engine is on"
 // +kubebuilder:printcolumn:name="InstanceManager",type=string,JSONPath=`.status.instanceManagerName`,description="The instance manager of the engine"

--- a/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
@@ -61,6 +61,7 @@ type EngineImageStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhei
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2 EngineImage instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="State of the engine image"

--- a/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/engineimage.go
@@ -61,6 +61,8 @@ type EngineImageStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhei
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2 EngineImage instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="State of the engine image"
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="The Longhorn engine image"
 // +kubebuilder:printcolumn:name="RefCount",type=integer,JSONPath=`.status.refCount`,description="Number of resources using the engine image"

--- a/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
@@ -104,6 +104,7 @@ type InstanceManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhim
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2 InstanceManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The state of the instance manager"

--- a/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/instancemanager.go
@@ -104,6 +104,8 @@ type InstanceManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhim
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2 InstanceManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The state of the instance manager"
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`,description="The type of the instance manager (engine or replica)"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeID`,description="The node that the instance manager is running on"

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -80,6 +80,7 @@ type NodeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhn
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2 Node instead"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions['Ready']['status']`,description="Indicate whether the node is ready"

--- a/k8s/pkg/apis/longhorn/v1beta1/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/node.go
@@ -80,6 +80,8 @@ type NodeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhn
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2 Node instead"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions['Ready']['status']`,description="Indicate whether the node is ready"
 // +kubebuilder:printcolumn:name="AllowScheduling",type=boolean,JSONPath=`.spec.allowScheduling`,description="Indicate whether the user disabled/enabled replica scheduling for the node"
 // +kubebuilder:printcolumn:name="Schedulable",type=string,JSONPath=`.status.conditions['Schedulable']['status']`,description="Indicate whether Longhorn can schedule replicas on the node"

--- a/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
@@ -45,6 +45,7 @@ type RecurringJobStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhrj
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2 RecurringJob instead"
 // +kubebuilder:printcolumn:name="Groups",type=string,JSONPath=`.spec.groups`,description="Sets groupings to the jobs. When set to \"default\" group will be added to the volume label when no other job label exist in volume"

--- a/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/recurringjob.go
@@ -45,6 +45,8 @@ type RecurringJobStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhrj
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2 RecurringJob instead"
 // +kubebuilder:printcolumn:name="Groups",type=string,JSONPath=`.spec.groups`,description="Sets groupings to the jobs. When set to \"default\" group will be added to the volume label when no other job label exist in volume"
 // +kubebuilder:printcolumn:name="Task",type=string,JSONPath=`.spec.task`,description="Should be one of \"backup\" or \"snapshot\""
 // +kubebuilder:printcolumn:name="Cron",type=string,JSONPath=`.spec.cron`,description="The cron expression represents recurring job scheduling"

--- a/k8s/pkg/apis/longhorn/v1beta1/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/replica.go
@@ -33,6 +33,7 @@ type ReplicaStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhr
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2 Replica instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the replica"

--- a/k8s/pkg/apis/longhorn/v1beta1/replica.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/replica.go
@@ -33,6 +33,8 @@ type ReplicaStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhr
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2 Replica instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.currentState`,description="The current state of the replica"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeID`,description="The node that the replica is on"
 // +kubebuilder:printcolumn:name="Disk",type=string,JSONPath=`.spec.diskID`,description="The disk that the replica is on"

--- a/k8s/pkg/apis/longhorn/v1beta1/setting.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/setting.go
@@ -6,6 +6,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhs
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2 Setting instead"
 // +kubebuilder:printcolumn:name="Value",type=string,JSONPath=`.value`,description="The value of the setting"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/k8s/pkg/apis/longhorn/v1beta1/setting.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/setting.go
@@ -6,6 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhs
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2 Setting instead"
 // +kubebuilder:printcolumn:name="Value",type=string,JSONPath=`.value`,description="The value of the setting"

--- a/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
@@ -29,6 +29,7 @@ type ShareManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhsm
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2 ShareManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The state of the share manager"

--- a/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/sharemanager.go
@@ -29,6 +29,8 @@ type ShareManagerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhsm
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2 ShareManager instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The state of the share manager"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.status.ownerID`,description="The node that the share manager is owned by"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/k8s/pkg/apis/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/volume.go
@@ -195,6 +195,8 @@ type VolumeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhv
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2 Volume instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The state of the volume"
 // +kubebuilder:printcolumn:name="Robustness",type=string,JSONPath=`.status.robustness`,description="The robustness of the volume"
 // +kubebuilder:printcolumn:name="Scheduled",type=string,JSONPath=`.status.conditions['scheduled']['status']`,description="The scheduled condition of the volume"

--- a/k8s/pkg/apis/longhorn/v1beta1/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta1/volume.go
@@ -195,6 +195,7 @@ type VolumeStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=lhv
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion
 // +kubebuilder:deprecatedversion:warning="longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2 Volume instead"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="The state of the volume"

--- a/scripts/package
+++ b/scripts/package
@@ -55,5 +55,5 @@ echo "${BUILD_CMD[@]}" "${IMAGE_BUILD_CMD_ARGS[@]}"
 
 echo "Built ${IMAGE}"
 
-mkdir ./bin || true
+mkdir -p ./bin
 echo "${IMAGE}" > ./bin/latest_image

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -832,9 +832,9 @@ func CreateAndUpdateBackingImageInProvidedCache(namespace string, lhClient *lhcl
 	return obj, nil
 }
 
-type untypedResourceUpdater func(namespace string, lhClient *lhclientset.Clientset, resourceMap any, forceWrite bool) error
+type untypedUpdateResourceFunc func(namespace string, lhClient *lhclientset.Clientset, resourceMap any, forceWrite bool) error
 
-func toUntypedResourceUpdater[K any](kind string, updater func(namespace string, lhClient *lhclientset.Clientset, resourceMap map[string]K, forceWrite bool) error) untypedResourceUpdater {
+func toUntypedUpdateResourceFunc[K any](kind string, updater func(namespace string, lhClient *lhclientset.Clientset, resourceMap map[string]K, forceWrite bool) error) untypedUpdateResourceFunc {
 	return func(namespace string, lhClient *lhclientset.Clientset, resourceMap any, forceWrite bool) error {
 		typedResourceMap, ok := resourceMap.(map[string]K)
 		if !ok {
@@ -844,27 +844,27 @@ func toUntypedResourceUpdater[K any](kind string, updater func(namespace string,
 	}
 }
 
-var resourceUpdaters = map[string]untypedResourceUpdater{
-	types.LonghornKindNode:                   toUntypedResourceUpdater(types.LonghornKindNode, updateNodes),
-	types.LonghornKindVolume:                 toUntypedResourceUpdater(types.LonghornKindVolume, updateVolumes),
-	types.LonghornKindEngine:                 toUntypedResourceUpdater(types.LonghornKindEngine, updateEngines),
-	types.LonghornKindReplica:                toUntypedResourceUpdater(types.LonghornKindReplica, updateReplicas),
-	types.LonghornKindBackupTarget:           toUntypedResourceUpdater(types.LonghornKindBackupTarget, updateBackupTargets),
-	types.LonghornKindBackupVolume:           toUntypedResourceUpdater(types.LonghornKindBackupVolume, updateBackupVolumes),
-	types.LonghornKindBackup:                 toUntypedResourceUpdater(types.LonghornKindBackup, updateBackups),
-	types.LonghornKindBackupBackingImage:     toUntypedResourceUpdater(types.LonghornKindBackupBackingImage, updateBackupBackingImages),
-	types.LonghornKindBackingImageDataSource: toUntypedResourceUpdater(types.LonghornKindBackingImageDataSource, updateBackingImageDataSources),
-	types.LonghornKindEngineImage:            toUntypedResourceUpdater(types.LonghornKindEngineImage, updateEngineImages),
-	types.LonghornKindInstanceManager:        toUntypedResourceUpdater(types.LonghornKindInstanceManager, updateInstanceManagers),
-	types.LonghornKindShareManager:           toUntypedResourceUpdater(types.LonghornKindShareManager, updateShareManagers),
-	types.LonghornKindBackingImage:           toUntypedResourceUpdater(types.LonghornKindBackingImage, updateBackingImages),
-	types.LonghornKindBackingImageManager:    toUntypedResourceUpdater(types.LonghornKindBackingImageManager, updateBackingImagesManager),
-	types.LonghornKindRecurringJob:           toUntypedResourceUpdater(types.LonghornKindRecurringJob, updateRecurringJobs),
-	types.LonghornKindSetting:                toUntypedResourceUpdater(types.LonghornKindSetting, updateSettings),
-	types.LonghornKindVolumeAttachment:       toUntypedResourceUpdater(types.LonghornKindVolumeAttachment, createOrUpdateVolumeAttachments),
-	types.LonghornKindSnapshot:               toUntypedResourceUpdater(types.LonghornKindSnapshot, updateSnapshots),
-	types.LonghornKindOrphan:                 toUntypedResourceUpdater(types.LonghornKindOrphan, updateOrphans),
-	types.LonghornKindSystemBackup:           toUntypedResourceUpdater(types.LonghornKindSystemBackup, updateSystemBackups),
+var resourceUpdaters = map[string]untypedUpdateResourceFunc{
+	types.LonghornKindNode:                   toUntypedUpdateResourceFunc(types.LonghornKindNode, updateNodes),
+	types.LonghornKindVolume:                 toUntypedUpdateResourceFunc(types.LonghornKindVolume, updateVolumes),
+	types.LonghornKindEngine:                 toUntypedUpdateResourceFunc(types.LonghornKindEngine, updateEngines),
+	types.LonghornKindReplica:                toUntypedUpdateResourceFunc(types.LonghornKindReplica, updateReplicas),
+	types.LonghornKindBackupTarget:           toUntypedUpdateResourceFunc(types.LonghornKindBackupTarget, updateBackupTargets),
+	types.LonghornKindBackupVolume:           toUntypedUpdateResourceFunc(types.LonghornKindBackupVolume, updateBackupVolumes),
+	types.LonghornKindBackup:                 toUntypedUpdateResourceFunc(types.LonghornKindBackup, updateBackups),
+	types.LonghornKindBackupBackingImage:     toUntypedUpdateResourceFunc(types.LonghornKindBackupBackingImage, updateBackupBackingImages),
+	types.LonghornKindBackingImageDataSource: toUntypedUpdateResourceFunc(types.LonghornKindBackingImageDataSource, updateBackingImageDataSources),
+	types.LonghornKindEngineImage:            toUntypedUpdateResourceFunc(types.LonghornKindEngineImage, updateEngineImages),
+	types.LonghornKindInstanceManager:        toUntypedUpdateResourceFunc(types.LonghornKindInstanceManager, updateInstanceManagers),
+	types.LonghornKindShareManager:           toUntypedUpdateResourceFunc(types.LonghornKindShareManager, updateShareManagers),
+	types.LonghornKindBackingImage:           toUntypedUpdateResourceFunc(types.LonghornKindBackingImage, updateBackingImages),
+	types.LonghornKindBackingImageManager:    toUntypedUpdateResourceFunc(types.LonghornKindBackingImageManager, updateBackingImagesManager),
+	types.LonghornKindRecurringJob:           toUntypedUpdateResourceFunc(types.LonghornKindRecurringJob, updateRecurringJobs),
+	types.LonghornKindSetting:                toUntypedUpdateResourceFunc(types.LonghornKindSetting, updateSettings),
+	types.LonghornKindVolumeAttachment:       toUntypedUpdateResourceFunc(types.LonghornKindVolumeAttachment, createOrUpdateVolumeAttachments),
+	types.LonghornKindSnapshot:               toUntypedUpdateResourceFunc(types.LonghornKindSnapshot, updateSnapshots),
+	types.LonghornKindOrphan:                 toUntypedUpdateResourceFunc(types.LonghornKindOrphan, updateOrphans),
+	types.LonghornKindSystemBackup:           toUntypedUpdateResourceFunc(types.LonghornKindSystemBackup, updateSystemBackups),
 }
 
 // UpdateResources persists all the resources' spec changes in provided cached `resourceMap`. This method is not thread-safe.

--- a/upgrade/v18xto190/upgrade.go
+++ b/upgrade/v18xto190/upgrade.go
@@ -11,10 +11,10 @@ import (
 	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
 )
 
-type listAndUpdateResourcesInProvidedCacheFunc func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) error
-type typedListAndUpdateResourcesInProvidedCacheFunc[K any] func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (map[string]*K, error)
+type listAndUpdateFunc func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) error
+type typedListAndUpdateFunc[K any] func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (map[string]*K, error)
 
-func toListAndUpdateResourcesInProvidedCacheFunc[K any](listUpdateFunc typedListAndUpdateResourcesInProvidedCacheFunc[K]) listAndUpdateResourcesInProvidedCacheFunc {
+func listAndUpdateResources[K any](listUpdateFunc typedListAndUpdateFunc[K]) listAndUpdateFunc {
 	return func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) error {
 		_, err := listUpdateFunc(namespace, lhClient, resourceMaps)
 		return err
@@ -28,22 +28,22 @@ func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeCli
 
 	// From v1.9.0, the v1beta1 API is deprecated, and v1beta2 is the storage version. Load all resource and write back into v1beta2.
 
-	updates := map[string]listAndUpdateResourcesInProvidedCacheFunc{
-		types.LonghornKindSetting:                toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateSettingsInProvidedCache),
-		types.LonghornKindNode:                   toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateNodesInProvidedCache),
-		types.LonghornKindInstanceManager:        toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateInstanceManagersInProvidedCache),
-		types.LonghornKindShareManager:           toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateShareManagersInProvidedCache),
-		types.LonghornKindEngine:                 toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateEnginesInProvidedCache),
-		types.LonghornKindEngineImage:            toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateEngineImagesInProvidedCache),
-		types.LonghornKindReplica:                toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateReplicasInProvidedCache),
-		types.LonghornKindVolume:                 toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateVolumesInProvidedCache),
-		types.LonghornKindBackupVolume:           toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackupVolumesInProvidedCache),
-		types.LonghornKindBackup:                 toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackupsInProvidedCache),
-		types.LonghornKindBackupTarget:           toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackupTargetsInProvidedCache),
-		types.LonghornKindBackingImageManager:    toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackingImageManagersInProvidedCache),
-		types.LonghornKindBackingImageDataSource: toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackingImageDataSourcesInProvidedCache),
-		types.LonghornKindBackingImage:           toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateBackingImagesInProvidedCache),
-		types.LonghornKindRecurringJob:           toListAndUpdateResourcesInProvidedCacheFunc(upgradeutil.ListAndUpdateRecurringJobsInProvidedCache),
+	updates := map[string]listAndUpdateFunc{
+		types.LonghornKindSetting:                listAndUpdateResources(upgradeutil.ListAndUpdateSettingsInProvidedCache),
+		types.LonghornKindNode:                   listAndUpdateResources(upgradeutil.ListAndUpdateNodesInProvidedCache),
+		types.LonghornKindInstanceManager:        listAndUpdateResources(upgradeutil.ListAndUpdateInstanceManagersInProvidedCache),
+		types.LonghornKindShareManager:           listAndUpdateResources(upgradeutil.ListAndUpdateShareManagersInProvidedCache),
+		types.LonghornKindEngine:                 listAndUpdateResources(upgradeutil.ListAndUpdateEnginesInProvidedCache),
+		types.LonghornKindEngineImage:            listAndUpdateResources(upgradeutil.ListAndUpdateEngineImagesInProvidedCache),
+		types.LonghornKindReplica:                listAndUpdateResources(upgradeutil.ListAndUpdateReplicasInProvidedCache),
+		types.LonghornKindVolume:                 listAndUpdateResources(upgradeutil.ListAndUpdateVolumesInProvidedCache),
+		types.LonghornKindBackupVolume:           listAndUpdateResources(upgradeutil.ListAndUpdateBackupVolumesInProvidedCache),
+		types.LonghornKindBackup:                 listAndUpdateResources(upgradeutil.ListAndUpdateBackupsInProvidedCache),
+		types.LonghornKindBackupTarget:           listAndUpdateResources(upgradeutil.ListAndUpdateBackupTargetsInProvidedCache),
+		types.LonghornKindBackingImageManager:    listAndUpdateResources(upgradeutil.ListAndUpdateBackingImageManagersInProvidedCache),
+		types.LonghornKindBackingImageDataSource: listAndUpdateResources(upgradeutil.ListAndUpdateBackingImageDataSourcesInProvidedCache),
+		types.LonghornKindBackingImage:           listAndUpdateResources(upgradeutil.ListAndUpdateBackingImagesInProvidedCache),
+		types.LonghornKindRecurringJob:           listAndUpdateResources(upgradeutil.ListAndUpdateRecurringJobsInProvidedCache),
 	}
 	for resourceKind, listUpdateFunc := range updates {
 		if err := listUpdateFunc(namespace, lhClient, resourceMaps); err != nil {

--- a/upgrade/v18xto190/upgrade.go
+++ b/upgrade/v18xto190/upgrade.go
@@ -1,0 +1,151 @@
+package v18xto190
+
+import (
+	"github.com/pkg/errors"
+
+	clientset "k8s.io/client-go/kubernetes"
+
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	upgradeutil "github.com/longhorn/longhorn-manager/upgrade/util"
+)
+
+const (
+	upgradeLogPrefix = "upgrade from v1.8.x to v1.9.0: "
+)
+
+func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeClient *clientset.Clientset, resourceMaps map[string]interface{}) error {
+	if resourceMaps == nil {
+		return errors.New("resourceMaps cannot be nil")
+	}
+
+	// From v1.9.0, the v1beta1 API is deprecated. Load all resource and write back into v1beta2.
+
+	updates := []func(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) error{
+		upgradeSettings,
+		upgradeNodes,
+		upgradeInstanceManagers,
+		upgradeShareManagers,
+		upgradeEngines,
+		upgradeEngineImages,
+		upgradeReplicas,
+		upgradeVolumes,
+		upgradeBackupVolumes,
+		upgradeBackups,
+		upgradeBackupTargets,
+		upgradeBackingImageManagers,
+		upgradeBackingImageDataSources,
+		upgradeBackingImages,
+		upgradeRecurringJobs,
+	}
+	for _, updateResource := range updates {
+		if err := updateResource(namespace, lhClient, resourceMaps); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeSettings(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateSettingsInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn settings during the settings upgrade")
+	}
+	return nil
+}
+
+func upgradeNodes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateNodesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn nodes during the nodes upgrade")
+	}
+	return nil
+}
+
+func upgradeInstanceManagers(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateInstanceManagersInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn instance managers during the instance manager upgrade")
+	}
+	return nil
+}
+
+func upgradeShareManagers(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateShareManagersInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn share managers during the share manager upgrade")
+	}
+	return nil
+}
+
+func upgradeEngines(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateEnginesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn engines during the engine upgrade")
+	}
+	return nil
+}
+
+func upgradeEngineImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateEngineImagesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn engine images during the engine image upgrade")
+	}
+	return nil
+}
+
+func upgradeReplicas(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateReplicasInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn replicas during the replica upgrade")
+	}
+	return nil
+}
+
+func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateVolumesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn volumes during the volume upgrade")
+	}
+	return nil
+}
+
+func upgradeBackupVolumes(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackupVolumesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backup volumes during the backup volume upgrade")
+	}
+	return nil
+}
+
+func upgradeBackups(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackupsInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backups during the backup upgrade")
+	}
+	return nil
+}
+
+func upgradeBackupTargets(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackupTargetsInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backup targets during the backup target upgrade")
+	}
+	return nil
+}
+
+func upgradeBackingImageManagers(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackingImageManagersInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backing image manager during the backing image manager upgrade")
+	}
+	return nil
+}
+
+func upgradeBackingImageDataSources(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackingImageDataSourcesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backing image data sources during the backing image data source upgrade")
+	}
+	return nil
+}
+
+func upgradeBackingImages(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateBackingImagesInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn backing images during the backing image upgrade")
+	}
+	return nil
+}
+
+func upgradeRecurringJobs(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
+	if _, err := upgradeutil.ListAndUpdateRecurringJobsInProvidedCache(namespace, lhClient, resourceMaps); err != nil {
+		return errors.Wrapf(err, upgradeLogPrefix+"failed to list all existing Longhorn recurring jobs during the recurring job upgrade")
+	}
+	return nil
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#10250

#### What this PR does / why we need it:

We're going to retire the v1beta1 CRDs (#10249), and the migration in this PR is the prerequisite.

Since we marked v1beta2 as the storage version, and we already have [K8s builtin trivial converter](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) and our customized conversion webhooks, we migrate the all existed resources to the new version by simply read in v1beta2 then write back WITHOUT modification.

- Mark all v1beta1 CRDs as deprecated
- Implement the migration logic from 1.8.x to 1.9.0

#### Special notes for your reviewer:

The following CRDs are included in this PR:

- BackingImage
- BackingImageDataSource
- BackingImageManager
- Backup
- BackupTarget
- BackupVolume
- Engine
- EngineImage
- InstanceManager
- Node
- RecurringJob
- Replica
- Setting
- ShareManager
- Volume

And the following CRDs are not included since they are new from v1beta2:

- BackupBackingImage
- Orphan
- Snapshot
- SupportBundle
- SystemBackup
- SystemRestore
- VolumeAttachment

But, in this PR, it will write all resource back from cache, include v1beta2 resources.

#### Additional documentation or context
