### PR TITLE
fix(engine): verify completed rebuild to recover WO replica stuck

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -972,6 +972,11 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		}
 		engine.Status.RebuildStatus = rebuildStatus
 
+		// If a rebuild completed while the gRPC connection to the sync agent was interrupted,
+		// reloadAndVerify is never called and the replica stays in WO mode indefinitely.
+		// Detect this case and call ReplicaRebuildVerify to transition the replica to RW.
+		m.verifyCompletedRebuild(engine, addressReplicaMap, rebuildStatus, engineClientProxy)
+
 		// It's meaningless to sync the trim related field for old engines or engines in old engine instance managers
 		if cliAPIVersion >= 7 && im.Status.APIVersion >= 3 {
 			// Check and correct flag UnmapMarkSnapChainRemoved for the engine and replicas
@@ -1177,6 +1182,33 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	}
 
 	return nil
+}
+
+// verifyCompletedRebuild detects replicas that finished rebuilding while the gRPC connection to the
+// sync agent was interrupted. In that case, reloadAndVerify is never called by startRebuilding and
+// the replica stays in WO mode indefinitely. We call ReplicaRebuildVerify here to transition it to RW.
+func (m *EngineMonitor) verifyCompletedRebuild(engine *longhorn.Engine, addressReplicaMap map[string]string,
+	rebuildStatus map[string]*longhorn.RebuildStatus, engineClientProxy engineapi.EngineClientProxy) {
+	for url, status := range rebuildStatus {
+		if status == nil || status.IsRebuilding || status.State != engineapi.ProcessStateComplete {
+			continue
+		}
+
+		replicaName := addressReplicaMap[engineapi.GetAddressFromBackendReplicaURL(url)]
+		if replicaName == "" {
+			continue
+		}
+
+		mode, exists := engine.Status.ReplicaModeMap[replicaName]
+		if !exists || mode != longhorn.ReplicaModeWO {
+			continue
+		}
+
+		m.logger.Infof("Replica %v completed rebuilding but is still in WO mode, calling ReplicaRebuildVerify", replicaName)
+		if err := engineClientProxy.ReplicaRebuildVerify(engine, replicaName, url); err != nil {
+			m.logger.WithError(err).Warnf("Failed to verify completed rebuild for replica %v, will retry on next poll", replicaName)
+		}
+	}
 }
 
 func (m *EngineMonitor) checkAndApplyRebuildQoS(engine *longhorn.Engine, engineClientProxy engineapi.EngineClientProxy, rebuildStatus map[string]*longhorn.RebuildStatus) error {

--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -1,22 +1,37 @@
 package controller
 
 import (
-	"fmt"
 	"io"
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	etypes "github.com/longhorn/longhorn-engine/pkg/types"
+	"github.com/longhorn/longhorn-manager/engineapi"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/util"
 )
 
-func TestNeedStatusUpdate(t *testing.T) {
-	assert := require.New(t)
+// mockEngineClientProxy wraps EngineSimulator and overrides ReplicaRebuildVerify for test control.
+type mockEngineClientProxy struct {
+	*engineapi.EngineSimulator
+	verifyErr    error
+	verifyCalled []string // replica names passed to ReplicaRebuildVerify
+}
 
+var _ engineapi.EngineClientProxy = (*mockEngineClientProxy)(nil)
+
+func (m *mockEngineClientProxy) Close() {}
+
+func (m *mockEngineClientProxy) ReplicaRebuildVerify(_ *longhorn.Engine, replicaName, _ string) error {
+	m.verifyCalled = append(m.verifyCalled, replicaName)
+	return m.verifyErr
+}
+
+func TestNeedStatusUpdate(t *testing.T) {
 	newMonitor := func() *EngineMonitor {
 		logger := logrus.New()
 		logger.Out = io.Discard
@@ -126,9 +141,97 @@ func TestNeedStatusUpdate(t *testing.T) {
 	tests["size update smaller than threshold, 150 GiB volume"] = tc
 
 	for name, tc := range tests {
-		fmt.Printf("testing %v\n", name)
-		needStatusUpdate, rateLimited := tc.monitor.needStatusUpdate(tc.existingEngine, tc.engine)
-		assert.Equal(tc.expectNeedStatusUpdate, needStatusUpdate, "needStatusUpdate")
-		assert.Equal(tc.expectRateLimited, rateLimited, "rateLimited")
+		t.Run(name, func(t *testing.T) {
+			assert := require.New(t)
+			needStatusUpdate, rateLimited := tc.monitor.needStatusUpdate(tc.existingEngine, tc.engine)
+			assert.Equal(tc.expectNeedStatusUpdate, needStatusUpdate, "needStatusUpdate")
+			assert.Equal(tc.expectRateLimited, rateLimited, "rateLimited")
+		})
+	}
+}
+
+func TestVerifyCompletedRebuild(t *testing.T) {
+	newMonitor := func() *EngineMonitor {
+		logger := logrus.New()
+		logger.Out = io.Discard
+		return &EngineMonitor{logger: logger}
+	}
+
+	const (
+		replicaRW = "replica-rw"
+		replicaWO = "replica-wo"
+		addrRW    = "10.0.0.1:10000"
+		addrWO    = "10.0.0.2:10000"
+		urlRW     = "tcp://" + addrRW
+		urlWO     = "tcp://" + addrWO
+	)
+
+	type testCase struct {
+		rebuildStatus     map[string]*longhorn.RebuildStatus
+		replicaModeMap    map[string]longhorn.ReplicaMode
+		addressReplicaMap map[string]string
+		verifyErr         error
+		expectVerified    []string // replica names we expect ReplicaRebuildVerify to be called for
+	}
+
+	tests := map[string]testCase{
+		// The core fix: replica finished rebuilding while the gRPC connection to the sync agent
+		// was interrupted. reloadAndVerify was never called, so the replica is stuck in WO.
+		"completed rebuild with WO replica triggers verify": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateComplete, IsRebuilding: false},
+			},
+			replicaModeMap:    map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap: map[string]string{addrWO: replicaWO},
+			expectVerified:    []string{replicaWO},
+		},
+		// Rebuild still in progress — must not call verify yet.
+		"in-progress rebuild is skipped": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateInProgress, IsRebuilding: true},
+			},
+			replicaModeMap:    map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap: map[string]string{addrWO: replicaWO},
+			expectVerified:    nil,
+		},
+		// Replica already in RW (normal rebuild path succeeded) — must not call verify again.
+		"completed rebuild with RW replica is skipped": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlRW: {State: engineapi.ProcessStateComplete, IsRebuilding: false},
+			},
+			replicaModeMap:    map[string]longhorn.ReplicaMode{replicaRW: longhorn.ReplicaModeRW},
+			addressReplicaMap: map[string]string{addrRW: replicaRW},
+			expectVerified:    nil,
+		},
+		// Verify fails (e.g. connection still flaky) — must only warn, not return error,
+		// so the next monitor poll cycle can retry instead of setting the replica to ERR.
+		"verify failure is logged but not returned": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateComplete, IsRebuilding: false},
+			},
+			replicaModeMap:    map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap: map[string]string{addrWO: replicaWO},
+			verifyErr:         errors.New("connection refused"),
+			expectVerified:    []string{replicaWO},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := require.New(t)
+
+			proxy := &mockEngineClientProxy{
+				EngineSimulator: &engineapi.EngineSimulator{},
+				verifyErr:       tc.verifyErr,
+			}
+			engine := &longhorn.Engine{
+				Status: longhorn.EngineStatus{
+					ReplicaModeMap: tc.replicaModeMap,
+				},
+			}
+
+			newMonitor().verifyCompletedRebuild(engine, tc.addressReplicaMap, tc.rebuildStatus, proxy)
+			assert.ElementsMatch(tc.expectVerified, proxy.verifyCalled, "ReplicaRebuildVerify call mismatch")
+		})
 	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes: 

Issue #9626
https://github.com/longhorn/longhorn/issues/9626

#### What this PR does / why we need it:

When a network interruption occurs during replica rebuilding, the gRPC connection to the sync agent can break while the file transfer (ssync) continues independently. In that case,reloadAndVerify is never called by startRebuilding and the replica stays in WO mode indefinitely after the transfer completes.                                                              
                                                                                                                                                                                            
This PR adds verifyCompletedRebuild to the engine monitor refresh loop, which detects replicas with state == "complete" and isRebuilding == false that are still in WO mode, and calls ReplicaRebuildVerify to transition them to RW. Verify errors are only logged (not returned) so the next poll cycle retries instead of setting the replica to ERR while the connection may still be flaky.

#### Special notes for your reviewer:

The fix mirrors the existing ReplicaRebuildVerify logic in syncWithRestoreStatus (restore path) but for the normal rebuild path, which was missing this recovery mechanism.               
                                                                                                                                                                                            
ReplicaRebuildVerify is idempotent-- if the replica is already RW (e.g. due to a concurrent call from startRebuilding), it returns immediately without side effects.


#### Additional documentation or context
Related sparse-tools retry fix: https://github.com/longhorn/sparse-tools/pull/120 (the HTTP-level retry in ssync allows the file transfer to complete despite the network interruption,making this WO-stuck scenario reproducible)  