### PR TITLE
revert: "fix: enqueue snapshot to ensure volumeattachment ticket can be correctly cleaned up"

### DIFF
--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -181,13 +181,13 @@ func (sc *SnapshotController) enqueueEngineChange(oldObj, curObj interface{}) {
 		return
 	}
 
-	snapshots = sc.filterSnapshotsForEngineEnqueuing(oldEngine, curEngine, snapshots)
+	snapshots = filterSnapshotsForEngineEnqueuing(oldEngine, curEngine, snapshots)
 	for _, snap := range snapshots {
 		sc.enqueueSnapshot(snap)
 	}
 }
 
-func (sc *SnapshotController) filterSnapshotsForEngineEnqueuing(oldEngine, curEngine *longhorn.Engine, snapshots map[string]*longhorn.Snapshot) map[string]*longhorn.Snapshot {
+func filterSnapshotsForEngineEnqueuing(oldEngine, curEngine *longhorn.Engine, snapshots map[string]*longhorn.Snapshot) map[string]*longhorn.Snapshot {
 	targetSnapshots := make(map[string]*longhorn.Snapshot)
 
 	if curEngine.Status.CurrentState != oldEngine.Status.CurrentState {
@@ -202,24 +202,9 @@ func (sc *SnapshotController) filterSnapshotsForEngineEnqueuing(oldEngine, curEn
 		}
 	}
 
-	va, err := sc.ds.GetLHVolumeAttachmentByVolumeName(curEngine.Spec.VolumeName)
-	if err != nil {
-		sc.logger.WithError(err).Warnf("Failed to get volume attachment for volume %s", curEngine.Spec.VolumeName)
-	}
-
 	for snapName, snap := range snapshots {
 		if !reflect.DeepEqual(oldEngine.Status.Snapshots[snapName], curEngine.Status.Snapshots[snapName]) {
 			targetSnapshots[snapName] = snap
-		}
-
-		// Longhorn#10874:
-		// Requeueue the snapshot if there is an attachment ticket for it to ensure
-		// the volumeattachment can be cleaned up after the snapshot is created.
-		if va != nil && va.Spec.AttachmentTickets != nil {
-			attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeSnapshotController, snap.Name)
-			if va.Spec.AttachmentTickets[attachmentTicketID] != nil {
-				targetSnapshots[snapName] = snap
-			}
 		}
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10808, longhorn/longhorn#10874

#### What this PR does / why we need it:

This reverts commit 014fd6ea9167d87bd794ca39c90a418531a02c58 for the cause of https://github.com/longhorn/longhorn/issues/10808#issuecomment-2883235961.

#### Special notes for your reviewer:

- Backport to v1.9.x, v1.8.x, v1.7.x

#### Additional documentation or context

`None`
