### PR TITLE
fix: reject snapshot purge when volume is being live migration

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -1618,7 +1618,7 @@ func (bic *BackingImageController) getEngineClientProxy(nodeName string, dataEng
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the default instance manager for node %v", nodeName)
 	}
-	engineClientProxy, err := engineapi.NewEngineClientProxy(instanceManager, log, bic.proxyConnCounter)
+	engineClientProxy, err := engineapi.NewEngineClientProxy(instanceManager, log, bic.proxyConnCounter, bic.ds)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the engine client proxy for instance manager %v", instanceManager.Name)
 	}

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -265,7 +265,7 @@ func getBackupTarget(controllerID string, backupTarget *longhorn.BackupTarget, d
 		return nil, nil, errors.Wrap(err, "failed to get running instance manager for proxy client")
 	}
 
-	engineClientProxy, err = engineapi.NewEngineClientProxy(instanceManager, log, proxyConnCounter)
+	engineClientProxy, err = engineapi.NewEngineClientProxy(instanceManager, log, proxyConnCounter, ds)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1774,6 +1774,7 @@ func (ec *EngineController) startRebuilding(e *longhorn.Engine, replicaName, add
 		// It is not necessary to check the value of DisableSnapshotPurge here because the webhook prevents enabling
 		// AutoCleanupSystemGeneratedSnapshot and DisableSnapshot purge simultaneously.
 		if autoCleanupSystemGeneratedSnapshot {
+			log.Info("Starting snapshot purge before rebuilding")
 			if err := engineClientProxy.SnapshotPurge(e); err != nil {
 				log.WithError(err).Error("Failed to start snapshot purge before rebuilding")
 				ec.eventRecorder.Eventf(e, corev1.EventTypeWarning, constant.EventReasonFailedStartingSnapshotPurge,

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1617,7 +1617,7 @@ func (imc *InstanceManagerController) startBackingImageMonitoring(im *longhorn.I
 		return
 	}
 
-	engineClientProxy, err := engineapi.NewEngineClientProxy(im, log, imc.proxyConnCounter)
+	engineClientProxy, err := engineapi.NewEngineClientProxy(im, log, imc.proxyConnCounter, imc.ds)
 	if err != nil {
 		log.Errorf("failed to get the engine client proxy for instance manager %v", im.Name)
 		return

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -350,7 +350,7 @@ func (c *VolumeController) syncVolume(key string) (err error) {
 			c.eventRecorder.Eventf(volume, corev1.EventTypeNormal, constant.EventReasonDelete, "Deleting volume %v", volume.Name)
 		}
 
-		if volume.Spec.AccessMode == longhorn.AccessModeReadWriteMany {
+		if volume.Spec.AccessMode == longhorn.AccessModeReadWriteMany && !volume.Spec.Migratable {
 			log.Info("Removing share manager for deleted volume")
 			if err := c.ds.DeleteShareManager(volume.Name); err != nil && !datastore.ErrorIsNotFound(err) {
 				return err

--- a/engineapi/proxy.go
+++ b/engineapi/proxy.go
@@ -63,10 +63,10 @@ func GetCompatibleClient(e *longhorn.Engine, fallBack interface{}, ds *datastore
 		return nil, errors.Errorf("BUG: invalid engine client proxy fallback client: %v", fallBack)
 	}
 
-	return NewEngineClientProxy(im, log, proxyConnCounter)
+	return NewEngineClientProxy(im, log, proxyConnCounter, ds)
 }
 
-func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogger, proxyConnCounter util.Counter) (c EngineClientProxy, err error) {
+func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogger, proxyConnCounter util.Counter, ds *datastore.DataStore) (c EngineClientProxy, err error) {
 	defer func() {
 		err = errors.Wrap(err, "failed to get engine client proxy")
 	}()
@@ -143,12 +143,14 @@ func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogge
 		logger:           logger,
 		grpcClient:       proxyClient,
 		proxyConnCounter: proxyConnCounter,
+		ds:               ds,
 	}, nil
 }
 
 type Proxy struct {
 	logger     logrus.FieldLogger
 	grpcClient *imclient.ProxyClient
+	ds         *datastore.DataStore
 
 	proxyConnCounter util.Counter
 }


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10495

#### What this PR does / why we need it:

Reject snapshot purge when volume is being live migration. If snapshot purge is executed while live migrating a volume, the disk files will be changed. The new engine and replicas are unable to be aware of the change and cannot list the new disk files, resulting in ERR replicas.

#### Special notes for your reviewer:

#### Additional documentation or context
