### PR TITLE
fix: enqueue snapshot to ensure volumeattachment ticket can be correctly cleaned up

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -507,7 +507,7 @@ func (bic *BackingImageController) prepareFirstV2Copy(bi *longhorn.BackingImage)
 	_, err = engineClientProxy.SPDKBackingImageCreate(bi.Name, bi.Status.UUID, firstV2CopyDiskUUID, bi.Status.Checksum, fileDownloadAddress, "", uint64(bi.Status.Size))
 	if err != nil {
 		if types.ErrorAlreadyExists(err) {
-			log.Infof("backing image already exists when preparing first v2 copy on disk %v", firstV2CopyDiskUUID)
+			log.Infof("Backing image already exists when preparing first v2 copy on disk %v", firstV2CopyDiskUUID)
 		}
 		bic.v2CopyBackoff.Next(firstV2CopyDiskUUID, time.Now())
 		return errors.Wrapf(err, "failed to create backing image on disk %v when preparing first v2 copy for backing image %v", firstV2CopyDiskUUID, bi.Name)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -402,7 +402,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 		}
 		if backup.Status.State == longhorn.BackupStateCompleted && existingBackupState != backup.Status.State {
 			if err := bc.syncBackupVolume(backupTargetName, canonicalBackupVolumeName); err != nil {
-				log.Warnf("failed to sync backup volume %v for backup target %v", canonicalBackupVolumeName, backupTargetName)
+				log.Warnf("Failed to sync backup volume %v for backup target %v", canonicalBackupVolumeName, backupTargetName)
 				return
 			}
 			if err := bc.deleteSnapshotAfterBackupCompleted(backup); err != nil {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10874

#### What this PR does / why we need it:

Requeueue the snapshot if there is an attachment ticket for it to ensure the volumeattachment can be cleaned up after the snapshot is created.


#### Special notes for your reviewer:

#### Additional documentation or context
