### PR TITLE
fix: volume stuck in detaching/attaching loop due to migration cannot finish

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -75,6 +75,7 @@ func isCloningRequiredAndNotCompleted(v *longhorn.Volume) bool {
 func isVolumeFullyDetached(vol *longhorn.Volume) bool {
 	return vol.Spec.NodeID == "" &&
 		vol.Spec.MigrationNodeID == "" &&
+		vol.Status.CurrentMigrationNodeID == "" &&
 		vol.Status.State == longhorn.VolumeStateDetached
 }
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1595,7 +1595,7 @@ func GetNewCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.En
 	// 3. Set the new current engine to active (might fail, preventing everything below).
 	// 4. Set the volume.Status.CurrentNodeID (might fail).
 	// So we might delete the active engine, fail to set the new current engine to active, and fail to set the
-	// volume.Spec.CurrentNodeID. Then, the volume attachment controller might try to do a full detachment, setting
+	// volume.Status.CurrentNodeID. Then, the volume attachment controller might try to do a full detachment, setting
 	// volume.Spec.NodeID == "". At this point, there is no engine that can ever be considered active again by the rules
 	// above, but we want to use the new current engine. It's engine.Spec.NodeID ==
 	// volume.Status.CurrentMigrationNodeID.
@@ -1607,6 +1607,19 @@ func GetNewCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.En
 				currentEngine = e
 			} else {
 				extras = append(extras, e)
+			}
+		}
+	}
+
+	// If volume only has 1 active engine left and it does not have spec nodeID, it cannot pass the above rules.
+	// However, we want to use it as the current engine
+	if currentEngine == nil {
+		if len(es) == 1 {
+			for _, e := range es {
+				if e.Spec.Active && e.Spec.NodeID == "" {
+					currentEngine = e
+					extras = []*longhorn.Engine{}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fix 2 issues:
1. If volume only has 1 active engine left and it does not have spec.nodeID, select it as the current engine. Do not stuck here
2. Do not attempt a new attach if the volume is currently under migration with vol.Status.CurrentMigrationNodeID != ""

longhorn/longhorn#11479

FYI, this is the flow of all engine picking related logic:

<img width="3216" height="1580" alt="Blank diagram" src="https://github.com/user-attachments/assets/5f7238f2-f555-42df-8a00-31b5de4e3865" />
