### PR TITLE
feat: make storage capacity tracking configurable

### DIFF
--- a/app/driver.go
+++ b/app/driver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
@@ -287,6 +288,15 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 		return err
 	}
 
+	storageCapacityTrackingSetting, err := lhClient.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(types.SettingNameCSIStorageCapacityTracking), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	storageCapacityTracking, err := strconv.ParseBool(storageCapacityTrackingSetting.Value)
+	if err != nil {
+		return err
+	}
+
 	var imagePullPolicy corev1.PullPolicy
 	switch imagePullPolicySetting.Value {
 	case string(types.SystemManagedPodsImagePullPolicyNever):
@@ -319,7 +329,7 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 		return err
 	}
 
-	csiDriverObjectDeployment := csi.NewCSIDriverObject()
+	csiDriverObjectDeployment := csi.NewCSIDriverObject(storageCapacityTracking)
 	if err := csiDriverObjectDeployment.Deploy(kubeClient); err != nil {
 		return err
 	}

--- a/app/driver.go
+++ b/app/driver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
@@ -287,11 +288,13 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 		return err
 	}
 
+	storageCapacityEnabled := false
 	storageCapacityTrackingSetting, err := lhClient.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(types.SettingNameCSIStorageCapacityTracking), metav1.GetOptions{})
 	if err != nil {
+		logrus.WithError(err).Warnf("failed to get storage capacity tracking setting, defaulting to false")
+	} else if storageCapacityEnabled, err = strconv.ParseBool(storageCapacityTrackingSetting.Value); err != nil {
 		return err
 	}
-	storageCapacityEnabled := types.IsCSIStorageCapacityEnabled(storageCapacityTrackingSetting.Value)
 
 	var imagePullPolicy corev1.PullPolicy
 	switch imagePullPolicySetting.Value {

--- a/app/driver.go
+++ b/app/driver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
@@ -292,10 +291,7 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 	if err != nil {
 		return err
 	}
-	storageCapacityTracking, err := strconv.ParseBool(storageCapacityTrackingSetting.Value)
-	if err != nil {
-		return err
-	}
+	storageCapacityEnabled := types.IsCSIStorageCapacityEnabled(storageCapacityTrackingSetting.Value)
 
 	var imagePullPolicy corev1.PullPolicy
 	switch imagePullPolicySetting.Value {
@@ -329,7 +325,7 @@ func deployCSIDriver(kubeClient *clientset.Clientset, lhClient *lhclientset.Clie
 		return err
 	}
 
-	csiDriverObjectDeployment := csi.NewCSIDriverObject(storageCapacityTracking)
+	csiDriverObjectDeployment := csi.NewCSIDriverObject(storageCapacityEnabled)
 	if err := csiDriverObjectDeployment.Deploy(kubeClient); err != nil {
 		return err
 	}

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -23,6 +23,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -261,7 +262,7 @@ func (sc *SettingController) syncNonDangerZoneSettingsForManagedComponents(setti
 			return err
 		}
 	case types.SettingNameCSIStorageCapacityTracking:
-		if err := sc.updateCSIStorageCapacityTracking(); err != nil {
+		if err := sc.syncCSIDriverStorageCapacity(); err != nil {
 			return err
 		}
 	}
@@ -1086,10 +1087,32 @@ func (sc *SettingController) updateNodeSelector() error {
 	return nil
 }
 
-func (sc *SettingController) updateCSIStorageCapacityTracking() error {
-	storageCapacity, err := sc.ds.GetSettingAsBool(types.SettingNameCSIStorageCapacityTracking)
+// syncCSIDriverStorageCapacity syncs the CSIDriver StorageCapacity field and restarts
+// longhorn-csi-plugin based on the capacity tracking setting.
+func (sc *SettingController) syncCSIDriverStorageCapacity() error {
+	setting, err := sc.ds.GetSetting(types.SettingNameCSIStorageCapacityTracking)
 	if err != nil {
 		return err
+	}
+	storageCapacityEnabled := types.IsCSIStorageCapacityEnabled(setting.Value)
+	// Restart longhorn-csi-plugin to update CSINode topology keys, which must reflect the new
+	// capacity tracking mode for capacity reporting to function correctly.
+	// Use the setting value as the annotation to avoid restart on every setting resync.
+	if storageCapacityEnabled {
+		ds, err := sc.ds.GetDaemonSet(types.CSIPluginName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get %v daemonset", types.CSIPluginName)
+		}
+		if ds.Spec.Template.Annotations[types.AnnotationCSIStorageCapacityTracking] != setting.Value {
+			restartPatch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+				types.AnnotationCSIStorageCapacityTracking, setting.Value)
+			if _, err := sc.kubeClient.AppsV1().DaemonSets(sc.namespace).Patch(
+				context.TODO(), types.CSIPluginName, k8stypes.MergePatchType, []byte(restartPatch), metav1.PatchOptions{},
+			); err != nil {
+				return errors.Wrapf(err, "failed to restart %v daemonset", types.CSIPluginName)
+			}
+			sc.logger.Infof("Restarted %v daemonset to apply new CSI topology keys (mode: %s)", types.CSIPluginName, setting.Value)
+		}
 	}
 
 	csiDriver, err := sc.ds.GetCSIDriver(types.LonghornDriverName)
@@ -1097,17 +1120,17 @@ func (sc *SettingController) updateCSIStorageCapacityTracking() error {
 		return err
 	}
 
-	if csiDriver.Spec.StorageCapacity != nil && *csiDriver.Spec.StorageCapacity == storageCapacity {
+	if csiDriver.Spec.StorageCapacity != nil && *csiDriver.Spec.StorageCapacity == storageCapacityEnabled {
 		return nil
 	}
 
-	csiDriver.Spec.StorageCapacity = ptr.To(storageCapacity)
+	csiDriver.Spec.StorageCapacity = ptr.To(storageCapacityEnabled)
 	// NOTE: StorageCapacity became mutable in Kubernetes 1.23+. On older versions, this update will fail.
 	if _, err := sc.ds.UpdateCSIDriver(csiDriver); err != nil {
 		return err
 	}
+	sc.logger.Infof("Updated CSI driver StorageCapacity to %v (value: %s)", storageCapacityEnabled, setting.Value)
 
-	sc.logger.Infof("Updated CSI driver StorageCapacity to %v", storageCapacity)
 	return nil
 }
 

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -23,7 +23,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -1087,49 +1086,26 @@ func (sc *SettingController) updateNodeSelector() error {
 	return nil
 }
 
-// syncCSIDriverStorageCapacity syncs the CSIDriver StorageCapacity field and restarts
-// longhorn-csi-plugin based on the capacity tracking setting.
+// syncCSIDriverStorageCapacity syncs the CSIDriver StorageCapacity field
 func (sc *SettingController) syncCSIDriverStorageCapacity() error {
-	setting, err := sc.ds.GetSetting(types.SettingNameCSIStorageCapacityTracking)
+	storageCapacityEnabled, err := sc.ds.GetSettingAsBool(types.SettingNameCSIStorageCapacityTracking)
 	if err != nil {
 		return err
-	}
-	storageCapacityEnabled := types.IsCSIStorageCapacityEnabled(setting.Value)
-	// Restart longhorn-csi-plugin to update CSINode topology keys, which must reflect the new
-	// capacity tracking mode for capacity reporting to function correctly.
-	// Use the setting value as the annotation to avoid restart on every setting resync.
-	if storageCapacityEnabled {
-		ds, err := sc.ds.GetDaemonSet(types.CSIPluginName)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get %v daemonset", types.CSIPluginName)
-		}
-		if ds.Spec.Template.Annotations[types.AnnotationCSIStorageCapacityTracking] != setting.Value {
-			restartPatch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
-				types.AnnotationCSIStorageCapacityTracking, setting.Value)
-			if _, err := sc.kubeClient.AppsV1().DaemonSets(sc.namespace).Patch(
-				context.TODO(), types.CSIPluginName, k8stypes.MergePatchType, []byte(restartPatch), metav1.PatchOptions{},
-			); err != nil {
-				return errors.Wrapf(err, "failed to restart %v daemonset", types.CSIPluginName)
-			}
-			sc.logger.Infof("Restarted %v daemonset to apply new CSI topology keys (mode: %s)", types.CSIPluginName, setting.Value)
-		}
 	}
 
 	csiDriver, err := sc.ds.GetCSIDriver(types.LonghornDriverName)
 	if err != nil {
 		return err
 	}
-
 	if csiDriver.Spec.StorageCapacity != nil && *csiDriver.Spec.StorageCapacity == storageCapacityEnabled {
 		return nil
 	}
 
 	csiDriver.Spec.StorageCapacity = ptr.To(storageCapacityEnabled)
-	// NOTE: StorageCapacity became mutable in Kubernetes 1.23+. On older versions, this update will fail.
 	if _, err := sc.ds.UpdateCSIDriver(csiDriver); err != nil {
 		return err
 	}
-	sc.logger.Infof("Updated CSI driver StorageCapacity to %v (value: %s)", storageCapacityEnabled, setting.Value)
+	sc.logger.Infof("Updated CSI driver StorageCapacity to %v", storageCapacityEnabled)
 
 	return nil
 }

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/utils/ptr"
 
 	lhns "github.com/longhorn/go-common-libs/ns"
 
@@ -257,6 +258,10 @@ func (sc *SettingController) syncNonDangerZoneSettingsForManagedComponents(setti
 		}
 	case types.SettingNameDefaultLonghornStaticStorageClass:
 		if err := sc.syncDefaultLonghornStaticStorageClass(); err != nil {
+			return err
+		}
+	case types.SettingNameCSIStorageCapacityTracking:
+		if err := sc.updateCSIStorageCapacityTracking(); err != nil {
 			return err
 		}
 	}
@@ -1078,6 +1083,31 @@ func (sc *SettingController) updateNodeSelector() error {
 		}
 	}
 
+	return nil
+}
+
+func (sc *SettingController) updateCSIStorageCapacityTracking() error {
+	storageCapacity, err := sc.ds.GetSettingAsBool(types.SettingNameCSIStorageCapacityTracking)
+	if err != nil {
+		return err
+	}
+
+	csiDriver, err := sc.ds.GetCSIDriver(types.LonghornDriverName)
+	if err != nil {
+		return err
+	}
+
+	if csiDriver.Spec.StorageCapacity != nil && *csiDriver.Spec.StorageCapacity == storageCapacity {
+		return nil
+	}
+
+	csiDriver.Spec.StorageCapacity = ptr.To(storageCapacity)
+	// NOTE: StorageCapacity became mutable in Kubernetes 1.23+. On older versions, this update will fail.
+	if _, err := sc.ds.UpdateCSIDriver(csiDriver); err != nil {
+		return err
+	}
+
+	sc.logger.Infof("Updated CSI driver StorageCapacity to %v", storageCapacity)
 	return nil
 }
 

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -23,10 +23,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
@@ -35,8 +34,6 @@ import (
 	longhornclient "github.com/longhorn/longhorn-manager/client"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
-	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions"
-	lhlisters "github.com/longhorn/longhorn-manager/k8s/pkg/client/listers/longhorn/v1beta2"
 )
 
 const (
@@ -59,13 +56,13 @@ const (
 
 type ControllerServer struct {
 	csi.UnimplementedControllerServer
-	apiClient     *longhornclient.RancherClient
-	nodeID        string
-	caps          []*csi.ControllerServiceCapability
-	accessModes   []*csi.VolumeCapability_AccessMode
-	log           *logrus.Entry
-	settingLister lhlisters.SettingNamespaceLister
-	nodeLister    lhlisters.NodeNamespaceLister
+	apiClient   *longhornclient.RancherClient
+	nodeID      string
+	caps        []*csi.ControllerServiceCapability
+	accessModes []*csi.VolumeCapability_AccessMode
+	log         *logrus.Entry
+	lhClient    lhclientset.Interface
+	lhNamespace string
 }
 
 func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string) (*ControllerServer, error) {
@@ -82,19 +79,6 @@ func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string)
 	lhClient, err := lhclientset.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get longhorn clientset")
-	}
-
-	informerFactory := lhinformers.NewSharedInformerFactoryWithOptions(lhClient, 0, lhinformers.WithNamespace(lhNamespace))
-	settingInformer := informerFactory.Longhorn().V1beta2().Settings()
-	_ = settingInformer.Informer()
-	nodeInformer := informerFactory.Longhorn().V1beta2().Nodes()
-	_ = nodeInformer.Informer()
-
-	// Start informers and wait for cache sync
-	stopCh := make(chan struct{})
-	informerFactory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, settingInformer.Informer().HasSynced, nodeInformer.Informer().HasSynced) {
-		return nil, errors.New("failed to sync informer caches")
 	}
 
 	return &ControllerServer{
@@ -117,9 +101,9 @@ func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string)
 				csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 				csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			}),
-		log:           logrus.StandardLogger().WithField("component", "csi-controller-server"),
-		settingLister: settingInformer.Lister().Settings(lhNamespace),
-		nodeLister:    nodeInformer.Lister().Nodes(lhNamespace),
+		log:         logrus.StandardLogger().WithField("component", "csi-controller-server"),
+		lhClient:    lhClient,
+		lhNamespace: lhNamespace,
 	}, nil
 }
 
@@ -729,19 +713,15 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 		}
 	}()
 
-	storageCapacityTrackingSetting, err := cs.getSettingAsString(types.SettingNameCSIStorageCapacityTracking)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameCSIStorageCapacityTracking, err)
-	}
-	allowEmptyNodeSelectorVolume, err := cs.getSettingAsBoolean(types.SettingNameAllowEmptyNodeSelectorVolume)
+	allowEmptyNodeSelectorVolume, err := cs.getSettingAsBoolean(ctx, types.SettingNameAllowEmptyNodeSelectorVolume)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameAllowEmptyNodeSelectorVolume, err)
 	}
-	allowEmptyDiskSelectorVolume, err := cs.getSettingAsBoolean(types.SettingNameAllowEmptyDiskSelectorVolume)
+	allowEmptyDiskSelectorVolume, err := cs.getSettingAsBoolean(ctx, types.SettingNameAllowEmptyDiskSelectorVolume)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameAllowEmptyDiskSelectorVolume, err)
 	}
-	overProvisioningPercentage, err := cs.getSettingAsInt(types.SettingNameStorageOverProvisioningPercentage)
+	overProvisioningPercentage, err := cs.getSettingAsInt(ctx, types.SettingNameStorageOverProvisioningPercentage)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameStorageOverProvisioningPercentage, err)
 	}
@@ -758,6 +738,10 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 	dataEngine := longhorn.DataEngineTypeV1
 	if dataEngineType, ok := scParameters["dataEngine"]; ok {
 		dataEngine = longhorn.DataEngineType(dataEngineType)
+	}
+	storageCapacityMode := types.CSIStorageCapacityTrackingModeNode
+	if storageCapacityModeRaw, ok := scParameters["storageCapacityMode"]; ok {
+		storageCapacityMode = types.CSIStorageCapacityTrackingMode(storageCapacityModeRaw)
 	}
 
 	nodeCapacity := func(node *longhorn.Node) (maximumVolumeSize int64, availableCapacity int64) {
@@ -793,10 +777,10 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 			overProvisionLimit := ((diskStatus.StorageMaximum - diskSpec.StorageReserved) * overProvisioningPercentage) / 100
 			storageSchedulable := overProvisionLimit - diskStatus.StorageScheduled
 			storageSchedulable = max(storageSchedulable, 0)
-			if dataEngine == longhorn.DataEngineTypeV1 && diskStatus.Type == longhorn.DiskTypeFilesystem {
-				maximumVolumeSize = max(maximumVolumeSize, storageSchedulable)
-				availableCapacity += storageSchedulable
-			} else if dataEngine == longhorn.DataEngineTypeV2 && diskStatus.Type == longhorn.DiskTypeBlock {
+			validDisk := (dataEngine == longhorn.DataEngineTypeV1 && diskStatus.Type == longhorn.DiskTypeFilesystem) ||
+				(dataEngine == longhorn.DataEngineTypeV2 && diskStatus.Type == longhorn.DiskTypeBlock)
+
+			if validDisk {
 				maximumVolumeSize = max(maximumVolumeSize, storageSchedulable)
 				availableCapacity += storageSchedulable
 			}
@@ -811,13 +795,13 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 	if topology == nil || len(topology.Segments) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "missing or empty accessible topology request parameter")
 	}
-	switch types.CSIStorageCapacityTracking(storageCapacityTrackingSetting) {
-	case types.CSIStorageCapacityTrackingNode:
+	switch storageCapacityMode {
+	case types.CSIStorageCapacityTrackingModeNode:
 		nodeID, ok := topology.Segments[corev1.LabelHostname]
 		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "missing %q topology segment", corev1.LabelHostname)
 		}
-		node, err := cs.nodeLister.Get(nodeID)
+		node, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Get(ctx, nodeID, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil, status.Errorf(codes.NotFound, "node %s not found", nodeID)
@@ -826,25 +810,25 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 		}
 		maximumVolumeSize, availableCapacity = nodeCapacity(node)
 		log.Infof("Node: %s, DataEngine: %s, MaximumVolumeSize: %d, AvailableCapacity: %d", nodeID, dataEngine, maximumVolumeSize, availableCapacity)
-	case types.CSIStorageCapacityTrackingZone:
+	case types.CSIStorageCapacityTrackingModeZone:
 		zone, ok := topology.Segments[corev1.LabelTopologyZone]
 		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "missing %q topology segment", corev1.LabelTopologyZone)
 		}
-		nodes, err := cs.nodeLister.List(labels.Everything())
+		nodeList, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to list nodes: %v", err)
 		}
-		for _, node := range nodes {
+		for _, node := range nodeList.Items {
 			if node.Status.Zone == zone {
-				nodeMaximumVolumeSize, nodeAvailableCapacity := nodeCapacity(node)
+				nodeMaximumVolumeSize, nodeAvailableCapacity := nodeCapacity(&node)
 				maximumVolumeSize = max(maximumVolumeSize, nodeMaximumVolumeSize)
 				availableCapacity += nodeAvailableCapacity
 			}
 		}
 		log.Infof("Zone: %s, DataEngine: %s, MaximumVolumeSize: %d, AvailableCapacity: %d", zone, dataEngine, maximumVolumeSize, availableCapacity)
 	default:
-		return nil, status.Errorf(codes.Internal, "unexpected value %q for setting %q", storageCapacityTrackingSetting, types.SettingNameCSIStorageCapacityTracking)
+		return nil, status.Errorf(codes.InvalidArgument, "unexpected value %q for storage class parameter 'storageCapacityMode'", storageCapacityMode)
 	}
 
 	rsp = &csi.GetCapacityResponse{
@@ -861,24 +845,24 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 	return rsp, nil
 }
 
-func (cs *ControllerServer) getSettingAsBoolean(name types.SettingName) (bool, error) {
-	obj, err := cs.settingLister.Get(string(name))
+func (cs *ControllerServer) getSettingAsBoolean(ctx context.Context, name types.SettingName) (bool, error) {
+	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
 	return strconv.ParseBool(obj.Value)
 }
 
-func (cs *ControllerServer) getSettingAsInt(name types.SettingName) (int64, error) {
-	obj, err := cs.settingLister.Get(string(name))
+func (cs *ControllerServer) getSettingAsInt(ctx context.Context, name types.SettingName) (int64, error) {
+	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
 	if err != nil {
 		return -1, err
 	}
 	return strconv.ParseInt(obj.Value, 10, 64)
 }
 
-func (cs *ControllerServer) getSettingAsString(name types.SettingName) (string, error) {
-	obj, err := cs.settingLister.Get(string(name))
+func (cs *ControllerServer) getSettingAsString(ctx context.Context, name types.SettingName) (string, error) {
+	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -1728,7 +1712,7 @@ func (cs *ControllerServer) getAccessibleTopologyFromRequirements(ctx context.Co
 	// Filter topology keys based on the CSI Allowed Topology Keys setting.
 	// Only keys listed in the setting are kept; if the setting is empty or missing,
 	// all topology keys are filtered out (no nodeAffinity on PV).
-	allowedKeysStr, err := cs.getSettingAsString(types.SettingNameCSIAllowedTopologyKeys)
+	allowedKeysStr, err := cs.getSettingAsString(ctx, types.SettingNameCSIAllowedTopologyKeys)
 	if err != nil {
 		log.WithError(err).Warn("Failed to get CSI allowed topology keys setting, filtering all topology keys")
 	}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -19,11 +19,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"k8s.io/client-go/rest"
-
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
@@ -32,6 +35,8 @@ import (
 	longhornclient "github.com/longhorn/longhorn-manager/client"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions"
+	lhlisters "github.com/longhorn/longhorn-manager/k8s/pkg/client/listers/longhorn/v1beta2"
 )
 
 const (
@@ -54,13 +59,13 @@ const (
 
 type ControllerServer struct {
 	csi.UnimplementedControllerServer
-	apiClient   *longhornclient.RancherClient
-	nodeID      string
-	caps        []*csi.ControllerServiceCapability
-	accessModes []*csi.VolumeCapability_AccessMode
-	log         *logrus.Entry
-	lhClient    lhclientset.Interface
-	lhNamespace string
+	apiClient     *longhornclient.RancherClient
+	nodeID        string
+	caps          []*csi.ControllerServiceCapability
+	accessModes   []*csi.VolumeCapability_AccessMode
+	log           *logrus.Entry
+	settingLister lhlisters.SettingNamespaceLister
+	nodeLister    lhlisters.NodeNamespaceLister
 }
 
 func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string) (*ControllerServer, error) {
@@ -77,6 +82,19 @@ func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string)
 	lhClient, err := lhclientset.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get longhorn clientset")
+	}
+
+	informerFactory := lhinformers.NewSharedInformerFactoryWithOptions(lhClient, 0, lhinformers.WithNamespace(lhNamespace))
+	settingInformer := informerFactory.Longhorn().V1beta2().Settings()
+	_ = settingInformer.Informer()
+	nodeInformer := informerFactory.Longhorn().V1beta2().Nodes()
+	_ = nodeInformer.Informer()
+
+	// Start informers and wait for cache sync
+	stopCh := make(chan struct{})
+	informerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, settingInformer.Informer().HasSynced, nodeInformer.Informer().HasSynced) {
+		return nil, errors.New("failed to sync informer caches")
 	}
 
 	return &ControllerServer{
@@ -99,9 +117,9 @@ func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string)
 				csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 				csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			}),
-		log:         logrus.StandardLogger().WithField("component", "csi-controller-server"),
-		lhClient:    lhClient,
-		lhNamespace: lhNamespace,
+		log:           logrus.StandardLogger().WithField("component", "csi-controller-server"),
+		settingLister: settingInformer.Lister().Settings(lhNamespace),
+		nodeLister:    nodeInformer.Lister().Nodes(lhNamespace),
 	}, nil
 }
 
@@ -700,140 +718,167 @@ func (cs *ControllerServer) ListVolumes(context.Context, *csi.ListVolumesRequest
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (rsp *csi.GetCapacityResponse, err error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "GetCapacity"})
 
 	log.Infof("GetCapacity is called with req %+v", req)
 
-	var err error
 	defer func() {
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get capacity")
 		}
 	}()
 
-	scParameters := req.GetParameters()
-	if scParameters == nil {
-		scParameters = map[string]string{}
-	}
-
-	nodeID, err := parseNodeID(req.GetAccessibleTopology())
+	storageCapacityTrackingSetting, err := cs.getSettingAsString(types.SettingNameCSIStorageCapacityTracking)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse node id: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameCSIStorageCapacityTracking, err)
 	}
-	node, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Get(ctx, nodeID, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "node %s not found", nodeID)
-		}
-		return nil, status.Errorf(codes.Internal, "unexpected error: %v", err)
-	}
-	if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady).Status != longhorn.ConditionStatusTrue {
-		return &csi.GetCapacityResponse{}, nil
-	}
-	if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeSchedulable).Status != longhorn.ConditionStatusTrue {
-		return &csi.GetCapacityResponse{}, nil
-	}
-	if !node.Spec.AllowScheduling || node.Spec.EvictionRequested {
-		return &csi.GetCapacityResponse{}, nil
-	}
-
-	allowEmptyNodeSelectorVolume, err := cs.getSettingAsBoolean(ctx, types.SettingNameAllowEmptyNodeSelectorVolume)
+	allowEmptyNodeSelectorVolume, err := cs.getSettingAsBoolean(types.SettingNameAllowEmptyNodeSelectorVolume)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameAllowEmptyNodeSelectorVolume, err)
 	}
-	var nodeSelector []string
-	if nodeSelectorRaw, ok := scParameters["nodeSelector"]; ok && len(nodeSelectorRaw) > 0 {
-		nodeSelector = strings.Split(nodeSelectorRaw, ",")
-	}
-	if !types.IsSelectorsInTags(node.Spec.Tags, nodeSelector, allowEmptyNodeSelectorVolume) {
-		return &csi.GetCapacityResponse{}, nil
-	}
-
-	var diskSelector []string
-	if diskSelectorRaw, ok := scParameters["diskSelector"]; ok && len(diskSelectorRaw) > 0 {
-		diskSelector = strings.Split(diskSelectorRaw, ",")
-	}
-	allowEmptyDiskSelectorVolume, err := cs.getSettingAsBoolean(ctx, types.SettingNameAllowEmptyDiskSelectorVolume)
+	allowEmptyDiskSelectorVolume, err := cs.getSettingAsBoolean(types.SettingNameAllowEmptyDiskSelectorVolume)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameAllowEmptyDiskSelectorVolume, err)
 	}
-	overProvisioningPercentage, err := cs.getSettingAsInt(ctx, types.SettingNameStorageOverProvisioningPercentage)
+	overProvisioningPercentage, err := cs.getSettingAsInt(types.SettingNameStorageOverProvisioningPercentage)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get setting %v: %v", types.SettingNameStorageOverProvisioningPercentage, err)
 	}
 
-	var v1AvailableCapacity int64 = 0
-	var v2AvailableCapacity int64 = 0
-	for diskName, diskStatus := range node.Status.DiskStatus {
-		diskSpec, exists := node.Spec.Disks[diskName]
-		if !exists {
-			continue
-		}
-		if !diskSpec.AllowScheduling || diskSpec.EvictionRequested {
-			continue
-		}
-		if types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeSchedulable).Status != longhorn.ConditionStatusTrue {
-			continue
-		}
-		if !types.IsSelectorsInTags(diskSpec.Tags, diskSelector, allowEmptyDiskSelectorVolume) {
-			continue
-		}
-
-		overProvisionLimit := ((diskStatus.StorageMaximum - diskSpec.StorageReserved) * overProvisioningPercentage) / 100
-		storageSchedulable := overProvisionLimit - diskStatus.StorageScheduled
-		if diskStatus.Type == longhorn.DiskTypeFilesystem {
-			v1AvailableCapacity = max(v1AvailableCapacity, storageSchedulable)
-		}
-		if diskStatus.Type == longhorn.DiskTypeBlock {
-			v2AvailableCapacity = max(v2AvailableCapacity, storageSchedulable)
-		}
+	scParameters := req.GetParameters()
+	var nodeSelector []string
+	if nodeSelectorRaw, ok := scParameters["nodeSelector"]; ok && len(nodeSelectorRaw) > 0 {
+		nodeSelector = strings.Split(nodeSelectorRaw, ",")
 	}
-
-	rsp := &csi.GetCapacityResponse{}
+	var diskSelector []string
+	if diskSelectorRaw, ok := scParameters["diskSelector"]; ok && len(diskSelectorRaw) > 0 {
+		diskSelector = strings.Split(diskSelectorRaw, ",")
+	}
 	dataEngine := longhorn.DataEngineTypeV1
 	if dataEngineType, ok := scParameters["dataEngine"]; ok {
 		dataEngine = longhorn.DataEngineType(dataEngineType)
 	}
-	switch dataEngine {
-	case longhorn.DataEngineTypeV1:
-		rsp.AvailableCapacity = v1AvailableCapacity
-	case longhorn.DataEngineTypeV2:
-		rsp.AvailableCapacity = v2AvailableCapacity
-	default:
-		return nil, status.Errorf(codes.InvalidArgument, "unknown data engine type %v", dataEngine)
+
+	nodeCapacity := func(node *longhorn.Node) (maximumVolumeSize int64, availableCapacity int64) {
+		if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady).Status != longhorn.ConditionStatusTrue {
+			return
+		}
+		if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeSchedulable).Status != longhorn.ConditionStatusTrue {
+			return
+		}
+		if !node.Spec.AllowScheduling || node.Spec.EvictionRequested {
+			return
+		}
+
+		if !types.IsSelectorsInTags(node.Spec.Tags, nodeSelector, allowEmptyNodeSelectorVolume) {
+			return
+		}
+
+		for diskName, diskStatus := range node.Status.DiskStatus {
+			diskSpec, exists := node.Spec.Disks[diskName]
+			if !exists {
+				continue
+			}
+			if !diskSpec.AllowScheduling || diskSpec.EvictionRequested {
+				continue
+			}
+			if types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeSchedulable).Status != longhorn.ConditionStatusTrue {
+				continue
+			}
+			if !types.IsSelectorsInTags(diskSpec.Tags, diskSelector, allowEmptyDiskSelectorVolume) {
+				continue
+			}
+
+			overProvisionLimit := ((diskStatus.StorageMaximum - diskSpec.StorageReserved) * overProvisioningPercentage) / 100
+			storageSchedulable := overProvisionLimit - diskStatus.StorageScheduled
+			storageSchedulable = max(storageSchedulable, 0)
+			if dataEngine == longhorn.DataEngineTypeV1 && diskStatus.Type == longhorn.DiskTypeFilesystem {
+				maximumVolumeSize = max(maximumVolumeSize, storageSchedulable)
+				availableCapacity += storageSchedulable
+			} else if dataEngine == longhorn.DataEngineTypeV2 && diskStatus.Type == longhorn.DiskTypeBlock {
+				maximumVolumeSize = max(maximumVolumeSize, storageSchedulable)
+				availableCapacity += storageSchedulable
+			}
+		}
+
+		return maximumVolumeSize, availableCapacity
 	}
 
-	log.Infof("Node: %s, DataEngine: %s, v1AvailableCapacity: %d, v2AvailableCapacity: %d", nodeID, dataEngine, v1AvailableCapacity, v2AvailableCapacity)
+	var maximumVolumeSize int64
+	var availableCapacity int64
+	topology := req.GetAccessibleTopology()
+	if topology == nil || len(topology.Segments) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "missing or empty accessible topology request parameter")
+	}
+	switch types.CSIStorageCapacityTracking(storageCapacityTrackingSetting) {
+	case types.CSIStorageCapacityTrackingNode:
+		nodeID, ok := topology.Segments[corev1.LabelHostname]
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "missing %q topology segment", corev1.LabelHostname)
+		}
+		node, err := cs.nodeLister.Get(nodeID)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, status.Errorf(codes.NotFound, "node %s not found", nodeID)
+			}
+			return nil, status.Errorf(codes.Internal, "failed to get node: %v", err)
+		}
+		maximumVolumeSize, availableCapacity = nodeCapacity(node)
+		log.Infof("Node: %s, DataEngine: %s, MaximumVolumeSize: %d, AvailableCapacity: %d", nodeID, dataEngine, maximumVolumeSize, availableCapacity)
+	case types.CSIStorageCapacityTrackingZone:
+		zone, ok := topology.Segments[corev1.LabelTopologyZone]
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "missing %q topology segment", corev1.LabelTopologyZone)
+		}
+		nodes, err := cs.nodeLister.List(labels.Everything())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to list nodes: %v", err)
+		}
+		for _, node := range nodes {
+			if node.Status.Zone == zone {
+				nodeMaximumVolumeSize, nodeAvailableCapacity := nodeCapacity(node)
+				maximumVolumeSize = max(maximumVolumeSize, nodeMaximumVolumeSize)
+				availableCapacity += nodeAvailableCapacity
+			}
+		}
+		log.Infof("Zone: %s, DataEngine: %s, MaximumVolumeSize: %d, AvailableCapacity: %d", zone, dataEngine, maximumVolumeSize, availableCapacity)
+	default:
+		return nil, status.Errorf(codes.Internal, "unexpected value %q for setting %q", storageCapacityTrackingSetting, types.SettingNameCSIStorageCapacityTracking)
+	}
+
+	rsp = &csi.GetCapacityResponse{
+		// Used by kube-scheduler to filter nodes that cannot fit the requested
+		// volume size. Takes precedence over AvailableCapacity for filtering.
+		// See https://github.com/kubernetes/kubernetes/commit/3fa43540b6eace70951c7867d60fda741b9bca05
+		MaximumVolumeSize: &wrapperspb.Int64Value{Value: maximumVolumeSize},
+		// Used by kube-scheduler to score nodes by total remaining capacity.
+		// Alpha as of v1.35; requires the StorageCapacityScoring feature flag.
+		// See KEP-4049 (Storage Capacity Scoring of Nodes for Dynamic Provisioning).
+		AvailableCapacity: availableCapacity,
+	}
+
 	return rsp, nil
 }
 
-func (cs *ControllerServer) getSettingAsBoolean(ctx context.Context, name types.SettingName) (bool, error) {
-	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
+func (cs *ControllerServer) getSettingAsBoolean(name types.SettingName) (bool, error) {
+	obj, err := cs.settingLister.Get(string(name))
 	if err != nil {
 		return false, err
 	}
-	value, err := strconv.ParseBool(obj.Value)
-	if err != nil {
-		return false, err
-	}
-	return value, nil
+	return strconv.ParseBool(obj.Value)
 }
 
-func (cs *ControllerServer) getSettingAsInt(ctx context.Context, name types.SettingName) (int64, error) {
-	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
+func (cs *ControllerServer) getSettingAsInt(name types.SettingName) (int64, error) {
+	obj, err := cs.settingLister.Get(string(name))
 	if err != nil {
 		return -1, err
 	}
-	value, err := strconv.ParseInt(obj.Value, 10, 64)
-	if err != nil {
-		return -1, err
-	}
-	return value, nil
+	return strconv.ParseInt(obj.Value, 10, 64)
 }
 
-func (cs *ControllerServer) getSettingAsString(ctx context.Context, name types.SettingName) (string, error) {
-	obj, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Get(ctx, string(name), metav1.GetOptions{})
+func (cs *ControllerServer) getSettingAsString(name types.SettingName) (string, error) {
+	obj, err := cs.settingLister.Get(string(name))
 	if err != nil {
 		return "", err
 	}
@@ -1683,18 +1728,11 @@ func (cs *ControllerServer) getAccessibleTopologyFromRequirements(ctx context.Co
 	// Filter topology keys based on the CSI Allowed Topology Keys setting.
 	// Only keys listed in the setting are kept; if the setting is empty or missing,
 	// all topology keys are filtered out (no nodeAffinity on PV).
-	allowedKeysStr, err := cs.getSettingAsString(ctx, types.SettingNameCSIAllowedTopologyKeys)
+	allowedKeysStr, err := cs.getSettingAsString(types.SettingNameCSIAllowedTopologyKeys)
 	if err != nil {
 		log.WithError(err).Warn("Failed to get CSI allowed topology keys setting, filtering all topology keys")
 	}
-
-	allowedKeys := make(map[string]bool)
-	for _, key := range strings.Split(allowedKeysStr, ",") {
-		key = strings.TrimSpace(key)
-		if key != "" {
-			allowedKeys[key] = true
-		}
-	}
+	allowedKeys := types.ParseCSIAllowedTopologyKeys(allowedKeysStr)
 
 	return cs.filterTopologyByAllowedKeys(accessibleTopology, allowedKeys)
 }

--- a/csi/controller_server_test.go
+++ b/csi/controller_server_test.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,29 +20,16 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake" // nolint: staticcheck
-	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions"
 )
 
 const testNamespace = "longhorn-system-test"
 
 func newTestControllerServer(t *testing.T, objs ...runtime.Object) *ControllerServer {
 	t.Helper()
-	lhClient := lhfake.NewSimpleClientset(objs...) // nolint: staticcheck
-	informerFactory := lhinformers.NewSharedInformerFactoryWithOptions(lhClient, 0, lhinformers.WithNamespace(testNamespace))
-	settingInformer := informerFactory.Longhorn().V1beta2().Settings()
-	_ = settingInformer.Informer()
-	nodeInformer := informerFactory.Longhorn().V1beta2().Nodes()
-	_ = nodeInformer.Informer()
-	stopCh := make(chan struct{})
-	t.Cleanup(func() { close(stopCh) })
-	informerFactory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, settingInformer.Informer().HasSynced, nodeInformer.Informer().HasSynced) {
-		t.Fatal("failed to sync informer caches")
-	}
 	return &ControllerServer{
-		log:           logrus.StandardLogger().WithField("component", "test"),
-		settingLister: settingInformer.Lister().Settings(testNamespace),
-		nodeLister:    nodeInformer.Lister().Nodes(testNamespace),
+		log:         logrus.StandardLogger().WithField("component", "test"),
+		lhClient:    lhfake.NewSimpleClientset(objs...), // nolint: staticcheck
+		lhNamespace: testNamespace,
 	}
 }
 
@@ -79,19 +65,19 @@ func TestGetCapacity(t *testing.T) {
 			testName:                "Node setting not found",
 			skipNodeSettingCreation: true,
 			node:                    newNode("node-0", "storage", "", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: setting.longhorn.io \"allow-empty-node-selector-volume\" not found"),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
 		},
 		{
 			testName:                "Disk setting not found",
 			skipDiskSettingCreation: true,
 			node:                    newNode("node-0", "storage", "", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: setting.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
 		},
 		{
 			testName:                            "Over-provisioning setting not found",
 			skipOverProvisioningSettingCreation: true,
 			node:                                newNode("node-0", "storage", "", true, true, true, false),
-			err:                                 status.Errorf(codes.Internal, "failed to get setting storage-over-provisioning-percentage: setting.longhorn.io \"storage-over-provisioning-percentage\" not found"),
+			err:                                 status.Errorf(codes.Internal, "failed to get setting storage-over-provisioning-percentage: settings.longhorn.io \"storage-over-provisioning-percentage\" not found"),
 		},
 		{
 			testName:                   "Invalid over-provisioning setting value",
@@ -253,7 +239,6 @@ func TestGetCapacity(t *testing.T) {
 	} {
 		t.Run(test.testName, func(t *testing.T) {
 			var objs []runtime.Object
-			objs = append(objs, newSetting(string(types.SettingNameCSIStorageCapacityTracking), "node"))
 			if !test.skipNodeCreation {
 				addDisksToNode(test.node, test.disks)
 				objs = append(objs, test.node)
@@ -354,7 +339,6 @@ func TestGetCapacityPerZone(t *testing.T) {
 		objs = append(objs, node)
 	}
 	objs = append(objs,
-		newSetting(string(types.SettingNameCSIStorageCapacityTracking), "zone"),
 		newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"),
 		newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"),
 		newSetting(string(types.SettingNameStorageOverProvisioningPercentage), "100"),
@@ -376,7 +360,9 @@ func TestGetCapacityPerZone(t *testing.T) {
 						corev1.LabelTopologyZone: tc.zone,
 					},
 				},
-				Parameters: map[string]string{},
+				Parameters: map[string]string{
+					"storageCapacityMode": "zone",
+				},
 			}
 			res, err := cs.GetCapacity(context.TODO(), req)
 			if err != nil {

--- a/csi/controller_server_test.go
+++ b/csi/controller_server_test.go
@@ -11,13 +11,41 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake" // nolint: staticcheck
+	lhinformers "github.com/longhorn/longhorn-manager/k8s/pkg/client/informers/externalversions"
 )
+
+const testNamespace = "longhorn-system-test"
+
+func newTestControllerServer(t *testing.T, objs ...runtime.Object) *ControllerServer {
+	t.Helper()
+	lhClient := lhfake.NewSimpleClientset(objs...) // nolint: staticcheck
+	informerFactory := lhinformers.NewSharedInformerFactoryWithOptions(lhClient, 0, lhinformers.WithNamespace(testNamespace))
+	settingInformer := informerFactory.Longhorn().V1beta2().Settings()
+	_ = settingInformer.Informer()
+	nodeInformer := informerFactory.Longhorn().V1beta2().Nodes()
+	_ = nodeInformer.Informer()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, settingInformer.Informer().HasSynced, nodeInformer.Informer().HasSynced) {
+		t.Fatal("failed to sync informer caches")
+	}
+	return &ControllerServer{
+		log:           logrus.StandardLogger().WithField("component", "test"),
+		settingLister: settingInformer.Lister().Settings(testNamespace),
+		nodeLister:    nodeInformer.Lister().Nodes(testNamespace),
+	}
+}
 
 type disk struct {
 	spec   longhorn.DiskSpec
@@ -25,10 +53,6 @@ type disk struct {
 }
 
 func TestGetCapacity(t *testing.T) {
-	cs := &ControllerServer{
-		lhNamespace: "longhorn-system-test",
-		log:         logrus.StandardLogger().WithField("component", "test-get-capacity"),
-	}
 	for _, test := range []struct {
 		testName                            string
 		node                                *longhorn.Node
@@ -40,224 +64,215 @@ func TestGetCapacity(t *testing.T) {
 		dataEngine                          string
 		diskSelector                        string
 		nodeSelector                        string
-		availableCapacity                   int64
+		maximumVolumeSize                   int64
 		disks                               []*disk
 		err                                 error
 	}{
 		{
-			testName:         "Node not found",
-			skipNodeCreation: true,
-			node:             newNode("node-0", "storage", true, true, true, false),
-			err:              status.Errorf(codes.NotFound, "node node-0 not found"),
+			testName:                   "Node not found",
+			skipNodeCreation:           true,
+			overProvisioningPercentage: "100",
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
+			err:                        status.Errorf(codes.NotFound, "node node-0 not found"),
 		},
 		{
 			testName:                "Node setting not found",
 			skipNodeSettingCreation: true,
-			node:                    newNode("node-0", "storage", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: settings.longhorn.io \"allow-empty-node-selector-volume\" not found"),
+			node:                    newNode("node-0", "storage", "", true, true, true, false),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-node-selector-volume: setting.longhorn.io \"allow-empty-node-selector-volume\" not found"),
 		},
 		{
 			testName:                "Disk setting not found",
 			skipDiskSettingCreation: true,
-			node:                    newNode("node-0", "storage", true, true, true, false),
-			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: settings.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
+			node:                    newNode("node-0", "storage", "", true, true, true, false),
+			err:                     status.Errorf(codes.Internal, "failed to get setting allow-empty-disk-selector-volume: setting.longhorn.io \"allow-empty-disk-selector-volume\" not found"),
 		},
 		{
 			testName:                            "Over-provisioning setting not found",
 			skipOverProvisioningSettingCreation: true,
-			node:                                newNode("node-0", "storage", true, true, true, false),
-			err:                                 status.Errorf(codes.Internal, "failed to get setting storage-over-provisioning-percentage: settings.longhorn.io \"storage-over-provisioning-percentage\" not found"),
+			node:                                newNode("node-0", "storage", "", true, true, true, false),
+			err:                                 status.Errorf(codes.Internal, "failed to get setting storage-over-provisioning-percentage: setting.longhorn.io \"storage-over-provisioning-percentage\" not found"),
 		},
 		{
 			testName:                   "Invalid over-provisioning setting value",
 			overProvisioningPercentage: "xyz",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			err:                        status.Errorf(codes.Internal, "failed to get setting storage-over-provisioning-percentage: strconv.ParseInt: parsing \"xyz\": invalid syntax"),
 		},
 		{
 			testName:                   "Unknown data engine type",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v5",
-			err:                        status.Errorf(codes.InvalidArgument, "unknown data engine type v5"),
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "v1 engine with no disks",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v1",
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "v2 engine with no disks",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Node condition is not ready",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", false, true, true, false),
+			node:                       newNode("node-0", "storage", "", false, true, true, false),
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Node condition is not schedulable",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, false, true, false),
+			node:                       newNode("node-0", "storage", "", true, false, true, false),
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Scheduling not allowed on a node",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, false, false),
+			node:                       newNode("node-0", "storage", "", true, true, false, false),
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Node eviction is requested",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, true),
+			node:                       newNode("node-0", "storage", "", true, true, true, true),
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Node tags don't match node selector",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "large,fast,linux", true, true, true, false),
+			node:                       newNode("node-0", "large,fast,linux", "", true, true, true, false),
 			nodeSelector:               "fast,storage",
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 		},
 		{
 			testName:                   "Must default to v1 engine when dataEngine key is missing",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false), newDisk(2000, 100, 0, "", true, true, true, false)},
-			availableCapacity:          1150,
+			maximumVolumeSize:          1150,
 		},
 		{
 			testName:                   "v1 engine with two valid disks",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage,large,fast,linux", true, true, true, false),
+			node:                       newNode("node-0", "storage,large,fast,linux", "", true, true, true, false),
 			nodeSelector:               "fast,storage",
 			dataEngine:                 "v1",
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false)},
-			availableCapacity:          1150,
+			maximumVolumeSize:          1150,
 		},
 		{
 			testName:                   "v1 engine with two valid disks and one with mismatched engine type",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v1",
-			availableCapacity:          1150,
+			maximumVolumeSize:          1150,
 			disks:                      []*disk{newDisk(1450, 300, 0, "ssd", false, true, true, false), newDisk(1000, 500, 0, "", false, true, true, false), newDisk(2000, 100, 0, "", true, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with two valid disks and one with mismatched engine type",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          1650,
+			maximumVolumeSize:          1650,
 			disks:                      []*disk{newDisk(1950, 300, 0, "", true, true, true, false), newDisk(1500, 500, 0, "", true, true, true, false), newDisk(2000, 100, 0, "", false, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with one valid disk and two with unmatched tags",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
 			diskSelector:               "ssd,fast",
-			availableCapacity:          1000,
+			maximumVolumeSize:          1000,
 			disks:                      []*disk{newDisk(1100, 100, 0, "fast,nvmf,ssd,hot", true, true, true, false), newDisk(2500, 500, 0, "ssd,slow,green", true, true, true, false), newDisk(2000, 100, 0, "hdd,fast", true, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with one valid disk and one with unhealthy condition",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          400,
+			maximumVolumeSize:          400,
 			disks:                      []*disk{newDisk(1100, 100, 0, "ssd", true, false, true, false), newDisk(500, 100, 0, "hdd", true, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with one valid disk and one with scheduling disabled",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          400,
+			maximumVolumeSize:          400,
 			disks:                      []*disk{newDisk(1100, 100, 0, "ssd", true, true, false, false), newDisk(500, 100, 0, "hdd", true, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with one valid disk and one marked for eviction",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          400,
+			maximumVolumeSize:          400,
 			disks:                      []*disk{newDisk(1100, 100, 0, "ssd", true, true, true, true), newDisk(500, 100, 0, "hdd", true, true, true, false)},
 		},
 		{
 			testName:                   "v2 engine with over-provisioning set to 200",
 			overProvisioningPercentage: "200",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v2",
-			availableCapacity:          1700,
+			maximumVolumeSize:          1700,
 			disks:                      []*disk{newDisk(1100, 100, 300, "ssd", true, true, true, false), newDisk(500, 100, 100, "hdd", true, true, true, false)},
 		},
 		{
 			testName:                   "v1 engine with over-provisioning set to 400",
 			overProvisioningPercentage: "400",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v1",
-			availableCapacity:          1500,
+			maximumVolumeSize:          1500,
 			disks:                      []*disk{newDisk(900, 400, 600, "ssd", false, true, true, false), newDisk(1500, 500, 2500, "hdd", false, true, true, false)},
 		},
 		{
 			testName:                   "Capacity floors at 0 when scheduled exceeds over-provisioning limit",
 			overProvisioningPercentage: "100",
-			node:                       newNode("node-0", "storage", true, true, true, false),
+			node:                       newNode("node-0", "storage", "", true, true, true, false),
 			dataEngine:                 "v1",
-			availableCapacity:          0,
+			maximumVolumeSize:          0,
 			disks:                      []*disk{newDisk(1000, 100, 1000, "", false, true, true, false)},
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			cs.lhClient = lhfake.NewSimpleClientset() // nolint: staticcheck
+			var objs []runtime.Object
+			objs = append(objs, newSetting(string(types.SettingNameCSIStorageCapacityTracking), "node"))
 			if !test.skipNodeCreation {
 				addDisksToNode(test.node, test.disks)
-				_, err := cs.lhClient.LonghornV1beta2().Nodes(cs.lhNamespace).Create(context.TODO(), test.node, metav1.CreateOptions{})
-				if err != nil {
-					t.Error("failed to create node")
-				}
+				objs = append(objs, test.node)
 			}
 			if !test.skipNodeSettingCreation {
-				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"), metav1.CreateOptions{})
-				if err != nil {
-					t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyNodeSelectorVolume)
-				}
+				objs = append(objs, newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"))
 			}
 			if !test.skipDiskSettingCreation {
-				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"), metav1.CreateOptions{})
-				if err != nil {
-					t.Errorf("failed to create setting %v", types.SettingNameAllowEmptyDiskSelectorVolume)
-				}
+				objs = append(objs, newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"))
 			}
 			if !test.skipOverProvisioningSettingCreation {
-				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(context.TODO(), newSetting(string(types.SettingNameStorageOverProvisioningPercentage), test.overProvisioningPercentage), metav1.CreateOptions{})
-				if err != nil {
-					t.Errorf("failed to create setting %v", types.SettingNameStorageOverProvisioningPercentage)
-				}
+				objs = append(objs, newSetting(string(types.SettingNameStorageOverProvisioningPercentage), test.overProvisioningPercentage))
 			}
+			cs := newTestControllerServer(t, objs...)
 
 			req := &csi.GetCapacityRequest{
 				AccessibleTopology: &csi.Topology{
 					Segments: map[string]string{
-						nodeTopologyKey: test.node.Name,
+						corev1.LabelHostname: test.node.Name,
 					},
 				},
 				Parameters: map[string]string{},
@@ -276,65 +291,104 @@ func TestGetCapacity(t *testing.T) {
 			} else if expectedStatus.Message() != actualStatus.Message() {
 				t.Errorf("expected error message: '%s', but got: '%s'", expectedStatus.Message(), actualStatus.Message())
 			}
-			if res != nil && res.AvailableCapacity != test.availableCapacity {
-				t.Errorf("expected available capacity: %d, but got: %d", test.availableCapacity, res.AvailableCapacity)
+			if res != nil && res.MaximumVolumeSize.Value != test.maximumVolumeSize {
+				t.Errorf("expected maximum volume size: %d, but got: %d", test.maximumVolumeSize, res.MaximumVolumeSize.Value)
 			}
 		})
 	}
 }
 
-func TestParseNodeID(t *testing.T) {
-	for _, test := range []struct {
-		topology *csi.Topology
-		err      error
-		nodeID   string
-	}{
-		{
-			err: fmt.Errorf("missing accessible topology request parameter"),
-		},
-		{
-			topology: &csi.Topology{
-				Segments: nil,
-			},
-			err: fmt.Errorf("missing accessible topology request parameter"),
-		},
-		{
-			topology: &csi.Topology{
-				Segments: map[string]string{
-					"some-key": "some-value",
-				},
-			},
-			err: fmt.Errorf("accessible topology request parameter is missing kubernetes.io/hostname key"),
-		},
-		{
-			topology: &csi.Topology{
-				Segments: map[string]string{
-					nodeTopologyKey: "node-0",
-				},
-			},
-			nodeID: "node-0",
-		},
-	} {
-		nodeID, err := parseNodeID(test.topology)
-		checkError(t, test.err, err)
-		if test.nodeID != nodeID {
-			t.Errorf("expected nodeID: %s, but got: %s", test.nodeID, nodeID)
-		}
-	}
-}
+func TestGetCapacityPerZone(t *testing.T) {
+	// Zone A: 3 nodes, 2 disks each
+	//   node-a0: disk0(max=2000, reserved=200, scheduled=0) + disk1(max=1000, reserved=100, scheduled=0)
+	//   node-a1: disk0(max=3000, reserved=300, scheduled=500) + disk1(max=1500, reserved=150, scheduled=0)
+	//   node-a2: disk0(max=1800, reserved=100, scheduled=200) + disk1(max=2200, reserved=200, scheduled=100)
+	//
+	// Zone B: 3 nodes, 2 disks each
+	//   node-b0: disk0(max=5000, reserved=500, scheduled=1000) + disk1(max=3000, reserved=300, scheduled=0)
+	//   node-b1: disk0(max=1000, reserved=100, scheduled=0) + disk1(max=800, reserved=100, scheduled=0)
+	//   node-b2: disk0(max=4000, reserved=400, scheduled=2000) + disk1(max=2000, reserved=200, scheduled=500)
 
-func checkError(t *testing.T, expected, actual error) {
-	if expected == nil {
-		if actual != nil {
-			t.Errorf("expected no error but got: %v", actual)
-		}
-	} else {
-		if actual == nil {
-			t.Errorf("expected error: %v, but got no error", expected)
-		}
-		if expected.Error() != actual.Error() {
-			t.Errorf("expected error: %v, but got: %v", expected, actual)
-		}
+	zoneANodes := []*longhorn.Node{
+		newNode("node-a0", "", "zone-a", true, true, true, false),
+		newNode("node-a1", "", "zone-a", true, true, true, false),
+		newNode("node-a2", "", "zone-a", true, true, true, false),
+	}
+	zoneADisks := [][]*disk{
+		{newDisk(2000, 200, 0, "", false, true, true, false), newDisk(1000, 100, 0, "", false, true, true, false)},
+		{newDisk(3000, 300, 500, "", false, true, true, false), newDisk(1500, 150, 0, "", false, true, true, false)},
+		{newDisk(1800, 100, 200, "", false, true, true, false), newDisk(2200, 200, 100, "", false, true, true, false)},
+	}
+
+	zoneBNodes := []*longhorn.Node{
+		newNode("node-b0", "", "zone-b", true, true, true, false),
+		newNode("node-b1", "", "zone-b", true, true, true, false),
+		newNode("node-b2", "", "zone-b", true, true, true, false),
+	}
+	zoneBDisks := [][]*disk{
+		{newDisk(5000, 500, 1000, "", false, true, true, false), newDisk(3000, 300, 0, "", false, true, true, false)},
+		{newDisk(1000, 100, 0, "", false, true, true, false), newDisk(800, 100, 0, "", false, true, true, false)},
+		{newDisk(4000, 400, 2000, "", false, true, true, false), newDisk(2000, 200, 500, "", false, true, true, false)},
+	}
+
+	// Per-node available capacity (over-provisioning=100%):
+	//   schedulable per disk = (max - reserved) * 100/100 - scheduled
+	//
+	// Zone A:
+	//   node-a0: (2000-200)-0=1800, (1000-100)-0=900     → available=2700, maxVol=1800
+	//   node-a1: (3000-300)-500=2200, (1500-150)-0=1350   → available=3550, maxVol=2200
+	//   node-a2: (1800-100)-200=1500, (2200-200)-100=1900 → available=3400, maxVol=1900
+	//   Zone total: available=9650, maxVol=max(1800,2200,1900)=2200
+	//
+	// Zone B:
+	//   node-b0: (5000-500)-1000=3500, (3000-300)-0=2700   → available=6200, maxVol=3500
+	//   node-b1: (1000-100)-0=900, (800-100)-0=700         → available=1600, maxVol=900
+	//   node-b2: (4000-400)-2000=1600, (2000-200)-500=1300 → available=2900, maxVol=1600
+	//   Zone total: available=10700, maxVol=max(3500,900,1600)=3500
+
+	allNodes := append(zoneANodes, zoneBNodes...)
+	allDisks := append(zoneADisks, zoneBDisks...)
+	var objs []runtime.Object
+	for i, node := range allNodes {
+		addDisksToNode(node, allDisks[i])
+		objs = append(objs, node)
+	}
+	objs = append(objs,
+		newSetting(string(types.SettingNameCSIStorageCapacityTracking), "zone"),
+		newSetting(string(types.SettingNameAllowEmptyNodeSelectorVolume), "true"),
+		newSetting(string(types.SettingNameAllowEmptyDiskSelectorVolume), "true"),
+		newSetting(string(types.SettingNameStorageOverProvisioningPercentage), "100"),
+	)
+	cs := newTestControllerServer(t, objs...)
+
+	for _, tc := range []struct {
+		zone              string
+		expectedAvailable int64
+		expectedMaxVol    int64
+	}{
+		{zone: "zone-a", expectedAvailable: 9650, expectedMaxVol: 2200},
+		{zone: "zone-b", expectedAvailable: 10700, expectedMaxVol: 3500},
+	} {
+		t.Run(tc.zone, func(t *testing.T) {
+			req := &csi.GetCapacityRequest{
+				AccessibleTopology: &csi.Topology{
+					Segments: map[string]string{
+						corev1.LabelTopologyZone: tc.zone,
+					},
+				},
+				Parameters: map[string]string{},
+			}
+			res, err := cs.GetCapacity(context.TODO(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.AvailableCapacity != tc.expectedAvailable {
+				t.Errorf("expected available capacity %d, got %d", tc.expectedAvailable, res.AvailableCapacity)
+			}
+			if res.MaximumVolumeSize.Value != tc.expectedMaxVol {
+				t.Errorf("expected maximum volume size %d, got %d", tc.expectedMaxVol, res.MaximumVolumeSize.Value)
+			}
+		})
 	}
 }
 
@@ -361,10 +415,11 @@ func newDisk(storageMaximum, storageReserved, storageScheduled int64, tags strin
 	return disk
 }
 
-func newNode(name, tags string, isCondReady, isCondSchedulable, allowScheduling, evictionRequested bool) *longhorn.Node {
+func newNode(name, tags, zone string, isCondReady, isCondSchedulable, allowScheduling, evictionRequested bool) *longhorn.Node {
 	node := &longhorn.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: testNamespace,
 		},
 		Spec: longhorn.NodeSpec{
 			Disks:             map[string]longhorn.DiskSpec{},
@@ -374,6 +429,7 @@ func newNode(name, tags string, isCondReady, isCondSchedulable, allowScheduling,
 		},
 		Status: longhorn.NodeStatus{
 			DiskStatus: map[string]*longhorn.DiskStatus{},
+			Zone:       zone,
 		},
 	}
 	if isCondReady {
@@ -396,17 +452,14 @@ func addDisksToNode(node *longhorn.Node, disks []*disk) {
 func newSetting(name, value string) *longhorn.Setting {
 	return &longhorn.Setting{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: testNamespace,
 		},
 		Value: value,
 	}
 }
 
 func TestGetAccessibleTopologyFromRequirements(t *testing.T) {
-	cs := &ControllerServer{
-		lhNamespace: "longhorn-system-test",
-		log:         logrus.StandardLogger().WithField("component", "test-topology"),
-	}
 
 	for _, test := range []struct {
 		testName            string
@@ -619,17 +672,11 @@ func TestGetAccessibleTopologyFromRequirements(t *testing.T) {
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			cs.lhClient = lhfake.NewSimpleClientset() // nolint: staticcheck
+			var objs []runtime.Object
 			if !test.skipSettingCreation {
-				_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(
-					context.TODO(),
-					newSetting(string(types.SettingNameCSIAllowedTopologyKeys), test.allowedTopologyKeys),
-					metav1.CreateOptions{},
-				)
-				if err != nil {
-					t.Fatalf("failed to create setting: %v", err)
-				}
+				objs = append(objs, newSetting(string(types.SettingNameCSIAllowedTopologyKeys), test.allowedTopologyKeys))
 			}
+			cs := newTestControllerServer(t, objs...)
 
 			result := cs.getAccessibleTopologyFromRequirements(context.TODO(), test.accessibilityReqs, false)
 
@@ -652,10 +699,6 @@ func TestGetAccessibleTopologyFromRequirements(t *testing.T) {
 }
 
 func TestGetAccessibleTopologyStrictTopology(t *testing.T) {
-	cs := &ControllerServer{
-		lhNamespace: "longhorn-system-test",
-		log:         logrus.StandardLogger().WithField("component", "test-strict-topology"),
-	}
 
 	for _, test := range []struct {
 		testName            string
@@ -746,15 +789,7 @@ func TestGetAccessibleTopologyStrictTopology(t *testing.T) {
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			cs.lhClient = lhfake.NewSimpleClientset() // nolint: staticcheck
-			_, err := cs.lhClient.LonghornV1beta2().Settings(cs.lhNamespace).Create(
-				context.TODO(),
-				newSetting(string(types.SettingNameCSIAllowedTopologyKeys), test.allowedTopologyKeys),
-				metav1.CreateOptions{},
-			)
-			if err != nil {
-				t.Fatalf("failed to create setting: %v", err)
-			}
+			cs := newTestControllerServer(t, newSetting(string(types.SettingNameCSIAllowedTopologyKeys), test.allowedTopologyKeys))
 
 			result := cs.getAccessibleTopologyFromRequirements(context.TODO(), test.accessibilityReqs, test.strictTopology)
 

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -636,14 +636,14 @@ type DriverObjectDeployment struct {
 	obj *storagev1.CSIDriver
 }
 
-func NewCSIDriverObject(storageCapacity bool) *DriverObjectDeployment {
+func NewCSIDriverObject(storageCapacityEnabled bool) *DriverObjectDeployment {
 	obj := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: types.LonghornDriverName,
 		},
 		Spec: storagev1.CSIDriverSpec{
 			PodInfoOnMount:  ptr.To(true),
-			StorageCapacity: ptr.To(storageCapacity),
+			StorageCapacity: ptr.To(storageCapacityEnabled),
 		},
 	}
 	return &DriverObjectDeployment{

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -636,14 +636,14 @@ type DriverObjectDeployment struct {
 	obj *storagev1.CSIDriver
 }
 
-func NewCSIDriverObject() *DriverObjectDeployment {
+func NewCSIDriverObject(storageCapacity bool) *DriverObjectDeployment {
 	obj := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: types.LonghornDriverName,
 		},
 		Spec: storagev1.CSIDriverSpec{
 			PodInfoOnMount:  ptr.To(true),
-			StorageCapacity: ptr.To(true),
+			StorageCapacity: ptr.To(storageCapacity),
 		},
 	}
 	return &DriverObjectDeployment{

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -940,11 +940,12 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		}
 	}
 
-	switch ns.getStorageCapacityTracking(ctx) {
-	case types.CSIStorageCapacityTrackingNode:
-		ns.ensureTopologyKey(topologySegments, kubeNode.Labels, corev1.LabelHostname)
-	case types.CSIStorageCapacityTrackingZone:
-		ns.ensureTopologyKey(topologySegments, kubeNode.Labels, corev1.LabelTopologyZone)
+	// Always expose hostname and zone topology keys in CSINode regardless of the csi-allowed-topology-keys setting.
+	// Controller server relies on these keys to locate the correct node or zone when responding to capacity queries.
+	// Note: these keys are only included in PV node affinity if listed in the csi-allowed-topology-keys setting.
+	if kubeNode != nil {
+		ns.ensureTopologyKey(kubeNode.Name, topologySegments, kubeNode.Labels, corev1.LabelHostname)
+		ns.ensureTopologyKey(kubeNode.Name, topologySegments, kubeNode.Labels, corev1.LabelTopologyZone)
 	}
 
 	return &csi.NodeGetInfoResponse{
@@ -957,28 +958,17 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 }
 
 // ensureTopologyKey adds the given label key to topologySegments if not already present, and warns if the label is missing.
-func (ns *NodeServer) ensureTopologyKey(topologySegments, nodeLabels map[string]string, key string) {
+func (ns *NodeServer) ensureTopologyKey(nodeName string, topologySegments, nodeLabels map[string]string, key string) {
 	labelVal, hasLabel := nodeLabels[key]
 	if !hasLabel {
-		ns.log.Errorf("Node is missing label %q, capacity tracking may not work correctly", key)
+		ns.log.Warnf("Node %q is missing label %q, capacity tracking may not work correctly", nodeName, key)
 		return
 	}
 	_, inTopology := topologySegments[key]
 	if !inTopology {
 		topologySegments[key] = labelVal
-		ns.log.Infof("Added label %q to CSINode topology keys", key)
+		ns.log.Infof("Added label %q to CSINode %q topology keys", key, nodeName)
 	}
-}
-
-// getCSIStorageCapacityTracking returns csi-storage-capacity-tracking setting.
-func (ns *NodeServer) getStorageCapacityTracking(ctx context.Context) types.CSIStorageCapacityTracking {
-	setting, err := ns.lhClient.LonghornV1beta2().Settings(ns.lhNamespace).Get(ctx, string(types.SettingNameCSIStorageCapacityTracking), metav1.GetOptions{})
-	if err != nil {
-		ns.log.WithError(err).Warnf("Failed to get %q setting, defaulting to node-level capacity tracking", types.SettingNameCSIStorageCapacityTracking)
-		return types.CSIStorageCapacityTrackingNode
-	}
-
-	return types.CSIStorageCapacityTracking(setting.Value)
 }
 
 // getAllowedTopologyKeys fetches the CSI Allowed Topology Keys setting and

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -923,11 +923,7 @@ func (ns *NodeServer) getEncryptionPassphrase(secrets map[string]string, volumeI
 }
 
 func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	// Default topology with hostname (required for CSI storage capacity calculation per node)
-	topologySegments := map[string]string{
-		nodeTopologyKey: ns.nodeID,
-	}
-
+	topologySegments := map[string]string{}
 	// Get allowed topology keys from setting
 	allowedKeys := ns.getAllowedTopologyKeys(ctx)
 
@@ -935,13 +931,20 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	// This enables StorageClass allowedTopologies to match node labels
 	kubeNode, err := ns.kubeClient.CoreV1().Nodes().Get(ctx, ns.nodeID, metav1.GetOptions{})
 	if err != nil {
-		ns.log.WithError(err).Warnf("Failed to get Kubernetes node %s for topology labels, using hostname only", ns.nodeID)
+		ns.log.WithError(err).Warnf("Failed to get Kubernetes node %s for topology labels", ns.nodeID)
 	} else {
 		for key, value := range kubeNode.Labels {
-			if key == nodeTopologyKey || allowedKeys[key] {
+			if allowedKeys[key] {
 				topologySegments[key] = value
 			}
 		}
+	}
+
+	switch ns.getStorageCapacityTracking(ctx) {
+	case types.CSIStorageCapacityTrackingNode:
+		ns.ensureTopologyKey(topologySegments, kubeNode.Labels, corev1.LabelHostname)
+	case types.CSIStorageCapacityTrackingZone:
+		ns.ensureTopologyKey(topologySegments, kubeNode.Labels, corev1.LabelTopologyZone)
 	}
 
 	return &csi.NodeGetInfoResponse{
@@ -953,9 +956,34 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	}, nil
 }
 
+// ensureTopologyKey adds the given label key to topologySegments if not already present, and warns if the label is missing.
+func (ns *NodeServer) ensureTopologyKey(topologySegments, nodeLabels map[string]string, key string) {
+	labelVal, hasLabel := nodeLabels[key]
+	if !hasLabel {
+		ns.log.Errorf("Node is missing label %q, capacity tracking may not work correctly", key)
+		return
+	}
+	_, inTopology := topologySegments[key]
+	if !inTopology {
+		topologySegments[key] = labelVal
+		ns.log.Infof("Added label %q to CSINode topology keys", key)
+	}
+}
+
+// getCSIStorageCapacityTracking returns csi-storage-capacity-tracking setting.
+func (ns *NodeServer) getStorageCapacityTracking(ctx context.Context) types.CSIStorageCapacityTracking {
+	setting, err := ns.lhClient.LonghornV1beta2().Settings(ns.lhNamespace).Get(ctx, string(types.SettingNameCSIStorageCapacityTracking), metav1.GetOptions{})
+	if err != nil {
+		ns.log.WithError(err).Warnf("Failed to get %q setting, defaulting to node-level capacity tracking", types.SettingNameCSIStorageCapacityTracking)
+		return types.CSIStorageCapacityTrackingNode
+	}
+
+	return types.CSIStorageCapacityTracking(setting.Value)
+}
+
 // getAllowedTopologyKeys fetches the CSI Allowed Topology Keys setting and
 // returns a map of allowed keys. If the setting is empty or cannot be fetched,
-// an empty map is returned (only nodeTopologyKey will be used).
+// an empty map is returned.
 func (ns *NodeServer) getAllowedTopologyKeys(ctx context.Context) map[string]bool {
 	obj, err := ns.lhClient.LonghornV1beta2().Settings(ns.lhNamespace).Get(ctx, string(types.SettingNameCSIAllowedTopologyKeys), metav1.GetOptions{})
 	if err != nil {
@@ -963,14 +991,7 @@ func (ns *NodeServer) getAllowedTopologyKeys(ctx context.Context) map[string]boo
 		return nil
 	}
 
-	allowedKeys := make(map[string]bool)
-	for _, key := range strings.Split(obj.Value, ",") {
-		key = strings.TrimSpace(key)
-		if key != "" {
-			allowedKeys[key] = true
-		}
-	}
-	return allowedKeys
+	return types.ParseCSIAllowedTopologyKeys(obj.Value)
 }
 
 func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {

--- a/csi/util.go
+++ b/csi/util.go
@@ -36,8 +36,6 @@ const (
 	defaultForceUmountTimeout = 30 * time.Second
 
 	tempTestMountPointValidStatusFile = ".longhorn-volume-mount-point-test.tmp"
-
-	nodeTopologyKey = "kubernetes.io/hostname"
 )
 
 // NewForcedParamsExec creates a osExecutor that allows for adding additional params to later occurring Run calls
@@ -610,17 +608,6 @@ func requireExclusiveAccess(vol *longhornclient.Volume, capability *csi.VolumeCa
 
 func getStageBlockVolumePath(stagingTargetPath, volumeID string) string {
 	return filepath.Join(stagingTargetPath, volumeID)
-}
-
-func parseNodeID(topology *csi.Topology) (string, error) {
-	if topology == nil || topology.Segments == nil {
-		return "", fmt.Errorf("missing accessible topology request parameter")
-	}
-	nodeId, ok := topology.Segments[nodeTopologyKey]
-	if !ok {
-		return "", fmt.Errorf("accessible topology request parameter is missing %s key", nodeTopologyKey)
-	}
-	return nodeId, nil
 }
 
 func isFileNotExistError(err error) bool {

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -552,6 +552,16 @@ func (s *DataStore) DeleteCSIDriver(name string) error {
 	return s.kubeClient.StorageV1().CSIDrivers().Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
+// GetCSIDriver gets the CSIDriver for the given name
+func (s *DataStore) GetCSIDriver(name string) (*storagev1.CSIDriver, error) {
+	return s.kubeClient.StorageV1().CSIDrivers().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// UpdateCSIDriver updates the CSIDriver
+func (s *DataStore) UpdateCSIDriver(csiDriver *storagev1.CSIDriver) (*storagev1.CSIDriver, error) {
+	return s.kubeClient.StorageV1().CSIDrivers().Update(context.TODO(), csiDriver, metav1.UpdateOptions{})
+}
+
 // ListManagerPods returns a list of Pods marked with app=longhorn-manager
 func (s *DataStore) ListManagerPods() ([]*corev1.Pod, error) {
 	selector, err := s.getManagerSelector()

--- a/types/setting.go
+++ b/types/setting.go
@@ -2016,21 +2016,22 @@ var (
 
 	SettingDefinitionCSIStorageCapacityTracking = SettingDefinition{
 		DisplayName: "CSI Storage Capacity Tracking",
-		Description: "Controls CSI storage capacity tracking (KEP-1472), which allows the kube-scheduler to filter " +
-			"nodes that cannot fit the requested volume. " +
-			"Possible values are \"disabled\" (tracking off), \"node\" (per-node capacity), and \"zone\" (per-zone capacity).",
+		Description: "Controls CSI storage capacity tracking, which allows the kube-scheduler to filter " +
+			"nodes that cannot fit the requested volume.",
 		Category:           SettingCategoryGeneral,
-		Type:               SettingTypeString,
+		Type:               SettingTypeBool,
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            string(CSIStorageCapacityTrackingNode),
-		Choices: []any{
-			string(CSIStorageCapacityTrackingDisabled),
-			string(CSIStorageCapacityTrackingNode),
-			string(CSIStorageCapacityTrackingZone),
-		},
+		Default:            "false",
 	}
+)
+
+type CSIStorageCapacityTrackingMode string
+
+const (
+	CSIStorageCapacityTrackingModeNode = CSIStorageCapacityTrackingMode("node")
+	CSIStorageCapacityTrackingModeZone = CSIStorageCapacityTrackingMode("zone")
 )
 
 type NodeDownPodDeletionPolicy string
@@ -2077,14 +2078,6 @@ type OrphanResourceType string
 const (
 	OrphanResourceTypeReplicaData = OrphanResourceType("replica-data")
 	OrphanResourceTypeInstance    = OrphanResourceType("instance")
-)
-
-type CSIStorageCapacityTracking string
-
-const (
-	CSIStorageCapacityTrackingDisabled CSIStorageCapacityTracking = "disabled"
-	CSIStorageCapacityTrackingNode     CSIStorageCapacityTracking = "node"
-	CSIStorageCapacityTrackingZone     CSIStorageCapacityTracking = "zone"
 )
 
 // ValidateSetting checks if the given value is valid for the given setting name.
@@ -2180,12 +2173,6 @@ func GetCustomizedDefaultSettings(defaultSettingCM *corev1.ConfigMap) (defaultSe
 	}
 
 	return defaultSettings, nil
-}
-
-// IsCSIStorageCapacityEnabled reports whether the capacity tracking mode is "node" or "zone".
-func IsCSIStorageCapacityEnabled(value string) bool {
-	mode := CSIStorageCapacityTracking(value)
-	return mode == CSIStorageCapacityTrackingNode || mode == CSIStorageCapacityTrackingZone
 }
 
 // ParseCSIAllowedTopologyKeys parses a comma-separated topology key list into a set.

--- a/types/setting.go
+++ b/types/setting.go
@@ -2004,7 +2004,8 @@ var (
 		Description: "Comma-separated list of topology keys to keep in CreateVolumeResponse AccessibleTopology. " +
 			"Only the specified keys remain in topology segments and are used for PV nodeAffinity " +
 			"(e.g., \"topology.kubernetes.io/zone,topology.kubernetes.io/region\"). " +
-			"When empty (default), no topology keys are allowed and AccessibleTopology will be empty.",
+			"When empty (default), no topology keys are allowed and AccessibleTopology will be empty. " +
+			"Note: The longhorn-csi-plugin daemonset must be restarted for changes to take effect.",
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeString,
 		Required:           false,
@@ -2015,15 +2016,20 @@ var (
 
 	SettingDefinitionCSIStorageCapacityTracking = SettingDefinition{
 		DisplayName: "CSI Storage Capacity Tracking",
-		Description: "Setting that enables or disables the CSI storage capacity tracking (KEP-1472). " +
-			"This corresponds to the StorageCapacity field on the CSIDriver object. " +
-			"Disabling this may be useful in environments where storage capacity tracking is not needed or causes issues.",
+		Description: "Controls CSI storage capacity tracking (KEP-1472), which allows the kube-scheduler to filter " +
+			"nodes that cannot fit the requested volume. " +
+			"Possible values are \"disabled\" (tracking off), \"node\" (per-node capacity), and \"zone\" (per-zone capacity).",
 		Category:           SettingCategoryGeneral,
-		Type:               SettingTypeBool,
+		Type:               SettingTypeString,
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            "true",
+		Default:            string(CSIStorageCapacityTrackingNode),
+		Choices: []any{
+			string(CSIStorageCapacityTrackingDisabled),
+			string(CSIStorageCapacityTrackingNode),
+			string(CSIStorageCapacityTrackingZone),
+		},
 	}
 )
 
@@ -2071,6 +2077,14 @@ type OrphanResourceType string
 const (
 	OrphanResourceTypeReplicaData = OrphanResourceType("replica-data")
 	OrphanResourceTypeInstance    = OrphanResourceType("instance")
+)
+
+type CSIStorageCapacityTracking string
+
+const (
+	CSIStorageCapacityTrackingDisabled CSIStorageCapacityTracking = "disabled"
+	CSIStorageCapacityTrackingNode     CSIStorageCapacityTracking = "node"
+	CSIStorageCapacityTrackingZone     CSIStorageCapacityTracking = "zone"
 )
 
 // ValidateSetting checks if the given value is valid for the given setting name.
@@ -2166,6 +2180,24 @@ func GetCustomizedDefaultSettings(defaultSettingCM *corev1.ConfigMap) (defaultSe
 	}
 
 	return defaultSettings, nil
+}
+
+// IsCSIStorageCapacityEnabled reports whether the capacity tracking mode is "node" or "zone".
+func IsCSIStorageCapacityEnabled(value string) bool {
+	mode := CSIStorageCapacityTracking(value)
+	return mode == CSIStorageCapacityTrackingNode || mode == CSIStorageCapacityTrackingZone
+}
+
+// ParseCSIAllowedTopologyKeys parses a comma-separated topology key list into a set.
+func ParseCSIAllowedTopologyKeys(value string) map[string]bool {
+	allowedKeys := make(map[string]bool)
+	for _, key := range strings.Split(value, ",") {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			allowedKeys[key] = true
+		}
+	}
+	return allowedKeys
 }
 
 // UnmarshalTolerations unmarshals the given toleration setting string into a slice of Toleration.

--- a/types/setting.go
+++ b/types/setting.go
@@ -172,6 +172,7 @@ const (
 	SettingNameSnapshotHeavyTaskConcurrentLimit                         = SettingName("snapshot-heavy-task-concurrent-limit")
 	SettingNameNodeDiskHealthMonitoring                                 = SettingName("node-disk-health-monitoring")
 	SettingNameCSIAllowedTopologyKeys                                   = SettingName("csi-allowed-topology-keys")
+	SettingNameCSIStorageCapacityTracking                               = SettingName("csi-storage-capacity-tracking")
 
 	// The settings are deprecated and Longhorn won't create Setting Resources for these parameters.
 	// TODO: Remove these settings in the future releases.
@@ -297,6 +298,7 @@ var (
 		SettingNameNodeDiskHealthMonitoring,
 		SettingNameSnapshotHeavyTaskConcurrentLimit,
 		SettingNameCSIAllowedTopologyKeys,
+		SettingNameCSIStorageCapacityTracking,
 	}
 )
 
@@ -456,6 +458,7 @@ var (
 		SettingNameNodeDiskHealthMonitoring:                                 SettingDefinitionNodeDiskHealthMonitoring,
 		SettingNameSnapshotHeavyTaskConcurrentLimit:                         SettingDefinitionSnapshotHeavyTaskConcurrentLimit,
 		SettingNameCSIAllowedTopologyKeys:                                   SettingDefinitionCSIAllowedTopologyKeys,
+		SettingNameCSIStorageCapacityTracking:                               SettingDefinitionCSIStorageCapacityTracking,
 	}
 
 	SettingDefinitionAllowRecurringJobWhileVolumeDetached = SettingDefinition{
@@ -2008,6 +2011,19 @@ var (
 		ReadOnly:           false,
 		DataEngineSpecific: false,
 		Default:            "",
+	}
+
+	SettingDefinitionCSIStorageCapacityTracking = SettingDefinition{
+		DisplayName: "CSI Storage Capacity Tracking",
+		Description: "Setting that enables or disables the CSI storage capacity tracking (KEP-1472). " +
+			"This corresponds to the StorageCapacity field on the CSIDriver object. " +
+			"Disabling this may be useful in environments where storage capacity tracking is not needed or causes issues.",
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeBool,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            "true",
 	}
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -232,8 +232,6 @@ const (
 
 	PVAnnotationLonghornVolumeSchedulingError = "longhorn.io/volume-scheduling-error"
 
-	AnnotationCSIStorageCapacityTracking = "longhorn.io/csi-storage-capacity-tracking"
-
 	CniNetworkNone           = ""
 	StorageNetworkInterface  = "lhnet1" // Data plane network
 	EndpointNetworkInterface = "lhnet2" // RWX volume nfs server endpoint

--- a/types/types.go
+++ b/types/types.go
@@ -232,6 +232,8 @@ const (
 
 	PVAnnotationLonghornVolumeSchedulingError = "longhorn.io/volume-scheduling-error"
 
+	AnnotationCSIStorageCapacityTracking = "longhorn.io/csi-storage-capacity-tracking"
+
 	CniNetworkNone           = ""
 	StorageNetworkInterface  = "lhnet1" // Data plane network
 	EndpointNetworkInterface = "lhnet2" // RWX volume nfs server endpoint


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/12807

#### What this PR does / why we need it:
The new setting `csi-storage-capacity-tracking` controls the granularity of CSI storage capacity tracking.
                                                      
- `disabled`: Capacity tracking is turned off. `StorageCapacity: false` on the CSIDriver object.                              
- `node`: Capacity is reported per node. This is the default and matches the current behavior.                                                   
- `zone`: Capacity is reported per zone.
 
#### Special notes for your reviewer:

#### Additional documentation or context
