### PR TITLE
feat(backuptarget): enforce NFS soft-mount options in webhook mutator

### DIFF
--- a/webhook/resources/backuptarget/mutator.go
+++ b/webhook/resources/backuptarget/mutator.go
@@ -1,7 +1,11 @@
 package backuptarget
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -10,6 +14,7 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 
 	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/webhook/admission"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -66,5 +71,132 @@ func mutate(newObj runtime.Object) (admission.PatchOps, error) {
 		patchOps = append(patchOps, patchOp)
 	}
 
+	newURL, changed, err := applyNFSSoftMountDefaults(backupTarget.Spec.BackupTargetURL)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to apply NFS soft-mount defaults for backupTarget %v", backupTarget.Name)
+		return nil, werror.NewInvalidError(err.Error(), "")
+	}
+	if changed {
+		marshaledURL, err := json.Marshal(newURL)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to marshal backupTargetURL for backupTarget %v", backupTarget.Name)
+			return nil, werror.NewInvalidError(err.Error(), "")
+		}
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/backupTargetURL", "value": %s}`, string(marshaledURL)))
+	}
+
 	return patchOps, nil
+}
+
+// applyNFSSoftMountDefaults enforces safe NFS mount options when nfsOptions is
+// explicitly set in an NFS BackupTarget URL.
+//
+// Returns the (possibly updated) URL, a boolean indicating whether the URL was
+// changed, and any error.
+//
+// Rules:
+//   - Non-NFS URLs (empty, s3://, cifs://, etc.) are returned unchanged.
+//   - If nfsOptions is absent, the URL is returned unchanged. The underlying
+//     NFS driver will use its built-in defaults (actimeo=1,soft,timeo=300,retry=2).
+//   - If nfsOptions is present but blank, the parameter is stripped from the URL.
+//   - If nfsOptions is present, the following are merged in to ensure the mount
+//     can time out instead of blocking indefinitely:
+//   - "hard" is removed.
+//   - "soft" is added if absent.
+//   - "timeo=<N>" is kept if already present; otherwise "timeo=300" is added.
+//   - "retry=<N>" is kept if already present; otherwise "retry=2" is added.
+func applyNFSSoftMountDefaults(rawURL string) (string, bool, error) {
+	if rawURL == "" {
+		return rawURL, false, nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		// Best-effort: leave the URL unchanged rather than blocking
+		// unrelated admission operations (e.g. credentialSecret updates).
+		return rawURL, false, nil
+	}
+
+	if u.Scheme != types.BackupStoreTypeNFS {
+		return rawURL, false, nil
+	}
+
+	const NFSOptionsKey = "nfsOptions"
+
+	q := u.Query()
+	rawValues, exists := q[NFSOptionsKey]
+	if !exists {
+		return rawURL, false, nil
+	}
+
+	// Flatten both the repeated-key form (?nfsOptions=a&nfsOptions=b) and
+	// the comma-separated form (?nfsOptions=a,b) into one option list.
+	opts := splitNFSOptionsValues(rawValues)
+	if len(opts) == 0 {
+		// nfsOptions key is present but all values are blank -- strip it.
+		q.Del(NFSOptionsKey)
+		u.RawQuery = q.Encode()
+		return u.String(), true, nil
+	}
+
+	merged := mergeNFSSoftMountOptions(opts)
+	if slices.Equal(opts, merged) {
+		return rawURL, false, nil
+	}
+
+	q.Set(NFSOptionsKey, strings.Join(merged, ","))
+	u.RawQuery = q.Encode()
+	return u.String(), true, nil
+}
+
+// splitNFSOptionsValues flattens repeated nfsOptions query values into one
+// slice of individual mount options. It handles both the repeated-key form
+// (?nfsOptions=a&nfsOptions=b) and the comma-separated form (?nfsOptions=a,b),
+// and guarantees that no empty strings are returned.
+func splitNFSOptionsValues(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, v := range values {
+		for _, opt := range strings.Split(v, ",") {
+			if opt != "" {
+				result = append(result, opt)
+			}
+		}
+	}
+	return result
+}
+
+// mergeNFSSoftMountOptions enforces the soft-mount policy on a slice of NFS
+// options and returns the updated slice.
+func mergeNFSSoftMountOptions(opts []string) []string {
+	hasSoft := false
+	hasTimeo := false
+	hasRetry := false
+
+	var result []string
+	for _, opt := range opts {
+		if opt == "hard" {
+			continue // always remove "hard"
+		}
+		if opt == "soft" {
+			hasSoft = true
+		}
+		if strings.HasPrefix(opt, "timeo=") {
+			hasTimeo = true
+		}
+		if strings.HasPrefix(opt, "retry=") {
+			hasRetry = true
+		}
+		result = append(result, opt)
+	}
+
+	if !hasSoft {
+		result = append(result, "soft")
+	}
+	if !hasTimeo {
+		result = append(result, "timeo=300")
+	}
+	if !hasRetry {
+		result = append(result, "retry=2")
+	}
+	return result
 }

--- a/webhook/resources/backuptarget/nfs_test.go
+++ b/webhook/resources/backuptarget/nfs_test.go
@@ -1,0 +1,102 @@
+package backuptarget
+
+import (
+	"testing"
+)
+
+func TestApplyNFSSoftMountDefaults(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "empty URL unchanged",
+			input:       "",
+			want:        "",
+			wantChanged: false,
+		},
+		{
+			name:        "s3 URL unchanged",
+			input:       "s3://mybucket@us-east-1/",
+			want:        "s3://mybucket@us-east-1/",
+			wantChanged: false,
+		},
+		{
+			name:        "cifs URL unchanged",
+			input:       "cifs://server/share",
+			want:        "cifs://server/share",
+			wantChanged: false,
+		},
+		{
+			name:        "NFS without nfsOptions left unchanged",
+			input:       "nfs://192.168.1.1:/share",
+			want:        "nfs://192.168.1.1:/share",
+			wantChanged: false,
+		},
+		{
+			name:        "NFS with blank nfsOptions strips the parameter",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=",
+			want:        "nfs://192.168.1.1:/share",
+			wantChanged: true,
+		},
+		{
+			name:        "NFS with multi-value nfsOptions gets flattened and merged",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=soft&nfsOptions=timeo%3D600",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=soft%2Ctimeo%3D600%2Cretry%3D2",
+			wantChanged: true,
+		},
+		{
+			name:        "NFS with rw,nolock gets soft defaults merged in",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=rw%2Cnolock",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=rw%2Cnolock%2Csoft%2Ctimeo%3D300%2Cretry%3D2",
+			wantChanged: true,
+		},
+		{
+			name:        "hard is removed and soft added",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=hard%2Crw",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=rw%2Csoft%2Ctimeo%3D300%2Cretry%3D2",
+			wantChanged: true,
+		},
+		{
+			name:        "custom timeo preserved, soft and retry added",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=timeo%3D600",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=timeo%3D600%2Csoft%2Cretry%3D2",
+			wantChanged: true,
+		},
+		{
+			name:        "custom retry preserved, soft and timeo added",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=retry%3D5",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=retry%3D5%2Csoft%2Ctimeo%3D300",
+			wantChanged: true,
+		},
+		{
+			name:        "all three defaults already present, URL unchanged",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=soft%2Ctimeo%3D300%2Cretry%3D2",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=soft%2Ctimeo%3D300%2Cretry%3D2",
+			wantChanged: false,
+		},
+		{
+			name:        "hard removed when soft already present",
+			input:       "nfs://192.168.1.1:/share?nfsOptions=soft%2Chard%2Ctimeo%3D300%2Cretry%3D2",
+			want:        "nfs://192.168.1.1:/share?nfsOptions=soft%2Ctimeo%3D300%2Cretry%3D2",
+			wantChanged: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed, err := applyNFSSoftMountDefaults(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("applyNFSSoftMountDefaults(%q)\n  got:  %q\n  want: %q", tc.input, got, tc.want)
+			}
+			if changed != tc.wantChanged {
+				t.Errorf("applyNFSSoftMountDefaults(%q) changed=%v, want %v", tc.input, changed, tc.wantChanged)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#12896

#### What this PR does / why we need it:

Always inject `soft`, `timeo=300`, and `retry=2` into `nfsOptions` for NFS BackupTarget URLs. This ensures that longhorn-backup-store NFS mounts time out instead of blocking indefinitely when the NFS server is slow or unreachable, preventing the process accumulation described in longhorn/longhorn#12896.

Merge rules applied in backupTargetMutator.mutate via admission webhook:
- `hard` removed when present
- `soft` added if absent
- `timeo=N` kept if already specified, otherwise `timeo=300` added
- `retry=N` kept if already specified, otherwise `retry=2` added

#### Special notes for your reviewer:

#### Additional documentation or context
