### PR TITLE
fix(backup): not check backup target available if

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -653,8 +653,9 @@ func (btc *BackupTargetController) pullBackupVolumeFromBackupTarget(backupTarget
 			ObjectMeta: metav1.ObjectMeta{
 				Name: backupVolumeName,
 				Labels: map[string]string{
-					types.LonghornLabelBackupTarget: backupTarget.Name,
-					types.LonghornLabelBackupVolume: remoteVolumeName,
+					types.LonghornLabelBackupTarget:                                   backupTarget.Name,
+					types.LonghornLabelBackupVolume:                                   remoteVolumeName,
+					types.GetLonghornLabelKey(types.CreateCustomResourceFromLonghorn): "true",
 				},
 				OwnerReferences: datastore.GetOwnerReferencesForBackupTarget(backupTarget),
 			},
@@ -759,8 +760,9 @@ func (btc *BackupTargetController) syncBackupBackingImage(backupTarget *longhorn
 			ObjectMeta: metav1.ObjectMeta{
 				Name: backupBackingImageName,
 				Labels: map[string]string{
-					types.LonghornLabelBackupTarget: backupTarget.Name,
-					types.LonghornLabelBackingImage: canonicalBackingImageName,
+					types.LonghornLabelBackupTarget:                                   backupTarget.Name,
+					types.LonghornLabelBackingImage:                                   canonicalBackingImageName,
+					types.GetLonghornLabelKey(types.CreateCustomResourceFromLonghorn): "true",
 				},
 				OwnerReferences: datastore.GetOwnerReferencesForBackupTarget(backupTarget),
 			},
@@ -831,7 +833,8 @@ func (btc *BackupTargetController) syncSystemBackup(backupTarget *longhorn.Backu
 				Labels: map[string]string{
 					// Label with the version to be used by the system-backup controller
 					// to get the config from the backup target.
-					types.GetVersionLabelKey(): longhornVersion,
+					types.GetVersionLabelKey():                                        longhornVersion,
+					types.GetLonghornLabelKey(types.CreateCustomResourceFromLonghorn): "true",
 				},
 				OwnerReferences: datastore.GetOwnerReferencesForBackupTarget(backupTarget),
 			},

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -338,7 +338,8 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 			ObjectMeta: metav1.ObjectMeta{
 				Name: backupName,
 				Labels: map[string]string{
-					types.LonghornLabelBackupTarget: backupTarget.Name,
+					types.LonghornLabelBackupTarget:                                   backupTarget.Name,
+					types.GetLonghornLabelKey(types.CreateCustomResourceFromLonghorn): "true",
 				},
 				OwnerReferences: datastore.GetOwnerReferencesForBackupVolume(backupVolume),
 			},

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3346,6 +3346,21 @@ func labelBackupVolume(backupVolumeName string, obj k8sruntime.Object) error {
 	return nil
 }
 
+// IsLabelLonghornCreateCustomResourceFromLonghornExisting check if the object label `longhorn.io/create-custom-resource-from-longhorn` exists
+func IsLabelLonghornCreateCustomResourceFromLonghornExisting(obj k8sruntime.Object) (bool, error) {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	labels := metadata.GetLabels()
+	if labels == nil {
+		return false, nil
+	}
+	_, ok := labels[types.GetLonghornLabelKey(types.CreateCustomResourceFromLonghorn)]
+	return ok, nil
+}
+
 // labelLonghornDeleteCustomResourceOnly labels the object with the label `longhorn.io/delete-custom-resource-only: true`
 func labelLonghornDeleteCustomResourceOnly(obj k8sruntime.Object) error {
 	metadata, err := meta.Accessor(obj)

--- a/types/types.go
+++ b/types/types.go
@@ -138,7 +138,8 @@ const (
 	ConfigMapResourceVersionKey = "configmap-resource-version"
 	UpdateSettingFromLonghorn   = "update-setting-from-longhorn"
 
-	DeleteCustomResourceOnly = "delete-custom-resource-only"
+	CreateCustomResourceFromLonghorn = "create-custom-resource-from-longhorn"
+	DeleteCustomResourceOnly         = "delete-custom-resource-only"
 
 	// annotations to note that deleting backup target is by Longhorn during uninstalling.
 	DeleteBackupTargetFromLonghorn = "delete-backup-target-from-longhorn"

--- a/webhook/resources/backup/validator.go
+++ b/webhook/resources/backup/validator.go
@@ -63,7 +63,11 @@ func (b *backupValidator) Create(request *admission.Request, newObj runtime.Obje
 		return werror.NewInvalidError(fmt.Sprintf("failed to get backup target %s: %v", backupTargetName, err), "")
 	}
 
-	if !backupTarget.Status.Available {
+	isLonghornCreated, err := datastore.IsLabelLonghornCreateCustomResourceFromLonghornExisting(backup)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to get backup %s label: %v, ", backup.Name, err), "")
+	}
+	if !isLonghornCreated && !backupTarget.Status.Available {
 		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
 	}
 

--- a/webhook/resources/backupbackingimage/validator.go
+++ b/webhook/resources/backupbackingimage/validator.go
@@ -71,7 +71,11 @@ func (bbi *backupBackingImageValidator) Create(request *admission.Request, newOb
 		return werror.NewInvalidError(fmt.Sprintf("failed to get backup target %s: %v", backupTargetName, err), "")
 	}
 
-	if !backupTarget.Status.Available {
+	isLonghornCreated, err := datastore.IsLabelLonghornCreateCustomResourceFromLonghornExisting(backupBackingImage)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to get backup backing image %s label: %v, ", backupBackingImage.Name, err), "")
+	}
+	if !isLonghornCreated && !backupTarget.Status.Available {
 		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
 	}
 

--- a/webhook/resources/systembackup/validator.go
+++ b/webhook/resources/systembackup/validator.go
@@ -39,15 +39,14 @@ func (v *systemBackupValidator) Resource() admission.Resource {
 }
 
 func (v *systemBackupValidator) Create(request *admission.Request, newObj runtime.Object) error {
-
-	backupTarget, err := v.ds.GetBackupTargetRO(types.DefaultBackupTargetName)
-
-	if err != nil {
-		return werror.NewBadRequest(err.Error())
+	systemBackup, ok := newObj.(*longhorn.SystemBackup)
+	if !ok {
+		return werror.NewInvalidError(fmt.Sprintf("%v is not a *longhorn.BackupBackingImage", newObj), "")
 	}
 
-	if !backupTarget.Status.Available {
-		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", types.DefaultBackupTargetName), "")
+	backupTarget, err := v.ds.GetBackupTargetRO(types.DefaultBackupTargetName)
+	if err != nil {
+		return werror.NewBadRequest(err.Error())
 	}
 
 	backupType, err := util.CheckBackupType(backupTarget.Spec.BackupTargetURL)
@@ -59,6 +58,14 @@ func (v *systemBackupValidator) Create(request *admission.Request, newObj runtim
 		if backupTarget.Spec.CredentialSecret == "" {
 			return werror.NewBadRequest(fmt.Sprintf("cannot access %s without credential secret", backupType))
 		}
+	}
+
+	isLonghornCreated, err := datastore.IsLabelLonghornCreateCustomResourceFromLonghornExisting(systemBackup)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to get system backup %s label: %v, ", systemBackup.Name, err), "")
+	}
+	if !isLonghornCreated && !backupTarget.Status.Available {
+		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", types.DefaultBackupTargetName), "")
 	}
 
 	return nil


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11337, https://github.com/longhorn/longhorn/issues/10085

#### What this PR does / why we need it:

There is no need to check the backup target availability if Backups, SystemBackups, and BackupBackingImages are created by Longhorn (the backup target controller).
The backup target is unavailable before we set up a valid backup target, and if it has existing backups, system backups, or backup backing images, setting the backup target to be available will be blocked  

#### Special notes for your reviewer:

#### Additional documentation or context
