### PR TITLE
fix(deps): add replace directive for `k8s.io/externaljwt`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ replace (
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.3
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.3
 	k8s.io/endpointslice => k8s.io/endpointslice v0.32.3
+	k8s.io/externaljwt => k8s.io/externaljwt v0.32.3
 	k8s.io/kms => k8s.io/kms v0.32.3
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.3
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.3


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
Listing all modules fails because there is no replace directive for `k8s.io/externaljwt`
``` bash
> go list -m -mod=mod all
go: k8s.io/externaljwt@v0.0.0: invalid version: unknown revision v0.0.0
```
Comments in the `go.mod` file recommends to add replace directives for all k8s.io dependencies of `k8s.io/kubernetes` that `k8s.io/kubernetes` itself replaces in its go.mod file

#### Special notes for your reviewer:

#### Additional documentation or context
