### PR TITLE
feat(setting): add instance-manager-pod-probe-timeout

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1577,6 +1577,11 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 	}
 	livenessProbeCommand := fmt.Sprintf("test $(%s; echo $?) -eq 0", strings.Join(livenessProbes, " && "))
 
+	podProbeTimeout, err := imc.ds.GetSettingAsInt(types.SettingNameInstanceManagerPodLivenessProbeTimeout)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameInstanceManagerPodLivenessProbeTimeout)
+	}
+
 	podSpec.Spec.Containers[0].LivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
@@ -1588,8 +1593,8 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			},
 		},
 		InitialDelaySeconds: datastore.IMPodProbeInitialDelay,
-		TimeoutSeconds:      datastore.IMPodProbeTimeoutSeconds,
-		PeriodSeconds:       datastore.IMPodProbePeriodSeconds,
+		TimeoutSeconds:      int32(podProbeTimeout),
+		PeriodSeconds:       int32(podProbeTimeout + 1),
 		FailureThreshold:    datastore.IMPodLivenessProbeFailureThreshold,
 	}
 

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -46,8 +46,6 @@ const (
 	PodStartupProbeFailureThreshold  = 36
 
 	IMPodProbeInitialDelay             = 3
-	IMPodProbeTimeoutSeconds           = IMPodProbePeriodSeconds - 1
-	IMPodProbePeriodSeconds            = 5
 	IMPodLivenessProbeFailureThreshold = 6
 )
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -1482,21 +1482,15 @@ var (
 		Default:            "2",
 	}
 
-<<<<<<< Updated upstream
-	SettingDefinitionInstanceManagerPodProbeTimeout = SettingDefinition{
-		DisplayName:        "Instance Manager Pod Probe Timeout",
-		Description:        "In seconds. The setting specifies the timeout for the instance manager pod probe. The default value is 4 seconds.",
-=======
 	SettingDefinitionInstanceManagerPodLivenessProbeTimeout = SettingDefinition{
 		DisplayName:        "Instance Manager Pod Liveness Probe Timeout",
 		Description:        "In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.",
->>>>>>> Stashed changes
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeInt,
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            "4",
+		Default:            "10",
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: 1,
 			ValueIntRangeMaximum: 60,

--- a/types/setting.go
+++ b/types/setting.go
@@ -155,6 +155,8 @@ const (
 	SettingNameOfflineReplicaRebuilding                                 = SettingName("offline-replica-rebuilding")
 	SettingNameReplicaRebuildingBandwidthLimit                          = SettingName("replica-rebuilding-bandwidth-limit")
 	SettingNameDefaultBackupBlockSize                                   = SettingName("default-backup-block-size")
+	SettingNameInstanceManagerPodLivenessProbeTimeout                   = SettingName("instance-manager-pod-liveness-probe-timeout")
+
 	// These three backup target parameters are used in the "longhorn-default-resource" ConfigMap
 	// to update the default BackupTarget resource.
 	// Longhorn won't create the Setting resources for these three parameters.
@@ -268,6 +270,7 @@ var (
 		SettingNameOfflineReplicaRebuilding,
 		SettingNameReplicaRebuildingBandwidthLimit,
 		SettingNameDefaultBackupBlockSize,
+		SettingNameInstanceManagerPodLivenessProbeTimeout,
 	}
 )
 
@@ -408,6 +411,7 @@ var (
 		SettingNameOfflineReplicaRebuilding:                                 SettingDefinitionOfflineReplicaRebuilding,
 		SettingNameReplicaRebuildingBandwidthLimit:                          SettingDefinitionReplicaRebuildingBandwidthLimit,
 		SettingNameDefaultBackupBlockSize:                                   SettingDefinitionDefaultBackupBlockSize,
+		SettingNameInstanceManagerPodLivenessProbeTimeout:                   SettingDefinitionInstanceManagerPodLivenessProbeTimeout,
 	}
 
 	SettingDefinitionAllowRecurringJobWhileVolumeDetached = SettingDefinition{
@@ -1476,6 +1480,27 @@ var (
 		DataEngineSpecific: false,
 		Choices:            []any{int64(2), int64(16)},
 		Default:            "2",
+	}
+
+<<<<<<< Updated upstream
+	SettingDefinitionInstanceManagerPodProbeTimeout = SettingDefinition{
+		DisplayName:        "Instance Manager Pod Probe Timeout",
+		Description:        "In seconds. The setting specifies the timeout for the instance manager pod probe. The default value is 4 seconds.",
+=======
+	SettingDefinitionInstanceManagerPodLivenessProbeTimeout = SettingDefinition{
+		DisplayName:        "Instance Manager Pod Liveness Probe Timeout",
+		Description:        "In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.",
+>>>>>>> Stashed changes
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            "4",
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 1,
+			ValueIntRangeMaximum: 60,
+		},
 	}
 
 	SettingDefinitionLogLevel = SettingDefinition{


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10788

Signed-off-by: Derek Su <derek.su@suse.com>

#### What this PR does / why we need it:

Make instance manager pod liveness probe timeout configurable.

#### Special notes for your reviewer:

#### Additional documentation or context
