### PR TITLE
feat(setting): make staleReplicaTimeout globally configurable

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1265,7 +1265,7 @@ func volumeSchema(volume *client.Schema) {
 
 	volumeStaleReplicaTimeout := volume.ResourceFields["staleReplicaTimeout"]
 	volumeStaleReplicaTimeout.Create = true
-	volumeStaleReplicaTimeout.Default = 2880
+	// volumeStaleReplicaTimeout.Default = 2880
 	volume.ResourceFields["staleReplicaTimeout"] = volumeStaleReplicaTimeout
 
 	volumeBackingImage := volume.ResourceFields["backingImage"]

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1238,11 +1238,34 @@ func (c *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*lo
 
 // cleanupEngineFrontends cleans up EngineFrontends during volume deletion
 func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, rs map[string]*longhorn.Replica) error {
-	// See comments for isSafeAsLastReplica for an explanation of why we call getSafeAsLastReplicaCount instead of
-	// getHealthyAndActiveReplicaCount here.
+	log := getLoggerForVolume(c.logger, v)
+
+	// 1. Convert our string constant to an int using strconv.Atoi
+	staleReplicaTimeoutSetting, err := strconv.Atoi(types.DefaultStaleReplicaTimeout)
+	if err != nil {
+		staleReplicaTimeoutSetting = 2880 // Absolute hardcoded fallback if parsing fails
+	}
+
+	// For the replenishment wait interval fallback, we use the standard default value (600 seconds)
+	replenishmentWaitIntervalSetting := 600
+
+	// 2. Try to fetch dynamic value from datastore, log warning and fallback if it fails
+	if dynamicTimeout, err := c.ds.GetSettingAsInt(types.SettingNameStaleReplicaTimeout); err != nil {
+		log.WithError(err).Warnf("Failed to get setting %v, falling back to default %v minutes",
+			types.SettingNameStaleReplicaTimeout, staleReplicaTimeoutSetting)
+	} else {
+		staleReplicaTimeoutSetting = int(dynamicTimeout) // Explicitly cast int64 to int
+	}
+
+	if dynamicInterval, err := c.ds.GetSettingAsInt(types.SettingNameReplicaReplenishmentWaitInterval); err != nil {
+		log.WithError(err).Warnf("Failed to get setting %v, falling back to default %v seconds",
+			types.SettingNameReplicaReplenishmentWaitInterval, replenishmentWaitIntervalSetting)
+	} else {
+		replenishmentWaitIntervalSetting = int(dynamicInterval) // Explicitly cast int64 to int
+	}
+
 	safeAsLastReplicaCount := getSafeAsLastReplicaCount(rs)
 	cleanupLeftoverReplicas := !isVolumeUpgrading(v) && !util.IsVolumeMigrating(v)
-	log := getLoggerForVolume(c.logger, v)
 
 	for _, r := range rs {
 		if cleanupLeftoverReplicas {
@@ -1268,10 +1291,10 @@ func (c *VolumeController) cleanupCorruptedOrStaleReplicas(v *longhorn.Volume, r
 			continue
 		}
 
-		if c.shouldCleanUpFailedReplica(v, r, safeAsLastReplicaCount) {
-			log.WithField("replica", r.Name).Info("Cleaning up corrupted, staled replica")
+		if c.shouldCleanUpFailedReplica(v, r, safeAsLastReplicaCount, staleReplicaTimeoutSetting, replenishmentWaitIntervalSetting) {
+			log.WithField("replica", r.Name).Info("Cleaning up corrupted, stale replica")
 			if err := c.deleteReplica(r, rs); err != nil {
-				return errors.Wrapf(err, "failed to clean up staled replica %v", r.Name)
+				return errors.Wrapf(err, "failed to clean up stale replica %v", r.Name)
 			}
 		}
 	}
@@ -6456,7 +6479,7 @@ func (c *VolumeController) ReconcilePersistentVolume(volume *longhorn.Volume) er
 	return nil
 }
 
-func (c *VolumeController) shouldCleanUpFailedReplica(v *longhorn.Volume, r *longhorn.Replica, safeAsLastReplicaCount int) bool {
+func (c *VolumeController) shouldCleanUpFailedReplica(v *longhorn.Volume, r *longhorn.Replica, safeAsLastReplicaCount int, staleReplicaTimeoutSetting, replenishmentWaitIntervalSetting int) bool {
 	log := getLoggerForVolume(c.logger, v).WithField("replica", r.Name)
 
 	// Even if healthyAt == "", lastHealthyAt != "" indicates this replica has some (potentially invalid) data. We MUST
@@ -6471,12 +6494,30 @@ func (c *VolumeController) shouldCleanUpFailedReplica(v *longhorn.Volume, r *lon
 		return true
 	}
 
-	// Failed too long ago to be useful during a rebuild.
-	if v.Spec.StaleReplicaTimeout > 0 &&
-		util.TimestampAfterTimeout(r.Spec.FailedAt, time.Duration(v.Spec.StaleReplicaTimeout)*time.Minute) {
-		log.Warnf("Replica %v failed too long ago to be useful during a rebuild", r.Name)
+	// Determine the base timeout: Volume Spec takes precedence over the Global Setting
+	timeout := staleReplicaTimeoutSetting
+	if v.Spec.StaleReplicaTimeout > 0 {
+		timeout = int(v.Spec.StaleReplicaTimeout)
+	}
+
+	// Respect Replica Replenishment Wait Interval:
+	// Since replenishment is in seconds and timeout is in minutes, we convert and round up.
+	// This ensures we never clean up a replica that the replenishment logic is still considering.
+	replenishmentWaitInMinutes := replenishmentWaitIntervalSetting / 60
+	if replenishmentWaitIntervalSetting > 0 && replenishmentWaitIntervalSetting%60 != 0 {
+		replenishmentWaitInMinutes++
+	}
+
+	if timeout < replenishmentWaitInMinutes {
+		timeout = replenishmentWaitInMinutes
+	}
+
+	// Apply the calculated timeout. A timeout of 0 means immediate cleanup.
+	if timeout >= 0 && util.TimestampAfterTimeout(r.Spec.FailedAt, time.Duration(timeout)*time.Minute) {
+		log.Warnf("Replica %v failed too long ago (%v minutes) to be useful during a rebuild", r.Name, timeout)
 		return true
 	}
+
 	// Failed for race condition at upgrading when waiting for instance-manager-r to start. Can never become healthy.
 	if r.Spec.Image != v.Spec.Image {
 		log.Warnf("Replica %v image %v is different from volume image %v", r.Name, r.Spec.Image, v.Spec.Image)

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	. "gopkg.in/check.v1"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -20,8 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/backupstore"
 
@@ -1341,6 +1341,93 @@ func (s *TestSuite) TestGetSnapshotCountThresholdFallback(c *C) {
 	log := logrus.NewEntry(logrus.StandardLogger())
 	threshold := vc.getSnapshotCountThreshold(v, log)
 	c.Assert(threshold, Equals, specMaxCount)
+}
+
+func (s *TestSuite) TestShouldCleanUpFailedReplica(c *C) {
+	// 1. Setup the mock environment
+	kubeClient := fake.NewSimpleClientset()
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+
+	// 2. Define the test cases
+	tests := []struct {
+		name                             string
+		volume                           *longhorn.Volume
+		replica                          *longhorn.Replica
+		staleReplicaTimeoutSetting       int
+		replenishmentWaitIntervalSetting int
+		expected                         bool
+	}{
+		{
+			name: "Scenario 1: Volume Spec overrides Global Setting",
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{StaleReplicaTimeout: 10},
+			},
+			replica: &longhorn.Replica{
+				Spec: longhorn.ReplicaSpec{
+					FailedAt: now.Add(-15 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			staleReplicaTimeoutSetting:       60,
+			replenishmentWaitIntervalSetting: 0,
+			expected:                         true,
+		},
+		{
+			name: "Scenario 2: Global used when Spec is 0",
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{StaleReplicaTimeout: 0},
+			},
+			replica: &longhorn.Replica{
+				Spec: longhorn.ReplicaSpec{
+					FailedAt: now.Add(-15 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			staleReplicaTimeoutSetting:       30,
+			replenishmentWaitIntervalSetting: 0,
+			expected:                         false,
+		},
+		{
+			name: "Scenario 3: Max with Replenishment Interval (Safety)",
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{StaleReplicaTimeout: 1},
+			},
+			replica: &longhorn.Replica{
+				Spec: longhorn.ReplicaSpec{
+					FailedAt: now.Add(-3 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			staleReplicaTimeoutSetting:       1,
+			replenishmentWaitIntervalSetting: 600, // 10 mins
+			expected:                         false,
+		},
+		{
+			name: "Scenario 4: Rounding up seconds to minutes (Stable)",
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{StaleReplicaTimeout: 0},
+			},
+			replica: &longhorn.Replica{
+				Spec: longhorn.ReplicaSpec{
+					FailedAt: now.Add(-110 * time.Second).Format(time.RFC3339),
+				},
+			},
+			staleReplicaTimeoutSetting:       0,
+			replenishmentWaitIntervalSetting: 61,
+			expected:                         false,
+		},
+	}
+
+	// 3. Run the cases
+	for _, tc := range tests {
+		// We pass 1 for safeAsLastReplicaCount to bypass the "last replica" protection logic
+		result := vc.shouldCleanUpFailedReplica(tc.volume, tc.replica, 1, tc.staleReplicaTimeoutSetting, tc.replenishmentWaitIntervalSetting)
+		c.Assert(result, Equals, tc.expected, Commentf("Failed case: %v", tc.name))
+	}
 }
 
 func (s *TestSuite) TestVolumeBackingImageSizeIncompatibleAfterDownload(c *C) {

--- a/csi/util.go
+++ b/csi/util.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	// defaultStaleReplicaTimeout set to 48 hours (2880 minutes)
-	defaultStaleReplicaTimeout                         = 2880
 	defaultStorageClassDisableRevisionCounterParameter = true
 
 	defaultForceUmountTimeout = 30 * time.Second
@@ -102,10 +100,11 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid parameter staleReplicaTimeout")
 		}
+		// Validation: Reject negative values
+		if srt < 0 {
+			return nil, errors.New("invalid parameter staleReplicaTimeout: must be greater than or equal to 0")
+		}
 		vol.StaleReplicaTimeout = int64(srt)
-	}
-	if vol.StaleReplicaTimeout <= 0 {
-		vol.StaleReplicaTimeout = defaultStaleReplicaTimeout
 	}
 
 	if share, ok := volOptions["share"]; ok {

--- a/csi/util_test.go
+++ b/csi/util_test.go
@@ -25,7 +25,7 @@ func TestGetVolumeOptions(t *testing.T) {
 			},
 			expectedVolume: &longhornclient.Volume{
 				NumberOfReplicas:        3,
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteOnce),
 				DataEngine:              string(longhorn.DataEngineTypeV1),
 				RevisionCounterDisabled: true,
@@ -37,7 +37,7 @@ func TestGetVolumeOptions(t *testing.T) {
 				"exclusive": "true",
 			},
 			expectedVolume: &longhornclient.Volume{
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteOncePod),
 				DataEngine:              string(longhorn.DataEngineTypeV1),
 				RevisionCounterDisabled: true,
@@ -49,7 +49,7 @@ func TestGetVolumeOptions(t *testing.T) {
 				"share": "true",
 			},
 			expectedVolume: &longhornclient.Volume{
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteMany),
 				DataEngine:              string(longhorn.DataEngineTypeV1),
 				RevisionCounterDisabled: true,
@@ -69,7 +69,7 @@ func TestGetVolumeOptions(t *testing.T) {
 				"migratable": "true",
 			},
 			expectedVolume: &longhornclient.Volume{
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteOnce),
 				DataEngine:              string(longhorn.DataEngineTypeV1),
 				RevisionCounterDisabled: true,
@@ -83,7 +83,7 @@ func TestGetVolumeOptions(t *testing.T) {
 				"migratable": "true",
 			},
 			expectedVolume: &longhornclient.Volume{
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteMany),
 				DataEngine:              string(longhorn.DataEngineTypeV1),
 				RevisionCounterDisabled: true,
@@ -96,11 +96,30 @@ func TestGetVolumeOptions(t *testing.T) {
 				"dataEngine": "v2",
 			},
 			expectedVolume: &longhornclient.Volume{
-				StaleReplicaTimeout:     defaultStaleReplicaTimeout,
+				StaleReplicaTimeout:     0,
 				AccessMode:              string(longhorn.AccessModeReadWriteOnce),
 				DataEngine:              string(longhorn.DataEngineTypeV2),
 				RevisionCounterDisabled: true,
 			},
+		},
+		"custom stale replica timeout": {
+			volumeID: "test-vol-custom-timeout",
+			volumeOptions: map[string]string{
+				"staleReplicaTimeout": "100",
+			},
+			expectedVolume: &longhornclient.Volume{
+				StaleReplicaTimeout:     100,
+				AccessMode:              string(longhorn.AccessModeReadWriteOnce),
+				DataEngine:              string(longhorn.DataEngineTypeV1),
+				RevisionCounterDisabled: true,
+			},
+		},
+		"negative stale replica timeout should fail": {
+			volumeID: "test-vol-negative",
+			volumeOptions: map[string]string{
+				"staleReplicaTimeout": "-10",
+			},
+			expectedError: true,
 		},
 	}
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -37,6 +37,8 @@ const (
 
 	DefaultBackupstorePollInterval = 300 * time.Second
 
+	DefaultStaleReplicaTimeoutSettingString = "2880"
+
 	BackupBlockSizeMi      int64 = 1 * 1024 * 1024
 	BackupBlockSize2Mi           = 2 * BackupBlockSizeMi
 	BackupBlockSize16Mi          = 16 * BackupBlockSizeMi
@@ -128,6 +130,7 @@ const (
 	SettingNameSupportBundleNodeCollectionTimeout                       = SettingName("support-bundle-node-collection-timeout")
 	SettingNameDeletingConfirmationFlag                                 = SettingName("deleting-confirmation-flag")
 	SettingNameEngineReplicaTimeout                                     = SettingName("engine-replica-timeout")
+	SettingNameStaleReplicaTimeout                                      = SettingName("stale-replica-timeout")
 	SettingNameSnapshotDataIntegrity                                    = SettingName("snapshot-data-integrity")
 	SettingNameSnapshotDataIntegrityImmediateCheckAfterSnapshotCreation = SettingName("snapshot-data-integrity-immediate-check-after-snapshot-creation")
 	SettingNameSnapshotDataIntegrityCronJob                             = SettingName("snapshot-data-integrity-cronjob")
@@ -229,6 +232,7 @@ var (
 		SettingNamePriorityClass,
 		SettingNameDisableRevisionCounter,
 		SettingNameReplicaReplenishmentWaitInterval,
+		SettingNameStaleReplicaTimeout,
 		SettingNameConcurrentReplicaRebuildPerNodeLimit,
 		SettingNameReplicaRebuildConcurrentSyncLimit,
 		SettingNameConcurrentBackingImageCopyReplenishPerNodeLimit,
@@ -391,6 +395,7 @@ var (
 		SettingNamePriorityClass:                                            SettingDefinitionPriorityClass,
 		SettingNameDisableRevisionCounter:                                   SettingDefinitionDisableRevisionCounter,
 		SettingNameReplicaReplenishmentWaitInterval:                         SettingDefinitionReplicaReplenishmentWaitInterval,
+		SettingNameStaleReplicaTimeout:                                      SettingDefinitionStaleReplicaTimeout,
 		SettingNameConcurrentReplicaRebuildPerNodeLimit:                     SettingDefinitionConcurrentReplicaRebuildPerNodeLimit,
 		SettingNameReplicaRebuildConcurrentSyncLimit:                        SettingDefinitionReplicaRebuildConcurrentSyncLimit,
 		SettingNameConcurrentBackingImageCopyReplenishPerNodeLimit:          SettingDefinitionConcurrentBackingImageCopyReplenishPerNodeLimit,
@@ -1087,6 +1092,23 @@ var (
 		ReadOnly:           false,
 		DataEngineSpecific: false,
 		Default:            "600",
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+		},
+	}
+
+	SettingDefinitionStaleReplicaTimeout = SettingDefinition{
+		DisplayName: "Stale Replica Timeout",
+		Description: "In minutes. The timeout determines how long Longhorn will wait before cleaning up a stale replica " +
+			"that is no longer part of the volume engine.\n" +
+			"The effective cleanup delay is the greater of this setting and the Replica Replenishment Wait Interval " +
+			"(converted to minutes and rounded up). Setting this to 0 allows cleanup as soon as that effective delay is reached.",
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            DefaultStaleReplicaTimeoutSettingString,
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: 0,
 		},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

[Related Issue](https://github.com/longhorn/longhorn/issues/4542)

#### What this PR does / why we need it:

It makes the `staleReplicaTimeout` configurable at a global level and introduces a configuration hierarchy for volume cleanup.

**Key Changes**:

- Added `stale-replica-timeout` as a registered setting in `longhorn-manager`.
- Updated the `VolumeController` to prioritize `Volume.Spec.StaleReplicaTimeout` if set; otherwise, it falls back to the new global setting.
- Modified the cleanup logic to ensure the `staleReplicaTimeout` respects the `Replica Replenishment Wait Interval`. The effective timeout is now the maximum of the two, preventing the premature deletion of replicas that the system is still attempting to reuse.
- Removed the hardcoded default (2880 minutes) from the CSI layer, allowing the controller to manage the default value through the global setting.

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A