### PR TITLE
fix(log): reduce auto balancing logging noise for detached volumes

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2429,7 +2429,9 @@ func (c *VolumeController) getReplicaCountForAutoBalanceBestEffort(v *longhorn.V
 	}
 
 	if v.Status.Robustness != longhorn.VolumeRobustnessHealthy {
-		log.Warnf("Cannot auto-balance volume in %s state", v.Status.Robustness)
+		if v.Status.State != longhorn.VolumeStateDetached {
+			log.Warnf("Cannot auto-balance volume in %s state", v.Status.Robustness)
+		}
 		return 0, nil, []string{}
 	}
 


### PR DESCRIPTION
Addition to incomplete previous commits (We missed some logging statements):
d6c9149b68f3ace84dd6c1ec4f43816ebc4dca2b
af83a2bee2f464e22a661c13494a3a30a9c6df8c

#### Which issue(s) this PR fixes:
[Issue](https://github.com/longhorn/longhorn/issues/10302)

#### What this PR does / why we need it:
Fix one logging statement we previously missed in other PRs:
https://github.com/longhorn/longhorn-manager/pull/3558
https://github.com/longhorn/longhorn-manager/pull/3589