### PR TITLE
fix: fix naming collision when creating bim based on the prefix of the disk uuid

### DIFF
--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -66,7 +66,7 @@ type CollectedDiskInfo struct {
 
 type GetDiskStatHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*lhtypes.DiskStat, error)
 type GetDiskConfigHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*util.DiskConfig, error)
-type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, *DiskServiceClient) (*util.DiskConfig, error)
+type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, *DiskServiceClient, *datastore.DataStore) (*util.DiskConfig, error)
 type GetReplicaDataStoresHandler func(longhorn.DiskType, *longhorn.Node, string, string, string, string, *DiskServiceClient) (map[string]string, error)
 
 func NewDiskMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, nodeName string, syncCallback func(key string)) (*DiskMonitor, error) {
@@ -291,7 +291,7 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			//   The handling of all disks containing the same fsid will be done in NodeController.
 			// Block-type disk
 			//   Create a bdev lvstore
-			if diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, diskUUID, disk.Path, string(diskDriver), diskServiceClient); err != nil {
+			if diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, diskUUID, disk.Path, string(diskDriver), diskServiceClient, m.ds); err != nil {
 				diskInfoMap[diskName] = NewDiskInfo(diskName, diskUUID, disk.Path, diskDriver, nodeOrDiskEvicted, nil,
 					orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo),
 					fmt.Sprintf("Disk %v(%v) on node %v is not ready: failed to generate disk config: error: %v",

--- a/controller/monitor/disk_utils.go
+++ b/controller/monitor/disk_utils.go
@@ -14,6 +14,7 @@ import (
 	lhns "github.com/longhorn/go-common-libs/ns"
 	lhtypes "github.com/longhorn/go-common-libs/types"
 
+	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/util"
 
@@ -21,7 +22,8 @@ import (
 )
 
 const (
-	defaultBlockSize = 512
+	defaultBlockSize      = 512
+	uuidGenerationRetries = 20
 )
 
 // GetDiskStat returns the disk stat of the given directory
@@ -119,10 +121,10 @@ func getBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskPath string
 }
 
 // GenerateDiskConfig generates a disk config for the given directory
-func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient) (*util.DiskConfig, error) {
+func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	switch diskType {
 	case longhorn.DiskTypeFilesystem:
-		return generateFilesystemTypeDiskConfig(diskName, diskPath)
+		return generateFilesystemTypeDiskConfig(diskName, diskPath, ds)
 	case longhorn.DiskTypeBlock:
 		return generateBlockTypeDiskConfig(client, diskName, diskUUID, diskPath, diskDriver, defaultBlockSize)
 	default:
@@ -130,15 +132,25 @@ func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath
 	}
 }
 
-func generateFilesystemTypeDiskConfig(diskName, diskPath string) (*util.DiskConfig, error) {
+func generateFilesystemTypeDiskConfig(diskName, diskPath string, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	var err error
 	defer func() {
 		err = errors.Wrapf(err, "failed to generate disk config for %v", diskPath)
 	}()
 
+	allDiskUUIDFirstFourCharSet, err := ds.GetAllDiskUUIDFirstFourChar()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get all diskUUIDs first four char set")
+	}
+
+	uuid, err := generateUniqueFirstFourCharUUID(allDiskUUIDFirstFourCharSet)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to generate unique disk UUID")
+	}
+
 	cfg := &util.DiskConfig{
 		DiskName: diskName,
-		DiskUUID: util.UUID(),
+		DiskUUID: uuid,
 	}
 	encoded, err := json.Marshal(cfg)
 	if err != nil {
@@ -223,4 +235,15 @@ func getSpdkReplicaInstanceNames(client *DiskServiceClient, diskType, diskName, 
 	}
 
 	return instanceNames, nil
+}
+
+func generateUniqueFirstFourCharUUID(allDiskUUIDFirstFourCharSet map[string]bool) (string, error) {
+	for i := 0; i < uuidGenerationRetries; i++ {
+		uuid := util.UUID()
+		prefix := uuid[:4]
+		if !allDiskUUIDFirstFourCharSet[prefix] {
+			return uuid, nil
+		}
+	}
+	return "", fmt.Errorf("failed to generate UUID with unique prefix after %v attempts", uuidGenerationRetries)
 }

--- a/controller/monitor/fake_disk_monitor.go
+++ b/controller/monitor/fake_disk_monitor.go
@@ -102,7 +102,7 @@ func fakeGetDiskConfig(diskType longhorn.DiskType, name, path string, diskDriver
 	}
 }
 
-func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, client *DiskServiceClient) (*util.DiskConfig, error) {
+func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	return &util.DiskConfig{
 		DiskName: name,
 		DiskUUID: TestDiskID1,

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -6140,3 +6140,19 @@ func (s *DataStore) IsStorageNetworkForRWXVolume() (bool, error) {
 
 	return types.IsStorageNetworkForRWXVolume(storageNetworkSetting, storageNetworkForRWXVolumeEnabled), nil
 }
+
+func (s *DataStore) GetAllDiskUUIDFirstFourChar() (map[string]bool, error) {
+	firstFourCharSet := make(map[string]bool)
+	nodes, err := s.ListNodesRO()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodes {
+		for _, diskStatus := range node.Status.DiskStatus {
+			firstFourCharSet[diskStatus.DiskUUID[:4]] = true
+		}
+	}
+
+	return firstFourCharSet, nil
+}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10616

When generating the disk uuid, we first get all existing disk uuid to check and prevent it from having the same first-4-char prefix.