### PR TITLE
fix(node): allow deleting node during uninstallation

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -143,6 +143,7 @@ const (
 	// annotations to note that deleting backup target is by Longhorn during uninstalling.
 	DeleteBackupTargetFromLonghorn = "delete-backup-target-from-longhorn"
 	DeleteEngineImageFromLonghorn  = "delete-engine-image-from-longhorn"
+	DeleteNodeFromLonghorn         = "delete-node-from-longhorn"
 
 	KubernetesStatusLabel = "KubernetesStatus"
 	KubernetesReplicaSet  = "ReplicaSet"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11131

#### What this PR does / why we need it:

Webhook prevents deleting Longhorn nodes when the corresponding Kubernetes node is healthy. Adding a special annotation, `delete-node-from-longhorn`, to allow deleting during Longhorn uninstallation.

#### Special notes for your reviewer:

#### Additional documentation or context

#3860
