### PR TITLE
fix(replica): check if disk candidates exist when rebuilding and detach offline-rebuilding volume if necessary

### DIFF
--- a/controller/volume_rebuilding_controller.go
+++ b/controller/volume_rebuilding_controller.go
@@ -336,7 +336,7 @@ func (vbc *VolumeRebuildingController) reconcile(volName string) (err error) {
 		return nil
 	}
 	if vbc.isVolumeReplicasRebuilding(vol, engine) {
-		deleteVATicketRequired = false
+		deleteVATicketRequired = types.GetCondition(vol.Status.Conditions, longhorn.VolumeConditionTypeScheduled).Status == longhorn.ConditionStatusFalse
 		return nil
 	}
 

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -129,7 +129,7 @@ func (rcs *ReplicaScheduler) scheduleReplicaToDiskOnLocalNode(replica *longhorn.
 func (rcs *ReplicaScheduler) FindDiskCandidates(replica *longhorn.Replica, replicas map[string]*longhorn.Replica, volume *longhorn.Volume) (map[string]*Disk, multierr.MultiError) {
 	errs := multierr.NewMultiError()
 
-	nodes, err := rcs.listSchedulableNodes()
+	nodes, err := rcs.ListSchedulableNodes()
 	if err != nil {
 		errs.Append(longhorn.ErrorReplicaScheduleLonghornClientOperationFailed,
 			errors.Wrapf(err, "failed to list schedulable nodes for scheduling replica %v", replica.Name))
@@ -562,7 +562,7 @@ func filterDisksWithMatchingReplicas(disks map[string]*Disk, replicas map[string
 	return disks
 }
 
-func (rcs *ReplicaScheduler) listSchedulableNodes() (map[string]*longhorn.Node, error) {
+func (rcs *ReplicaScheduler) ListSchedulableNodes() (map[string]*longhorn.Node, error) {
 	nodeInfo, err := rcs.ds.ListNodes()
 	if err != nil {
 		return nil, err
@@ -657,7 +657,7 @@ func (rcs *ReplicaScheduler) CheckAndReuseFailedReplica(replicas map[string]*lon
 
 	replicas = filterActiveReplicas(replicas)
 
-	allNodesInfo, err := rcs.listSchedulableNodes()
+	allNodesInfo, err := rcs.ListSchedulableNodes()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11274

#### What this PR does / why we need it:

- If a disk candidate exists, degraded volumes will start offline rebuilding which is enabled.
- Detach offline-rebuilding volumes if the volume condition `Scheduled` is false.

#### Special notes for your reviewer:

#### Additional documentation or context

Regression test: https://10.115.5.5/job/private/job/longhorn-tests-regression/177/
