### PR TITLE
feat(scheduler): add detailed error messages for disk schedulability checks

### DIFF
--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -1364,7 +1364,7 @@ func (s *NodeControllerSuite) TestEventOnNotReady(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 			"node1-not-ready": {
 				Type:    "Warning",
@@ -1453,7 +1453,7 @@ func (s *NodeControllerSuite) TestEventOnDiskPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 			"node1-disk-pressure": {
 				Type:    "Warning",
@@ -1542,7 +1542,7 @@ func (s *NodeControllerSuite) TestEventOnMemoryPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 			"node1-memory-pressure": {
 				Type:    "Warning",
@@ -1631,7 +1631,7 @@ func (s *NodeControllerSuite) TestEventOnPidPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 			"node1-pid-pressure": {
 				Type:    "Warning",
@@ -1720,7 +1720,7 @@ func (s *NodeControllerSuite) TestEventOnNetworkPressure(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 			"node1-network-pressure": {
 				Type:    "Warning",
@@ -1820,7 +1820,7 @@ func (s *NodeControllerSuite) TestNoEventOnUnknownTrueNodeCondition(c *C) {
 			"": {
 				Type:    "Warning",
 				Reason:  "Schedulable",
-				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 has 0 available, but requires reserved 0, minimal 25% to schedule more replicas",
+				Message: "Disk fsid (/var/lib/longhorn) on the node test-node-name-1 is not schedulable for more replica",
 			},
 		},
 	}

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -833,10 +833,7 @@ func (rcs *ReplicaScheduler) IsSchedulableToDisk(size int64, requiredStorage int
 	minimalAvailable := int64(float64(info.StorageMaximum) * float64(info.MinimalAvailablePercentage) / 100)
 	if currentAvailable <= minimalAvailable {
 		return false, fmt.Sprintf(
-			"Actual space usage condition failed: CurrentAvailable = %d (StorageAvailable - Required) is less than or equal to MinimalAvailable = %d (%d%% of Storage Max). "+
-				"Potential solution: reduce the 'Storage Minimal Available Percentage' setting or free up disk space."+
-				"See 'References/Settings Reference' at https://longhorn.io/docs/ for details."+
-				"e.g., use: kubectl edit settings storage-minimal-available-percentage -n longhorn-system",
+			"Actual space usage condition failed: CurrentAvailable = %d (StorageAvailable - Required) is less than or equal to MinimalAvailable = %d (%d%% of Storage Max).",
 			currentAvailable, minimalAvailable, info.MinimalAvailablePercentage,
 		)
 	}
@@ -848,10 +845,7 @@ func (rcs *ReplicaScheduler) IsSchedulableToDisk(size int64, requiredStorage int
 	overProvisionLimit := int64(float64(info.StorageMaximum-info.StorageReserved) * float64(info.OverProvisioningPercentage) / 100)
 	if scheduledTotal > overProvisionLimit {
 		return false, fmt.Sprintf(
-			"Scheduling space condition failed: ScheduledTotal = %d (Size + StorageScheduled) is greater than ProvisionedLimit = %d (%d%% of StorageMax - StorageReserved). "+
-				"Potential solution: reduce 'Storage Reserved' in the LH UI or reduce 'Storage Over Provisioning Percentage'. "+
-				"See 'References/Settings Reference' at https://longhorn.io/docs/ for details."+
-				"e.g., use: kubectl edit settings storage-over-provisioning-percentage -n longhorn-system",
+			"Scheduling space condition failed: ScheduledTotal = %d (Size + StorageScheduled) is greater than ProvisionedLimit = %d (%d%% of StorageMax - StorageReserved). ",
 			scheduledTotal, overProvisionLimit, info.OverProvisioningPercentage,
 		)
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue [longhorn/longhorn#10436](https://github.com/longhorn/longhorn/issues/10436)

#### What this PR does / why we need it:

- Refactor IsSchedulableToDisk to return detailed error reason alongside result
- Improve logging in node controller and replica scheduler for unschedulable conditions
- Replace ambiguous messages with actionable suggestions (e.g., tuning reserved space or over-provisioning)
- Update related unit tests to match new error message format

#### Special notes for your reviewer:

- This is a behavioral/logging improvement only; no core scheduling logic is changed

#### Additional documentation or context

https://www.suse.com/support/kb/doc/?id=000021268
