### PR TITLE
fix: Allow applying different values for Snapshot Data Integrity Check CronJob for v1 and v2

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -1369,8 +1369,8 @@ var (
 		Type:               SettingTypeString,
 		Required:           true,
 		ReadOnly:           false,
-		DataEngineSpecific: false,
-		Default:            "0 0 */7 * *",
+		DataEngineSpecific: true,
+		Default:            fmt.Sprintf("{%q:%q,%q:%q}", longhorn.DataEngineTypeV1, string("0 0 */7 * *"), longhorn.DataEngineTypeV2, string("0 0 */7 * *")),
 	}
 
 	SettingDefinitionSnapshotMaxCount = SettingDefinition{


### PR DESCRIPTION
fix: Allow applying different values for Snapshot Data Integrity Check CronJob for v1 and v2

ref:#11537

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11537

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
