### PR TITLE
feat(csi): enable storage capacity-aware pod scheduling using `CSIStorageCapacity`

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -771,24 +771,6 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 	return rsp, nil
 }
 
-func max(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func parseNodeID(topology *csi.Topology) (string, error) {
-	if topology == nil || topology.Segments == nil {
-		return "", fmt.Errorf("missing accessible topology request parameter")
-	}
-	nodeId, ok := topology.Segments[nodeTopologyKey]
-	if !ok {
-		return "", fmt.Errorf("accessible topology request parameter is missing %s key", nodeTopologyKey)
-	}
-	return nodeId, nil
-}
-
 func (cs *ControllerServer) getSettingAsBoolean(name types.SettingName) (bool, error) {
 	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(context.TODO(), string(name), metav1.GetOptions{})
 	if err != nil {

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -30,6 +30,7 @@ func TestGetCapacity(t *testing.T) {
 		log:         logrus.StandardLogger().WithField("component", "test-get-capacity"),
 	}
 	for _, test := range []struct {
+		testName                string
 		node                    *longhorn.Node
 		skipNodeCreation        bool
 		skipNodeSettingCreation bool
@@ -42,64 +43,76 @@ func TestGetCapacity(t *testing.T) {
 		err                     error
 	}{
 		{
+			testName:         "Node not found",
 			skipNodeCreation: true,
 			node:             newNode("node-0", "storage", true, true, true, false),
 			err:              status.Errorf(codes.NotFound, "node node-0 not found"),
 		},
 		{
+			testName:                "Node setting not found",
 			skipNodeSettingCreation: true,
 			node:                    newNode("node-0", "storage", true, true, true, false),
 			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
 		},
 		{
+			testName:                "Disk setting not found",
 			skipDiskSettingCreation: true,
 			node:                    newNode("node-0", "storage", true, true, true, false),
 			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
 		},
 		{
-			node: newNode("node-0", "storage", true, true, true, false),
-			err:  status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
+			testName: "Missing data engine type",
+			node:     newNode("node-0", "storage", true, true, true, false),
+			err:      status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
 		},
 		{
+			testName:   "Unknown data engine type",
 			node:       newNode("node-0", "storage", true, true, true, false),
 			dataEngine: "v5",
 			err:        status.Errorf(codes.InvalidArgument, "unknown data engine type v5"),
 		},
 		{
+			testName:          "v1 engine with no disks",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v1",
 			availableCapacity: 0,
 		},
 		{
+			testName:          "v2 engine with no disks",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 0,
 		},
 		{
+			testName:          "Node condition is not ready",
 			node:              newNode("node-0", "storage", false, true, true, false),
 			dataEngine:        "v1",
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
 			availableCapacity: 0,
 		},
 		{
+			testName:          "Node condition is not schedulable",
 			node:              newNode("node-0", "storage", true, false, true, false),
 			dataEngine:        "v1",
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
 			availableCapacity: 0,
 		},
 		{
+			testName:          "Scheduling not allowed on a node",
 			node:              newNode("node-0", "storage", true, true, false, false),
 			dataEngine:        "v1",
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
 			availableCapacity: 0,
 		},
 		{
+			testName:          "Node eviction is requested",
 			node:              newNode("node-0", "storage", true, true, true, true),
 			dataEngine:        "v1",
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
 			availableCapacity: 0,
 		},
 		{
+			testName:          "Node tags don't match node selector",
 			node:              newNode("node-0", "large,fast,linux", true, true, true, false),
 			nodeSelector:      "fast,storage",
 			dataEngine:        "v1",
@@ -107,6 +120,7 @@ func TestGetCapacity(t *testing.T) {
 			availableCapacity: 0,
 		},
 		{
+			testName:          "v1 engine with two valid disks",
 			node:              newNode("node-0", "storage,large,fast,linux", true, true, true, false),
 			nodeSelector:      "fast,storage",
 			dataEngine:        "v1",
@@ -114,18 +128,21 @@ func TestGetCapacity(t *testing.T) {
 			availableCapacity: 1150,
 		},
 		{
+			testName:          "v1 engine with two valid disks and one with mismatched engine type",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v1",
 			availableCapacity: 1150,
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false), newDisk(2000, 100, "", true, true, true, false)},
 		},
 		{
+			testName:          "v2 engine with two valid disks and one with mismatched engine type",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 1650,
 			disks:             []*disk{newDisk(1950, 300, "", true, true, true, false), newDisk(1500, 500, "", true, true, true, false), newDisk(2000, 100, "", false, true, true, false)},
 		},
 		{
+			testName:          "v2 engine with one valid disk and two with unmatched tags",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			diskSelector:      "ssd,fast",
@@ -133,70 +150,75 @@ func TestGetCapacity(t *testing.T) {
 			disks:             []*disk{newDisk(1100, 100, "fast,nvmf,ssd,hot", true, true, true, false), newDisk(2500, 500, "ssd,slow,green", true, true, true, false), newDisk(2000, 100, "hdd,fast", true, true, true, false)},
 		},
 		{
+			testName:          "v2 engine with one valid disk and one with unhealthy condition",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, false, true, false), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 		{
+			testName:          "v2 engine with one valid disk and one with scheduling disabled",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, false, false), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 		{
+			testName:          "v2 engine with one valid disk and one marked for eviction",
 			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, true, true), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 	} {
-		cs.lhClient = lhfake.NewSimpleClientset()
-		if !test.skipNodeCreation {
-			addDisksToNode(test.node, test.disks)
-			_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), test.node, metav1.CreateOptions{})
-			if err != nil {
-				t.Error("failed to create node")
+		t.Run(test.testName, func(t *testing.T) {
+			cs.lhClient = lhfake.NewSimpleClientset()
+			if !test.skipNodeCreation {
+				addDisksToNode(test.node, test.disks)
+				_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), test.node, metav1.CreateOptions{})
+				if err != nil {
+					t.Error("failed to create node")
+				}
 			}
-		}
-		if !test.skipNodeSettingCreation {
-			_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"), metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyNodeSelectorVolume)
+			if !test.skipNodeSettingCreation {
+				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"), metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyNodeSelectorVolume)
+				}
 			}
-		}
-		if !test.skipDiskSettingCreation {
-			_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyDiskSelectorVolume)
+			if !test.skipDiskSettingCreation {
+				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyDiskSelectorVolume)
+				}
 			}
-		}
 
-		req := &csi.GetCapacityRequest{
-			AccessibleTopology: &csi.Topology{
-				Segments: map[string]string{
-					nodeTopologyKey: test.node.Name,
+			req := &csi.GetCapacityRequest{
+				AccessibleTopology: &csi.Topology{
+					Segments: map[string]string{
+						nodeTopologyKey: test.node.Name,
+					},
 				},
-			},
-			Parameters: map[string]string{},
-		}
-		if test.dataEngine != "" {
-			req.Parameters["dataEngine"] = test.dataEngine
-		}
-		req.Parameters["diskSelector"] = test.diskSelector
-		req.Parameters["nodeSelector"] = test.nodeSelector
-		res, err := cs.GetCapacity(context.TODO(), req)
+				Parameters: map[string]string{},
+			}
+			if test.dataEngine != "" {
+				req.Parameters["dataEngine"] = test.dataEngine
+			}
+			req.Parameters["diskSelector"] = test.diskSelector
+			req.Parameters["nodeSelector"] = test.nodeSelector
+			res, err := cs.GetCapacity(context.TODO(), req)
 
-		expectedStatus := status.Convert(test.err)
-		actualStatus := status.Convert(err)
-		if expectedStatus.Code() != actualStatus.Code() {
-			t.Errorf("expected error code: %v, but got: %v", expectedStatus.Code(), actualStatus.Code())
-		} else if expectedStatus.Message() != actualStatus.Message() {
-			t.Errorf("expected error message: '%s', but got: '%s'", expectedStatus.Message(), actualStatus.Message())
-		}
-		if res != nil && res.AvailableCapacity != test.availableCapacity {
-			t.Errorf("expected available capacity: %d, but got: %d", test.availableCapacity, res.AvailableCapacity)
-		}
+			expectedStatus := status.Convert(test.err)
+			actualStatus := status.Convert(err)
+			if expectedStatus.Code() != actualStatus.Code() {
+				t.Errorf("expected error code: %v, but got: %v", expectedStatus.Code(), actualStatus.Code())
+			} else if expectedStatus.Message() != actualStatus.Message() {
+				t.Errorf("expected error message: '%s', but got: '%s'", expectedStatus.Message(), actualStatus.Message())
+			}
+			if res != nil && res.AvailableCapacity != test.availableCapacity {
+				t.Errorf("expected available capacity: %d, but got: %d", test.availableCapacity, res.AvailableCapacity)
+			}
+		})
 	}
 }
 

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -3,6 +3,8 @@ package csi
 import (
 	"context"
 	"fmt"
+	"github.com/longhorn/longhorn-manager/types"
+	"strings"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -16,6 +18,11 @@ import (
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
+type disk struct {
+	spec   longhorn.DiskSpec
+	status longhorn.DiskStatus
+}
+
 func TestGetCapacity(t *testing.T) {
 	cs := &ControllerServer{
 		lhNamespace: "longhorn-system-test",
@@ -25,13 +32,20 @@ func TestGetCapacity(t *testing.T) {
 		nodeID            string
 		createNode        bool
 		dataEngine        string
+		diskSelector      string
 		availableCapacity int64
+		disks             []*disk
 		err               error
 	}{
 		{
 			nodeID:     "node-0",
 			dataEngine: "v1",
 			err:        status.Errorf(codes.NotFound, "node node-0 not found"),
+		},
+		{
+			nodeID:     "node-0",
+			createNode: true,
+			err:        status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
 		},
 		{
 			nodeID:     "node-0",
@@ -43,18 +57,62 @@ func TestGetCapacity(t *testing.T) {
 			nodeID:            "node-0",
 			createNode:        true,
 			dataEngine:        "v1",
-			availableCapacity: 1028,
+			availableCapacity: 0,
 		},
 		{
 			nodeID:            "node-0",
 			createNode:        true,
 			dataEngine:        "v2",
-			availableCapacity: 1028,
+			availableCapacity: 0,
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v1",
+			availableCapacity: 1150,
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false), newDisk(2000, 100, "", true, true, true, false)},
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			availableCapacity: 1650,
+			disks:             []*disk{newDisk(1950, 300, "", true, true, true, false), newDisk(1500, 500, "", true, true, true, false), newDisk(2000, 100, "", false, true, true, false)},
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			diskSelector:      "ssd,fast",
+			availableCapacity: 1000,
+			disks:             []*disk{newDisk(1100, 100, "fast,nvmf,ssd,hot", true, true, true, false), newDisk(2500, 500, "ssd,slow,green", true, true, true, false), newDisk(2000, 100, "hdd,fast", true, true, true, false)},
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			availableCapacity: 400,
+			disks:             []*disk{newDisk(1100, 100, "ssd", true, false, true, false), newDisk(500, 100, "hdd", true, true, true, false)},
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			availableCapacity: 400,
+			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, false, false), newDisk(500, 100, "hdd", true, true, true, false)},
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			availableCapacity: 400,
+			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, true, true), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 	} {
 		cs.lhClient = lhfake.NewSimpleClientset()
+		cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
 		if test.createNode {
-			node := newNode(test.nodeID, cs.lhNamespace, test.dataEngine, test.availableCapacity)
+			node := newNode(test.nodeID, cs.lhNamespace, test.disks)
 			_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("failed to create mock node: %v", err)
@@ -66,10 +124,12 @@ func TestGetCapacity(t *testing.T) {
 					nodeTopologyKey: test.nodeID,
 				},
 			},
-			Parameters: map[string]string{
-				"dataEngine": test.dataEngine,
-			},
+			Parameters: map[string]string{},
 		}
+		if test.dataEngine != "" {
+			req.Parameters["dataEngine"] = test.dataEngine
+		}
+		req.Parameters["diskSelector"] = test.diskSelector
 		res, err := cs.GetCapacity(context.TODO(), req)
 
 		expectedStatus := status.Convert(test.err)
@@ -80,41 +140,7 @@ func TestGetCapacity(t *testing.T) {
 			t.Errorf("expected error message: '%s', but got: '%s'", expectedStatus.Message(), actualStatus.Message())
 		}
 		if res != nil && res.AvailableCapacity != test.availableCapacity {
-			t.Errorf("expected available capacity: %d, but got: %d", res.AvailableCapacity, test.availableCapacity)
-		}
-	}
-}
-
-func TestParseDataEngine(t *testing.T) {
-	for _, test := range []struct {
-		parameters map[string]string
-		err        error
-		dataEngine string
-	}{
-		{
-			err: fmt.Errorf("missing storage class parameters"),
-		},
-		{
-			parameters: map[string]string{},
-			err:        fmt.Errorf("storage class parameters missing data engine key"),
-		},
-		{
-			parameters: map[string]string{
-				"dataEngine": "v1",
-			},
-			dataEngine: "v1",
-		},
-		{
-			parameters: map[string]string{
-				"dataEngine": "v5",
-			},
-			dataEngine: "v5",
-		},
-	} {
-		dataEngine, err := parseDataEngine(test.parameters)
-		checkError(t, test.err, err)
-		if test.dataEngine != string(dataEngine) {
-			t.Errorf("expected dataEngine: %s, but got: %s", test.dataEngine, dataEngine)
+			t.Errorf("expected available capacity: %d, but got: %d", test.availableCapacity, res.AvailableCapacity)
 		}
 	}
 }
@@ -174,23 +200,54 @@ func checkError(t *testing.T, expected, actual error) {
 	}
 }
 
-func newNode(name, namespace, dataEngine string, storageSize int64) *longhorn.Node {
-	diskType := longhorn.DiskTypeFilesystem
-	if dataEngine == "v2" {
-		diskType = longhorn.DiskTypeBlock
+func newDisk(storageAvailable, storageReserved int64, tags string, isBlockType, isCondOk, allowScheduling, evictionRequested bool) *disk {
+	disk := &disk{
+		spec: longhorn.DiskSpec{
+			StorageReserved:   storageReserved,
+			Tags:              strings.Split(tags, ","),
+			AllowScheduling:   allowScheduling,
+			EvictionRequested: evictionRequested,
+		},
+		status: longhorn.DiskStatus{
+			StorageAvailable: storageAvailable,
+			Type:             longhorn.DiskTypeFilesystem,
+		},
 	}
-	return &longhorn.Node{
+	if isBlockType {
+		disk.status.Type = longhorn.DiskTypeBlock
+	}
+	if isCondOk {
+		disk.status.Conditions = []longhorn.Condition{{Type: longhorn.DiskConditionTypeSchedulable, Status: longhorn.ConditionStatusTrue}}
+	}
+	return disk
+}
+
+func newNode(name, namespace string, disks []*disk) *longhorn.Node {
+	node := &longhorn.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Status: longhorn.NodeStatus{
-			DiskStatus: map[string]*longhorn.DiskStatus{
-				"disk": {
-					StorageAvailable: storageSize,
-					Type:             diskType,
-				},
-			},
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{},
 		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{},
+		},
+	}
+	for i, disk := range disks {
+		name := fmt.Sprintf("disk-%d", i)
+		node.Spec.Disks[name] = disk.spec
+		node.Status.DiskStatus[name] = &disk.status
+	}
+	return node
+}
+
+func newSetting(name, value string) *longhorn.Setting {
+	return &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Value: value,
 	}
 }

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -3,7 +3,6 @@ package csi
 import (
 	"context"
 	"fmt"
-	"github.com/longhorn/longhorn-manager/types"
 	"strings"
 	"testing"
 
@@ -13,6 +12,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
@@ -48,12 +49,12 @@ func TestGetCapacity(t *testing.T) {
 		{
 			skipNodeSettingCreation: true,
 			node:                    newNode("node-0", "storage", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting, err: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
 		},
 		{
 			skipDiskSettingCreation: true,
 			node:                    newNode("node-0", "storage", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting, err: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
 		},
 		{
 			node: newNode("node-0", "storage", true, true, true, false),

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -1,0 +1,196 @@
+package csi
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+func TestGetCapacity(t *testing.T) {
+	cs := &ControllerServer{
+		lhNamespace: "longhorn-system-test",
+		log:         logrus.StandardLogger().WithField("component", "test-get-capacity"),
+	}
+	for _, test := range []struct {
+		nodeID            string
+		createNode        bool
+		dataEngine        string
+		availableCapacity int64
+		err               error
+	}{
+		{
+			nodeID:     "node-0",
+			dataEngine: "v1",
+			err:        status.Errorf(codes.NotFound, "node node-0 not found"),
+		},
+		{
+			nodeID:     "node-0",
+			createNode: true,
+			dataEngine: "v5",
+			err:        status.Errorf(codes.InvalidArgument, "unknown data engine type v5"),
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v1",
+			availableCapacity: 1028,
+		},
+		{
+			nodeID:            "node-0",
+			createNode:        true,
+			dataEngine:        "v2",
+			availableCapacity: 1028,
+		},
+	} {
+		cs.lhClient = lhfake.NewSimpleClientset()
+		if test.createNode {
+			node := newNode(test.nodeID, cs.lhNamespace, test.dataEngine, test.availableCapacity)
+			_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("failed to create mock node: %v", err)
+			}
+		}
+		req := &csi.GetCapacityRequest{
+			AccessibleTopology: &csi.Topology{
+				Segments: map[string]string{
+					nodeTopologyKey: test.nodeID,
+				},
+			},
+			Parameters: map[string]string{
+				"dataEngine": test.dataEngine,
+			},
+		}
+		res, err := cs.GetCapacity(context.TODO(), req)
+
+		expectedStatus := status.Convert(test.err)
+		actualStatus := status.Convert(err)
+		if expectedStatus.Code() != actualStatus.Code() {
+			t.Errorf("expected error code: %v, but got: %v", expectedStatus.Code(), actualStatus.Code())
+		} else if expectedStatus.Message() != actualStatus.Message() {
+			t.Errorf("expected error message: '%s', but got: '%s'", expectedStatus.Message(), actualStatus.Message())
+		}
+		if res != nil && res.AvailableCapacity != test.availableCapacity {
+			t.Errorf("expected available capacity: %d, but got: %d", res.AvailableCapacity, test.availableCapacity)
+		}
+	}
+}
+
+func TestParseDataEngine(t *testing.T) {
+	for _, test := range []struct {
+		parameters map[string]string
+		err        error
+		dataEngine string
+	}{
+		{
+			err: fmt.Errorf("missing storage class parameters"),
+		},
+		{
+			parameters: map[string]string{},
+			err:        fmt.Errorf("storage class parameters missing data engine key"),
+		},
+		{
+			parameters: map[string]string{
+				"dataEngine": "v1",
+			},
+			dataEngine: "v1",
+		},
+		{
+			parameters: map[string]string{
+				"dataEngine": "v5",
+			},
+			dataEngine: "v5",
+		},
+	} {
+		dataEngine, err := parseDataEngine(test.parameters)
+		checkError(t, test.err, err)
+		if test.dataEngine != string(dataEngine) {
+			t.Errorf("expected dataEngine: %s, but got: %s", test.dataEngine, dataEngine)
+		}
+	}
+}
+
+func TestParseNodeID(t *testing.T) {
+	for _, test := range []struct {
+		topology *csi.Topology
+		err      error
+		nodeID   string
+	}{
+		{
+			err: fmt.Errorf("missing accessible topology request parameter"),
+		},
+		{
+			topology: &csi.Topology{
+				Segments: nil,
+			},
+			err: fmt.Errorf("missing accessible topology request parameter"),
+		},
+		{
+			topology: &csi.Topology{
+				Segments: map[string]string{
+					"some-key": "some-value",
+				},
+			},
+			err: fmt.Errorf("accessible topology request parameter is missing kubernetes.io/hostname key"),
+		},
+		{
+			topology: &csi.Topology{
+				Segments: map[string]string{
+					nodeTopologyKey: "node-0",
+				},
+			},
+			nodeID: "node-0",
+		},
+	} {
+		nodeID, err := parseNodeID(test.topology)
+		checkError(t, test.err, err)
+		if test.nodeID != nodeID {
+			t.Errorf("expected nodeID: %s, but got: %s", test.nodeID, nodeID)
+		}
+	}
+}
+
+func checkError(t *testing.T, expected, actual error) {
+	if expected == nil {
+		if actual != nil {
+			t.Errorf("expected no error but got: %v", actual)
+		}
+	} else {
+		if actual == nil {
+			t.Errorf("expected error: %v, but got no error", expected)
+		}
+		if expected.Error() != actual.Error() {
+			t.Errorf("expected error: %v, but got: %v", expected, actual)
+		}
+	}
+}
+
+func newNode(name, namespace, dataEngine string, storageSize int64) *longhorn.Node {
+	diskType := longhorn.DiskTypeFilesystem
+	if dataEngine == "v2" {
+		diskType = longhorn.DiskTypeBlock
+	}
+	return &longhorn.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				"disk": {
+					StorageAvailable: storageSize,
+					Type:             diskType,
+				},
+			},
+		},
+	}
+}

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -29,99 +29,152 @@ func TestGetCapacity(t *testing.T) {
 		log:         logrus.StandardLogger().WithField("component", "test-get-capacity"),
 	}
 	for _, test := range []struct {
-		nodeID            string
-		createNode        bool
-		dataEngine        string
-		diskSelector      string
-		availableCapacity int64
-		disks             []*disk
-		err               error
+		node                    *longhorn.Node
+		skipNodeCreation        bool
+		skipNodeSettingCreation bool
+		skipDiskSettingCreation bool
+		dataEngine              string
+		diskSelector            string
+		nodeSelector            string
+		availableCapacity       int64
+		disks                   []*disk
+		err                     error
 	}{
 		{
-			nodeID:     "node-0",
-			dataEngine: "v1",
-			err:        status.Errorf(codes.NotFound, "node node-0 not found"),
+			skipNodeCreation: true,
+			node:             newNode("node-0", "storage", true, true, true, false),
+			err:              status.Errorf(codes.NotFound, "node node-0 not found"),
 		},
 		{
-			nodeID:     "node-0",
-			createNode: true,
-			err:        status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
+			skipNodeSettingCreation: true,
+			node:                    newNode("node-0", "storage", true, true, true, false),
+			err:                     status.Errorf(codes.Internal, "failed to get setting, err: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
 		},
 		{
-			nodeID:     "node-0",
-			createNode: true,
+			skipDiskSettingCreation: true,
+			node:                    newNode("node-0", "storage", true, true, true, false),
+			err:                     status.Errorf(codes.Internal, "failed to get setting, err: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
+		},
+		{
+			node: newNode("node-0", "storage", true, true, true, false),
+			err:  status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
+		},
+		{
+			node:       newNode("node-0", "storage", true, true, true, false),
 			dataEngine: "v5",
 			err:        status.Errorf(codes.InvalidArgument, "unknown data engine type v5"),
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v1",
 			availableCapacity: 0,
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 0,
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", false, true, true, false),
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 0,
+		},
+		{
+			node:              newNode("node-0", "storage", true, false, true, false),
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 0,
+		},
+		{
+			node:              newNode("node-0", "storage", true, true, false, false),
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 0,
+		},
+		{
+			node:              newNode("node-0", "storage", true, true, true, true),
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 0,
+		},
+		{
+			node:              newNode("node-0", "large,fast,linux", true, true, true, false),
+			nodeSelector:      "fast,storage",
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 0,
+		},
+		{
+			node:              newNode("node-0", "storage,large,fast,linux", true, true, true, false),
+			nodeSelector:      "fast,storage",
+			dataEngine:        "v1",
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
+			availableCapacity: 1150,
+		},
+		{
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v1",
 			availableCapacity: 1150,
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false), newDisk(2000, 100, "", true, true, true, false)},
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 1650,
 			disks:             []*disk{newDisk(1950, 300, "", true, true, true, false), newDisk(1500, 500, "", true, true, true, false), newDisk(2000, 100, "", false, true, true, false)},
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			diskSelector:      "ssd,fast",
 			availableCapacity: 1000,
 			disks:             []*disk{newDisk(1100, 100, "fast,nvmf,ssd,hot", true, true, true, false), newDisk(2500, 500, "ssd,slow,green", true, true, true, false), newDisk(2000, 100, "hdd,fast", true, true, true, false)},
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, false, true, false), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, false, false), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 		{
-			nodeID:            "node-0",
-			createNode:        true,
+			node:              newNode("node-0", "storage", true, true, true, false),
 			dataEngine:        "v2",
 			availableCapacity: 400,
 			disks:             []*disk{newDisk(1100, 100, "ssd", true, true, true, true), newDisk(500, 100, "hdd", true, true, true, false)},
 		},
 	} {
 		cs.lhClient = lhfake.NewSimpleClientset()
-		cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
-		if test.createNode {
-			node := newNode(test.nodeID, cs.lhNamespace, test.disks)
-			_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		if !test.skipNodeCreation {
+			addDisksToNode(test.node, test.disks)
+			_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), test.node, metav1.CreateOptions{})
 			if err != nil {
-				t.Errorf("failed to create mock node: %v", err)
+				t.Error("failed to create node")
 			}
 		}
+		if !test.skipNodeSettingCreation {
+			_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"), metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyNodeSelectorVolume)
+			}
+		}
+		if !test.skipDiskSettingCreation {
+			_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyDiskSelectorVolume)
+			}
+		}
+
 		req := &csi.GetCapacityRequest{
 			AccessibleTopology: &csi.Topology{
 				Segments: map[string]string{
-					nodeTopologyKey: test.nodeID,
+					nodeTopologyKey: test.node.Name,
 				},
 			},
 			Parameters: map[string]string{},
@@ -130,6 +183,7 @@ func TestGetCapacity(t *testing.T) {
 			req.Parameters["dataEngine"] = test.dataEngine
 		}
 		req.Parameters["diskSelector"] = test.diskSelector
+		req.Parameters["nodeSelector"] = test.nodeSelector
 		res, err := cs.GetCapacity(context.TODO(), req)
 
 		expectedStatus := status.Convert(test.err)
@@ -222,25 +276,36 @@ func newDisk(storageAvailable, storageReserved int64, tags string, isBlockType, 
 	return disk
 }
 
-func newNode(name, namespace string, disks []*disk) *longhorn.Node {
+func newNode(name, tags string, isCondReady, isCondSchedulable, allowScheduling, evictionRequested bool) *longhorn.Node {
 	node := &longhorn.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 		Spec: longhorn.NodeSpec{
-			Disks: map[string]longhorn.DiskSpec{},
+			Disks:             map[string]longhorn.DiskSpec{},
+			Tags:              strings.Split(tags, ","),
+			AllowScheduling:   allowScheduling,
+			EvictionRequested: evictionRequested,
 		},
 		Status: longhorn.NodeStatus{
 			DiskStatus: map[string]*longhorn.DiskStatus{},
 		},
 	}
+	if isCondReady {
+		node.Status.Conditions = append(node.Status.Conditions, longhorn.Condition{Type: longhorn.NodeConditionTypeReady, Status: longhorn.ConditionStatusTrue})
+	}
+	if isCondSchedulable {
+		node.Status.Conditions = append(node.Status.Conditions, longhorn.Condition{Type: longhorn.NodeConditionTypeSchedulable, Status: longhorn.ConditionStatusTrue})
+	}
+	return node
+}
+
+func addDisksToNode(node *longhorn.Node, disks []*disk) {
 	for i, disk := range disks {
 		name := fmt.Sprintf("disk-%d", i)
 		node.Spec.Disks[name] = disk.spec
 		node.Status.DiskStatus[name] = &disk.status
 	}
-	return node
 }
 
 func newSetting(name, value string) *longhorn.Setting {

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -591,13 +591,14 @@ type DriverObjectDeployment struct {
 }
 
 func NewCSIDriverObject() *DriverObjectDeployment {
-	falseFlag := true
+	trueFlag := true
 	obj := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: types.LonghornDriverName,
 		},
 		Spec: storagev1.CSIDriverSpec{
-			PodInfoOnMount: &falseFlag,
+			PodInfoOnMount:  &trueFlag,
+			StorageCapacity: &trueFlag,
 		},
 	}
 	return &DriverObjectDeployment{

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -117,6 +117,8 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 			"--default-fstype=ext4",
+			"--enable-capacity",
+			"--capacity-ownerref-level=2",
 			fmt.Sprintf("--kube-api-qps=%v", types.KubeAPIQPS),
 			fmt.Sprintf("--kube-api-burst=%v", types.KubeAPIBurst),
 			fmt.Sprintf("--http-endpoint=:%v", types.CSISidecarMetricsPort),

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -593,14 +593,13 @@ type DriverObjectDeployment struct {
 }
 
 func NewCSIDriverObject() *DriverObjectDeployment {
-	trueFlag := true
 	obj := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: types.LonghornDriverName,
 		},
 		Spec: storagev1.CSIDriverSpec{
-			PodInfoOnMount:  &trueFlag,
-			StorageCapacity: &trueFlag,
+			PodInfoOnMount:  ptr.To(true),
+			StorageCapacity: ptr.To(true),
 		},
 	}
 	return &DriverObjectDeployment{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -105,6 +105,22 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 										},
 									},
 								},
+								{
+									Name: "NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -106,6 +106,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 									},
 								},
 								{
+									// required by external-provisioner to set owner references for CSIStorageCapacity objects
 									Name: "NAMESPACE",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{
@@ -114,6 +115,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 									},
 								},
 								{
+									// required by external-provisioner to set owner references for CSIStorageCapacity objects
 									Name: "POD_NAME",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{

--- a/csi/identity_server.go
+++ b/csi/identity_server.go
@@ -42,6 +42,13 @@ func (ids *IdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.G
 				},
 			},
 			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
+			{
 				Type: &csi.PluginCapability_VolumeExpansion_{
 					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
 						Type: csi.PluginCapability_VolumeExpansion_ONLINE,

--- a/csi/manager.go
+++ b/csi/manager.go
@@ -43,7 +43,7 @@ func (m *Manager) Run(driverName, nodeID, endpoint, identityVersion, managerURL 
 
 	m.cs, err = NewControllerServer(apiClient, nodeID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create CSI controller server ")
+		return errors.Wrap(err, "failed to create CSI controller server")
 	}
 
 	s := NewNonBlockingGRPCServer()

--- a/csi/manager.go
+++ b/csi/manager.go
@@ -43,7 +43,7 @@ func (m *Manager) Run(driverName, nodeID, endpoint, identityVersion, managerURL 
 
 	m.cs, err = NewControllerServer(apiClient, nodeID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create CSI control server ")
+		return errors.Wrap(err, "Failed to create CSI controller server ")
 	}
 
 	s := NewNonBlockingGRPCServer()

--- a/csi/manager.go
+++ b/csi/manager.go
@@ -41,7 +41,11 @@ func (m *Manager) Run(driverName, nodeID, endpoint, identityVersion, managerURL 
 		return errors.Wrap(err, "Failed to create CSI node server ")
 	}
 
-	m.cs = NewControllerServer(apiClient, nodeID)
+	m.cs, err = NewControllerServer(apiClient, nodeID)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create CSI control server ")
+	}
+
 	s := NewNonBlockingGRPCServer()
 	s.Start(endpoint, m.ids, m.cs, m.ns)
 	s.Wait()

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	defaultFsType   = "ext4"
-	nodeTopologyKey = "kubernetes.io/hostname"
+	defaultFsType = "ext4"
 )
 
 type fsParameters struct {

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -890,9 +890,16 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 }
 
 func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	node, err := ns.kubeClient.CoreV1().Nodes().Get(ctx, ns.nodeID, metav1.GetOptions{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
 	return &csi.NodeGetInfoResponse{
 		NodeId:            ns.nodeID,
 		MaxVolumesPerNode: 0, // technically the scsi kernel limit is the max limit of volumes
+		AccessibleTopology: &csi.Topology{
+			Segments: node.Labels,
+		},
 	}, nil
 }
 

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	defaultFsType = "ext4"
+	defaultFsType   = "ext4"
+	nodeTopologyKey = "kubernetes.io/hostname"
 )
 
 type fsParameters struct {
@@ -890,15 +891,13 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 }
 
 func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	node, err := ns.kubeClient.CoreV1().Nodes().Get(ctx, ns.nodeID, metav1.GetOptions{})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
-	}
 	return &csi.NodeGetInfoResponse{
 		NodeId:            ns.nodeID,
 		MaxVolumesPerNode: 0, // technically the scsi kernel limit is the max limit of volumes
 		AccessibleTopology: &csi.Topology{
-			Segments: node.Labels,
+			Segments: map[string]string{
+				nodeTopologyKey: ns.nodeID,
+			},
 		},
 	}, nil
 }

--- a/csi/util.go
+++ b/csi/util.go
@@ -35,6 +35,8 @@ const (
 	defaultForceUmountTimeout = 30 * time.Second
 
 	tempTestMountPointValidStatusFile = ".longhorn-volume-mount-point-test.tmp"
+
+	nodeTopologyKey = "kubernetes.io/hostname"
 )
 
 // NewForcedParamsExec creates a osExecutor that allows for adding additional params to later occurring Run calls
@@ -465,4 +467,15 @@ func requiresSharedAccess(vol *longhornclient.Volume, cap *csi.VolumeCapability)
 
 func getStageBlockVolumePath(stagingTargetPath, volumeID string) string {
 	return filepath.Join(stagingTargetPath, volumeID)
+}
+
+func parseNodeID(topology *csi.Topology) (string, error) {
+	if topology == nil || topology.Segments == nil {
+		return "", fmt.Errorf("missing accessible topology request parameter")
+	}
+	nodeId, ok := topology.Segments[nodeTopologyKey]
+	if !ok {
+		return "", fmt.Errorf("accessible topology request parameter is missing %s key", nodeTopologyKey)
+	}
+	return nodeId, nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10685

#### What this PR does / why we need it:

Enable storage capacity-aware pod scheduling using `CSIStorageCapacity`. 

Changes:
- set `StorageCapacity` field of csi driver to `true`
- added `GET_CAPACITY` capability and implemented `GetCapacity` rpc
- added `VOLUME_ACCESSIBILITY_CONSTRAINTS` plugin capability and slightly changed `NodeGetInfo` rpc implementation to return accessible topologies. This is needed because kubelet uses response from `NodeGetInfo` rpc to populate `topologyKeys` field of the `CSINode` objects, which is then consumed by the external-provisioner to build the `AccessibleTopolgies` field of the `GetCapacityRequest`.
- added flags to the external-provisioner deployment to make it automatically produce `CSIStorageCapacity` objects.

These changes won't affect existing users unless they use storage class with `volumeBindingMode` set to the `WaitForFirstConsumer`.

I've tested this PR manually in my local k8s cluster. It seems to be working well. I'm planning to add integrations tests in the https://github.com/longhorn/longhorn-tests/tree/master/manager repository once/if this PR is accecpted.

#### Special notes for your reviewer:

#### Additional documentation or context
