### PR TITLE
fix(backup): correct backup block size validation logic for remote backup creation

### DIFF
--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -341,11 +341,11 @@ func (bvc *BackupVolumeController) reconcile(backupVolumeName string) (err error
 				backupBlockSizeParam := backupInfo.Parameters[lhbackup.LonghornBackupParameterBackupBlockSize]
 				if blockSizeBytes, convertErr := util.ConvertSize(backupBlockSizeParam); convertErr != nil {
 					log.WithError(convertErr).Warnf("Invalid backup block size string from the remote backup %v: %v", backupName, backupBlockSizeParam)
-				} else if sizeErr := types.ValidateBackupBlockSize(-1, blockSizeBytes); sizeErr != nil {
-					log.WithError(sizeErr).Warnf("Invalid backup block size from the remote backup %v: %v", backupName, backupBlockSizeParam)
 				} else {
 					if blockSizeBytes == 0 {
 						blockSize = types.BackupBlockSize2Mi
+					} else if sizeErr := types.ValidateBackupBlockSize(-1, blockSizeBytes); sizeErr != nil {
+						log.WithError(sizeErr).Warnf("Invalid backup block size from the remote backup %v: %v", backupName, backupBlockSizeParam)
 					} else {
 						blockSize = blockSizeBytes
 					}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#5215

#### What this PR does / why we need it:

While creating a backup from remote backup store, the zero block size should be corrected to 2 MiB legacy default size, rather thank rejecting it by `types.ValidateBackupBlockSize`.

#### Special notes for your reviewer:

#### Additional documentation or context
