### PR TITLE
fix: volume encryption not working in Talos 1.9.x

### DIFF
--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -110,6 +110,18 @@ func EncryptVolume(devicePath, passphrase string, cryptoParams *EncryptParams) e
 		lhtypes.LuksTimeout); err != nil {
 		return errors.Wrapf(err, "failed to encrypt device %s with LUKS", devicePath)
 	}
+
+	isEncrypted, err = isDeviceEncrypted(devicePath)
+	if err != nil {
+		logrus.WithError(err).Warnf("Failed to check IsDeviceEncrypted after encrypting volume %v", devicePath)
+		return err
+	}
+	if !isEncrypted {
+		logrus.Warnf("Attempted to encrypt device %s with LUKS, but it is not encrypted", devicePath)
+		return nil
+	}
+
+	logrus.Infof("Device %s is encrypted with LUKS", devicePath)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.21.0
 	github.com/longhorn/backing-image-manager v1.8.1
 	github.com/longhorn/backupstore v0.0.0-20250315040513-2fb98aebc16a
-	github.com/longhorn/go-common-libs v0.0.0-20250312065002-72871a09bee0
+	github.com/longhorn/go-common-libs v0.0.0-20250319033109-764d1dea35f3
 	github.com/longhorn/go-iscsi-helper v0.0.0-20250111093313-7e1930499625
 	github.com/longhorn/go-spdk-helper v0.0.2-0.20250313071458-3dd5863e9249
 	github.com/longhorn/longhorn-engine v1.9.0-dev-20250223.0.20250225091521-921f63f3a87d

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/longhorn/backing-image-manager v1.8.1 h1:Va/Ncu1YCksUelegLF7HmawgZqt9
 github.com/longhorn/backing-image-manager v1.8.1/go.mod h1:SC3vqkxf6ntuMQmZ902IBExROqGy7JSMlqyE4tf4c6o=
 github.com/longhorn/backupstore v0.0.0-20250315040513-2fb98aebc16a h1:JdC/VSfjNJvrDEks0w3xvHveLEhV/vqAVOg066dUbx0=
 github.com/longhorn/backupstore v0.0.0-20250315040513-2fb98aebc16a/go.mod h1:hbgoIHIthPPsMu5HToirO2X56PkmUOEhWnEYZGxFiA0=
-github.com/longhorn/go-common-libs v0.0.0-20250312065002-72871a09bee0 h1:NSlPmMO0Szn4H69rypN/bsVhShgEAwMq3wBacWmPUvI=
-github.com/longhorn/go-common-libs v0.0.0-20250312065002-72871a09bee0/go.mod h1:Yke3SMmcKCzngAu8fm5PNND2WiF/8blhsV4s6piy5zM=
+github.com/longhorn/go-common-libs v0.0.0-20250319033109-764d1dea35f3 h1:sCyCt+54yhQ6qUVDupFfFogyCyBrfpQw3HdP61CXwxE=
+github.com/longhorn/go-common-libs v0.0.0-20250319033109-764d1dea35f3/go.mod h1:Yke3SMmcKCzngAu8fm5PNND2WiF/8blhsV4s6piy5zM=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250111093313-7e1930499625 h1:d39A3041RyFve26tIuKUuzrh2CkBY970xlGIXgMA998=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250111093313-7e1930499625/go.mod h1:yIm3sGRuYOw/Y3XzRhG5+3FlZBOfrU5EZOavzwL2jVs=
 github.com/longhorn/go-spdk-helper v0.0.2-0.20250313071458-3dd5863e9249 h1:x9nxSZfVVg1bJFM8zUQVRvwxSDmkJglXccNGt/WSV9g=

--- a/vendor/github.com/longhorn/go-common-libs/ns/crypto.go
+++ b/vendor/github.com/longhorn/go-common-libs/ns/crypto.go
@@ -12,7 +12,7 @@ import (
 // LuksOpen runs cryptsetup luksOpen with the given passphrase and
 // returns the stdout and error.
 func (nsexec *Executor) LuksOpen(volume, devicePath, passphrase string, timeout time.Duration) (stdout string, err error) {
-	args := []string{"luksOpen", devicePath, volume, "-d", "/dev/stdin"}
+	args := []string{"luksOpen", devicePath, volume, "-d", "-"}
 	return nsexec.CryptsetupWithPassphrase(passphrase, args, timeout)
 }
 
@@ -32,7 +32,7 @@ func (nsexec *Executor) LuksFormat(devicePath, passphrase, keyCipher, keyHash, k
 		"--hash", keyHash,
 		"--key-size", keySize,
 		"--pbkdf", pbkdf,
-		devicePath, "-d", "/dev/stdin",
+		devicePath, "-d", "-",
 	}
 	return nsexec.CryptsetupWithPassphrase(passphrase, args, timeout)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/longhorn/backupstore/logging
 github.com/longhorn/backupstore/systembackup
 github.com/longhorn/backupstore/types
 github.com/longhorn/backupstore/util
-# github.com/longhorn/go-common-libs v0.0.0-20250312065002-72871a09bee0
+# github.com/longhorn/go-common-libs v0.0.0-20250319033109-764d1dea35f3
 ## explicit; go 1.23.0
 github.com/longhorn/go-common-libs/backup
 github.com/longhorn/go-common-libs/exec


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10584

#### What this PR does / why we need it:

- Update Longhorn to the `-d -` for cryptsetup instead of `-d /dev/stdin` for compatibility with newer Talos versions.
- Add validation after device encryption.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/10584#issuecomment-2734973730
