### PR TITLE
feat(api): add VolumeAttachment list and get routes #11400

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -292,5 +292,9 @@ func NewRouter(s *Server) *mux.Router {
 	r.Path("/v1/ws/events").Handler(f(schemas, eventListStream))
 	r.Path("/v1/ws/{period}/events").Handler(f(schemas, eventListStream))
 
+	// VolumeAttachment routes
+	r.Methods("GET").Path("/v1/volumeattachments").Handler(f(schemas, s.VolumeAttachmentList))
+	r.Methods("GET").Path("/v1/volumeattachments/{name}").Handler(f(schemas, s.VolumeAttachmentGet))
+
 	return r
 }

--- a/api/volumeattachment.go
+++ b/api/volumeattachment.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
+	"github.com/rancher/go-rancher/api"
+)
+
+func (s *Server) VolumeAttachmentGet(rw http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+
+	id := mux.Vars(req)["name"]
+
+	volumeAttachment, err := s.m.GetVolumeAttachment(id)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get volume attachment  '%s'", id)
+	}
+	apiContext.Write(toVolumeAttachmentResource(volumeAttachment))
+	return nil
+}
+
+func (s *Server) VolumeAttachmentList(rw http.ResponseWriter, req *http.Request) (err error) {
+	apiContext := api.GetApiContext(req)
+
+	volumeAttachmentList, err := s.m.ListVolumeAttachment()
+	if err != nil {
+		return errors.Wrap(err, "failed to list volume attachments")
+	}
+	apiContext.Write(toVolumeAttachmentCollection(volumeAttachmentList, apiContext))
+	return nil
+}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -5446,6 +5446,21 @@ func (s *DataStore) GetLHVolumeAttachmentByVolumeName(volName string) (*longhorn
 	return s.GetLHVolumeAttachment(vaName)
 }
 
+// ListLHVolumeAttachments returns all VolumeAttachments in the cluster
+func (s *DataStore) ListLHVolumeAttachments() ([]*longhorn.VolumeAttachment, error) {
+	vaList, err := s.lhVolumeAttachmentLister.VolumeAttachments(s.namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*longhorn.VolumeAttachment, 0, len(vaList))
+	for _, va := range vaList {
+		result = append(result, va.DeepCopy())
+	}
+
+	return result, nil
+}
+
 // ListSupportBundles returns an object contains all SupportBundles
 func (s *DataStore) ListSupportBundles() (map[string]*longhorn.SupportBundle, error) {
 	itemMap := make(map[string]*longhorn.SupportBundle)

--- a/manager/volume_attachment.go
+++ b/manager/volume_attachment.go
@@ -7,3 +7,7 @@ import (
 func (m *VolumeManager) GetVolumeAttachment(volumeName string) (*longhorn.VolumeAttachment, error) {
 	return m.ds.GetLHVolumeAttachmentByVolumeName(volumeName)
 }
+
+func (m *VolumeManager) ListVolumeAttachment() ([]*longhorn.VolumeAttachment, error) {
+	return m.ds.ListLHVolumeAttachments()
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/11400

#### What this PR does / why we need it:

This PR introduces read-only API support for managing VolumeAttachment CRs.

- Adds `GET /v1/volumeattachments` for listing all VolumeAttachment resources
- Adds `GET /v1/volumeattachments/{name}` for retrieving a specific VolumeAttachment by name
- Formats the output to include attachment tickets, their satisfaction status, and conditions

#### Special notes for your reviewer:

#### Test
- Create and attach volume 
- Run 
```bash
curl -s http://localhost:8080/v1/volumeattachments
curl -s http://localhost:8080/v1/volumeattachments/<name>
```

> Note: Make sure the API is reachable locally by checking: 
```bash 
curl -v http://localhost:8080/v1/volumes
```

#### Additional documentation or context

Sample output 

`curl -s http://localhost:8080/v1/volumeattachments`

```json
{
  "data": [
    {
      "actions": {},
      "attachments": {
        "longhorn-ui": {
          "attachmentID": "longhorn-ui",
          "attachmentType": "longhorn-api",
          "conditions": [
            {
              "lastProbeTime": "",
              "lastTransitionTime": "2025-08-05T08:01:27Z",
              "message": "",
              "reason": "",
              "status": "True",
              "type": "Satisfied"
            }
          ],
          "nodeID": "vm2-virtualbox",
          "parameters": {
            "disableFrontend": "false",
            "lastAttachedBy": ""
          },
          "satisfied": true
        }
      },
      "id": "u8",
      "links": {
        "self": "http://localhost:8080/v1/volumeattachments/u8"
      },
      "type": "volumeAttachment",
      "volume": "u8"
    },
    {
      "actions": {},
      "attachments": {
        "longhorn-ui": {
          "attachmentID": "longhorn-ui",
          "attachmentType": "longhorn-api",
          "conditions": [
            {
              "lastProbeTime": "",
              "lastTransitionTime": "2025-08-06T03:33:33Z",
              "message": "",
              "reason": "",
              "status": "True",
              "type": "Satisfied"
            }
          ],
          "nodeID": "vm2-virtualbox",
          "parameters": {
            "disableFrontend": "false",
            "lastAttachedBy": ""
          },
          "satisfied": true
        }
      },
      "id": "u9",
      "links": {
        "self": "http://localhost:8080/v1/volumeattachments/u9"
      },
      "type": "volumeAttachment",
      "volume": "u9"
    }
  ],
  "links": {
    "self": "http://localhost:8080/v1/volumeattachments"
  },
  "resourceType": "volumeAttachment",
  "type": "collection"
}
```

`curl -s http://localhost:8080/v1/volumeattachments/u8`

```json
{
  "actions": {},
  "attachments": {
    "longhorn-ui": {
      "attachmentID": "longhorn-ui",
      "attachmentType": "longhorn-api",
      "conditions": [
        {
          "lastProbeTime": "",
          "lastTransitionTime": "2025-08-05T08:01:27Z",
          "message": "",
          "reason": "",
          "status": "True",
          "type": "Satisfied"
        }
      ],
      "nodeID": "vm2-virtualbox",
      "parameters": {
        "disableFrontend": "false",
        "lastAttachedBy": ""
      },
      "satisfied": true
    }
  },
  "id": "u8",
  "links": {
    "self": "http://localhost:8080/v1/volumeattachments/u8"
  },
  "type": "volumeAttachment",
  "volume": "u8"
}
```


