### PR TITLE
fix(engine): transition WO replica to ERR on terminal rebuild failure

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -871,7 +871,13 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 			// alongside it.
 			currentReplicaTransitionTimeMap[replica] = util.Now()
 		} else {
-			if r.Mode != engine.Status.ReplicaModeMap[replica] {
+			prevMode := engine.Status.ReplicaModeMap[replica]
+			// A persisted ERR for a replica the engine still reports as WO is an override from
+			// markFailedRebuildsAsErr; the engine keeps reporting WO until the replica is actually
+			// stopped. Treat this as unchanged so we don't spam "rebuilding" events or reset the
+			// transition time every cycle.
+			overrideStillInEffect := prevMode == longhorn.ReplicaModeERR && r.Mode == longhorn.ReplicaModeWO
+			if r.Mode != prevMode && !overrideStillInEffect {
 				switch r.Mode {
 				case longhorn.ReplicaModeERR:
 					m.eventRecorder.Eventf(engine, corev1.EventTypeWarning, constant.EventReasonFaulted, "Detected replica %v (%v) in error", replica, addr)
@@ -888,7 +894,7 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 			} else {
 				oldTime, ok := engine.Status.ReplicaTransitionTimeMap[replica]
 				if !ok {
-					m.logger.Errorf("BUG: Replica %v (%v) was previously in mode %v but transition time was not recorded", replica, addr, engine.Status.ReplicaModeMap[replica])
+					m.logger.Errorf("BUG: Replica %v (%v) was previously in mode %v but transition time was not recorded", replica, addr, prevMode)
 					currentReplicaTransitionTimeMap[replica] = util.Now()
 				} else {
 					currentReplicaTransitionTimeMap[replica] = oldTime
@@ -961,10 +967,18 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 			}
 		}
 
-		// The rebuild failure will be handled by ec.startRebuilding()
-		rebuildStatus, err := engineClientProxy.ReplicaRebuildStatus(engine)
-		if err != nil {
-			return err
+		// Rebuild failures during ec.startRebuilding() are handled by that function. Failures
+		// surfaced afterwards (sync agent retries exhausted, gRPC interruption, node down)
+		// leave the replica stuck in WO — markFailedRebuildsAsErr below catches those.
+		rebuildStatus, statusErr := engineClientProxy.ReplicaRebuildStatus(engine)
+		if statusErr != nil {
+			// Run markFailedRebuildsAsErr anyway so Path 2 (Replica CR FailedAt /
+			// InstanceStateError) can still clean up stuck WO entries when the rebuild
+			// status fetch itself is timing out (the node-down case it was designed for).
+			// Path 1 harmlessly no-ops on a nil rebuildStatus.
+			m.logger.WithError(statusErr).Warn("Failed to fetch rebuild status; running Replica CR failure cleanup only")
+			m.markFailedRebuildsAsErr(engine, existingEngine, addressReplicaMap, nil, m.ds.GetReplicaRO)
+			return statusErr
 		}
 
 		if err := m.checkAndApplyRebuildQoS(engine, engineClientProxy, rebuildStatus); err != nil {
@@ -972,9 +986,7 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		}
 		engine.Status.RebuildStatus = rebuildStatus
 
-		// If a rebuild completed while the gRPC connection to the sync agent was interrupted,
-		// reloadAndVerify is never called and the replica stays in WO mode indefinitely.
-		// Detect this case and call ReplicaRebuildVerify to transition the replica to RW.
+		m.markFailedRebuildsAsErr(engine, existingEngine, addressReplicaMap, rebuildStatus, m.ds.GetReplicaRO)
 		m.verifyCompletedRebuild(engine, addressReplicaMap, rebuildStatus, engineClientProxy)
 
 		// It's meaningless to sync the trim related field for old engines or engines in old engine instance managers
@@ -1182,6 +1194,87 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 	}
 
 	return nil
+}
+
+// markFailedRebuildsAsErr transitions a WO replica to ERR when we can prove the rebuild is dead.
+// Without this, ReplicaList keeps reporting WO and rebuildNewReplica blocks forever. Two signals
+// are considered:
+//  1. The sync agent reports a failed rebuild status (normal case: engine reachable, replica dead).
+//  2. The Replica CR is marked failed (node-down case: rebuild status fetch may be timing out).
+//
+// Event and transition time are emitted only on the first transition because the engine keeps
+// reporting WO, so our ERR override is re-applied every cycle until the replica is stopped.
+func (m *EngineMonitor) markFailedRebuildsAsErr(engine, existingEngine *longhorn.Engine,
+	addressReplicaMap map[string]string, rebuildStatus map[string]*longhorn.RebuildStatus,
+	getReplica func(name string) (*longhorn.Replica, error)) {
+	// Path 1: the sync agent itself reports the rebuild as errored.
+	for url, status := range rebuildStatus {
+		if status == nil || status.IsRebuilding {
+			continue
+		}
+		if status.State != engineapi.ProcessStateError && status.Error == "" {
+			continue
+		}
+
+		addr := engineapi.GetAddressFromBackendReplicaURL(url)
+		replicaName := addressReplicaMap[addr]
+		if replicaName == "" {
+			continue
+		}
+
+		reason := fmt.Sprintf("sync agent reported rebuild state=%q", status.State)
+		if status.Error != "" {
+			reason = fmt.Sprintf("%s, error: %v", reason, status.Error)
+		}
+		m.flipWOReplicaToErr(engine, existingEngine, replicaName, addr, reason)
+	}
+
+	// Path 2: the Replica CR is already known-failed (e.g., node down, instance-manager unreachable),
+	// but the engine still reports WO. Without flipping to ERR, rebuildNewReplica never unblocks.
+	for replicaName, mode := range engine.Status.ReplicaModeMap {
+		if mode != longhorn.ReplicaModeWO {
+			continue
+		}
+		if strings.HasPrefix(replicaName, unknownReplicaPrefix) {
+			continue
+		}
+		r, err := getReplica(replicaName)
+		if err != nil || r == nil {
+			continue
+		}
+		if r.Spec.FailedAt == "" && r.Status.CurrentState != longhorn.InstanceStateError {
+			continue
+		}
+
+		m.flipWOReplicaToErr(engine, existingEngine, replicaName, engine.Status.CurrentReplicaAddressMap[replicaName],
+			fmt.Sprintf("replica CR is failed (FailedAt=%q, CurrentState=%q)",
+				r.Spec.FailedAt, r.Status.CurrentState))
+	}
+}
+
+// flipWOReplicaToErr overrides a stale WO entry in ReplicaModeMap with ERR. Callers are
+// responsible for deciding that the WO state is truly stale; this helper only enforces the
+// first-transition guard (event + transition time).
+func (m *EngineMonitor) flipWOReplicaToErr(engine, existingEngine *longhorn.Engine,
+	replicaName, addr, reason string) {
+	if engine.Status.ReplicaModeMap[replicaName] != longhorn.ReplicaModeWO {
+		return
+	}
+	alreadyErr := existingEngine.Status.ReplicaModeMap[replicaName] == longhorn.ReplicaModeERR
+	engine.Status.ReplicaModeMap[replicaName] = longhorn.ReplicaModeERR
+	if alreadyErr {
+		return
+	}
+
+	m.logger.Warnf("Transitioning replica %v (%v) from WO to ERR: %v", replicaName, addr, reason)
+	if m.eventRecorder != nil {
+		m.eventRecorder.Eventf(engine, corev1.EventTypeWarning, constant.EventReasonFaulted,
+			"Replica %v (%v) transitioned from WO to ERR: %v", replicaName, addr, reason)
+	}
+	if engine.Status.ReplicaTransitionTimeMap == nil {
+		engine.Status.ReplicaTransitionTimeMap = map[string]string{}
+	}
+	engine.Status.ReplicaTransitionTimeMap[replicaName] = util.Now()
 }
 
 // verifyCompletedRebuild detects replicas that finished rebuilding while the gRPC connection to the

--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -150,6 +150,279 @@ func TestNeedStatusUpdate(t *testing.T) {
 	}
 }
 
+func TestMarkFailedRebuildsAsErr(t *testing.T) {
+	newMonitor := func() *EngineMonitor {
+		logger := logrus.New()
+		logger.Out = io.Discard
+		return &EngineMonitor{logger: logger}
+	}
+
+	const (
+		replicaRW = "replica-rw"
+		replicaWO = "replica-wo"
+		addrRW    = "10.0.0.1:10000"
+		addrWO    = "10.0.0.2:10000"
+		urlRW     = "tcp://" + addrRW
+		urlWO     = "tcp://" + addrWO
+	)
+
+	type testCase struct {
+		rebuildStatus            map[string]*longhorn.RebuildStatus
+		replicaModeMap           map[string]longhorn.ReplicaMode
+		existingReplicaModeMap   map[string]longhorn.ReplicaMode
+		addressReplicaMap        map[string]string
+		currentReplicaAddressMap map[string]string            // engine.Status.CurrentReplicaAddressMap (replica -> addr)
+		replicas                 map[string]*longhorn.Replica // stub for GetReplicaRO
+		expectModeMap            map[string]longhorn.ReplicaMode
+		expectTransitionUpdate   bool // true if TransitionTimeMap[replicaWO|replicaRW] should be bumped
+	}
+
+	tests := map[string]testCase{
+		// Core support-bundle case: sync agent gave up, engine reports state=error, replica
+		// still WO in ReplicaModeMap. Must transition to ERR so rebuildNewReplica unblocks.
+		"state=error on WO replica transitions to ERR": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {
+					State:        engineapi.ProcessStateError,
+					IsRebuilding: false,
+					Error:        "syncing has failed for 3 times, will error out",
+				},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// Error message set without explicit state field — still counts as failed.
+		"error field alone on WO replica transitions to ERR": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {Error: "connection reset by peer"},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// State=error without an Error message — still terminal. The reason string passed to
+		// flipWOReplicaToErr must surface the state so the event/log isn't empty.
+		"state=error with empty Error still transitions": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateError, IsRebuilding: false},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// Nil rebuildStatus (engine unreachable, caller ran Path 2 only) must still flip WO->ERR
+		// via Path 2 when the Replica CR reports FailedAt.
+		"nil rebuildStatus runs Path 2 only": {
+			rebuildStatus:            nil,
+			replicaModeMap:           map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap:   map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:        map[string]string{addrWO: replicaWO},
+			currentReplicaAddressMap: map[string]string{replicaWO: addrWO},
+			replicas: map[string]*longhorn.Replica{
+				replicaWO: {Spec: longhorn.ReplicaSpec{FailedAt: "2026-04-23T07:29:33Z"}},
+			},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// Rebuild still in progress — must not touch the mode even if Error is set transiently.
+		"in-progress rebuild with error leaves WO alone": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateInProgress, IsRebuilding: true, Error: "transient"},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Successful completion must not flip to ERR — verifyCompletedRebuild handles that path.
+		"complete rebuild leaves WO alone": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateComplete, IsRebuilding: false},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Stale rebuild error for a replica that is already RW (shouldn't happen, but be safe).
+		"error on already-RW replica is ignored": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlRW: {State: engineapi.ProcessStateError, Error: "stale"},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaRW: longhorn.ReplicaModeRW},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaRW: longhorn.ReplicaModeRW},
+			addressReplicaMap:      map[string]string{addrRW: replicaRW},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaRW: longhorn.ReplicaModeRW},
+		},
+		// URL maps to no known replica — skip silently.
+		"unknown replica url is skipped": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateError, Error: "boom"},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{}, // no mapping
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Engine keeps reporting WO every cycle, so without a guard we would re-emit the event
+		// and reset the transition time forever. If the previous persisted mode was already ERR,
+		// flip the mode again but skip event/transition-time updates.
+		"re-applied ERR override does not bump transition time": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateError, Error: "still failing"},
+			},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: false,
+		},
+		// Mixed map: one replica errored, one completed. The errored one transitions; the
+		// completed one is handled by verifyCompletedRebuild and must be left untouched here.
+		"mixed errored and completed": {
+			rebuildStatus: map[string]*longhorn.RebuildStatus{
+				urlWO: {State: engineapi.ProcessStateError, Error: "fail"},
+				urlRW: {State: engineapi.ProcessStateComplete, IsRebuilding: false},
+			},
+			replicaModeMap: map[string]longhorn.ReplicaMode{
+				replicaWO: longhorn.ReplicaModeWO,
+				replicaRW: longhorn.ReplicaModeWO,
+			},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{
+				replicaWO: longhorn.ReplicaModeWO,
+				replicaRW: longhorn.ReplicaModeWO,
+			},
+			addressReplicaMap: map[string]string{addrWO: replicaWO, addrRW: replicaRW},
+			expectModeMap: map[string]longhorn.ReplicaMode{
+				replicaWO: longhorn.ReplicaModeERR,
+				replicaRW: longhorn.ReplicaModeWO,
+			},
+			expectTransitionUpdate: true,
+		},
+		// Nil status entry must not panic or trigger anything.
+		"nil status entry is skipped": {
+			rebuildStatus:          map[string]*longhorn.RebuildStatus{urlWO: nil},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Path 2 — node-down case: ReplicaRebuildStatus is empty (sync agent unreachable), but
+		// the Replica CR is already marked FailedAt. Must flip WO -> ERR regardless.
+		"replica CR FailedAt transitions stuck WO to ERR": {
+			rebuildStatus:            map[string]*longhorn.RebuildStatus{}, // engine can't reach sync agent
+			replicaModeMap:           map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap:   map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:        map[string]string{addrWO: replicaWO},
+			currentReplicaAddressMap: map[string]string{replicaWO: addrWO},
+			replicas: map[string]*longhorn.Replica{
+				replicaWO: {Spec: longhorn.ReplicaSpec{FailedAt: "2026-04-22T07:29:33Z"}},
+			},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// Path 2 — CurrentState=Error also counts as failed even when FailedAt not yet set.
+		"replica CR in InstanceStateError transitions stuck WO to ERR": {
+			rebuildStatus:          map[string]*longhorn.RebuildStatus{},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			replicas: map[string]*longhorn.Replica{
+				replicaWO: {Status: longhorn.ReplicaStatus{InstanceStatus: longhorn.InstanceStatus{CurrentState: longhorn.InstanceStateError}}},
+			},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: true,
+		},
+		// Path 2 — healthy Replica CR must not be touched even if engine still reports WO.
+		"healthy replica CR leaves WO alone": {
+			rebuildStatus:          map[string]*longhorn.RebuildStatus{},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			replicas: map[string]*longhorn.Replica{
+				replicaWO: {Status: longhorn.ReplicaStatus{InstanceStatus: longhorn.InstanceStatus{CurrentState: longhorn.InstanceStateRunning}}},
+			},
+			expectModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Path 2 — replica CR missing from datastore (NotFound): skip, don't flip.
+		"missing replica CR leaves WO alone": {
+			rebuildStatus:          map[string]*longhorn.RebuildStatus{},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			replicas:               nil, // getter returns error for all names
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+		},
+		// Path 2 — re-apply guard: replica already ERR in existing, still WO in current (engine
+		// keeps reporting WO). Flip mode again but don't bump transition time.
+		"replica CR failed but already ERR skips transition bump": {
+			rebuildStatus:          map[string]*longhorn.RebuildStatus{},
+			replicaModeMap:         map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeWO},
+			existingReplicaModeMap: map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			addressReplicaMap:      map[string]string{addrWO: replicaWO},
+			replicas: map[string]*longhorn.Replica{
+				replicaWO: {Spec: longhorn.ReplicaSpec{FailedAt: "2026-04-22T07:29:33Z"}},
+			},
+			expectModeMap:          map[string]longhorn.ReplicaMode{replicaWO: longhorn.ReplicaModeERR},
+			expectTransitionUpdate: false,
+		},
+	}
+
+	const priorTime = "2000-01-01T00:00:00Z"
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := require.New(t)
+
+			transitionTimeMap := map[string]string{}
+			for r := range tc.replicaModeMap {
+				transitionTimeMap[r] = priorTime
+			}
+			engine := &longhorn.Engine{
+				Status: longhorn.EngineStatus{
+					ReplicaModeMap:           tc.replicaModeMap,
+					ReplicaTransitionTimeMap: transitionTimeMap,
+					CurrentReplicaAddressMap: tc.currentReplicaAddressMap,
+				},
+			}
+			existingEngine := &longhorn.Engine{
+				Status: longhorn.EngineStatus{
+					ReplicaModeMap: tc.existingReplicaModeMap,
+				},
+			}
+			getReplica := func(name string) (*longhorn.Replica, error) {
+				r, ok := tc.replicas[name]
+				if !ok {
+					return nil, errors.New("replica not found")
+				}
+				return r, nil
+			}
+
+			newMonitor().markFailedRebuildsAsErr(engine, existingEngine, tc.addressReplicaMap, tc.rebuildStatus, getReplica)
+			assert.Equal(tc.expectModeMap, engine.Status.ReplicaModeMap, "ReplicaModeMap mismatch")
+
+			for replicaName, mode := range tc.expectModeMap {
+				if mode != longhorn.ReplicaModeERR {
+					continue
+				}
+				if tc.expectTransitionUpdate {
+					assert.NotEqual(priorTime, engine.Status.ReplicaTransitionTimeMap[replicaName],
+						"TransitionTime should be updated for %v", replicaName)
+				} else {
+					assert.Equal(priorTime, engine.Status.ReplicaTransitionTimeMap[replicaName],
+						"TransitionTime should not be touched for %v", replicaName)
+				}
+			}
+		})
+	}
+}
+
 func TestVerifyCompletedRebuild(t *testing.T) {
 	newMonitor := func() *EngineMonitor {
 		logger := logrus.New()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#12969

#### What this PR does / why we need it:
When a replica rebuild fails terminally (sync agent retries exhausted, gRPC interruption, or node down), the engine keeps reporting the replica as WO in ReplicaList. This leaves rebuildNewReplica blocked indefinitely and the volume unable to recover, because longhorn-engine never resets the error state on its own until a new PrepareRebuild is issued.
                                                                                                                                                                                            
Add markFailedRebuildsAsErr to the engine monitor refresh loop. Two signals are considered:                                                                                                 
 
1. The sync agent reports rebuild state=error or a non-empty Error.                                                                                                                         
2. The Replica CR is marked FailedAt or its CurrentState is InstanceStateError.

When either fires for a replica still in WO, flip it to ERR so the volume controller can fail the replica and a fresh rebuild slot opens. Event and ReplicaTransitionTime are recorded only on the first transition because the engine keeps reporting WO, so the ERR override is re-applied every cycle until the replica is stopped.

This is the manager-side cleanup from [here](https://github.com/longhorn/longhorn/issues/12949#issuecomment-4301067043)


#### Special notes for your reviewer:
- Verified against support bundle 965a9de8 from longhorn/longhorn#12949 (original stuck-WO reproduction) - the logic would flip the stuck replica e2e-test-volume-0-r-f97d8784 (state=error,  progress=55, WO) to ERR on the next reconcile, unblocking rebuildNewReplica.                                                                                                               

#### Additional documentation or context
- Related: longhorn/longhorn#12949, longhorn/longhorn#12969, longhorn/longhorn#9626                                                                                                         
- Engine-side companion fix: longhorn/longhorn-engine#1759 (gRPC context propagation ;prevents overlapping stale sync sessions, but does not on its own clean up the stuck-WO state)
- A separate issue remains on the engine side (SyncRetryCount=3 in longhorn-engine/pkg/types/types.go) which causes each fresh rebuild to also fail under the harsher "disconnect whole node repeatedly" test variant; that is out of scope for this PR and should be tracked separately.                                                                                     
