### PR TITLE
fix(engineimage): allow deleting default engine image during uninstalation

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -140,8 +140,9 @@ const (
 
 	DeleteCustomResourceOnly = "delete-custom-resource-only"
 
-	// const value `DeleteBackupTargetFromLonghorn` is used for annotation to note that deleting backup target is by Longhorn during uninstalling.
+	// annotations to note that deleting backup target is by Longhorn during uninstalling.
 	DeleteBackupTargetFromLonghorn = "delete-backup-target-from-longhorn"
+	DeleteEngineImageFromLonghorn  = "delete-engine-image-from-longhorn"
 
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11130

#### What this PR does / why we need it:

Webhook prevents deleting default engine images. Adding a special annotation, `delete-engine-image`, to allow deleting during Longhorn uninstallation.

#### Special notes for your reviewer:

#### Additional documentation or context
