### PR TITLE
fix(uninstall): remove support-bundle before deleting manager

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -23,11 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/longhorn-manager/csi/crypto"
 	"github.com/longhorn/longhorn-manager/types"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10731

#### What this PR does / why we need it:

~Patch to remove support bundle finalizer, allowing bypassing webhooks, which may be unavailable during uninstallation.~ https://github.com/longhorn/longhorn-manager/pull/3712#issuecomment-2820244244

Delete support bundles before deleting managers.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
