### PR TITLE
fix: check latest snapshot.Status.CreationTime before deleting VA ticket for snapshot

### DIFF
--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -465,7 +465,7 @@ func (sc *SnapshotController) reconcile(snapshotName string) (err error) {
 	alreadyCreatedBefore := snapshot.Status.CreationTime != ""
 
 	defer func() {
-		if !requestCreateNewSnapshot || alreadyCreatedBefore {
+		if !requestCreateNewSnapshot || snapshot.Status.CreationTime != "" {
 			err = sc.handleAttachmentTicketDeletion(snapshot)
 		}
 	}()


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10808

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
