### PR TITLE
feat(orphan): introduce orphan-resource-auto-deletion-grace-period setting

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -2233,32 +2233,31 @@ func (m *InstanceManagerMonitor) syncOrphans(im *longhorn.InstanceManager, insta
 
 func (m *InstanceManagerMonitor) isEngineOrphaned(instanceName, instanceManager string) (bool, error) {
 	existEngine, err := m.ds.GetEngineRO(instanceName)
-	switch {
-	case err == nil:
-		// Engine CR still exists - check the ownership
-		return m.isInstanceOrphanedInInstanceManager(&existEngine.ObjectMeta, &existEngine.Spec.InstanceSpec, &existEngine.Status.InstanceStatus, instanceManager), nil
-	case apierrors.IsNotFound(err):
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 		// Engine CR not found - instance is orphaned
 		return true, nil
-	default:
+		}
 		// Unexpected error - unable to check if engine instance is orphaned or not
 		return false, err
 	}
+	// Engine CR still exists - check the ownership
+	return m.isInstanceOrphanedInInstanceManager(&existEngine.ObjectMeta, &existEngine.Spec.InstanceSpec, &existEngine.Status.InstanceStatus, instanceManager), nil
 }
 
 func (m *InstanceManagerMonitor) isReplicaOrphaned(instanceName, instanceManager string) (bool, error) {
 	existReplica, err := m.ds.GetReplicaRO(instanceName)
-	switch {
-	case err == nil:
-		// Replica CR still exists - check the ownership
-		return m.isInstanceOrphanedInInstanceManager(&existReplica.ObjectMeta, &existReplica.Spec.InstanceSpec, &existReplica.Status.InstanceStatus, instanceManager), nil
-	case apierrors.IsNotFound(err):
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 		// Replica CR not found - instance is orphaned
 		return true, nil
-	default:
+		}
 		// Unexpected error - unable to check if replica instance is orphaned or not
 		return false, err
 	}
+
+	// Replica CR still exists - check the ownership
+	return m.isInstanceOrphanedInInstanceManager(&existReplica.ObjectMeta, &existReplica.Spec.InstanceSpec, &existReplica.Status.InstanceStatus, instanceManager), nil
 }
 
 // isInstanceOrphanedInInstanceManager returns true only when it is very certain that an instance is scheduled on another instance manager

--- a/types/setting.go
+++ b/types/setting.go
@@ -101,6 +101,7 @@ const (
 	SettingNameKubernetesClusterAutoscalerEnabled                       = SettingName("kubernetes-cluster-autoscaler-enabled")
 	SettingNameOrphanAutoDeletion                                       = SettingName("orphan-auto-deletion") // replaced by SettingNameOrphanResourceAutoDeletion
 	SettingNameOrphanResourceAutoDeletion                               = SettingName("orphan-resource-auto-deletion")
+	SettingNameOrphanResourceAutoDeletionGracePeriod                    = SettingName("orphan-resource-auto-deletion-grace-period")
 	SettingNameStorageNetwork                                           = SettingName("storage-network")
 	SettingNameStorageNetworkForRWXVolumeEnabled                        = SettingName("storage-network-for-rwx-volume-enabled")
 	SettingNameFailedBackupTTL                                          = SettingName("failed-backup-ttl")
@@ -203,6 +204,7 @@ var (
 		SettingNameGuaranteedInstanceManagerCPU,
 		SettingNameKubernetesClusterAutoscalerEnabled,
 		SettingNameOrphanResourceAutoDeletion,
+		SettingNameOrphanResourceAutoDeletionGracePeriod,
 		SettingNameStorageNetwork,
 		SettingNameStorageNetworkForRWXVolumeEnabled,
 		SettingNameFailedBackupTTL,
@@ -331,6 +333,7 @@ var (
 		SettingNameGuaranteedInstanceManagerCPU:                             SettingDefinitionGuaranteedInstanceManagerCPU,
 		SettingNameKubernetesClusterAutoscalerEnabled:                       SettingDefinitionKubernetesClusterAutoscalerEnabled,
 		SettingNameOrphanResourceAutoDeletion:                               SettingDefinitionOrphanResourceAutoDeletion,
+		SettingNameOrphanResourceAutoDeletionGracePeriod:                    SettingDefinitionOrphanResourceAutoDeletionGracePeriod,
 		SettingNameStorageNetwork:                                           SettingDefinitionStorageNetwork,
 		SettingNameStorageNetworkForRWXVolumeEnabled:                        SettingDefinitionStorageNetworkForRWXVolumeEnabled,
 		SettingNameFailedBackupTTL:                                          SettingDefinitionFailedBackupTTL,
@@ -1070,6 +1073,20 @@ var (
 		Required: false,
 		ReadOnly: false,
 		Default:  "",
+	}
+
+	SettingDefinitionOrphanResourceAutoDeletionGracePeriod = SettingDefinition{
+		DisplayName: "Orphan Resource Auto-Deletion Grace Period",
+		Description: "Specifies the wait time, in seconds, before Longhorn automatically deletes an orphaned Custom Resource (CR) and its associated resources. \n\n" +
+			"**Note:** If a user manually deletes an orphaned CR, the deletion occurs immediately and does not respect this grace period. \n\n",
+		Category: SettingCategoryGeneral,
+		Type:     SettingTypeInt,
+		Required: true,
+		ReadOnly: false,
+		Default:  "300",
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+		},
 	}
 
 	SettingDefinitionStorageNetwork = SettingDefinition{


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10904

#### What this PR does / why we need it:

1. switch-case works better for conditions based on a single number or string, whereas if-else is more suitable for decisions involving multiple variables.
2. In the current implementation, with auto orphan deletion enabled, the orphan CR and its associated process are deleted almost immediately after the orphan CR is created. This behavior might be too abrupt. We could introduce a configurable setting, such as a wait interval (deletion grace period), to delay this automatic deletion. For instance, if the interval is set to 60 seconds, the orphan CR and its process would be deleted 60 seconds after the creation timestamp.
Manual deletion of the orphan CR by the user would bypass this delay and proceed immediately.

#### Special notes for your reviewer:

#### Additional documentation or context
