### PR TITLE
feat(setting): move instance-manager-pod-liveness-probe-timeout to danger zone settings

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -757,6 +758,8 @@ func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *lon
 			isSettingSynced, err = imc.isSettingStorageNetworkSynced(setting, pod)
 		case types.SettingNameV1DataEngine, types.SettingNameV2DataEngine:
 			isSettingSynced, err = imc.isSettingDataEngineSynced(settingName, im)
+		case types.SettingNameInstanceManagerPodLivenessProbeTimeout:
+			isSettingSynced, err = imc.isSettingInstanceManagerPodLivenessProbeTimeoutSynced(setting, pod)
 		}
 		if err != nil {
 			return false, false, false, err
@@ -814,6 +817,21 @@ func (imc *InstanceManagerController) isSettingGuaranteedInstanceManagerCPUSynce
 
 func (imc *InstanceManagerController) isSettingPriorityClassSynced(setting *longhorn.Setting, pod *corev1.Pod) (bool, error) {
 	return pod.Spec.PriorityClassName == setting.Value, nil
+}
+
+func (imc *InstanceManagerController) isSettingInstanceManagerPodLivenessProbeTimeoutSynced(setting *longhorn.Setting, pod *corev1.Pod) (bool, error) {
+	if pod.Spec.Containers[0].LivenessProbe == nil {
+		// If the liveness probe is not set, we consider it synced.
+		return true, nil
+	}
+
+	timeoutSeconds, err := strconv.Atoi(setting.Value)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to convert %v setting value %v to int",
+			types.SettingNameInstanceManagerPodLivenessProbeTimeout, setting.Value)
+	}
+
+	return pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds == int32(timeoutSeconds), nil
 }
 
 func (imc *InstanceManagerController) isSettingStorageNetworkSynced(setting *longhorn.Setting, pod *corev1.Pod) (bool, error) {

--- a/types/setting.go
+++ b/types/setting.go
@@ -1483,9 +1483,11 @@ var (
 	}
 
 	SettingDefinitionInstanceManagerPodLivenessProbeTimeout = SettingDefinition{
-		DisplayName:        "Instance Manager Pod Liveness Probe Timeout",
-		Description:        "In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.",
-		Category:           SettingCategoryGeneral,
+		DisplayName: "Instance Manager Pod Liveness Probe Timeout",
+		Description: "In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.\n\n" +
+			"WARNING: \n\n" +
+			"  - When applying the setting, Longhorn will try to restart all instance-manager pods if all volumes are detached and eventually restart the instance manager pod without instances running on the instance manager. \n\n",
+		Category:           SettingCategoryDangerZone,
 		Type:               SettingTypeInt,
 		Required:           true,
 		ReadOnly:           false,


### PR DESCRIPTION


When applying the setting, Longhorn will try to restart all instance-manager pods if all volumes are detached and eventually restart the instance manager pod without instances running on the instance manager.



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10788

#### What this PR does / why we need it:

When applying the setting, Longhorn will try to restart all instance-manager pods if all volumes are detached and eventually restart the instance manager pod without instances running on the instance manager.


#### Special notes for your reviewer:

#### Additional documentation or context
