### PR TITLE
feat(setting): replace orphan-auto-deletion with orphan-resource-auto…

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -256,10 +256,6 @@ func (sc *SettingController) syncNonDangerZoneSettingsForManagedComponents(setti
 		if err := sc.syncDefaultLonghornStaticStorageClass(); err != nil {
 			return err
 		}
-	case types.SettingNameOrphanResourceAutoDeletion:
-		if err := sc.syncOrphanResourceAutoDeletion(); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -895,32 +891,6 @@ func (sc *SettingController) syncDefaultLonghornStaticStorageClass() error {
 			return err
 		}
 		return nil
-	}
-
-	return err
-}
-
-func (sc *SettingController) syncOrphanResourceAutoDeletion() error {
-	setting, err := sc.ds.GetSettingOrphanResourceAutoDeletion()
-	if err != nil {
-		return err
-	}
-	var replicaDataCleanupValue string
-	if setting[types.OrphanResourceTypeReplicaData] {
-		replicaDataCleanupValue = "true"
-	} else {
-		replicaDataCleanupValue = "false"
-	}
-
-	deprecatedSetting, err := sc.ds.GetSetting(types.SettingNameOrphanAutoDeletion)
-	if err != nil {
-		return err
-	}
-	if replicaDataCleanupValue != deprecatedSetting.Value {
-		deprecatedSetting.Value = replicaDataCleanupValue
-		if _, err := sc.ds.UpdateSetting(deprecatedSetting); err != nil {
-			return err
-		}
 	}
 
 	return err
@@ -1614,7 +1584,6 @@ func (info *ClusterInfo) collectSettings() error {
 		types.SettingNameKubernetesClusterAutoscalerEnabled:                       true,
 		types.SettingNameNodeDownPodDeletionPolicy:                                true,
 		types.SettingNameNodeDrainPolicy:                                          true,
-		types.SettingNameOrphanAutoDeletion:                                       true,
 		types.SettingNameOrphanResourceAutoDeletion:                               true,
 		types.SettingNameRecurringFailedJobsHistoryLimit:                          true,
 		types.SettingNameRecurringSuccessfulJobsHistoryLimit:                      true,

--- a/types/setting.go
+++ b/types/setting.go
@@ -99,7 +99,7 @@ const (
 	SettingNameBackingImageRecoveryWaitInterval                         = SettingName("backing-image-recovery-wait-interval")
 	SettingNameGuaranteedInstanceManagerCPU                             = SettingName("guaranteed-instance-manager-cpu")
 	SettingNameKubernetesClusterAutoscalerEnabled                       = SettingName("kubernetes-cluster-autoscaler-enabled")
-	SettingNameOrphanAutoDeletion                                       = SettingName("orphan-auto-deletion")
+	SettingNameOrphanAutoDeletion                                       = SettingName("orphan-auto-deletion") // replaced by SettingNameOrphanResourceAutoDeletion
 	SettingNameOrphanResourceAutoDeletion                               = SettingName("orphan-resource-auto-deletion")
 	SettingNameStorageNetwork                                           = SettingName("storage-network")
 	SettingNameStorageNetworkForRWXVolumeEnabled                        = SettingName("storage-network-for-rwx-volume-enabled")
@@ -202,7 +202,6 @@ var (
 		SettingNameBackingImageRecoveryWaitInterval,
 		SettingNameGuaranteedInstanceManagerCPU,
 		SettingNameKubernetesClusterAutoscalerEnabled,
-		SettingNameOrphanAutoDeletion,
 		SettingNameOrphanResourceAutoDeletion,
 		SettingNameStorageNetwork,
 		SettingNameStorageNetworkForRWXVolumeEnabled,
@@ -249,6 +248,10 @@ var (
 		SettingNameOfflineReplicaRebuilding,
 	}
 )
+
+var replacedSettingNames = map[SettingName]bool{
+	SettingNameOrphanAutoDeletion: true, // SettingNameOrphanResourceAutoDeletion
+}
 
 type SettingCategory string
 
@@ -327,7 +330,6 @@ var (
 		SettingNameBackingImageRecoveryWaitInterval:                         SettingDefinitionBackingImageRecoveryWaitInterval,
 		SettingNameGuaranteedInstanceManagerCPU:                             SettingDefinitionGuaranteedInstanceManagerCPU,
 		SettingNameKubernetesClusterAutoscalerEnabled:                       SettingDefinitionKubernetesClusterAutoscalerEnabled,
-		SettingNameOrphanAutoDeletion:                                       SettingDefinitionOrphanAutoDeletion,
 		SettingNameOrphanResourceAutoDeletion:                               SettingDefinitionOrphanResourceAutoDeletion,
 		SettingNameStorageNetwork:                                           SettingDefinitionStorageNetwork,
 		SettingNameStorageNetworkForRWXVolumeEnabled:                        SettingDefinitionStorageNetworkForRWXVolumeEnabled,
@@ -1052,18 +1054,6 @@ var (
 		Type:     SettingTypeBool,
 		Required: true,
 		ReadOnly: false,
-		Default:  "false",
-	}
-
-	SettingDefinitionOrphanAutoDeletion = SettingDefinition{
-		DisplayName: "Orphan Auto-Deletion",
-		Description: "This setting allows Longhorn to delete the orphan resource and its corresponding orphaned data automatically. \n\n" +
-			"Orphan resources on down or unknown nodes will not be cleaned up automatically. \n\n" +
-			fmt.Sprintf("Deprecated: enable \"%s\" in %s instead. \n\n", OrphanResourceTypeReplicaData, SettingNameOrphanResourceAutoDeletion),
-		Category: SettingCategoryOrphan,
-		Type:     SettingTypeBool,
-		Required: true,
-		ReadOnly: true,
 		Default:  "false",
 	}
 
@@ -1823,6 +1813,10 @@ func UnmarshalOrphanResourceTypes(resourceTypesSetting string) (map[OrphanResour
 		return nil, fmt.Errorf("invalid orphan resource types: %s", strings.Join(invalidItems, ", "))
 	}
 	return resourceTypes, nil
+}
+
+func IsSettingReplaced(name SettingName) bool {
+	return replacedSettingNames[name]
 }
 
 // GetSettingDefinition gets the setting definition in `settingDefinitions` by the parameter `name`

--- a/upgrade/v18xto190/upgrade.go
+++ b/upgrade/v18xto190/upgrade.go
@@ -1,12 +1,9 @@
 package v18xto190
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/longhorn/longhorn-manager/types"
@@ -72,10 +69,6 @@ func updateCRs(namespace string, lhClient *lhclientset.Clientset, kubeClient *cl
 		return err
 	}
 
-	if err := upgradeSettings(namespace, lhClient, resourceMaps); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -98,55 +91,5 @@ func upgradeVolumes(namespace string, lhClient *lhclientset.Clientset, resourceM
 		}
 	}
 
-	return nil
-}
-
-func upgradeSettings(namespace string, lhClient *lhclientset.Clientset, resourceMaps map[string]interface{}) (err error) {
-	defer func() {
-		err = errors.Wrapf(err, upgradeLogPrefix+"upgrade settings failed")
-	}()
-
-	settingsMap, err := upgradeutil.ListAndUpdateSettingsInProvidedCache(namespace, lhClient, resourceMaps)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "failed to list all existing Longhorn settings during the settings upgrade")
-	}
-
-	if err := updateOrphanResourceAutoDeletionSetting(settingsMap); err != nil {
-		return errors.Wrapf(err, "failed to update orphan resource auto-deletion settings")
-	}
-
-	return nil
-}
-
-func updateOrphanResourceAutoDeletionSetting(settingsMap map[string]*longhorn.Setting) (err error) {
-	oldSetting, exist := settingsMap[string(types.SettingNameOrphanAutoDeletion)]
-	if !exist {
-		return nil
-	}
-	newSetting, exist := settingsMap[string(types.SettingNameOrphanResourceAutoDeletion)]
-	if !exist {
-		newSetting = &longhorn.Setting{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: string(types.SettingNameOrphanResourceAutoDeletion),
-			},
-		}
-		settingsMap[string(types.SettingNameOrphanResourceAutoDeletion)] = newSetting
-	}
-	resourceTypes, err := types.UnmarshalOrphanResourceTypes(newSetting.Value)
-	if err != nil {
-		return err
-	}
-
-	resourceTypes[types.OrphanResourceTypeReplicaData] = oldSetting.Value == "true"
-	enabledResourceType := make([]string, 0, len(resourceTypes))
-	for rt, enabled := range resourceTypes {
-		if enabled {
-			enabledResourceType = append(enabledResourceType, string(rt))
-		}
-	}
-	newSetting.Value = strings.Join(enabledResourceType, ";")
 	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6764
https://github.com/longhorn/longhorn/issues/6764#issuecomment-2834461677

replaces #3730

#### What this PR does / why we need it:

- Upgrade stage does not create new objects. It update only the existing objects, and remove settings without definition.
- Leave settings to be replaced in settings setup stage, replacing the old settings, and remove the replaced settings at the end of this stage.
- Since the old `orphan-auto-deletion` settings is replaced and removed, we don't need to sync it in setting controller.

#### Special notes for your reviewer:

#### Additional documentation or context