### PR TITLE
fix: prevent instance manager blocking by the owner of orphan CRs

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1415,7 +1415,7 @@ func (imc *InstanceManagerController) createGenericManagerPodSpec(im *longhorn.I
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            im.Name,
 			Namespace:       imc.namespace,
-			OwnerReferences: datastore.GetOwnerReferencesForInstanceManager(im),
+			OwnerReferences: datastore.GetOwnerReferencesForInstanceManager(im, true),
 			Annotations:     map[string]string{types.GetLonghornLabelKey(types.LastAppliedTolerationAnnotationKeySuffix): string(tolerationsByte)},
 		},
 		Spec: corev1.PodSpec{
@@ -2300,7 +2300,7 @@ func (m *InstanceManagerMonitor) createOrphan(name string, im *longhorn.Instance
 	orphan := &longhorn.Orphan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
-			OwnerReferences: datastore.GetOwnerReferencesForInstanceManager(im),
+			OwnerReferences: datastore.GetOwnerReferencesForInstanceManager(im, false),
 		},
 		Spec: longhorn.OrphanSpec{
 			NodeID:     m.controllerID,

--- a/controller/orphan_controller.go
+++ b/controller/orphan_controller.go
@@ -460,6 +460,10 @@ func (oc *OrphanController) getRunningInstanceManagerClientForOrphan(orphan *lon
 		oc.logger.WithField("instanceManager", imName).Warnf("Orphan instance %v is not managed by current running instance manager %v", orphan.Name, im.Name)
 		return nil, nil
 	}
+	if !im.DeletionTimestamp.IsZero() {
+		oc.logger.WithField("instanceManager", imName).Warnf("Orphan instance %v is managed by a deleted instance manager %v", orphan.Name, im.Name)
+		return nil, nil
+	}
 	return engineapi.NewInstanceManagerClient(im, false)
 }
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3634,9 +3634,8 @@ func (s *DataStore) ListEnginesByNodeRO(name string) ([]*longhorn.Engine, error)
 
 // GetOwnerReferencesForInstanceManager returns OwnerReference for the given
 // instance Manager name and UID
-func GetOwnerReferencesForInstanceManager(im *longhorn.InstanceManager) []metav1.OwnerReference {
+func GetOwnerReferencesForInstanceManager(im *longhorn.InstanceManager, blockOwnerDeletion bool) []metav1.OwnerReference {
 	controller := true
-	blockOwnerDeletion := true
 	return []metav1.OwnerReference{
 		{
 			APIVersion: longhorn.SchemeGroupVersion.String(),


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10840

#### What this PR does / why we need it:

Disable `BlockOwnerDeletion` flag in the owner reference of instance orphans. The deletion of instance manager should depend on the deletion of orphan CRs.

#### Special notes for your reviewer:

#### Additional documentation or context

- Initial orphaned instance cleanup design: longhorn/longhorn#6764
- Handle im connection failure while shutting im down: longhorn/longhorn-manager#3719
- This PR is also needed on v1.9.x