### PR TITLE
feat(rebuild): implement per-volume and global QoS control for replic…

### DIFF
--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -250,6 +250,11 @@ func (e *EngineBinary) ReplicaRebuildStatus(*longhorn.Engine) (map[string]*longh
 	return data, nil
 }
 
+func (e *EngineBinary) ReplicaRebuildQosSet(engine *longhorn.Engine, qosLimitMbps int64) error {
+	// NOTE: Not implemented for EngineBinary (deprecated path)
+	return nil
+}
+
 // VolumeFrontendStart calls engine binary
 // TODO: Deprecated, replaced by gRPC proxy
 func (e *EngineBinary) VolumeFrontendStart(engine *longhorn.Engine) error {

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -240,6 +240,10 @@ func (e *EngineSimulator) ReplicaRebuildStatus(*longhorn.Engine) (map[string]*lo
 	return nil, errors.New(ErrNotImplement)
 }
 
+func (e *EngineSimulator) ReplicaRebuildQosSet(engine *longhorn.Engine, qosLimitMbps int64) error {
+	return errors.New(ErrNotImplement)
+}
+
 func (e *EngineSimulator) VolumeFrontendStart(*longhorn.Engine) error {
 	return errors.New(ErrNotImplement)
 }

--- a/engineapi/proxy_replica.go
+++ b/engineapi/proxy_replica.go
@@ -51,6 +51,11 @@ func (p *Proxy) ReplicaRebuildStatus(e *longhorn.Engine) (status map[string]*lon
 	return status, nil
 }
 
+func (p *Proxy) ReplicaRebuildQosSet(e *longhorn.Engine, qosLimitMbps int64) error {
+	return p.grpcClient.ReplicaRebuildingQosSet(string(e.Spec.DataEngine), e.Name, e.Spec.VolumeName,
+		p.DirectToURL(e), qosLimitMbps)
+}
+
 func (p *Proxy) ReplicaRebuildVerify(e *longhorn.Engine, replicaName, url string) (err error) {
 	if err := ValidateReplicaURL(url); err != nil {
 		return err

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -92,6 +92,7 @@ type EngineClient interface {
 	ReplicaAdd(engine *longhorn.Engine, replicaName, url string, isRestoreVolume, fastSync bool, localSync *etypes.FileLocalSync, replicaFileSyncHTTPClientTimeout, grpcTimeoutSeconds int64) error
 	ReplicaRemove(engine *longhorn.Engine, url, replicaName string) error
 	ReplicaRebuildStatus(*longhorn.Engine) (map[string]*longhorn.RebuildStatus, error)
+	ReplicaRebuildQosSet(engine *longhorn.Engine, qosLimitMbps int64) error
 	ReplicaRebuildVerify(engine *longhorn.Engine, replicaName, url string) error
 	ReplicaModeUpdate(engine *longhorn.Engine, url string, mode string) error
 

--- a/go.mod
+++ b/go.mod
@@ -68,9 +68,9 @@ require (
 	github.com/longhorn/backupstore v0.0.0-20250624115502-f6e828377c27
 	github.com/longhorn/go-common-libs v0.0.0-20250624104228-81fc0ee0e090
 	github.com/longhorn/go-iscsi-helper v0.0.0-20250628151415-4c3f08918bb0
-	github.com/longhorn/go-spdk-helper v0.0.2
+	github.com/longhorn/go-spdk-helper v0.0.3-0.20250628151439-b5bf3dd40b0e
 	github.com/longhorn/longhorn-engine v1.9.0
-	github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250518.0.20250519060809-955e286a739c
+	github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250629.0.20250703154654-ce049b97ccc0
 	github.com/longhorn/longhorn-share-manager v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -117,12 +117,12 @@ github.com/longhorn/go-common-libs v0.0.0-20250624104228-81fc0ee0e090 h1:Su0qrRx
 github.com/longhorn/go-common-libs v0.0.0-20250624104228-81fc0ee0e090/go.mod h1:MKOEEDTIuCNTMUuHol8UvdNqcX9Uueo1SvllrTgXOT8=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250628151415-4c3f08918bb0 h1:TwtCNOqppvJcYjQqBx7nKTITjNQoZgBD/E63whWj4Mk=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250628151415-4c3f08918bb0/go.mod h1:Cmtm777Xa2TNs50+ipLMiYshVWtKsaFKbpWX/PKBgFM=
-github.com/longhorn/go-spdk-helper v0.0.2 h1:cK7obTyCI1ytm0SMaUEjwsHeX6hK+82kPjuAQkf+Tvg=
-github.com/longhorn/go-spdk-helper v0.0.2/go.mod h1:lZYWKf8YNOV4TSf57u8Tj1ilDQLQlW2M/HgFlecoRno=
+github.com/longhorn/go-spdk-helper v0.0.3-0.20250628151439-b5bf3dd40b0e h1:YsxSAC53Y15i1A+a0hAdvV+00CTGLQwTfne0BcDvEYY=
+github.com/longhorn/go-spdk-helper v0.0.3-0.20250628151439-b5bf3dd40b0e/go.mod h1:zyKqJPfuZhBu9BXr4GUDtlBkOooSf7HEEMZcMr6xITo=
 github.com/longhorn/longhorn-engine v1.9.0 h1:NSQNwAFQZdF+nywTJbyW0qJBKIWPE6J2Vy0qWCsup4I=
 github.com/longhorn/longhorn-engine v1.9.0/go.mod h1:dvVqPWauvH2hrMlI6sDd3y8wsA4wsAtCX7WB+JwcbwA=
-github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250518.0.20250519060809-955e286a739c h1:W9/fwmx/uhCzZfE9g7Lf6i4VaD6fl20IgeQF1cFblrU=
-github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250518.0.20250519060809-955e286a739c/go.mod h1:8gfwbZRPzNazr3eLPm3/JS2pQIdflj0yFn1J4E4vLy8=
+github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250629.0.20250703154654-ce049b97ccc0 h1:iK4ZjCbjN5vmjcCpRNzSS3TlGEr97s/4vkOqeOdsXdU=
+github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250629.0.20250703154654-ce049b97ccc0/go.mod h1:KEproiQhC3/j2puVsYDzTosv7X+JNHMUVWmzvv38K3M=
 github.com/longhorn/longhorn-share-manager v1.9.0 h1:t6WnF9CzN7ivNJD9iHKjyci13Uy1Z9nWO8xDudYMtys=
 github.com/longhorn/longhorn-share-manager v1.9.0/go.mod h1:9tf9Gh+YWTfDLEC8/qY25LmWgNelKF/6GK6rxNzA0vg=
 github.com/longhorn/types v0.0.0-20250613005741-b79d2bcff04b h1:Y/AySVFU2coY5g8uIrChKNc58eM4oVqpHB1/dwMAn2M=

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1463,6 +1463,9 @@ spec:
               rebuildStatus:
                 additionalProperties:
                   properties:
+                    appliedRebuildingMBps:
+                      format: int64
+                      type: integer
                     error:
                       type: string
                     fromReplicaAddress:
@@ -3536,6 +3539,13 @@ spec:
                 - disabled
                 - enabled
                 type: string
+              rebuildingMbytesPerSecond:
+                description: RebuildingMBytesPerSecond limits the write bandwidth
+                  (in megabytes per second) on the destination replica during rebuilding.
+                  Set to 0 to disable bandwidth limiting.
+                format: int64
+                minimum: 0
+                type: integer
               replicaAutoBalance:
                 enum:
                 - ignored

--- a/k8s/pkg/apis/longhorn/v1beta2/engine.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/engine.go
@@ -77,6 +77,8 @@ type RebuildStatus struct {
 	State string `json:"state"`
 	// +optional
 	FromReplicaAddress string `json:"fromReplicaAddress"`
+	// +optional
+	AppliedRebuildingMBps int64 `json:"appliedRebuildingMBps"`
 }
 
 type SnapshotCloneStatus struct {

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -306,6 +306,10 @@ type VolumeSpec struct {
 	// - disabled: Disable offline rebuilding for this volume, regardless of the global setting
 	// +optional
 	OfflineRebuilding VolumeOfflineRebuilding `json:"offlineRebuilding"`
+	// RebuildingMBytesPerSecond limits the write bandwidth (in megabytes per second) on the destination replica during rebuilding. Set to 0 to disable bandwidth limiting.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	RebuildingMbytesPerSecond int64 `json:"rebuildingMbytesPerSecond,omitempty"`
 }
 
 // VolumeStatus defines the observed state of the Longhorn volume

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/rebuildstatus.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/rebuildstatus.go
@@ -21,11 +21,12 @@ package v1beta2
 // RebuildStatusApplyConfiguration represents a declarative configuration of the RebuildStatus type for use
 // with apply.
 type RebuildStatusApplyConfiguration struct {
-	Error              *string `json:"error,omitempty"`
-	IsRebuilding       *bool   `json:"isRebuilding,omitempty"`
-	Progress           *int    `json:"progress,omitempty"`
-	State              *string `json:"state,omitempty"`
-	FromReplicaAddress *string `json:"fromReplicaAddress,omitempty"`
+	Error                 *string `json:"error,omitempty"`
+	IsRebuilding          *bool   `json:"isRebuilding,omitempty"`
+	Progress              *int    `json:"progress,omitempty"`
+	State                 *string `json:"state,omitempty"`
+	FromReplicaAddress    *string `json:"fromReplicaAddress,omitempty"`
+	AppliedRebuildingMBps *int64  `json:"appliedRebuildingMBps,omitempty"`
 }
 
 // RebuildStatusApplyConfiguration constructs a declarative configuration of the RebuildStatus type for use with
@@ -71,5 +72,13 @@ func (b *RebuildStatusApplyConfiguration) WithState(value string) *RebuildStatus
 // If called multiple times, the FromReplicaAddress field is set to the value of the last call.
 func (b *RebuildStatusApplyConfiguration) WithFromReplicaAddress(value string) *RebuildStatusApplyConfiguration {
 	b.FromReplicaAddress = &value
+	return b
+}
+
+// WithAppliedRebuildingMBps sets the AppliedRebuildingMBps field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AppliedRebuildingMBps field is set to the value of the last call.
+func (b *RebuildStatusApplyConfiguration) WithAppliedRebuildingMBps(value int64) *RebuildStatusApplyConfiguration {
+	b.AppliedRebuildingMBps = &value
 	return b
 }

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/volumespec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/volumespec.go
@@ -59,6 +59,7 @@ type VolumeSpecApplyConfiguration struct {
 	FreezeFilesystemForSnapshot *longhornv1beta2.FreezeFilesystemForSnapshot   `json:"freezeFilesystemForSnapshot,omitempty"`
 	BackupTargetName            *string                                        `json:"backupTargetName,omitempty"`
 	OfflineRebuilding           *longhornv1beta2.VolumeOfflineRebuilding       `json:"offlineRebuilding,omitempty"`
+	RebuildingMbytesPerSecond   *int64                                         `json:"rebuildingMbytesPerSecond,omitempty"`
 }
 
 // VolumeSpecApplyConfiguration constructs a declarative configuration of the VolumeSpec type for use with
@@ -340,5 +341,13 @@ func (b *VolumeSpecApplyConfiguration) WithBackupTargetName(value string) *Volum
 // If called multiple times, the OfflineRebuilding field is set to the value of the last call.
 func (b *VolumeSpecApplyConfiguration) WithOfflineRebuilding(value longhornv1beta2.VolumeOfflineRebuilding) *VolumeSpecApplyConfiguration {
 	b.OfflineRebuilding = &value
+	return b
+}
+
+// WithRebuildingMbytesPerSecond sets the RebuildingMbytesPerSecond field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RebuildingMbytesPerSecond field is set to the value of the last call.
+func (b *VolumeSpecApplyConfiguration) WithRebuildingMbytesPerSecond(value int64) *VolumeSpecApplyConfiguration {
+	b.RebuildingMbytesPerSecond = &value
 	return b
 }

--- a/types/setting.go
+++ b/types/setting.go
@@ -138,6 +138,7 @@ const (
 	SettingNameV2DataEngineLogFlags                                     = SettingName("v2-data-engine-log-flags")
 	SettingNameV2DataEngineFastReplicaRebuilding                        = SettingName("v2-data-engine-fast-replica-rebuilding")
 	SettingNameV2DataEngineSnapshotDataIntegrity                        = SettingName("v2-data-engine-snapshot-data-integrity")
+	SettingNameV2DataEngineRebuildingMbytesPerSecond                    = SettingName("v2-data-engine-rebuilding-mbytes-per-second")
 	SettingNameFreezeFilesystemForSnapshot                              = SettingName("freeze-filesystem-for-snapshot")
 	SettingNameAutoCleanupSnapshotWhenDeleteBackup                      = SettingName("auto-cleanup-when-delete-backup")
 	SettingNameAutoCleanupSnapshotAfterOnDemandBackupCompleted          = SettingName("auto-cleanup-snapshot-after-on-demand-backup-completed")
@@ -237,6 +238,7 @@ var (
 		SettingNameV2DataEngineLogFlags,
 		SettingNameV2DataEngineFastReplicaRebuilding,
 		SettingNameV2DataEngineSnapshotDataIntegrity,
+		SettingNameV2DataEngineRebuildingMbytesPerSecond,
 		SettingNameReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume,
@@ -366,6 +368,7 @@ var (
 		SettingNameV2DataEngineLogFlags:                                     SettingDefinitionV2DataEngineLogFlags,
 		SettingNameV2DataEngineFastReplicaRebuilding:                        SettingDefinitionV2DataEngineFastReplicaRebuilding,
 		SettingNameV2DataEngineSnapshotDataIntegrity:                        SettingDefinitionV2DataEngineSnapshotDataIntegrity,
+		SettingNameV2DataEngineRebuildingMbytesPerSecond:                    SettingDefinitionV2DataEngineRebuildingMbytesPerSecond,
 		SettingNameReplicaDiskSoftAntiAffinity:                              SettingDefinitionReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume:                             SettingDefinitionAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume:                             SettingDefinitionAllowEmptyDiskSelectorVolume,
@@ -1519,6 +1522,18 @@ var (
 			string(longhorn.SnapshotDataIntegrityDisabled),
 			string(longhorn.SnapshotDataIntegrityFastCheck),
 		},
+	}
+
+	SettingDefinitionV2DataEngineRebuildingMbytesPerSecond = SettingDefinition{
+		DisplayName: "V2 Data Engine Rebuilding MBytes Per Second",
+		Description: "This setting specifies the default write bandwidth limit (in megabytes per second) for volume replica rebuilding when using the v2 data engine (SPDK). " +
+			"If this value is set to 0, there will be no write bandwidth limitation. " +
+			"Individual volumes can override this setting by specifying their own rebuilding bandwidth limit.",
+		Category: SettingCategoryV2DataEngine,
+		Type:     SettingTypeInt,
+		Required: false,
+		ReadOnly: false,
+		Default:  "0",
 	}
 
 	SettingDefinitionAutoCleanupSnapshotWhenDeleteBackup = SettingDefinition{

--- a/vendor/github.com/longhorn/longhorn-instance-manager/pkg/client/proxy_types.go
+++ b/vendor/github.com/longhorn/longhorn-instance-manager/pkg/client/proxy_types.go
@@ -67,11 +67,12 @@ type EngineBackupInfo struct {
 }
 
 type ReplicaRebuildStatus struct {
-	Error              string
-	IsRebuilding       bool
-	Progress           int
-	State              string
-	FromReplicaAddress string
+	Error                 string
+	IsRebuilding          bool
+	Progress              int
+	State                 string
+	FromReplicaAddress    string
+	AppliedRebuildingMBps int64
 }
 
 type SnapshotHashStatus struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev
 github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
-# github.com/longhorn/go-spdk-helper v0.0.2
+# github.com/longhorn/go-spdk-helper v0.0.3-0.20250628151439-b5bf3dd40b0e
 ## explicit; go 1.23.0
 github.com/longhorn/go-spdk-helper/pkg/types
 # github.com/longhorn/longhorn-engine v1.9.0
@@ -179,7 +179,7 @@ github.com/longhorn/longhorn-engine/pkg/meta
 github.com/longhorn/longhorn-engine/pkg/replica/client
 github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
-# github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250518.0.20250519060809-955e286a739c
+# github.com/longhorn/longhorn-instance-manager v1.10.0-dev-20250629.0.20250703154654-ce049b97ccc0
 ## explicit; go 1.24.0
 github.com/longhorn/longhorn-instance-manager/pkg/api
 github.com/longhorn/longhorn-instance-manager/pkg/client


### PR DESCRIPTION
…a rebuilding (v2 engine)

- Adds  in EngineMonitor to apply QoS during rebuilding
- Supports per-volume  and global setting fallback
- Adds  to  to track actual QoS applied
- Updates CRD, types, and applyconfig for the new fields

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10770

#### What this PR does / why we need it:

- Adds support for applying replica rebuilding QoS on v2 (SPDK) engine replicas
- Introduces a global setting `v2-data-engine-rebuilding-mbytes-per-second` to control default bandwidth limit
- Adds a per-volume override field `rebuildingMbytesPerSecond` in VolumeSpec
- Ensures actual QoS application is tracked via `AppliedRebuildingMbps` in Engine.Status.RebuildStatus
- Updates CRD schema and generated applyconfiguration files

#### Special notes for your reviewer:

- If both global and per-volume values are 0, no QoS will be applied (unlimited)
- Rebuild QoS is only supported for `DataEngine: v2` volumes

#### Additional documentation or context
