### PR TITLE
fix: do not silent the error returned by ReconcileBackupVolumeState

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -528,7 +528,7 @@ func (c *VolumeController) syncVolume(key string) (err error) {
 	}
 
 	if err := c.ReconcileBackupVolumeState(volume); err != nil {
-		return nil
+		return err
 	}
 
 	if err := c.ReconcileVolumeState(volume, engines, replicas); err != nil {


### PR DESCRIPTION
Right now when there are multiple backup volumes of the same volume on the same backup target, we silently ignore the error, return nil, and abort the volume syncing: https://github.com/longhorn/longhorn-manager/blob/7b9d2aa08a572b2b8bce35b3ff0e90dfaa1b0eaf/controller/volume_controller.go#L530-L532

User would have no idea of why the volume is stuck.

longhorn/longhorn#11152


