### PR TITLE
fix: make sure the BIM has a ready backing image replica before creating a backing image backup

### DIFF
--- a/controller/backup_backing_image_controller.go
+++ b/controller/backup_backing_image_controller.go
@@ -362,23 +362,9 @@ func (bc *BackupBackingImageController) checkMonitor(bbi *longhorn.BackupBacking
 	}
 
 	// pick one backing image manager to do backup
-	var targetBim *longhorn.BackingImageManager
-	for diskUUID := range backingImage.Spec.DiskFileSpecMap {
-		bimMap, err := bc.ds.ListBackingImageManagersByDiskUUID(diskUUID)
-		if err != nil {
-			return nil, err
-		}
-		for _, bim := range bimMap {
-			if bim.DeletionTimestamp == nil {
-				if uuidInManager, exists := bim.Status.BackingImageFileMap[backingImage.Name]; exists && uuidInManager.UUID == backingImage.Status.UUID {
-					targetBim = bim
-					break
-				}
-			}
-		}
-		if targetBim != nil {
-			break
-		}
+	targetBim, err := bc.findSuitableBackingImageManager(backingImage)
+	if err != nil {
+		return nil, err
 	}
 	if targetBim == nil {
 		return nil, fmt.Errorf("failed to find backing image manager to backup backing image %v", bbi.Name)
@@ -482,4 +468,32 @@ func (bc *BackupBackingImageController) backupNotInFinalState(bbi *longhorn.Back
 	return bbi.Status.State != longhorn.BackupStateCompleted &&
 		bbi.Status.State != longhorn.BackupStateError &&
 		bbi.Status.State != longhorn.BackupStateUnknown
+}
+
+func (bc *BackupBackingImageController) findSuitableBackingImageManager(backingImage *longhorn.BackingImage) (*longhorn.BackingImageManager, error) {
+	for diskUUID := range backingImage.Spec.DiskFileSpecMap {
+		bimMap, err := bc.ds.ListBackingImageManagersByDiskUUID(diskUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, bim := range bimMap {
+			// Skip deleted managers
+			if bim.DeletionTimestamp != nil {
+				continue
+			}
+
+			// Check if this manager has the backing image file
+			uuidInManager, exists := bim.Status.BackingImageFileMap[backingImage.Name]
+			if !exists {
+				continue
+			}
+
+			// Check if UUID matches and state is ready
+			if uuidInManager.UUID == backingImage.Status.UUID && uuidInManager.State == longhorn.BackingImageStateReady {
+				return bim, nil
+			}
+		}
+	}
+	return nil, nil
 }


### PR DESCRIPTION
Make sure the BIM has a ready backing image replica before creating a backing image backup.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11675

#### What this PR does / why we need it:
When Longhorn creates a BackupBackingImage (BBI), it may [select a BackingImageManager (BIM) that doesn’t have a ready BackingImage (BI) replica](https://github.com/longhorn/longhorn-manager/blob/979b8d559b4fe2cb087e39a32d08ce1e329a0cef/controller/backup_backing_image_controller.go#L366-L382). As a result, the BIM pod might try to read a file that isn’t ready during BBI creation.

#### Special notes for your reviewer:

#### Additional documentation or context
Reproduction steps:
* Set up a cluster with Longhorn (I used Harvester).
* Run this [[script](https://github.com/WebberHuang1118/misc-tools/blob/main/backingimage/create_bi_bbi_cycle.sh)](https://github.com/WebberHuang1118/misc-tools/blob/main/backingimage/create_bi_bbi_cycle.sh) to repeatedly create BIs and BBIs.
* The script is able to pass more than 10 rounds. 