### PR TITLE
fix(backingimage): rename lhbim to avoid disk uuid conflict

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -343,6 +343,7 @@ const (
 	engineImagePrefix          = "ei-"
 	instanceManagerImagePrefix = "imi-"
 	shareManagerImagePrefix    = "smi-"
+	backingImageManagerPrefix  = "bim-"
 	orphanPrefix               = "orphan-"
 
 	BackingImageDataSourcePodNamePrefix = "backing-image-ds-"
@@ -418,7 +419,7 @@ func EngineBinaryExistOnHostForImage(image string) (bool, error) {
 }
 
 func GetBackingImageManagerName(image, diskUUID string) string {
-	return fmt.Sprintf("backing-image-manager-%s-%s", util.GetStringChecksum(image)[:4], diskUUID[:4])
+	return backingImageManagerPrefix + util.GetStringChecksumSHA256(strings.TrimSpace(fmt.Sprintf("%s-%s", image, diskUUID)))
 }
 
 func GetBackingImageDirectoryName(backingImageName, backingImageUUID string) string {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11455

#### What this PR does / why we need it:

Hash the full disk UUID to avoid conflict.

#### Special notes for your reviewer:

#### Additional documentation or context
