### PR TITLE
feat: improve starting time of longhorn-csi-plugin

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -380,6 +380,18 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt(DefaultCSILivenessProbePort),
+									},
+								},
+								InitialDelaySeconds: datastore.PodProbeInitialDelay,
+								TimeoutSeconds:      datastore.PodProbeTimeoutSeconds,
+								PeriodSeconds:       datastore.PodProbePeriodSeconds,
+								FailureThreshold:    datastore.PodStartupProbeFailureThreshold,
+							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/csi/manager.go
+++ b/csi/manager.go
@@ -1,6 +1,8 @@
 package csi
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -13,6 +15,9 @@ type Manager struct {
 	cs  *ControllerServer
 }
 
+// It can take up to 10s for each try. So total retry time would be 180s
+const rancherClientInitMaxRetry = 18
+
 func init() {}
 
 func GetCSIManager() *Manager {
@@ -24,9 +29,9 @@ func (m *Manager) Run(driverName, nodeID, endpoint, identityVersion, managerURL 
 
 	// Longhorn API Client
 	clientOpts := &longhornclient.ClientOpts{Url: managerURL}
-	apiClient, err := longhornclient.NewRancherClient(clientOpts)
+	apiClient, err := initRancherClient(clientOpts)
 	if err != nil {
-		return errors.Wrap(err, "Failed to initialize Longhorn API client")
+		return err
 	}
 
 	// Create GRPC servers
@@ -42,4 +47,20 @@ func (m *Manager) Run(driverName, nodeID, endpoint, identityVersion, managerURL 
 	s.Wait()
 
 	return nil
+}
+
+func initRancherClient(clientOpts *longhornclient.ClientOpts) (*longhornclient.RancherClient, error) {
+	var lastErr error
+
+	for i := 0; i < rancherClientInitMaxRetry; i++ {
+		apiClient, err := longhornclient.NewRancherClient(clientOpts)
+		if err == nil {
+			return apiClient, nil
+		}
+		logrus.Warnf("Failed to initialize Longhorn API client %v. Retrying", err)
+		lastErr = err
+		time.Sleep(time.Second)
+	}
+
+	return nil, errors.Wrap(lastErr, "Failed to initialize Longhorn API client")
 }

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -43,6 +43,7 @@ const (
 	PodProbeTimeoutSeconds           = PodProbePeriodSeconds - 1
 	PodProbePeriodSeconds            = 5
 	PodLivenessProbeFailureThreshold = 3
+	PodStartupProbeFailureThreshold  = 36
 
 	IMPodProbeInitialDelay             = 3
 	IMPodProbeTimeoutSeconds           = IMPodProbePeriodSeconds - 1


### PR DESCRIPTION
### Add longhorn-csi-plugin retry logic
Retry the Longhorn client initialization instead of failing immediately after
the first try

### Add StartupProbe for Longhorn CSI plugin
StartupProbe is needed because Longhorn CSI plugin might need more time
at the begining to establish connection to Longhorn manager API. Without
StartupProbe, we would have to rely on the LivenessProbe which will not
wait for the long enough, unnessary crash the Longhorn CSI plugin container,
and causing more delay.

longhorn/longhorn#9482