### PR TITLE
fix: check backup target status before backup creation (backport to #3847)

### DIFF
--- a/webhook/resources/backup/validator.go
+++ b/webhook/resources/backup/validator.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 	werror "github.com/longhorn/longhorn-manager/webhook/error"
@@ -49,6 +50,21 @@ func (b *backupValidator) Create(request *admission.Request, newObj runtime.Obje
 	if backup.Spec.BackupMode != longhorn.BackupModeFull &&
 		backup.Spec.BackupMode != longhorn.BackupModeIncremental {
 		return werror.NewInvalidError(fmt.Sprintf("BackupMode %v is not a valid option", backup.Spec.BackupMode), "")
+	}
+
+	// Check if backup target exists and is available
+	backupTargetName, ok := backup.Labels[types.LonghornLabelBackupTarget]
+	if !ok || backupTargetName == "" {
+		return werror.NewInvalidError("missing backup target label on backup object", "")
+	}
+
+	backupTarget, err := b.ds.GetBackupTarget(backupTargetName)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to get backup target %s: %v", backupTargetName, err), "")
+	}
+
+	if !backupTarget.Status.Available {
+		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
 	}
 
 	return nil

--- a/webhook/resources/backupbackingimage/validator.go
+++ b/webhook/resources/backupbackingimage/validator.go
@@ -63,5 +63,17 @@ func (bbi *backupBackingImageValidator) Create(request *admission.Request, newOb
 		}
 	}
 
+	// Check if backup target exists and is available
+	backupTargetName := backupBackingImage.Labels[types.LonghornLabelBackupTarget]
+
+	backupTarget, err := bbi.ds.GetBackupTarget(backupTargetName)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to get backup target %s: %v", backupTargetName, err), "")
+	}
+
+	if !backupTarget.Status.Available {
+		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
+	}
+
 	return nil
 }

--- a/webhook/resources/systembackup/validator.go
+++ b/webhook/resources/systembackup/validator.go
@@ -39,9 +39,15 @@ func (v *systemBackupValidator) Resource() admission.Resource {
 }
 
 func (v *systemBackupValidator) Create(request *admission.Request, newObj runtime.Object) error {
+
 	backupTarget, err := v.ds.GetBackupTargetRO(types.DefaultBackupTargetName)
+
 	if err != nil {
 		return werror.NewBadRequest(err.Error())
+	}
+
+	if !backupTarget.Status.Available {
+		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", types.DefaultBackupTargetName), "")
 	}
 
 	backupType, err := util.CheckBackupType(backupTarget.Spec.BackupTargetURL)


### PR DESCRIPTION



(cherry picked from commit 00fb7c6e656c2fd847d1d2f4b7b0e5e1d6d029f4)

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10085 https://github.com/longhorn/longhorn/issues/11324

#### What this PR does / why we need it:

check if the backup target is available before creating a backup, backup backing image, and system backup.

#### Special notes for your reviewer:

#### Additional documentation or context
