### PR TITLE
feat(controller, datastore): add volume / node compatible check

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -619,6 +619,19 @@ func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineIm
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
+	volumeName, err := bc.getBackupVolumeName(b)
+	if err != nil {
+		return false, err
+	}
+
+	compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID)
+	if err != nil {
+		return false, err
+	}
+	if !compatible {
+		return false, nil
+	}
+
 	isResponsible := isControllerResponsibleFor(bc.controllerID, bc.ds, b.Name, "", b.Status.OwnerID)
 
 	currentOwnerEngineAvailable, err := bc.ds.CheckEngineImageReadiness(defaultEngineImage, b.Status.OwnerID)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -624,12 +624,8 @@ func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineIm
 		return false, err
 	}
 
-	compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID)
-	if err != nil {
+	if compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID); err != nil || !compatible {
 		return false, err
-	}
-	if !compatible {
-		return false, nil
 	}
 
 	isResponsible := isControllerResponsibleFor(bc.controllerID, bc.ds, b.Name, "", b.Status.OwnerID)

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -620,12 +620,10 @@ func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineIm
 	}()
 
 	volumeName, err := bc.getBackupVolumeName(b)
-	if err != nil {
-		return false, err
-	}
-
-	if compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID); err != nil || !compatible {
-		return false, err
+	if err == nil {
+		if compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID); err != nil || !compatible {
+			return false, err
+		}
 	}
 
 	isResponsible := isControllerResponsibleFor(bc.controllerID, bc.ds, b.Name, "", b.Status.OwnerID)

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -461,6 +461,14 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
+	compatible, err := bvc.ds.IsVolumeCompatibleWithNodeEngine(bv.Spec.VolumeName, bvc.controllerID)
+	if err != nil {
+		return false, err
+	}
+	if !compatible {
+		return false, nil
+	}
+
 	isResponsible := isControllerResponsibleFor(bvc.controllerID, bvc.ds, bv.Name, "", bv.Status.OwnerID)
 
 	currentOwnerEngineAvailable, err := bvc.ds.CheckEngineImageReadiness(defaultEngineImage, bv.Status.OwnerID)

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -461,12 +461,8 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
-	compatible, err := bvc.ds.IsVolumeCompatibleWithNodeEngine(bv.Spec.VolumeName, bvc.controllerID)
-	if err != nil {
+	if compatible, err := bvc.ds.IsVolumeCompatibleWithNodeEngine(bv.Spec.VolumeName, bvc.controllerID); err != nil || !compatible {
 		return false, err
-	}
-	if !compatible {
-		return false, nil
 	}
 
 	isResponsible := isControllerResponsibleFor(bvc.controllerID, bvc.ds, bv.Name, "", bv.Status.OwnerID)

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -6466,7 +6466,7 @@ func (s *DataStore) IsVolumeCompatibleWithNodeEngine(volumeName string, nodeName
 	// If it's a v1 volume, v1 data engine is enabled in cluster
 	// no option for disable v1 engine on the specific node
 	// always compatible
-	if !types.IsDataEngineV2(volume.Spec.DataEngine) {
+	if types.IsDataEngineV1(volume.Spec.DataEngine) {
 		return true, nil
 	}
 
@@ -6477,7 +6477,7 @@ func (s *DataStore) IsVolumeCompatibleWithNodeEngine(volumeName string, nodeName
 	}
 
 	// v2 volume is only compatible if node has NOT disabled v2
-	return !v2Disabled, nil
+	return types.IsDataEngineV2(volume.Spec.DataEngine) && !v2Disabled, nil
 }
 
 func (s *DataStore) GetCurrentDiskBackingImageMap() (map[string][]*longhorn.BackingImage, error) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue # https://github.com/longhorn/longhorn/issues/11619

#### What this PR does / why we need it:

When enable v2 data engine, we allow user to disable v2 on the specific nodes. In this case, if the backup is scheduled to the non-v2 engine, it may have error. 

This PR add a checking in `isResponsibleFor()` for making sure the v2 volume will be scheduled to the node supported v2.

#### Special notes for your reviewer:

#### Additional documentation or context

####  Test Steps
1. disable v1 engine & enable v2 engine 
2. add `node.longhorn.io/disable-v2-data-engine="true"` on some nodes
    -  `k label nodes vm1-virtualbox  node.longhorn.io/disable-v2-data-engine="true" --overwrite` 
    -  `kubectl get nodes -L node.longhorn.io/disable-v2-data-engine`
3. create v2 volume and backup it
    - Do multiple backup and wait for complete
4. there should not have the backup on the non-v2 node (check the ownerID)
``` 
kubectl get backup -n longhorn-system -o custom-columns=NAME:.metadata.name,SNAPSHOTNAME:.status.snapshotName,SNAPSHOTSIZE:.status.size,SNAPSHOTCREATEDAT:.status.snapshotCreatedAt,BACKUPTARGET:.status.backupTargetName,STATE:.status.state,LASTSYNCEDAT:.status.lastSyncedAt,OWNERID:.status.ownerID
```
```
k get backupvolumes -n l   -o custom-columns=NAME:.metadata.name,BACKUPTARGET:.spec.backupTargetName,OWNERID:.status.ownerID,VOLUME:.spec.volumeName
```

<img width="1862" height="517" alt="Screenshot from 2025-09-03 13-34-38" src="https://github.com/user-attachments/assets/94c33110-0039-432d-9c38-1a300bef5e4a" />

