### PR TITLE
fix: fix NPE issue when recurring jobs handles a deleted volume

### DIFF
--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -144,7 +144,11 @@ func (job *VolumeJob) run() (err error) {
 	volumeName := job.volumeName
 	volume, err := volumeAPI.ById(volumeName)
 	if err != nil {
-		return errors.Wrapf(err, "could not get volume %v", volumeName)
+		return errors.Wrapf(err, "failed to get volume %v", volumeName)
+	}
+	if volume == nil {
+		job.logger.Infof("Volume %v not found, skipping", volumeName)
+		return nil
 	}
 
 	if len(volume.Controllers) > 1 {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Since API `volumeAPI.ById(volumeName)` will not return any error when the volume is gone, the job needs to handle nil volume case separately.

https://github.com/longhorn/longhorn/issues/11925

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
