### PR TITLE
feat(api): add WebSocket streams for VolumeAttachment list

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -296,5 +296,9 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/volumeattachments").Handler(f(schemas, s.VolumeAttachmentList))
 	r.Methods("GET").Path("/v1/volumeattachments/{name}").Handler(f(schemas, s.VolumeAttachmentGet))
 
+	volumeAttachmentListStream := NewStreamHandlerFunc("volumeattachments", s.wsc.NewWatcher("volumeAttachment"), s.volumeAttachmentList)
+	r.Path("/v1/ws/volumeattachments").Handler(f(schemas, volumeAttachmentListStream))
+	r.Path("/v1/ws/{period}/volumeattachments").Handler(f(schemas, volumeAttachmentListStream))
+
 	return r
 }

--- a/api/volumeattachment.go
+++ b/api/volumeattachment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
 )
 
 func (s *Server) VolumeAttachmentGet(rw http.ResponseWriter, req *http.Request) error {
@@ -31,4 +32,12 @@ func (s *Server) VolumeAttachmentList(rw http.ResponseWriter, req *http.Request)
 	}
 	apiContext.Write(toVolumeAttachmentCollection(volumeAttachmentList, apiContext))
 	return nil
+}
+
+func (s *Server) volumeAttachmentList(apiContext *api.ApiContext) (*client.GenericCollection, error) {
+	volumeAttachmentList, err := s.m.ListVolumeAttachment()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list volume attachments")
+	}
+	return toVolumeAttachmentCollection(volumeAttachmentList, apiContext), nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
 
https://github.com/longhorn/longhorn/issues/11400

#### What this PR does / why we need it:

Support WebSocket streams for `VolumeAttachment` list

#### Special notes for your reviewer:

new websocket route
- `"/v1/ws/volumeattachments"`
- `"/v1/ws/{period}/volumeattachments"`


#### Additional documentation or context

```bash

> david@david-suse:~$ wscat -c ws://localhost:8080/v1/ws/volumeattachments | jq
{
  "data": [
    {
      "actions": {},
      "attachments": {
        "csi-e920bd359d775d2c722e6ae6edc450db919a0c589e3da2b9a99606a9b6b917ea": {
          "attachmentID": "csi-e920bd359d775d2c722e6ae6edc450db919a0c589e3da2b9a99606a9b6b917ea",
          "attachmentType": "csi-attacher",
          "conditions": [
            {
              "lastProbeTime": "",
              "lastTransitionTime": "2025-08-15T06:48:13Z",
              "message": "The attachment ticket is satisfied",
              "reason": "",
              "status": "True",
              "type": "Satisfied"
            }
          ],
          "nodeID": "vm1-virtualbox",
          "parameters": {
            "disableFrontend": "false",
            "lastAttachedBy": ""
          },
          "satisfied": true
        },
        "csi-eb139d7ec587d7a0671a98aaaad0c7d9b0111f215f58afda511bf850259dab3d": {
          "attachmentID": "csi-eb139d7ec587d7a0671a98aaaad0c7d9b0111f215f58afda511bf850259dab3d",
          "attachmentType": "csi-attacher",
          "conditions": [
            {
              "lastProbeTime": "",
              "lastTransitionTime": "2025-08-15T06:48:13Z",
              "message": "The attachment ticket is satisfied",
              "reason": "",
              "status": "True",
              "type": "Satisfied"
            }
          ],
          "nodeID": "vm2-virtualbox",
          "parameters": {
            "disableFrontend": "false",
            "lastAttachedBy": ""
          },
          "satisfied": true
        },
        "share-manager-controller-pvc-7b0f4287-f4c0-479f-95fb-aadd6f10c76d": {
          "attachmentID": "share-manager-controller-pvc-7b0f4287-f4c0-479f-95fb-aadd6f10c76d",
          "attachmentType": "share-manager-controller",
          "conditions": [
            {
              "lastProbeTime": "",
              "lastTransitionTime": "2025-08-15T06:48:08Z",
              "message": "",
              "reason": "",
              "status": "True",
              "type": "Satisfied"
            }
          ],
          "nodeID": "vm1-virtualbox",
          "parameters": {
            "disableFrontend": "false"
          },
          "satisfied": true
        }
      },
      "id": "pvc-7b0f4287-f4c0-479f-95fb-aadd6f10c76d",
      "links": {
        "self": "http://localhost:8080/v1/volumeattachments/pvc-7b0f4287-f4c0-479f-95fb-aadd6f10c76d"
      },
      "type": "volumeAttachment",
      "volume": "pvc-7b0f4287-f4c0-479f-95fb-aadd6f10c76d"
    }
  ],
  "links": {
    "self": "http://localhost:8080/v1/ws/volumeattachments"
  },
  "resourceType": "volumeAttachment",
  "type": "collection"
}

```
