### PR TITLE
fix(engine_controller): v2 volume also require checkSizeBeforeRestoration

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -1372,7 +1372,8 @@ func preRestoreCheckAndSync(log logrus.FieldLogger, engine *longhorn.Engine,
 		return false, fmt.Errorf("backup volume is empty for backup restoration of engine %v", engine.Name)
 	}
 
-	if cliAPIVersion >= engineapi.CLIAPIMinVersionForExistingEngineBeforeUpgrade {
+	if (types.IsDataEngineV1(engine.Spec.DataEngine) && cliAPIVersion >= engineapi.CLIAPIMinVersionForExistingEngineBeforeUpgrade) ||
+		types.IsDataEngineV2(engine.Spec.DataEngine) {
 		return checkSizeBeforeRestoration(log, engine, ds)
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/11767

#### What this PR does / why we need it:

V2 volume require checkSizeBeforeRestoration() for updating the size before restoration

#### Special notes for your reviewer:

#### Additional documentation or context
