### PR TITLE
fix: fix auto balance bugs

### DIFF
--- a/controller/volume_autobalance_test.go
+++ b/controller/volume_autobalance_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -513,4 +514,420 @@ func (s *TestSuite) TestAutoBalanceNoTargetNode(c *C) {
 		Commentf("Expected replenishCount=0 when all nodes already have replicas"))
 	c.Assert(hardNodeAffinity, Equals, "",
 		Commentf("Expected empty hardNodeAffinity when no target node is available"))
+}
+
+// TestAutoBalanceUnstableNodeRebuildLoop reproduces the exact rebuild-cleanup
+// loop (issue #11730 and #12926) observed in production:
+//
+//  1. Zone/Node auto-balance creates a replica on a node whose kube Ready transition
+//     time is 30+ minutes later than other nodes (the "unstable" node).
+//  2. The replica rebuilds successfully → volume has N+1 healthy replicas.
+//  3. cleanupExtraHealthyReplicas → cleanupAutoBalancedReplicas is called.
+//     - Before the fix, the cleanup logic deleted the sole replica in zone-b
+//     on the "unstable" node FIRST, causing auto-balance to immediately recreate it → infinite loop.
+//     - After the fix, cleanupReplicaInUnstableEnv deleted the extra replicas from
+//     overcrowded nodes or zones (the zone-a replicas, since zone-a has 2 while zone-b has 1) FIRST,
+//     leaving the sole replica in zone-b untouched and the scheduling balanced.
+func (s *TestSuite) TestAutoBalanceUnstableNodeRebuildLoop(c *C) {
+	// ...existing code... (setup unchanged through replica creation)
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+		{TestDaemon3, TestNode3, TestIP3},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	engineImage.Status.NodeDeploymentMap[TestNode3] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create 3 Longhorn nodes in 2 zones:
+	//   Node1 (zone "zone-a"), Node2 (zone "zone-a"), Node3 (zone "zone-b")
+	// Node3 is the "unstable" node with a much later Ready transition time.
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node1.Status.Zone = "zone-a"
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2.Status.Zone = "zone-a"
+	node3 := newNode(TestNode3, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node3.Status.Zone = "zone-b" // only node in zone-b
+
+	for _, node := range []*longhorn.Node{node1, node2, node3} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+	}
+
+	// Create kube nodes with different Ready transition times:
+	//   Node1, Node2: became ready at t=0 (stable)
+	//   Node3: became ready at t=0+2h (unstable — 2 hours later, well over 30 min threshold)
+	stableReadyTime := metav1.NewTime(metav1.Now().Add(-24 * time.Hour))
+	unstableReadyTime := metav1.NewTime(stableReadyTime.Add(2 * time.Hour)) // 2h later
+
+	knode1 := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode1, stableReadyTime)
+	knode2 := newKubernetesNode(TestNode2, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode2, stableReadyTime)
+	knode3 := newKubernetesNode(TestNode3, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode3, unstableReadyTime) // "unstable"
+
+	for _, knode := range []*corev1.Node{knode1, knode2, knode3} {
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+		{TestInstanceManagerName + "-" + TestNode3, TestOwnerID3, TestNode3, TestIP3},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Settings
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceBestEffort),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Create volume with 3 replicas.
+	// Simulate the state AFTER auto-balance has added a new replica on the
+	// unstable node (Node3 in zone-b) and it finished rebuilding:
+	//   - replica1 on Node1 (zone-a) — original
+	//   - replica2 on Node2 (zone-a) — original
+	//   - replica3 on Node3 (zone-b) — just rebuilt by auto-balance (extra)
+	// healthyCount=3 > NumberOfReplicas=2 → cleanupExtraHealthyReplicas fires
+	volume := newVolume(TestVolumeName, 2)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1) // zone-a
+	replica2 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1) // zone-a
+	replica3 := newReplicaForVolume(volume, engine, TestNode3, TestDiskID1) // zone-b (unstable node)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	replica1.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode1
+	replica2.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode2
+	replica3.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode3
+
+	// Need to create replicas in the datastore for deleteReplica to work
+	rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
+	for _, r := range replicas {
+		rObj, err := lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), r, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = rIndexer.Add(rObj)
+		c.Assert(err, IsNil)
+	}
+
+	// Call cleanupAutoBalancedReplicas (the full refactored function) with the 3 replicas.
+	// The expected behavior with the fix is:
+	//   Step 1: not-ready env — no nodes are down, skipped.
+	//   Step 2: overcrowded node/zone — zone-a has 2 replicas (replica1 and replica2),
+	//   so these 2 replicas are the preferred deletion candidates. Replica3 in zone-b
+	//   or the only unstable node is NOT a candidate for deletion.
+	//   Step 3 & 4: unstable env — never reached because step 2 handled it.
+	//   → replica3 in zone-b is preserved, no loop.
+	cleaned, err := vc.cleanupAutoBalancedReplicas(volume, replicas)
+	c.Assert(err, IsNil)
+	c.Assert(cleaned, Equals, true,
+		Commentf("cleanupAutoBalancedReplicas should have deleted one replica"))
+
+	fmt.Printf("  unstable-node-loop: cleaned=%v\n", cleaned)
+
+	// Verify replica3 (zone-b, unstable node) was NOT deleted
+	c.Assert(replicas[replica3.Name], NotNil,
+		Commentf("replica3 on the unstable node (sole replica in zone-b) should not have been deleted"))
+
+	// Verify one of the zone-a replicas WAS deleted (the overcrowded zone)
+	zoneADeleted := replicas[replica1.Name] == nil || replicas[replica2.Name] == nil
+	c.Assert(zoneADeleted, Equals, true,
+		Commentf("one replica from zone-a (overcrowded zone with 2 replicas) should have been deleted"))
+}
+
+// TestAutoBalanceUnstableNodeMixedCase tests the mixed case where the unstable
+// replica is in the overcrowded zone. Step 2 should prefer to delete the
+// unstable replica from the overcrowded candidates, achieving both goals:
+// removing excess from the overcrowded zone AND cleaning up the unstable data.
+//
+// Setup:
+//
+//	Zone-a: Node1 (r1, stable), Node2 (r2, UNSTABLE) — 2 replicas
+//	Zone-b: Node3 (r3, stable) — 1 replica
+//	NumberOfReplicas = 2 → 3 healthy, 1 extra
+//
+// Expected: r2 is deleted (unstable + overcrowded), r1 and r3 preserved.
+func (s *TestSuite) TestAutoBalanceUnstableNodeMixedCase(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+		{TestDaemon3, TestNode3, TestIP3},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	engineImage.Status.NodeDeploymentMap[TestNode3] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Zone-a: Node1 (stable), Node2 (UNSTABLE)
+	// Zone-b: Node3 (stable)
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node1.Status.Zone = "zone-a"
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2.Status.Zone = "zone-a" // unstable node, but in the overcrowded zone
+	node3 := newNode(TestNode3, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node3.Status.Zone = "zone-b"
+
+	for _, node := range []*longhorn.Node{node1, node2, node3} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+	}
+
+	// Kube nodes: Node2 is unstable (Ready transition 2h later)
+	stableReadyTime := metav1.NewTime(metav1.Now().Add(-24 * time.Hour))
+	unstableReadyTime := metav1.NewTime(stableReadyTime.Add(2 * time.Hour))
+
+	knode1 := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode1, stableReadyTime)
+	knode2 := newKubernetesNode(TestNode2, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode2, unstableReadyTime) // UNSTABLE
+	knode3 := newKubernetesNode(TestNode3, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	setKubeNodeReadyTransitionTime(knode3, stableReadyTime)
+
+	for _, knode := range []*corev1.Node{knode1, knode2, knode3} {
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+		{TestInstanceManagerName + "-" + TestNode3, TestOwnerID3, TestNode3, TestIP3},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Settings
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceBestEffort),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Volume with 2 replicas, 3 healthy (one extra):
+	//   r1 on Node1 (zone-a, stable)
+	//   r2 on Node2 (zone-a, UNSTABLE)
+	//   r3 on Node3 (zone-b, stable)
+	volume := newVolume(TestVolumeName, 2)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1) // zone-a, stable
+	replica2 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1) // zone-a, UNSTABLE
+	replica3 := newReplicaForVolume(volume, engine, TestNode3, TestDiskID1) // zone-b, stable
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	replica1.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode1
+	replica2.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode2
+	replica3.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode3
+
+	// Create replicas in the datastore for deleteReplica to work
+	rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
+	for _, r := range replicas {
+		rObj, err := lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), r, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = rIndexer.Add(rObj)
+		c.Assert(err, IsNil)
+	}
+
+	cleaned, err := vc.cleanupAutoBalancedReplicas(volume, replicas)
+	c.Assert(err, IsNil)
+	c.Assert(cleaned, Equals, true)
+
+	// replica2 (unstable + in overcrowded zone) should be the one deleted
+	c.Assert(replicas[replica2.Name], IsNil,
+		Commentf("replica2 (unstable node in overcrowded zone with 2 replicas) should have been deleted"))
+
+	// replica1 (stable, zone-a) and replica3 (stable, zone-b) should survive
+	c.Assert(replicas[replica1.Name], NotNil,
+		Commentf("replica1 (stable node in zone-a) should have been preserved"))
+	c.Assert(replicas[replica3.Name], NotNil,
+		Commentf("replica3 (stable node in zone-b) should have been preserved"))
+}
+
+// setKubeNodeReadyTransitionTime sets the LastTransitionTime on the NodeReady
+// condition of a kube node.
+func setKubeNodeReadyTransitionTime(node *corev1.Node, t metav1.Time) {
+	for i, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			node.Status.Conditions[i].LastTransitionTime = t
+			return
+		}
+	}
 }

--- a/controller/volume_autobalance_test.go
+++ b/controller/volume_autobalance_test.go
@@ -1,0 +1,516 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/controller"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imutil "github.com/longhorn/longhorn-instance-manager/pkg/util"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	TestNode3    = "test-node-name-3"
+	TestOwnerID3 = TestNode3
+	TestIP3      = "9.10.11.12"
+	TestDaemon3  = "longhorn-manager-3"
+)
+
+// TestAutoBalanceNodeLeastEffort verifies that when replica auto-balance is set
+// to least-effort and replicas are unevenly distributed across nodes, the
+// getReplenishReplicasCount function returns a non-empty hardNodeAffinity
+// pointing to an unused node. Before the fix, hardNodeAffinity was always ""
+// for the least-effort path, causing the scheduler to potentially place the new
+// replica on an already-overcrowded node, leading to an infinite
+// rebuild-cleanup loop.
+func (s *TestSuite) TestAutoBalanceNodeLeastEffort(c *C) {
+	testAutoBalanceReplicasCount(c, longhorn.ReplicaAutoBalanceLeastEffort)
+}
+
+// TestAutoBalanceNodeBestEffort verifies the same behavior for best-effort.
+// Before the fix, the best-effort path could return adjustCount > 0 with
+// hardNodeAffinity "" when nCandidates was empty.
+func (s *TestSuite) TestAutoBalanceNodeBestEffort(c *C) {
+	testAutoBalanceReplicasCount(c, longhorn.ReplicaAutoBalanceBestEffort)
+}
+
+func testAutoBalanceReplicasCount(c *C, autoBalanceSetting longhorn.ReplicaAutoBalance) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods for each node
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+		{TestDaemon3, TestNode3, TestIP3},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image deployed on all 3 nodes
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	engineImage.Status.NodeDeploymentMap[TestNode3] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create 3 Longhorn nodes, all allow scheduling
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node3 := newNode(TestNode3, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	for _, node := range []*longhorn.Node{node1, node2, node3} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+
+		knode := newKubernetesNode(
+			node.Name,
+			corev1.ConditionTrue,
+			corev1.ConditionFalse,
+			corev1.ConditionFalse,
+			corev1.ConditionFalse,
+			corev1.ConditionFalse,
+			corev1.ConditionTrue,
+		)
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers for all 3 nodes
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+		{TestInstanceManagerName + "-" + TestNode3, TestOwnerID3, TestNode3, TestIP3},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(
+				imInfo.name, longhorn.InstanceManagerStateRunning,
+				imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{},
+				map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1,
+				TestInstanceManagerImage,
+				false,
+			),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Create settings
+	settingsToCreate := map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(autoBalanceSetting),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	}
+	for name, value := range settingsToCreate {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Create a volume with 3 replicas, attached and healthy
+	volume := newVolume(TestVolumeName, 3)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	// Create replicas: 2 on TestNode1 (overcrowded), 1 on TestNode2, 0 on TestNode3
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica2 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1) // Second replica on same node!
+	replica3 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	// Set all replicas as healthy and running
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	// Test: getReplenishReplicasCount should return a non-empty hardNodeAffinity
+	// pointing to the unused node (TestNode3) when auto-balance detects imbalance.
+	replenishCount, hardNodeAffinity := vc.getReplenishReplicasCount(volume, replicas, engine)
+
+	fmt.Printf("  autoBalance=%v replenishCount=%d hardNodeAffinity=%q\n",
+		autoBalanceSetting, replenishCount, hardNodeAffinity)
+
+	// With 2 replicas on TestNode1 and 1 on TestNode2, and TestNode3 empty:
+	// The auto-balance logic should detect this imbalance and request 1 new replica.
+	c.Assert(replenishCount, Equals, 1,
+		Commentf("Expected replenishCount=1 for imbalanced replica distribution with %v", autoBalanceSetting))
+
+	// CRITICAL ASSERTION: hardNodeAffinity must NOT be empty.
+	// Before the fix for issue #11730 and #12926, the least-effort path returned ("", adjustCount) which caused the
+	// scheduler to place the new replica on any node (potentially the overcrowded one),
+	// creating an infinite rebuild-cleanup loop.
+	c.Assert(hardNodeAffinity, Not(Equals), "",
+		Commentf("hardNodeAffinity must not be empty to prevent rebuild-cleanup loop with %v", autoBalanceSetting))
+
+	// The target node should be TestNode3 (the only unused node)
+	c.Assert(hardNodeAffinity, Equals, TestNode3,
+		Commentf("hardNodeAffinity should point to the unused node %v with %v", TestNode3, autoBalanceSetting))
+}
+
+// TestAutoBalanceReplicasCountBalanced verifies that when replicas are already
+// evenly distributed across nodes, getReplenishReplicasCount returns 0 and
+// no rebalancing is triggered.
+func (s *TestSuite) TestAutoBalanceReplicasCountBalanced(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+		{TestDaemon3, TestNode3, TestIP3},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	engineImage.Status.NodeDeploymentMap[TestNode3] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create 3 Longhorn nodes
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node3 := newNode(TestNode3, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	for _, node := range []*longhorn.Node{node1, node2, node3} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+		knode := newKubernetesNode(node.Name, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+		{TestInstanceManagerName + "-" + TestNode3, TestOwnerID3, TestNode3, TestIP3},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Create settings with least-effort
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceLeastEffort),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Create volume with 3 replicas evenly distributed: 1 per node
+	volume := newVolume(TestVolumeName, 3)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica2 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+	replica3 := newReplicaForVolume(volume, engine, TestNode3, TestDiskID1)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	// When balanced (1 replica per node), no replenishment should be needed
+	replenishCount, hardNodeAffinity := vc.getReplenishReplicasCount(volume, replicas, engine)
+
+	c.Assert(replenishCount, Equals, 0,
+		Commentf("Expected replenishCount=0 when replicas are already balanced"))
+	c.Assert(hardNodeAffinity, Equals, "",
+		Commentf("Expected empty hardNodeAffinity when no rebalance is needed"))
+}
+
+// TestAutoBalanceNoTargetNode verifies that when auto-balance detects an
+// imbalance but no suitable target node exists (e.g., all nodes already have
+// replicas), getReplenishReplicasCount returns 0 instead of returning
+// adjustCount > 0 with an empty hardNodeAffinity. Before the fix, it would
+// return (adjustCount, ""), triggering a pointless rebuild-cleanup loop.
+func (s *TestSuite) TestAutoBalanceNoTargetNode(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods for 2 nodes only
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Engine image deployed on 2 nodes
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create 2 Longhorn nodes (only 2 nodes available)
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	for _, node := range []*longhorn.Node{node1, node2} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+		knode := newKubernetesNode(node.Name, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Settings with best-effort
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceBestEffort),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Volume with 3 replicas but only 2 nodes: 2 on node1, 1 on node2
+	// All nodes already have replicas, so there's no unused node to target
+	volume := newVolume(TestVolumeName, 3)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica2 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1) // 2nd on node1
+	replica3 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	// After the fix, when there is no unused node to target, best-effort should not trigger rebalance.
+	//
+	// Before the fix, `getReplicaCountForAutoBalanceLeastEffort` or `getReplicaCountForAutoBalanceBestEffort`
+	// in `getReplenishReplicasCount` could return (adjustCount > 0, hardNodeAffinity = "")
+	// which may trigger a pointless rebuild.
+	replenishCount, hardNodeAffinity := vc.getReplenishReplicasCount(volume, replicas, engine)
+	c.Assert(replenishCount, Equals, 0,
+		Commentf("Expected replenishCount=0 when all nodes already have replicas"))
+	c.Assert(hardNodeAffinity, Equals, "",
+		Commentf("Expected empty hardNodeAffinity when no target node is available"))
+}

--- a/controller/volume_autobalance_test.go
+++ b/controller/volume_autobalance_test.go
@@ -1118,3 +1118,219 @@ func (s *TestSuite) TestDataLocalityCleanupWhenEngineNodeOvercrowded(c *C) {
 	c.Assert(replicas[replica2.Name], NotNil,
 		Commentf("replica2 (local on engine Node1) should have been preserved"))
 }
+
+// TestAutoBalanceCountingConsistency verifies that the add side
+// (getReplenishReplicasCount / getReplicaCountForAutoBalanceNode) and cleanup
+// side (getPreferredOvercrowdedReplicaCandidatesForDeletion) agree on replica
+// counts when a healthy+active replica is in a non-Running state (e.g.,
+// Starting).
+//
+// One Example Scenario:
+//   - Node A: 2 replicas (r1 Running + r2 Starting but healthy+active)
+//   - Node B: 1 replica (r3 Running)
+//   - Node C: empty
+//
+// Before the fix:
+//   - Add side used `CurrentState == Running` → undercounted Node A (saw 1)
+//   - Cleanup side counted ALL replicas → overcounted Node A (saw 2+)
+//   - This mismatch caused the add side to think Node A was balanced while the
+//     cleanup side thought it was overcrowded, contributing to the loop.
+//
+// After the fix, both sides use `isHealthyAndActiveReplica`, so they agree:
+//   - Add side: A=2, B=1, C=0 → imbalanced, adjustCount=1, target=C
+//   - Cleanup side: A is overcrowded (2 replicas) → candidates include r1,r2
+func (s *TestSuite) TestAutoBalanceCountingConsistency(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()
+	lhClient := lhfake.NewSimpleClientset()
+	extensionsClient := apiextensionsfake.NewSimpleClientset()
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods for 3 nodes
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+		{TestDaemon3, TestNode3, TestIP3},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	engineImage.Status.NodeDeploymentMap[TestNode3] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create 3 Longhorn nodes
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node3 := newNode(TestNode3, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	for _, node := range []*longhorn.Node{node1, node2, node3} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+		knode := newKubernetesNode(node.Name, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+		{TestInstanceManagerName + "-" + TestNode3, TestOwnerID3, TestNode3, TestIP3},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Settings: least-effort auto-balance
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceLeastEffort),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Volume with 3 replicas:
+	//   r1 on Node1 (healthy+active, Running)
+	//   r2 on Node1 (healthy+active, Starting — NOT Running)
+	//   r3 on Node2 (healthy+active, Running)
+	//   Node3 is empty
+	volume := newVolume(TestVolumeName, 3)
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica2 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1) // 2nd on same node
+	replica3 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	// Key: set r2 to Starting (healthy+active but NOT Running).
+	// Before the fix, the add side (Running filter) would skip r2 and see
+	// Node1 as having only 1 replica → balanced with Node2 (1 each).
+	// After the fix, both sides count r2 → Node1 has 2, Node2 has 1.
+	replica2.Status.CurrentState = longhorn.InstanceStateStarting
+
+	// ---- Verify add side ----
+	// getReplenishReplicasCount should see Node1=2 (r1+r2), Node2=1, Node3=0
+	// and request 1 new replica targeting Node3.
+	replenishCount, hardNodeAffinity := vc.getReplenishReplicasCount(volume, replicas, engine)
+
+	c.Assert(replenishCount, Equals, 1,
+		Commentf("Add side should detect imbalance: Node1=2, Node2=1, Node3=0"))
+	c.Assert(hardNodeAffinity, Equals, TestNode3,
+		Commentf("Add side should target the empty node (Node3)"))
+
+	// ---- Verify cleanup side ----
+	// getPreferredOvercrowdedReplicaCandidatesForDeletion should see Node1
+	// as overcrowded (2 replicas including the Starting one).
+	candidates, err := vc.getPreferredOvercrowdedReplicaCandidatesForDeletion(replicas)
+	c.Assert(err, IsNil)
+
+	// Node1 has 2 replicas → overcrowded → candidates should include r1 and r2
+	candidateSet := make(map[string]bool, len(candidates))
+	for _, name := range candidates {
+		candidateSet[name] = true
+	}
+	c.Assert(candidateSet[replica1.Name], Equals, true,
+		Commentf("Cleanup side should include r1 (on overcrowded Node1) in candidates"))
+	c.Assert(candidateSet[replica2.Name], Equals, true,
+		Commentf("Cleanup side should include r2 (Starting but healthy+active, on overcrowded Node1) in candidates"))
+	c.Assert(candidateSet[replica3.Name], Equals, false,
+		Commentf("Cleanup side should NOT include r3 (sole replica on Node2) in candidates"))
+
+	// ---- Verify failed replicas are excluded from both sides ----
+	// Add a failed replica on Node2 to verify it's not counted by either side.
+	failedReplica := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+	failedReplica.Spec.FailedAt = getTestNow()
+	failedReplica.Status.CurrentState = longhorn.InstanceStateStopped
+	replicas[failedReplica.Name] = failedReplica
+
+	// Add side: failed replica should NOT be counted → Node2 still has 1
+	replenishCount2, hardNodeAffinity2 := vc.getReplenishReplicasCount(volume, replicas, engine)
+	c.Assert(replenishCount2, Equals, 1,
+		Commentf("Add side should still detect same imbalance after adding failed replica"))
+	c.Assert(hardNodeAffinity2, Equals, TestNode3,
+		Commentf("Add side should still target Node3 after adding failed replica"))
+
+	// Cleanup side: failed replica should NOT be counted → Node2 still has 1
+	candidates2, err := vc.getPreferredOvercrowdedReplicaCandidatesForDeletion(replicas)
+	c.Assert(err, IsNil)
+	candidateSet2 := make(map[string]bool, len(candidates2))
+	for _, name := range candidates2 {
+		candidateSet2[name] = true
+	}
+	c.Assert(candidateSet2[failedReplica.Name], Equals, false,
+		Commentf("Cleanup side should NOT include the failed replica in candidates"))
+}

--- a/controller/volume_autobalance_test.go
+++ b/controller/volume_autobalance_test.go
@@ -931,3 +931,190 @@ func setKubeNodeReadyTransitionTime(node *corev1.Node, t metav1.Time) {
 		}
 	}
 }
+
+// TestDataLocalityCleanupWhenEngineNodeOvercrowded verifies that
+// cleanupDataLocalityReplicas correctly deletes a non-local replica even when
+// the engine node is the most overcrowded node.
+//
+// Before the fix, cleanupDataLocalityReplicas passed all replicas (including
+// local ones) to getPreferredOvercrowdedReplicaCandidatesForDeletion. When the
+// engine node was overcrowded, the candidate list contained only local replicas
+// which the deletion loop skipped — resulting in no deletion at all.
+//
+// Setup:
+//
+//	Engine on Node1.
+//	Node1: r1, r2 (both local, overcrowded)
+//	Node2: r3 (non-local)
+//	NumberOfReplicas = 2, DataLocality = best-effort
+//	3 healthy replicas → 1 extra
+//
+// Expected: r3 (non-local) is deleted.
+func (s *TestSuite) TestDataLocalityCleanupWhenEngineNodeOvercrowded(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()
+	lhClient := lhfake.NewSimpleClientset()
+	extensionsClient := apiextensionsfake.NewSimpleClientset()
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	knIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	// Create daemon pods
+	for _, dp := range []struct {
+		name, node, ip string
+	}{
+		{TestDaemon1, TestNode1, TestIP1},
+		{TestDaemon2, TestNode2, TestIP2},
+	} {
+		d := newDaemonPod(corev1.PodRunning, dp.name, TestNamespace, dp.node, dp.ip, nil)
+		p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), d, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = pIndexer.Add(p)
+		c.Assert(err, IsNil)
+	}
+
+	// Create engine image
+	engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+	engineImage.Status.NodeDeploymentMap[TestNode1] = true
+	engineImage.Status.NodeDeploymentMap[TestNode2] = true
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+	err = eiIndexer.Add(ei)
+	c.Assert(err, IsNil)
+
+	// Create Longhorn nodes
+	node1 := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	for _, node := range []*longhorn.Node{node1, node2} {
+		n, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nIndexer.Add(n)
+		c.Assert(err, IsNil)
+		knode := newKubernetesNode(node.Name, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kn, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), knode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = knIndexer.Add(kn)
+		c.Assert(err, IsNil)
+	}
+
+	// Create instance managers
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	for _, imInfo := range []struct {
+		name, ownerID, nodeID, ip string
+	}{
+		{TestInstanceManagerName + "-" + TestNode1, TestOwnerID1, TestNode1, TestIP1},
+		{TestInstanceManagerName + "-" + TestNode2, TestOwnerID2, TestNode2, TestIP2},
+	} {
+		im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(
+			context.TODO(),
+			newInstanceManager(imInfo.name, longhorn.InstanceManagerStateRunning, imInfo.ownerID, imInfo.nodeID, imInfo.ip,
+				map[string]longhorn.InstanceProcess{}, map[string]longhorn.InstanceProcess{},
+				longhorn.DataEngineTypeV1, TestInstanceManagerImage, false),
+			metav1.CreateOptions{},
+		)
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+	}
+
+	// Settings
+	for name, value := range map[string]string{
+		string(types.SettingNameDefaultEngineImage):               TestEngineImage,
+		string(types.SettingNameDefaultInstanceManagerImage):      TestInstanceManagerImage,
+		string(types.SettingNameReplicaAutoBalance):               string(longhorn.ReplicaAutoBalanceDisabled),
+		string(types.SettingNameReplicaReplenishmentWaitInterval): "0",
+	} {
+		s := initSettingsNameValue(name, value)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Volume with DataLocality = best-effort, 2 replicas desired.
+	// Engine on Node1, which has 2 replicas (overcrowded). Node2 has 1.
+	volume := newVolume(TestVolumeName, 2)
+	volume.Spec.DataLocality = longhorn.DataLocalityBestEffort
+	volume.Status.State = longhorn.VolumeStateAttached
+	volume.Status.CurrentNodeID = TestNode1
+	volume.Status.Robustness = longhorn.VolumeRobustnessHealthy
+	volume.Status.CurrentImage = TestEngineImage
+
+	engine := newEngineForVolume(volume)
+	engine.Spec.NodeID = TestNode1
+	engine.Spec.DesireState = longhorn.InstanceStateRunning
+	engine.Status.CurrentState = longhorn.InstanceStateRunning
+	engine.Status.OwnerID = TestNode1
+	engine.Status.IP = TestIP1
+	engine.Status.StorageIP = TestIP1
+	engine.Status.Port = 9501
+	engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+	// r1, r2 on Node1 (engine node, overcrowded), r3 on Node2 (non-local)
+	replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica2 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+	replica3 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+
+	replicas := map[string]*longhorn.Replica{
+		replica1.Name: replica1,
+		replica2.Name: replica2,
+		replica3.Name: replica3,
+	}
+
+	for name, r := range replicas {
+		r.Spec.HealthyAt = getTestNow()
+		r.Spec.LastHealthyAt = r.Spec.HealthyAt
+		r.Status.CurrentState = longhorn.InstanceStateRunning
+		r.Status.IP = randomIP()
+		r.Status.StorageIP = r.Status.IP
+		r.Status.Port = randomPort()
+		r.Spec.DesireState = longhorn.InstanceStateRunning
+		engine.Spec.ReplicaAddressMap[name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+		engine.Status.ReplicaModeMap[name] = longhorn.ReplicaModeRW
+	}
+
+	replica1.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode1
+	replica2.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode1
+	replica3.Status.InstanceManagerName = TestInstanceManagerName + "-" + TestNode2
+
+	// Create replicas in the datastore for deleteReplica to work
+	rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
+	for _, r := range replicas {
+		rObj, err := lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), r, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = rIndexer.Add(rObj)
+		c.Assert(err, IsNil)
+	}
+
+	// Call cleanupDataLocalityReplicas.
+	// hasLocalReplicaOnSameNodeAsEngine is true (r1 and r2 are on engine node).
+	// The function should delete r3 (the non-local replica on Node2).
+	//
+	// Bug scenario (if passing rs instead of nonLocalReplicaMap):
+	//   getPreferredOvercrowdedReplicaCandidatesForDeletion(rs) sees Node1
+	//   with 2 replicas → returns [r1, r2] → both on engine node → deletion
+	//   loop skips both → cleaned=false. WRONG.
+	cleaned, err := vc.cleanupDataLocalityReplicas(volume, engine, replicas)
+	c.Assert(err, IsNil)
+	c.Assert(cleaned, Equals, true,
+		Commentf("cleanupDataLocalityReplicas should have deleted the non-local replica"))
+
+	// r3 (non-local, on Node2) should be deleted
+	c.Assert(replicas[replica3.Name], IsNil,
+		Commentf("replica3 (non-local on Node2) should have been deleted"))
+
+	// r1 and r2 (local, on engine Node1) should be preserved
+	c.Assert(replicas[replica1.Name], NotNil,
+		Commentf("replica1 (local on engine Node1) should have been preserved"))
+	c.Assert(replicas[replica2.Name], NotNil,
+		Commentf("replica2 (local on engine Node1) should have been preserved"))
+}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2650,7 +2650,7 @@ func getRebuildingReplicaCount(e *longhorn.Engine) int {
 type replicaAutoBalanceCount func(*longhorn.Volume, *longhorn.Engine, map[string]*longhorn.Replica) (int, map[string][]string, error)
 
 func (c *VolumeController) getReplicaCountForAutoBalanceLeastEffort(v *longhorn.Volume, e *longhorn.Engine,
-	rs map[string]*longhorn.Replica, fnCount replicaAutoBalanceCount) int {
+	rs map[string]*longhorn.Replica, fnCount replicaAutoBalanceCount) (int, map[string][]string) {
 	log := getLoggerForVolume(c.logger, v).WithField("replicaAutoBalanceOption", longhorn.ReplicaAutoBalanceLeastEffort)
 
 	var err error
@@ -2669,23 +2669,24 @@ func (c *VolumeController) getReplicaCountForAutoBalanceLeastEffort(v *longhorn.
 		string(longhorn.ReplicaAutoBalanceBestEffort),
 	}
 	if !util.Contains(enabled, string(setting)) {
-		return 0
+		return 0, nil
 	}
 
 	if v.Status.Robustness != longhorn.VolumeRobustnessHealthy {
 		if v.Status.State != longhorn.VolumeStateDetached {
 			log.Warnf("Failed to auto-balance volume in %s state", v.Status.Robustness)
 		}
-		return 0
+		return 0, nil
 	}
 
 	var adjustCount int
-	adjustCount, _, err = fnCount(v, e, rs)
+	var extraRNames map[string][]string
+	adjustCount, extraRNames, err = fnCount(v, e, rs)
 	if err != nil {
-		return 0
+		return 0, nil
 	}
 	log.Debugf("Found %v replica candidate for auto-balance", adjustCount)
-	return adjustCount
+	return adjustCount, extraRNames
 }
 
 func (c *VolumeController) getReplicaCountForAutoBalanceBestEffort(v *longhorn.Volume, e *longhorn.Engine,
@@ -2965,6 +2966,20 @@ func (c *VolumeController) getReplicaCountForAutoBalanceZone(v *longhorn.Volume,
 	readyNodes, err := c.listReadySchedulableAndScheduledNodesRO(v, rs, log)
 	if err != nil {
 		return 0, nil, err
+	}
+
+	// Zone-level balancing is meaningless when no nodes have zone info.
+	// All replicas would land in zone "" and always appear balanced.
+	hasZone := false
+	for _, node := range readyNodes {
+		if node.Status.Zone != "" {
+			hasZone = true
+			break
+		}
+	}
+	if !hasZone {
+		log.Debugf("Skipping zone auto-balance: no nodes have zone information")
+		return 0, nil, nil
 	}
 
 	var usedZones []string
@@ -3251,11 +3266,25 @@ func (c *VolumeController) getReplenishReplicasCount(v *longhorn.Volume, rs map[
 	case v.Spec.NumberOfReplicas > usableCount:
 		return v.Spec.NumberOfReplicas - usableCount, ""
 	case v.Spec.NumberOfReplicas == usableCount:
-		if adjustCount := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone); adjustCount != 0 {
-			return adjustCount, ""
+		if adjustCount, zoneExtraRs := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone); adjustCount != 0 {
+			// zoneExtraRs keys are zones that already have running replicas.
+			// Derive unused zones by finding zones of ready nodes that are not in zoneExtraRs.
+			unusedZones := c.getUnusedZonesForAutoBalance(v, zoneExtraRs)
+			nCandidates := c.getNodeCandidatesForAutoBalanceZone(v, e, rs, unusedZones)
+			if len(nCandidates) != 0 {
+				return adjustCount, nCandidates[0]
+			}
+			// Do not trigger rebalance without a target node.
+			return 0, ""
 		}
-		if adjustCount := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceNode); adjustCount != 0 {
-			return adjustCount, ""
+		if adjustCount, nodeExtraRs := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceNode); adjustCount != 0 {
+			// Find unused ready nodes not already in nodeExtraRs as target candidates.
+			nCandidate := c.getNodeCandidateForAutoBalanceNode(v, rs, nodeExtraRs)
+			if nCandidate != "" {
+				return adjustCount, nCandidate
+			}
+			// Do not trigger rebalance without a target node.
+			return 0, ""
 		}
 
 		var nCandidates []string
@@ -3271,7 +3300,10 @@ func (c *VolumeController) getReplenishReplicasCount(v *longhorn.Volume, rs map[
 			return adjustCount, nCandidates[0]
 		}
 
-		return adjustCount, ""
+		// Do not trigger rebalance without a target node, as the scheduler may
+		// place the new replica on an already-overcrowded node, resulting in a
+		// rebuild-cleanup loop.
+		return 0, ""
 	}
 	return 0, ""
 }
@@ -3349,6 +3381,95 @@ func (c *VolumeController) getNodeCandidatesForAutoBalanceZone(v *longhorn.Volum
 		log.Infof("Found node candidates: %v ", candidateNames)
 	}
 	return candidateNames
+}
+
+// getNodeCandidateForAutoBalanceNode returns a ready, schedulable node that
+// does not already have a running replica for this volume (i.e., not in
+// nodeExtraRs). This is used by least-effort auto-balance to provide a
+// hardNodeAffinity so the new replica is placed on an unused node instead of
+// an already-overcrowded one.
+func (c *VolumeController) getNodeCandidateForAutoBalanceNode(v *longhorn.Volume, rs map[string]*longhorn.Replica, nodeExtraRs map[string][]string) string {
+	log := getLoggerForVolume(c.logger, v).WithFields(
+		logrus.Fields{
+			"replicaAutoBalanceOption": longhorn.ReplicaAutoBalanceLeastEffort,
+			"replicaAutoBalanceType":   "node",
+		},
+	)
+
+	readyNodes, err := c.ds.ListReadyAndSchedulableNodesRO()
+	if err != nil {
+		log.WithError(err).Warn("Failed to list ready nodes for auto-balance node candidate")
+		return ""
+	}
+
+	ei := &longhorn.EngineImage{}
+	if types.IsDataEngineV1(v.Spec.DataEngine) {
+		ei, err = c.getEngineImageRO(v.Status.CurrentImage)
+		if err != nil {
+			log.WithError(err).Warn("Failed to get engine image for auto-balance node candidate")
+			return ""
+		}
+	}
+
+	for nName, n := range readyNodes {
+		// Skip nodes that already have a running replica for this volume.
+		if _, exists := nodeExtraRs[nName]; exists {
+			continue
+		}
+
+		if !n.Spec.AllowScheduling {
+			continue
+		}
+
+		if isReady, _ := c.ds.CheckDataEngineImageReadiness(ei.Spec.Image, v.Spec.DataEngine, nName); !isReady {
+			continue
+		}
+
+		// Also skip nodes that have any replica (including non-running) for this volume,
+		// to avoid placing a new replica on a node with a rebuilding or starting replica.
+		hasReplica := false
+		for _, r := range rs {
+			if r.Spec.NodeID == nName {
+				hasReplica = true
+				break
+			}
+		}
+		if hasReplica {
+			continue
+		}
+
+		log.Infof("Found node candidate %v for auto-balance", nName)
+		return nName
+	}
+
+	log.Debug("No unused node candidate found for auto-balance")
+	return ""
+}
+
+// getUnusedZonesForAutoBalance returns zones of ready schedulable nodes that
+// are NOT already in usedZones (zones with existing replicas).
+func (c *VolumeController) getUnusedZonesForAutoBalance(v *longhorn.Volume, usedZones map[string][]string) []string {
+	log := getLoggerForVolume(c.logger, v).WithField("replicaAutoBalanceType", "zone")
+
+	readyNodes, err := c.ds.ListReadyAndSchedulableNodesRO()
+	if err != nil {
+		log.WithError(err).Warn("Failed to list ready nodes for unused zones")
+		return nil
+	}
+
+	unusedZoneSet := make(map[string]bool)
+	for _, node := range readyNodes {
+		zone := node.Status.Zone
+		if _, used := usedZones[zone]; !used {
+			unusedZoneSet[zone] = true
+		}
+	}
+
+	var unusedZones []string
+	for zone := range unusedZoneSet {
+		unusedZones = append(unusedZones, zone)
+	}
+	return unusedZones
 }
 
 func (c *VolumeController) hasEngineStatusSynced(e *longhorn.Engine, rs map[string]*longhorn.Replica) bool {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1156,7 +1156,7 @@ func (c *VolumeController) cleanupExtraHealthyReplicas(v *longhorn.Volume, e *lo
 	// existing replicas. And this causes a rebuilding loop if this new
 	// replica is for data locality.
 	// Ref: https://github.com/longhorn/longhorn/issues/4761
-	if cleaned, err = c.cleanupAutoBalancedReplicas(v, e, rs); err != nil || cleaned {
+	if cleaned, err = c.cleanupAutoBalancedReplicas(v, rs); err != nil || cleaned {
 		return err
 	}
 
@@ -1208,7 +1208,8 @@ func (c *VolumeController) cleanupEvictionRequestedReplicas(v *longhorn.Volume, 
 func (c *VolumeController) cleanupReplicaInNotReadyEnv(v *longhorn.Volume, rs map[string]*longhorn.Replica) (bool, error) {
 	log := getLoggerForVolume(c.logger, v)
 
-	// Pick up the replicas in not-ready nodes or in not-running instance manager first
+	// Pick up the replicas in not-ready nodes, in not-running instance manager,
+	// or on not-ready disks first.
 	var chosenReplica *longhorn.Replica
 	for _, r := range rs {
 		if r.Spec.NodeID == "" {
@@ -1232,6 +1233,31 @@ func (c *VolumeController) cleanupReplicaInNotReadyEnv(v *longhorn.Volume, rs ma
 			chosenReplica = rs[r.Name]
 			break
 		}
+		// Check if the replica's disk is not ready (disconnected, filesystem
+		// changed, etc.). This does NOT include disk pressure — a pressured
+		// disk still has healthy replicas, and that case is handled by step 4's
+		// storage-based sort instead.
+		node, err := c.ds.GetNodeRO(r.Spec.NodeID)
+		if err != nil {
+			return false, err
+		}
+		if node != nil {
+			for _, diskStatus := range node.Status.DiskStatus {
+				if diskStatus.DiskUUID != r.Spec.DiskID {
+					continue
+				}
+				diskReady := types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeReady)
+				if diskReady.Status != longhorn.ConditionStatusTrue {
+					log.Infof("Deleting replica %v on not-ready disk %v of node %v (reason: %v)",
+						r.Name, r.Spec.DiskID, r.Spec.NodeID, diskReady.Reason)
+					chosenReplica = rs[r.Name]
+				}
+				break
+			}
+			if chosenReplica != nil {
+				break
+			}
+		}
 	}
 
 	if chosenReplica != nil {
@@ -1243,27 +1269,42 @@ func (c *VolumeController) cleanupReplicaInNotReadyEnv(v *longhorn.Volume, rs ma
 	return false, nil
 }
 
-// cleanupReplicaInUnstableEnv uses kube node Ready transition time as a heuristic to identify replicas on recently recovered nodes, assuming the disk or node was unstable before recovery.
-func (c *VolumeController) cleanupReplicaInUnstableEnv(v *longhorn.Volume, rs map[string]*longhorn.Replica) (bool, error) {
+// getReplicaOnUnstableNode identifies a replica that sits on an "unstable"
+// node — one whose kube Ready transition time is significantly later than
+// others (>30 min gap).
+//
+// When candidates is non-nil, only replicas in that set are considered.
+// This allows step 3 of cleanupAutoBalancedReplicas to find the most recently
+// unstable replica within the overcrowded candidate list specifically, rather
+// than globally.
+//
+// Note: not-ready nodes are already handled by cleanupReplicaInNotReadyEnv
+// (step 1), which runs before this function is called.
+//
+// Returns the replica or nil if no unstable replica is found.
+func (c *VolumeController) getReplicaOnUnstableNode(v *longhorn.Volume, rs map[string]*longhorn.Replica, candidateReplicaNames []string) (*longhorn.Replica, error) {
 	log := getLoggerForVolume(c.logger, v)
 
-	// Pick up the replicas on the node that becomes ready most recently.
-	// Here we use kube node rather than Longhorn node because Longhorn node's ready condition will be affected by
-	// the corresponding longhorn-manager pod.
-	var chosenReplica, lastReadyReplica *longhorn.Replica
-	var lastReadyTransitionTime, secondLastReadyTransitionTime metav1.Time
 	nodeReplicaMap := make(map[string]*longhorn.Replica, len(rs))
 	for _, r := range rs {
 		if isHealthyAndActiveReplica(r, false) {
 			nodeReplicaMap[r.Spec.NodeID] = r
 		}
 	}
+
 	nodes, err := c.ds.ListKubeNodesRO()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
+
+	type nodeInfo struct {
+		replica        *longhorn.Replica
+		transitionTime metav1.Time
+	}
+	var infos []nodeInfo
 	for _, node := range nodes {
-		if nodeReplicaMap[node.Name] == nil {
+		r := nodeReplicaMap[node.Name]
+		if r == nil {
 			continue
 		}
 		var readyCondition corev1.NodeCondition
@@ -1279,41 +1320,72 @@ func (c *VolumeController) cleanupReplicaInUnstableEnv(v *longhorn.Volume, rs ma
 			log.Warnf("Failed to find ready condition for node %v during the replica cleanup, will skip it", node.Name)
 			continue
 		}
-		// In case of a replica being on not-ready node, chose it first.
-		if readyCondition.Status != corev1.ConditionTrue {
-			chosenReplica = nodeReplicaMap[node.Name]
-			break
-		}
+		infos = append(infos, nodeInfo{
+			replica:        r,
+			transitionTime: readyCondition.LastTransitionTime,
+		})
+	}
 
-		if readyCondition.LastTransitionTime.After(lastReadyTransitionTime.Time) {
-			lastReadyReplica = nodeReplicaMap[node.Name]
-			secondLastReadyTransitionTime = lastReadyTransitionTime
-			lastReadyTransitionTime = readyCondition.LastTransitionTime
-		} else if readyCondition.LastTransitionTime.After(secondLastReadyTransitionTime.Time) {
-			secondLastReadyTransitionTime = readyCondition.LastTransitionTime
+	var lastTime, secondLastTime metav1.Time
+	for _, info := range infos {
+		if info.transitionTime.After(lastTime.Time) {
+			secondLastTime = lastTime
+			lastTime = info.transitionTime
+		} else if info.transitionTime.After(secondLastTime.Time) {
+			secondLastTime = info.transitionTime
 		}
 	}
 
-	// If there is a node being ready recently and the transition time is 30 minutes later than others,
-	// it is likely that the disk was having issues before and just got recovered.
-	// So choose the replica in that disk for deletion.
-	if chosenReplica == nil && !lastReadyTransitionTime.IsZero() && !secondLastReadyTransitionTime.IsZero() &&
-		lastReadyTransitionTime.After(secondLastReadyTransitionTime.Add(UnstableNodeReadyTimeThreshold)) {
-		log.Infof("Deleting replica %v on node %s disk %v since its kube node ready transition time %v is over %v minutes later than others",
-			lastReadyReplica.Name, lastReadyReplica.Spec.NodeID, lastReadyReplica.Spec.DiskID, lastReadyTransitionTime.Format(time.RFC3339), UnstableNodeReadyTimeThreshold.Minutes())
-		chosenReplica = lastReadyReplica
+	if lastTime.IsZero() || secondLastTime.IsZero() ||
+		!lastTime.After(secondLastTime.Add(UnstableNodeReadyTimeThreshold)) {
+		return nil, nil
 	}
 
-	if chosenReplica != nil {
-		if err := c.deleteReplica(chosenReplica, rs); err != nil {
-			return false, err
+	var unstableCandidates map[string]bool
+	if len(candidateReplicaNames) > 0 {
+		unstableCandidates = make(map[string]bool, len(candidateReplicaNames))
+		for _, rName := range candidateReplicaNames {
+			unstableCandidates[rName] = true
 		}
-		return true, nil
 	}
-	return false, nil
+
+	var chosen *longhorn.Replica
+	var chosenTime metav1.Time
+	for _, info := range infos {
+		if !info.transitionTime.After(secondLastTime.Add(UnstableNodeReadyTimeThreshold)) {
+			continue
+		}
+		if unstableCandidates != nil && !unstableCandidates[info.replica.Name] {
+			continue
+		}
+		if chosen == nil || info.transitionTime.After(chosenTime.Time) {
+			chosen = info.replica
+			chosenTime = info.transitionTime
+		}
+	}
+
+	if chosen != nil {
+		log.Infof("Replica %v is on unstable node %s disk %v (kube node ready transition time %v is over %v minutes later than others)",
+			chosen.Name, chosen.Spec.NodeID, chosen.Spec.DiskID, chosenTime.Format(time.RFC3339), UnstableNodeReadyTimeThreshold.Minutes())
+	}
+	return chosen, nil
 }
 
-func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (bool, error) {
+// cleanupAutoBalancedReplicas deletes one extra healthy replica when the
+// volume has more healthy replicas than spec.NumberOfReplicas. It follows
+// a strict priority order to avoid conflicting with auto-balance decisions:
+//
+//  1. Delete a replica in a not-ready environment (node down, instance
+//     manager not running, or disk not ready). These replicas are on
+//     potentially failing infrastructure and are safe to remove first.
+//  2. Delete an extra replica from the most overcrowded nodes or zones.
+//  3. When there are multiple candidates for overcrowded nodes or zones,
+//     or all healthy replicas are evenly spread,
+//     prefer to delete a replica on an unstable node
+//     (whose kube Ready transition time is significantly later than others).
+//  4. If no unstable replica is found, the replica from the most overcrowded
+//     group with the least available disk storage is deleted.
+func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) (bool, error) {
 	log := getLoggerForVolume(c.logger, v).WithField("replicaAutoBalanceType", "delete")
 
 	setting := c.ds.GetAutoBalancedReplicasSetting(v, log)
@@ -1321,54 +1393,59 @@ func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, e *lo
 		return false, nil
 	}
 
-	// In case of potential regressions or unexpected behavior changes, these cleanups are available only when
-	// the auto balance setting is enabled.
+	// Step 1: Delete replicas in not-ready environment first.
 	// See https://github.com/longhorn/longhorn/issues/11730 and https://github.com/longhorn/longhorn/issues/12511
 	if cleaned, err := c.cleanupReplicaInNotReadyEnv(v, rs); err != nil || cleaned {
 		return cleaned, err
 	}
 
-	if cleaned, err := c.cleanupReplicaInUnstableEnv(v, rs); err != nil || cleaned {
-		return cleaned, err
-	}
-
-	var rNames []string
-	if setting == longhorn.ReplicaAutoBalanceBestEffort {
-		_, rNames, _ = c.getReplicaCountForAutoBalanceBestEffort(v, e, rs, c.getReplicaCountForAutoBalanceNode)
-		if len(rNames) == 0 {
-			_, rNames, _ = c.getReplicaCountForAutoBalanceBestEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone)
-		}
-	}
-
-	var err error
-	if len(rNames) == 0 {
-		rNames, err = c.getPreferredReplicaCandidatesForDeletion(rs)
-		if err != nil {
-			return false, err
-		}
-
-		log.Infof("Found replica deletion candidates %v", rNames)
-	} else {
-		log.Infof("Found replica deletion candidates %v with best-effort", rNames)
-	}
-
-	rNames, err = c.getSortedReplicasByAscendingStorageAvailable(rNames, rs)
+	// Step 2: Pick up all extra replicas from overcrowded nodes or zones if possible.
+	// When replicas are evenly spread, returns all replica names for steps 3 and 4.
+	preferredReplicaNames, err := c.getPreferredOvercrowdedReplicaCandidatesForDeletion(rs)
 	if err != nil {
 		return false, err
 	}
+	if len(preferredReplicaNames) == 0 {
+		return false, fmt.Errorf("unexpectedly found no replica candidates for deletion when checking overcrowding")
+	}
 
-	r := rs[rNames[0]]
-	log.Infof("Deleting replica %v", r.Name)
+	log.Infof("Found preferred replica deletion candidates %v with replica auto balance %v", preferredReplicaNames, setting)
+
+	// Step 3: Prefer to delete a replica on an unstable node (one whose kube Ready
+	// transition time is significantly later than others) from the candidates.
+	// The candidates can be from overcrowded nodes/zones
+	// or all healthy replicas when there is no overcrowding.
+	unstableReplica, err := c.getReplicaOnUnstableNode(v, rs, preferredReplicaNames)
+	if err != nil {
+		return false, err
+	}
+	if unstableReplica != nil {
+		log.Infof("Deleting replica %v on unstable node %v", unstableReplica.Name, unstableReplica.Spec.NodeID)
+		if err := c.deleteReplica(unstableReplica, rs); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	// Step 4: If there is no replica on unstable nodes,
+	// fallback to delete the replica on the disk with the least available storage.
+	preferredReplicaNames, err = c.getSortedReplicasByAscendingStorageAvailable(preferredReplicaNames, rs)
+	if err != nil {
+		return false, err
+	}
+	r := rs[preferredReplicaNames[0]]
+	log.Infof("Deleting replica %v on the disk with the least available storage", r.Name)
 	if err := c.deleteReplica(r, rs); err != nil {
 		return false, err
 	}
+
 	return true, nil
 }
 
 func (c *VolumeController) cleanupDataLocalityReplicas(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (bool, error) {
 	if !isDataLocalityDisabled(v) &&
 		hasLocalReplicaOnSameNodeAsEngine(e, rs) {
-		rNames, err := c.getPreferredReplicaCandidatesForDeletion(rs)
+		rNames, err := c.getPreferredOvercrowdedReplicaCandidatesForDeletion(rs)
 		if err != nil {
 			return false, err
 		}
@@ -2383,7 +2460,7 @@ func imInStartingOrRunningState(im *longhorn.InstanceManager) bool {
 		im.Status.CurrentState == longhorn.InstanceManagerStateRunning
 }
 
-func (c *VolumeController) getPreferredReplicaCandidatesForDeletion(rs map[string]*longhorn.Replica) ([]string, error) {
+func (c *VolumeController) getPreferredOvercrowdedReplicaCandidatesForDeletion(rs map[string]*longhorn.Replica) (preferred []string, err error) {
 	diskToReplicaMap := make(map[string][]string)
 	nodeToReplicaMap := make(map[string][]string)
 	zoneToReplicaMap := make(map[string][]string)
@@ -2400,37 +2477,34 @@ func (c *VolumeController) getPreferredReplicaCandidatesForDeletion(rs map[strin
 	for _, r := range rs {
 		diskToReplicaMap[r.Spec.NodeID+r.Spec.DiskID] = append(diskToReplicaMap[r.Spec.NodeID+r.Spec.DiskID], r.Name)
 		nodeToReplicaMap[r.Spec.NodeID] = append(nodeToReplicaMap[r.Spec.NodeID], r.Name)
-		if node, ok := nodeMap[r.Spec.NodeID]; ok {
+		if node, ok := nodeMap[r.Spec.NodeID]; ok && node.Status.Zone != "" {
 			zoneToReplicaMap[node.Status.Zone] = append(zoneToReplicaMap[node.Status.Zone], r.Name)
 		}
 	}
 
-	var deletionCandidates []string
-
-	// prefer to delete replicas on the same disk
-	deletionCandidates = findValueWithBiggestLength(diskToReplicaMap)
-	if len(deletionCandidates) > 1 {
-		return deletionCandidates, nil
+	// Try disk > node > zone in order of priority.
+	var maxCrowdedCount int
+	var tiedOvercrowdedNodeReplicasMap map[string][]string
+	for _, m := range []map[string][]string{diskToReplicaMap, nodeToReplicaMap, zoneToReplicaMap} {
+		// `zoneToReplicaMap` may be empty if none of the nodes have zone information.
+		// We should skip it and avoid treating all replicas as tied overcrowded candidates.
+		if len(m) == 0 {
+			continue
+		}
+		// `maxCrowdedCount == 1` means no overcrowding at this level of locality.
+		// Then, we will continue to the next loop and check the next level until we find overcrowding.
+		// If there is no overcrowding at all levels, the returned `tiedOvercrowdedNodeReplicasMap` should include all replicas.
+		maxCrowdedCount, tiedOvercrowdedNodeReplicasMap = findAllValuesWithBiggestLength(m)
+		if maxCrowdedCount > 1 {
+			break
+		}
 	}
 
-	// if all replicas are on different disks, prefer to delete replicas on the same node
-	deletionCandidates = findValueWithBiggestLength(nodeToReplicaMap)
-	if len(deletionCandidates) > 1 {
-		return deletionCandidates, nil
+	preferred = make([]string, 0, maxCrowdedCount*len(tiedOvercrowdedNodeReplicasMap))
+	for _, replicas := range tiedOvercrowdedNodeReplicasMap {
+		preferred = append(preferred, replicas...)
 	}
-
-	// if all replicas are on different nodes, prefer to delete replicas on the same zone
-	deletionCandidates = findValueWithBiggestLength(zoneToReplicaMap)
-	if len(deletionCandidates) > 1 {
-		return deletionCandidates, nil
-	}
-
-	// if all replicas are on different zones, return all replicas' names in the input RS
-	deletionCandidates = make([]string, 0, len(rs))
-	for rName := range rs {
-		deletionCandidates = append(deletionCandidates, rName)
-	}
-	return deletionCandidates, nil
+	return preferred, nil
 }
 
 // getSortedReplicasByAscendingStorageAvailable retrieves a sorted list of replica names
@@ -2491,14 +2565,25 @@ func (c *VolumeController) getSortedReplicasByAscendingStorageAvailable(replicaC
 	return sortedReplicas, nil
 }
 
-func findValueWithBiggestLength(m map[string][]string) []string {
-	targetKey, currentMax := "", 0
-	for k, v := range m {
-		if len(v) > currentMax {
-			targetKey, currentMax = k, len(v)
+// findAllValuesWithBiggestLength returns a list of lists from the input list map that are
+// tied at the maximum length.
+func findAllValuesWithBiggestLength(m map[string][]string) (maxLength int, tiedBiggestListMap map[string][]string) {
+	for _, v := range m {
+		if len(v) > maxLength {
+			maxLength = len(v)
 		}
 	}
-	return m[targetKey]
+	if maxLength < 1 {
+		return 0, nil
+	}
+
+	tiedBiggestListMap = make(map[string][]string)
+	for k, v := range m {
+		if len(v) == maxLength {
+			tiedBiggestListMap[k] = v
+		}
+	}
+	return maxLength, tiedBiggestListMap
 }
 
 func isDataLocalityBestEffort(v *longhorn.Volume) bool {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1443,28 +1443,39 @@ func (c *VolumeController) cleanupAutoBalancedReplicas(v *longhorn.Volume, rs ma
 }
 
 func (c *VolumeController) cleanupDataLocalityReplicas(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (bool, error) {
-	if !isDataLocalityDisabled(v) &&
-		hasLocalReplicaOnSameNodeAsEngine(e, rs) {
-		rNames, err := c.getPreferredOvercrowdedReplicaCandidatesForDeletion(rs)
-		if err != nil {
-			return false, err
-		}
+	if isDataLocalityDisabled(v) || !hasLocalReplicaOnSameNodeAsEngine(e, rs) {
+		return false, nil
+	}
 
-		// Randomly delete extra non-local healthy replicas in the preferred candidate list rNames
-		// Sometime cleanupExtraHealthyReplicas() is called more than once with the same input (v,e,rs).
-		// To make the deleting operation idempotent and prevent deleting more replica than needed,
-		// we always delete the replica with the smallest name.
-		sort.Strings(rNames)
-		for _, rName := range rNames {
-			r := rs[rName]
-			if r.Spec.NodeID != e.Spec.NodeID {
-				if err := c.deleteReplica(r, rs); err != nil {
-					return false, err
-				}
-				return true, nil
-			}
+	// Only consider non-local replicas for deletion. The overcrowding
+	// analysis must exclude the local (engine-node) replicas, otherwise
+	// the engine node itself may be the most overcrowded group — yielding
+	// all-local candidates that the deletion loop would skip entirely.
+	nonLocalReplicaMap := make(map[string]*longhorn.Replica)
+	for _, r := range rs {
+		if r.Spec.NodeID != e.Spec.NodeID && isHealthyAndActiveReplica(r, false) {
+			nonLocalReplicaMap[r.Name] = r
 		}
 	}
+	rNames, err := c.getPreferredOvercrowdedReplicaCandidatesForDeletion(nonLocalReplicaMap)
+	if err != nil {
+		return false, err
+	}
+
+	// Delete the non-local replica with the smallest name for idempotency.
+	// cleanupExtraHealthyReplicas() can be called more than once with the
+	// same input, so a deterministic pick prevents deleting more than needed.
+	sort.Strings(rNames)
+	for _, rName := range rNames {
+		r := rs[rName]
+		if r.Spec.NodeID != e.Spec.NodeID {
+			if err := c.deleteReplica(r, rs); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+
 	return false, nil
 }
 

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2485,7 +2485,14 @@ func (c *VolumeController) getPreferredOvercrowdedReplicaCandidatesForDeletion(r
 		nodeMap[node.Name] = node
 	}
 
+	// Only consider healthy and active replicas for the overcrowding
+	// analysis. Failed/rebuilding/inactive replicas are handled by other
+	// cleanup paths (e.g. cleanupCorruptedOrStaleReplicas) and should not
+	// inflate a node's replica count here.
 	for _, r := range rs {
+		if !isHealthyAndActiveReplica(r, false) {
+			continue
+		}
 		diskToReplicaMap[r.Spec.NodeID+r.Spec.DiskID] = append(diskToReplicaMap[r.Spec.NodeID+r.Spec.DiskID], r.Name)
 		nodeToReplicaMap[r.Spec.NodeID] = append(nodeToReplicaMap[r.Spec.NodeID], r.Name)
 		if node, ok := nodeMap[r.Spec.NodeID]; ok && node.Status.Zone != "" {
@@ -3096,7 +3103,7 @@ func (c *VolumeController) getReplicaCountForAutoBalanceZone(v *longhorn.Volume,
 		}
 	}
 	for _, r := range rs {
-		if r.Status.CurrentState != longhorn.InstanceStateRunning {
+		if !isHealthyAndActiveReplica(r, false) {
 			continue
 		}
 
@@ -3251,7 +3258,7 @@ func (c *VolumeController) getReplicaCountForAutoBalanceNode(v *longhorn.Volume,
 
 	nodeExtraRs := make(map[string][]string)
 	for _, r := range rs {
-		if r.Status.CurrentState != longhorn.InstanceStateRunning {
+		if !isHealthyAndActiveReplica(r, false) {
 			continue
 		}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/12926

#### What this PR does / why we need it:

# Root Cause Analysis: Healthy Volume Stuck in Rebuild-Cleanup Loop with Replica Auto Balance

## Loop Scenario:

1. Auto-balance detects imbalance → creates a new replica (without targeting a specific node)
2. Replica rebuilds successfully → volume has N+1 healthy replicas
3. Cleanup deletes a replica — but potentially the **wrong** one (including the newly added one)
4. Volume returns to the original imbalanced state → goto step 1

---

## The Bug1: `getReplicaCountForAutoBalanceLeastEffort` does not provide node affinity

```go
// volume_controller.go:3253-3258
case v.Spec.NumberOfReplicas == usableCount:
    if adjustCount := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone); adjustCount != 0 {
        return adjustCount, ""   // ← BUG: returns hardNodeAffinity = ""
    }
    if adjustCount := c.getReplicaCountForAutoBalanceLeastEffort(v, e, rs, c.getReplicaCountForAutoBalanceNode); adjustCount != 0 {
        return adjustCount, ""   // ← BUG: returns hardNodeAffinity = ""
    }
```

When `least-effort` detects an imbalance (e.g., 2 replicas on node A, 1 on node B, node C is empty), it returns `adjustCount=1` but **`hardNodeAffinity=""`** — meaning the new replica has no node placement constraint. The scheduler may place it on any node, including the already-overcrowded node A.

### Contrast with `best-effort` (line 3262–3274):

```go
// volume_controller.go:3262-3274
adjustCount, _, nCandidates := c.getReplicaCountForAutoBalanceBestEffort(v, e, rs, c.getReplicaCountForAutoBalanceNode)
if adjustCount == 0 {
    adjustCount, _, zCandidates := c.getReplicaCountForAutoBalanceBestEffort(v, e, rs, c.getReplicaCountForAutoBalanceZone)
    if adjustCount != 0 {
        nCandidates = c.getNodeCandidatesForAutoBalanceZone(v, e, rs, zCandidates)
    }
}
if adjustCount != 0 && len(nCandidates) != 0 {
    return adjustCount, nCandidates[0]   // ← Correctly uses node affinity
}

return adjustCount, ""   // ← BUG: Same problem when nCandidates is empty
```

`best-effort` **tries** to provide a target node via `nCandidates[0]`, but when `nCandidates` is empty (line 3274), it falls back to returning `adjustCount > 0` with `hardNodeAffinity = ""` — creating the same loop potential.

---

## The Bug2: Counting Mismatch Between Add and Cleanup

### Add side: `getReplicaCountForAutoBalanceNode` (line 3141–3158)
Only counts **`Running`** replicas:
```go
if r.Status.CurrentState != longhorn.InstanceStateRunning {
    continue
}
```

### Cleanup side: `getPreferredReplicaCandidatesForDeletion` (line 2400–2406)  
Counts **ALL** replicas (including non-running, rebuilding, failed):
```go
for _, r := range rs {
    diskToReplicaMap[r.Spec.NodeID+r.Spec.DiskID] = append(...)
    nodeToReplicaMap[r.Spec.NodeID] = append(...)
    ...
}
```

This means the "add" side may see node A as having 1 Running replica (imbalanced), while the "cleanup" side sees node A as having 2 replicas (including a non-running one), leading to different decisions about which node is overcrowded.

---

## The Bug3: `cleanupReplicaInUnstableEnv` cannot handle one node with multiple replicas

```go
    nodeReplicaMap := make(map[string]*longhorn.Replica, len(rs))
    for _, r := range rs {
        if isHealthyAndActiveReplica(r, false) {
            nodeReplicaMap[r.Spec.NodeID] = r
        }
    }
```


#### Special notes for your reviewer:

#### Additional documentation or context
