### PR TITLE
Add support for a new Pod Deletion Policy

### DIFF
--- a/controller/kubernetes_pod_controller.go
+++ b/controller/kubernetes_pod_controller.go
@@ -35,6 +35,8 @@ const (
 	controllerAgentName = "longhorn-kubernetes-pod-controller"
 
 	remountRequestDelayDuration = 5 * time.Second
+
+	podDeletionAnnotation = "longhorn.io/allow-deletion"
 )
 
 type KubernetesPodController struct {
@@ -472,7 +474,7 @@ func (kc *KubernetesPodController) getPodWithConflictedAttachment(pods []*corev1
 //
 // Force delete a pod when all of the below conditions are meet:
 // 1. NodeDownPodDeletionPolicy is different than DoNothing
-// 2. pod belongs to a StatefulSet/Deployment depend on NodeDownPodDeletionPolicy
+// 2. pod belongs to a StatefulSet/Deployment depend on NodeDownPodDeletionPolicy OR is explicitly marked for deletion.
 // 3. node containing the pod is down
 // 4. the pod is terminating and the DeletionTimestamp has passed.
 // 5. pod has a PV with provisioner driver.longhorn.io
@@ -484,7 +486,8 @@ func (kc *KubernetesPodController) handlePodDeletionIfNodeDown(pod *corev1.Pod, 
 
 	shouldDelete := (deletionPolicy == types.NodeDownPodDeletionPolicyDeleteStatefulSetPod && isOwnedByStatefulSet(pod)) ||
 		(deletionPolicy == types.NodeDownPodDeletionPolicyDeleteDeploymentPod && isOwnedByDeployment(pod)) ||
-		(deletionPolicy == types.NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPod && (isOwnedByStatefulSet(pod) || isOwnedByDeployment(pod)))
+		(deletionPolicy == types.NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPod && (isOwnedByStatefulSet(pod) || isOwnedByDeployment(pod))) ||
+		(deletionPolicy == types.NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPodAndAnnotatedPods && (isOwnedByStatefulSet(pod) || isOwnedByDeployment(pod) || isAnnotatedWithDeletionAnnotation(pod)))
 
 	if !shouldDelete {
 		return nil
@@ -679,6 +682,15 @@ func isOwnedByDeployment(pod *corev1.Pod) bool {
 		return ownerRef.Kind == types.KubernetesReplicaSet
 	}
 	return false
+}
+
+func isAnnotatedWithDeletionAnnotation(pod *corev1.Pod) bool {
+	if val, ok := pod.ObjectMeta.Annotations[podDeletionAnnotation]; ok {
+		if strings.ToLower(val) == "true" {
+			return true
+		}
+	}
+	return false // We did not find the annotation, or the annotation is something else than "true" or "True"
 }
 
 // enqueuePodChange determines if the pod requires processing based on whether the pod has a PV created by us (driver.longhorn.io)

--- a/types/setting.go
+++ b/types/setting.go
@@ -1760,10 +1760,11 @@ var (
 type NodeDownPodDeletionPolicy string
 
 const (
-	NodeDownPodDeletionPolicyDoNothing                             = NodeDownPodDeletionPolicy("do-nothing") // Kubernetes default behavior
-	NodeDownPodDeletionPolicyDeleteStatefulSetPod                  = NodeDownPodDeletionPolicy("delete-statefulset-pod")
-	NodeDownPodDeletionPolicyDeleteDeploymentPod                   = NodeDownPodDeletionPolicy("delete-deployment-pod")
-	NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPod = NodeDownPodDeletionPolicy("delete-both-statefulset-and-deployment-pod")
+	NodeDownPodDeletionPolicyDoNothing                                             = NodeDownPodDeletionPolicy("do-nothing") // Kubernetes default behavior
+	NodeDownPodDeletionPolicyDeleteStatefulSetPod                                  = NodeDownPodDeletionPolicy("delete-statefulset-pod")
+	NodeDownPodDeletionPolicyDeleteDeploymentPod                                   = NodeDownPodDeletionPolicy("delete-deployment-pod")
+	NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPod                 = NodeDownPodDeletionPolicy("delete-both-statefulset-and-deployment-pod")
+	NodeDownPodDeletionPolicyDeleteBothStatefulsetAndDeploymentPodAndAnnotatedPods = NodeDownPodDeletionPolicy("delete-both-statefulset-and-deployment-pod-and-annotated-pods")
 )
 
 type NodeDrainPolicy string


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue (https://github.com/longhorn/longhorn/issues/11876)

#### What this PR does / why we need it:
This PR adds an extra PodDeletionPolicy called: `delete-both-statefulset-and-deployment-pod-and-annotated-pods` (for lack of a better name...)
It adds an additional option to set an Annotation on a Pod to mark it for explicit deletion.

This helps in cases where the Pod is not managed by a StatefulSet, Deployment or DaemonSet.
This is useful in situations where an Operator or Controller manages the Pod manually.

This requires Administrators to explicitly configure those annotations on the pod before longhorn engages in the deletion of the pod(s).

#### Special notes for your reviewer:
It's quite hard to test, we will have to setup a 3 node cluster, with a pod that has a pvc that is stuck in Terminating, and see if the longhorn-manager now correctly deletes the pod after it's grace period has expired.

#### Additional documentation or context
Docs PR here: https://github.com/longhorn/website/pull/1210
