### PR TITLE
fix(csi): GetCapacity rpc must default to v1 engine

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -753,12 +753,12 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 		}
 	}
 
-	dataEngine, ok := scParameters["dataEngine"]
-	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key")
-	}
 	rsp := &csi.GetCapacityResponse{}
-	switch longhorn.DataEngineType(dataEngine) {
+	dataEngine := longhorn.DataEngineTypeV1
+	if dataEngineType, ok := scParameters["dataEngine"]; ok {
+		dataEngine = longhorn.DataEngineType(dataEngineType)
+	}
+	switch dataEngine {
 	case longhorn.DataEngineTypeV1:
 		rsp.AvailableCapacity = v1AvailableCapacity
 	case longhorn.DataEngineTypeV2:

--- a/csi/controlller_server_test.go
+++ b/csi/controlller_server_test.go
@@ -61,11 +61,6 @@ func TestGetCapacity(t *testing.T) {
 			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
 		},
 		{
-			testName: "Missing data engine type",
-			node:     newNode("node-0", "storage", true, true, true, false),
-			err:      status.Errorf(codes.InvalidArgument, "storage class parameters missing 'dataEngine' key"),
-		},
-		{
 			testName:   "Unknown data engine type",
 			node:       newNode("node-0", "storage", true, true, true, false),
 			dataEngine: "v5",
@@ -118,6 +113,12 @@ func TestGetCapacity(t *testing.T) {
 			dataEngine:        "v1",
 			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false)},
 			availableCapacity: 0,
+		},
+		{
+			testName:          "Must default to v1 engine when dataEngine key is missing",
+			node:              newNode("node-0", "storage", true, true, true, false),
+			disks:             []*disk{newDisk(1450, 300, "ssd", false, true, true, false), newDisk(1000, 500, "", false, true, true, false), newDisk(2000, 100, "", true, true, true, false)},
+			availableCapacity: 1150,
 		},
 		{
 			testName:          "v1 engine with two valid disks",


### PR DESCRIPTION
…ey is missing

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #https://github.com/longhorn/longhorn/issues/11906

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
