### PR TITLE
fix(backing_image): reconcile backing image disk evict event by spec disks

### DIFF
--- a/controller/backing_image_controller.go
+++ b/controller/backing_image_controller.go
@@ -1527,7 +1527,7 @@ func (bic *BackingImageController) enqueueBackingImageForNodeUpdate(oldObj, curr
 		}
 	}
 
-	diskBackingImageMap, err := bic.ds.GetDiskBackingImageMap()
+	diskBackingImageMap, err := bic.ds.GetCurrentDiskBackingImageMap()
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("failed to get disk backing image map when handling node update"))
 		return

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -5966,7 +5966,7 @@ func (s *DataStore) IsV2DataEngineDisabledForNode(nodeName string) (bool, error)
 	return false, nil
 }
 
-func (s *DataStore) GetDiskBackingImageMap() (map[string][]*longhorn.BackingImage, error) {
+func (s *DataStore) GetCurrentDiskBackingImageMap() (map[string][]*longhorn.BackingImage, error) {
 	diskBackingImageMap := map[string][]*longhorn.BackingImage{}
 	backingImages, err := s.ListBackingImages()
 	if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11034

#### What this PR does / why we need it:

There is some chance that the status does not reflect spec due to reconciliation timing gap. The `DataStore.GetDiskBackingImageMap` lists the backing images by disk, and is used by the following two controllers:

- node controller: to attach node/disk eviction flag onto backing image spec
- backing image controller: when node changed, list the backing image CRs on evicted disks

The CR's status should be reconciled from the spec instead of the status.

#### Special notes for your reviewer:

#### Additional documentation or context

longhorn/longhorn#10464