### PR TITLE
fix(storage-network): skip migratable RWX volume workloads restarted

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/longhorn/longhorn-manager/constant"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -264,6 +265,11 @@ func (kc *KubernetesPodController) handleWorkloadPodDeletionIfCSIPluginPodIsDown
 		// Exclude non-RWX volumes.
 		if volume.Spec.AccessMode != longhorn.AccessModeReadWriteMany {
 			_log.Debugf("%s. Volume access mode is %v", logSkip, volume.Spec.AccessMode)
+			continue
+		}
+
+		if util.IsMigratableVolume(volume) {
+			_log.Debugf("%s. Volume is migratable RWX volume", logSkip)
 			continue
 		}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11158

#### What this PR does / why we need it:

For the storage network scenario, RWX volumes in Longhorn are not true NFS-based RWX volumes, so the workload should not be restarted when the CSI plugin pod restarts.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
