### PR TITLE
fix: add nvme manual disk driver when auto detection failed to detect the nvme driver

### DIFF
--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1937,6 +1937,7 @@ spec:
                       - ""
                       - auto
                       - aio
+                      - nvme
                       type: string
                     diskType:
                       enum:

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -78,6 +78,7 @@ const (
 	DiskDriverNone = DiskDriver("")
 	DiskDriverAuto = DiskDriver("auto")
 	DiskDriverAio  = DiskDriver("aio")
+	DiskDriverNvme = DiskDriver("nvme")
 )
 
 type SnapshotCheckStatus struct {
@@ -91,7 +92,7 @@ type DiskSpec struct {
 	Type DiskType `json:"diskType"`
 	// +optional
 	Path string `json:"path"`
-	// +kubebuilder:validation:Enum="";auto;aio
+	// +kubebuilder:validation:Enum="";auto;aio;nvme
 	// +optional
 	DiskDriver DiskDriver `json:"diskDriver"`
 	// +optional


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#11127

#### What this PR does / why we need it:

I had issues using NVMe drives on a talos cluster with a recent kernel.
After a bit of digging I found out that the driver name for "vfio_pci" is not the same.
Running the "auto-detection" driver commands manually : 
```
nsenter --mount=/proc/1/ns/mnt --ipc=/proc/1/ns/ipc --net=/proc/1/ns/net env PCI_ALLOWED=0000:02:00.0 bash /usr/src/spdk/scripts/setup.sh
0000:01:00.0 (144d a80a): Skipping denied controller at 0000:01:00.0
0000:01:00.0 (144d a80a): Active devices: mount@nvme0n1:nvme0n1p5, so not binding PCI dev
0000:02:00.0 (144d a80a): nvme -> vfio-pci
INFO: Requested 1024 hugepages but 1024 already allocated 

nsenter --mount=/proc/1/ns/mnt --ipc=/proc/1/ns/ipc --net=/proc/1/ns/net env PCI_ALLOWED=0000:02:00.0 bash /usr/src/spdk/scripts/setup.sh disk-status 0000:02:00.0
0000:01:00.0 (144d a80a): Skipping denied controller at 0000:01:00.0
0000:01:00.0 (144d a80a): Active devices: mount@nvme0n1:nvme0n1p5, so not binding PCI dev
{"bdf":"0000:02:00.0","type":"NVMe","driver":"vfio-pci","vendor":"144d","numa":"unknown","device":"-","block_devices":"-"}

uname -a
Linux instance-manager-b2105364cf7e819d6e95b009ebbcd205 6.12.31-talos #1 SMP Tue Jun  3 10:47:32 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
instance-manager-b2105364cf7e819d6e95b009ebbcd205:/ # 
```

The issue come from the module name returned by spdk from the Talos kernel it is `vfio-pci` and not the excepted `vfio_pci` here : 
https://github.com/longhorn/longhorn-spdk-engine/blob/main/pkg/spdk/disk/types.go#L56
https://github.com/longhorn/go-common-libs/blob/main/types/file.go#L20

I solved this by editing the CRD manually and allowing to manual set the "nvme" disk driver.

#### Special notes for your reviewer:
May not be the best solution and dosen't fix the autodetection code (Maybe checking both `-` and `_` version in the if ?) but it offer the ability to control it manually.

#### Additional documentation or context
