### PR TITLE
fix: safely delete VolumeAttachment for force-deleted pods

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -329,6 +329,10 @@ func (kc *KubernetesPodController) handleWorkloadPodDeletionIfCSIPluginPodIsDown
 // cleanupForceDeletedPodResources removes stale resources left behind when a pod
 // is force-deleted (i.e., deletion grace period is zero).
 func (kc *KubernetesPodController) cleanupForceDeletedPodResources(pod *corev1.Pod) error {
+	if !isControllerResponsibleFor(kc.controllerID, kc.ds, pod.Name, "", pod.Spec.NodeName) {
+		return nil
+	}
+
 	if pod.DeletionTimestamp == nil {
 		return nil
 	}

--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -333,7 +334,7 @@ func (kc *KubernetesPodController) cleanupForceDeletedPodResources(pod *corev1.P
 		return nil
 	}
 
-	if pod.DeletionTimestamp == nil {
+	if pod.DeletionTimestamp.IsZero() {
 		return nil
 	}
 
@@ -348,22 +349,108 @@ func (kc *KubernetesPodController) cleanupForceDeletedPodResources(pod *corev1.P
 		return err
 	}
 
-	for _, va := range volumeAttachments {
-		if va.DeletionTimestamp != nil {
+	for _, volumeAttachment := range volumeAttachments {
+		shouldDeleteVolumeAttachment, err := kc.shouldDeleteVolumeAttachmentForForceDeletedPod(pod, volumeAttachment)
+		if err != nil {
+			logrus.WithError(err).Errorf("%v: failed to check if volume attachment %q for force-deleted pod %q should be deleted", controllerAgentName, volumeAttachment.Name, pod.Name)
 			continue
 		}
 
-		kc.logger.Infof("%v: deleting volume attachment %q for force-deleted pod %q", controllerAgentName, va.Name, pod.Name)
+		if !shouldDeleteVolumeAttachment {
+			continue
+		}
 
-		err := kc.kubeClient.StorageV1().VolumeAttachments().Delete(context.TODO(), va.Name, metav1.DeleteOptions{})
+		kc.logger.Infof("%v: deleting volume attachment %q for force-deleted pod %q", controllerAgentName, volumeAttachment.Name, pod.Name)
+
+		err = kc.kubeClient.StorageV1().VolumeAttachments().Delete(context.TODO(), volumeAttachment.Name, metav1.DeleteOptions{})
 		if err != nil {
 			if datastore.ErrorIsNotFound(err) {
 				continue
 			}
-			return errors.Wrapf(err, "failed to delete volume attachment %q for force-deleted pod %q", va.Name, pod.Name)
+			return errors.Wrapf(err, "failed to delete volume attachment %q for force-deleted pod %q", volumeAttachment.Name, pod.Name)
 		}
 
-		kc.logger.Infof("%v: deleted volume attachment %q for force-deleted pod %q", controllerAgentName, va.Name, pod.Name)
+		kc.logger.Infof("%v: deleted volume attachment %q for force-deleted pod %q", controllerAgentName, volumeAttachment.Name, pod.Name)
+	}
+
+	return nil
+}
+
+// shouldDeleteVolumeAttachmentForForceDeletedPod checks whether the VolumeAttachment
+// associated with a force-deleted Pod should be deleted.
+func (kc *KubernetesPodController) shouldDeleteVolumeAttachmentForForceDeletedPod(pod *corev1.Pod, volumeAttachment *storagev1.VolumeAttachment) (bool, error) {
+	if !volumeAttachment.DeletionTimestamp.IsZero() {
+		return false, nil // Already marked for deletion.
+	}
+
+	if !volumeAttachment.Status.Attached {
+		return false, nil // Not currently attached, let Kubernetes handle its lifecycle.
+	}
+
+	persistentVolumeName := volumeAttachment.Spec.Source.PersistentVolumeName
+	if persistentVolumeName == nil {
+		kc.logger.Infof("%v: volume attachment %q has no associated persistent volume; skipping cleanup for force-deleted pod %q",
+			controllerAgentName, volumeAttachment.Name, pod.Name)
+		return false, nil // No persistent volume, let Kubernetes handle its lifecycle.
+	}
+
+	persistentVolume, err := kc.ds.GetPersistentVolumeRO(*volumeAttachment.Spec.Source.PersistentVolumeName)
+	if err != nil {
+		return false, err
+	}
+
+	claimRef := persistentVolume.Spec.ClaimRef
+	if claimRef == nil {
+		kc.logger.Infof("%v: persistent volume %q has no claimRef; cleaning up volume attachment %q for force-deleted pod %q",
+			controllerAgentName, persistentVolume.Name, volumeAttachment.Name, pod.Name)
+		return true, nil // No claim, safe to delete.
+	}
+
+	pods, err := kc.ds.ListPodsByPersistentVolumeClaimName(claimRef.Name, pod.Namespace)
+	if err != nil {
+		return false, err
+	}
+
+	if conflictingPod := kc.getPodWithConflictedAttachment(pods, pod); conflictingPod != nil {
+		kc.logger.Infof("%v: found conflicting pod %q with attachment for volume %q; cleaning up volume attachment %q for force-deleted pod %q",
+			controllerAgentName, conflictingPod.Name, persistentVolume.Name, volumeAttachment.Name, pod.Name)
+		return true, nil // There are pods that require the volume and run on another node.
+	}
+
+	return false, nil
+}
+
+// getPodWithConflictedAttachment returns the first pod in Pending phase from the
+// given list of pods that has a "Multi-Attach error" event caused by the specified
+// conflictingPod
+func (kc *KubernetesPodController) getPodWithConflictedAttachment(pods []*corev1.Pod, conflictingPod *corev1.Pod) *corev1.Pod {
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		if pod.Status.Phase != corev1.PodPending {
+			continue
+		}
+
+		events, err := kc.ds.GetResourceEventList("Pod", pod.Name, pod.Namespace)
+		if err != nil {
+			logrus.WithError(err).Warnf("%v: failed to get events for pod %v", controllerAgentName, pod.Name)
+			continue
+		}
+
+		for _, event := range events.Items {
+			if !strings.Contains(event.Message, "Multi-Attach error") {
+				continue
+			}
+
+			if strings.Contains(event.Message, conflictingPod.Name) {
+				return pod
+			}
+
+			logrus.Debugf("%s: pod %v has Multi-Attach error, but not caused by pod %v, skipping cleanup",
+				controllerAgentName, pod.Name, conflictingPod.Name)
+		}
 	}
 
 	return nil

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -421,6 +421,35 @@ func (s *DataStore) ListPodsRO(namespace string) ([]*corev1.Pod, error) {
 	return s.podLister.Pods(namespace).List(labels.Everything())
 }
 
+// ListPodsByPersistentVolumeClaimName returns a list of pods that are using the
+// specified PersistentVolumeClaim in the given namespace.
+func (s *DataStore) ListPodsByPersistentVolumeClaimName(claimName string, namespace string) ([]*corev1.Pod, error) {
+	pods, err := s.ListPodsRO(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	matchedPods := []*corev1.Pod{}
+	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim == nil {
+				continue
+			}
+
+			if volume.PersistentVolumeClaim.ClaimName == claimName {
+				matchedPods = append(matchedPods, pod)
+				break
+			}
+		}
+	}
+
+	return matchedPods, nil
+}
+
 // GetPod returns a mutable Pod object for the given name and namespace
 func (s *DataStore) GetPod(name string) (*corev1.Pod, error) {
 	var pod *corev1.Pod

--- a/datastore/uncached.go
+++ b/datastore/uncached.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -25,6 +26,15 @@ import (
 // For example, support bundle creation
 func (s *DataStore) GetLonghornEventList() (*corev1.EventList, error) {
 	return s.kubeClient.CoreV1().Events(s.namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "involvedObject.apiVersion=longhorn.io/v1beta2"})
+}
+
+// GetResourceEventList retrieves a list of events associated with a specific resource
+// in the given namespace. It queries the Kubernetes API for events where the involved
+// object matches the provided kind and name.
+func (s *DataStore) GetResourceEventList(kind, name, namespace string) (*corev1.EventList, error) {
+	return s.kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=%s", name, kind),
+	})
 }
 
 // GetAllPodsList returns an uncached list of pods for the given namespace


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10689

#### What this PR does / why we need it:

Add logic to determine whether a VolumeAttachment associated with a force-deleted pod should be cleaned up. This ensures that stale attachments can be removed safely.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/9248#issuecomment-2800206182
