### PR TITLE
fix(backingimage): prevent eviction of in-used copies

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3198,17 +3198,22 @@ func (s *DataStore) ListReplicasByDiskUUID(uuid string) (map[string]*longhorn.Re
 	return s.listReplicas(diskSelector)
 }
 
-func getBackingImageSelector(backingImageName string) (labels.Selector, error) {
+func getBackingImageSelector(backingImageName, diskUUID string) (labels.Selector, error) {
+	matchLabels := map[string]string{
+		types.GetLonghornLabelKey(types.LonghornLabelBackingImage): backingImageName,
+	}
+	if diskUUID != "" {
+		matchLabels[types.LonghornDiskUUIDKey] = diskUUID
+	}
 	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			types.GetLonghornLabelKey(types.LonghornLabelBackingImage): backingImageName,
-		},
+		MatchLabels: matchLabels,
 	})
 }
 
 // ListReplicasByBackingImage gets a list of Replicas using a specific backing image the given namespace.
-func (s *DataStore) ListReplicasByBackingImage(backingImageName string) ([]*longhorn.Replica, error) {
-	backingImageSelector, err := getBackingImageSelector(backingImageName)
+// If diskUUID is not empty, it will also filter the replicas by the diskUUID.
+func (s *DataStore) ListReplicasByBackingImage(backingImageName, diskUUID string) ([]*longhorn.Replica, error) {
+	backingImageSelector, err := getBackingImageSelector(backingImageName, diskUUID)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/backingimage.go
+++ b/manager/backingimage.go
@@ -166,7 +166,7 @@ func (m *VolumeManager) CleanUpBackingImageDiskFiles(name string, diskFileList [
 		}
 	}()
 
-	replicas, err := m.ds.ListReplicasByBackingImage(name)
+	replicas, err := m.ds.ListReplicasByBackingImage(name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/webhook/resources/backingimage/validator.go
+++ b/webhook/resources/backingimage/validator.go
@@ -156,7 +156,7 @@ func (b *backingImageValidator) Delete(request *admission.Request, oldObj runtim
 		return werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.BackingImage", oldObj), "")
 	}
 
-	replicas, err := b.ds.ListReplicasByBackingImage(backingImage.Name)
+	replicas, err := b.ds.ListReplicasByBackingImage(backingImage.Name, "")
 	if err != nil {
 		return werror.NewInvalidError(fmt.Sprintf("cannot delete backing image %v since the error %v", backingImage.Name, err.Error()), "")
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11053

#### What this PR does / why we need it:

Backing image copy should be deleted only when all replicas are removed from a disk. If the copy is deleted, the engine monitor will mark the replica as ERR, which prevent the removal by the volume controller. 

#### Special notes for your reviewer:

#### Additional documentation or context
