### PR TITLE
fix: get the correct owner for v2 volume

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -621,7 +621,7 @@ func (bc *BackupController) isResponsibleFor(b *longhorn.Backup, defaultEngineIm
 
 	volumeName, err := bc.getBackupVolumeName(b)
 	if err == nil {
-		if compatible, err := bc.ds.IsVolumeCompatibleWithNodeEngine(volumeName, bc.controllerID); err != nil || !compatible {
+		if compatible, err := bc.ds.IsNodeSupportingDataEngine(volumeName, bc.controllerID); err != nil || !compatible {
 			return false, err
 		}
 	}

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -461,7 +461,7 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
-	if compatible, err := bvc.ds.IsVolumeCompatibleWithNodeEngine(bv.Spec.VolumeName, bvc.controllerID); err != nil || !compatible {
+	if compatible, err := bvc.ds.IsNodeSupportingDataEngine(bv.Spec.VolumeName, bvc.controllerID); err != nil || !compatible {
 		return false, err
 	}
 

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2302,6 +2302,12 @@ func (ec *EngineController) isResponsibleFor(e *longhorn.Engine, defaultEngineIm
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
+	if types.IsDataEngineV2(e.Spec.DataEngine) {
+		if isV2DisabledForNode, err := ec.ds.IsV2DataEngineDisabledForNode(ec.controllerID); err != nil || isV2DisabledForNode {
+			return false, err
+		}
+	}
+
 	// If a regular RWX is delinquent, try to switch ownership quickly to the owner node of the share manager CR
 	isOwnerNodeDelinquent, err := ec.ds.IsNodeDelinquent(e.Status.OwnerID, e.Spec.VolumeName)
 	if err != nil {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -885,6 +885,13 @@ func (rc *ReplicaController) enqueueAllRebuildingReplicaOnCurrentNode() {
 }
 
 func (rc *ReplicaController) isResponsibleFor(r *longhorn.Replica) (bool, error) {
+	// If the replica is not handled by this node, skip it.
+	if types.IsDataEngineV2(r.Spec.DataEngine) {
+		if isV2DisabledForNode, err := rc.ds.IsV2DataEngineDisabledForNode(rc.controllerID); err != nil || isV2DisabledForNode {
+			return false, err
+		}
+	}
+
 	// If a regular RWX is delinquent, try to switch ownership quickly to the owner node of the share manager CR
 	isOwnerNodeDelinquent, err := rc.ds.IsNodeDelinquent(r.Status.OwnerID, r.Spec.VolumeName)
 	if err != nil {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -4539,6 +4539,12 @@ func (c *VolumeController) isResponsibleFor(v *longhorn.Volume, defaultEngineIma
 		err = errors.Wrap(err, "error while checking isResponsibleFor")
 	}()
 
+	if types.IsDataEngineV2(v.Spec.DataEngine) {
+		if isV2DisabledForNode, err := c.ds.IsV2DataEngineDisabledForNode(c.controllerID); err != nil || isV2DisabledForNode {
+			return false, err
+		}
+	}
+
 	// If a regular RWX is delinquent, try to switch ownership quickly to the owner node of the share manager CR
 	isOwnerNodeDelinquent, err := c.ds.IsNodeDelinquent(v.Status.OwnerID, v.Name)
 	if err != nil {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -6458,10 +6458,11 @@ func (s *DataStore) IsV2DataEngineDisabledForNode(nodeName string) (bool, error)
 	return false, nil
 }
 
-func (s *DataStore) IsVolumeCompatibleWithNodeEngine(volumeName string, nodeName string) (bool, error) {
-	// v1 volumes are always considered compatible.
-	// v2 volumes are compatible only if the node has NOT disabled v2 engine.
-
+// IsNodeSupportingDataEngine returns true if the node supports the volume's data engine.
+//
+//	v1 volumes are always considered compatible.
+//	v2 volumes are supported only if the node has NOT disabled v2 engine.
+func (s *DataStore) IsNodeSupportingDataEngine(volumeName string, nodeName string) (bool, error) {
 	volume, err := s.GetVolumeRO(volumeName)
 	if err != nil {
 		// Because the volume doesn't exist,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11774

#### What this PR does / why we need it:

Some nodes will label a disabled v2 data engine, and then these nodes should not be the owner for the v2 volumes.

#### Special notes for your reviewer:

#### Additional documentation or context
