### PR TITLE
fix: require restored replica count before completing restore

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -4287,9 +4287,9 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 	// a restore/DR volume is considered as finished if the following conditions are satisfied:
 	// 1) The restored backup is up-to-date;
 	// 2) The volume is no longer a DR volume;
-	// 3) The restore/DR volume is
-	//   3.1) it's state `Healthy`;
-	//   3.2) or it's state `Degraded` with all the scheduled replica included in the engine
+	// 3) The restore/DR volume is either:
+	//   3.1) Healthy with at least spec.numberOfReplicas RW replicas;
+	//   3.2) or Degraded with degraded availability allowed, at least one RW replica, and all scheduled replicas included in the engine.
 	if v.Spec.FromBackup == "" {
 		return nil
 	}
@@ -4337,7 +4337,7 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 		}
 	}
 
-	allScheduledReplicasIncluded, err := c.checkAllScheduledReplicasIncluded(v, e, rs)
+	healthyReplicaCount, allScheduledReplicasIncluded, err := c.checkRestoredReplicaReadiness(e, rs)
 	if err != nil {
 		return err
 	}
@@ -4347,7 +4347,14 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 		return err
 	}
 
-	if !isPurging && ((v.Status.Robustness == longhorn.VolumeRobustnessHealthy && allScheduledReplicasIncluded) || (v.Status.Robustness == longhorn.VolumeRobustnessDegraded && degradedVolumeSupported)) {
+	restoreCompleted := false
+	if v.Status.Robustness == longhorn.VolumeRobustnessHealthy {
+		restoreCompleted = healthyReplicaCount >= v.Spec.NumberOfReplicas
+	} else if v.Status.Robustness == longhorn.VolumeRobustnessDegraded && degradedVolumeSupported {
+		restoreCompleted = healthyReplicaCount > 0 && allScheduledReplicasIncluded
+	}
+
+	if !isPurging && restoreCompleted {
 		log.Infof("Restore/DR volume finished with the last restored backup %s", e.Status.LastRestoredBackup)
 		v.Status.IsStandby = false
 		v.Status.RestoreRequired = false
@@ -4356,28 +4363,32 @@ func (c *VolumeController) checkAndFinishVolumeRestore(v *longhorn.Volume, e *lo
 	return nil
 }
 
-func (c *VolumeController) checkAllScheduledReplicasIncluded(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica) (bool, error) {
-	healthReplicaCount := 0
+func (c *VolumeController) checkRestoredReplicaReadiness(e *longhorn.Engine, rs map[string]*longhorn.Replica) (int, bool, error) {
+	healthyReplicaCount := 0
 	hasReplicaNotIncluded := false
 
 	for _, r := range rs {
+		if r.DeletionTimestamp != nil {
+			hasReplicaNotIncluded = true
+			continue
+		}
 		// skip unscheduled replicas
 		if r.Spec.NodeID == "" {
 			continue
 		}
 		if isDownOrDeleted, err := c.ds.IsNodeDownOrDeleted(r.Spec.NodeID); err != nil {
-			return false, err
+			return 0, false, err
 		} else if isDownOrDeleted {
 			continue
 		}
 		if mode := e.Status.ReplicaModeMap[r.Name]; mode == longhorn.ReplicaModeRW {
-			healthReplicaCount++
+			healthyReplicaCount++
 		} else {
 			hasReplicaNotIncluded = true
 		}
 	}
 
-	return healthReplicaCount > 0 && (healthReplicaCount >= v.Spec.NumberOfReplicas || !hasReplicaNotIncluded), nil
+	return healthyReplicaCount, !hasReplicaNotIncluded, nil
 }
 
 func (c *VolumeController) updateRequestedDataSourceForVolumeCloning(v *longhorn.Volume, e *longhorn.Engine) (err error) {

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1342,6 +1342,96 @@ func (s *TestSuite) TestGetSnapshotCountThresholdFallback(c *C) {
 	c.Assert(threshold, Equals, specMaxCount)
 }
 
+func (s *TestSuite) TestCheckAndFinishVolumeRestoreReplicaReadiness(c *C) {
+	datastore.SkipListerCheck = true
+
+	testBackupURL := backupstore.EncodeBackupURL(TestBackupName, TestVolumeName, TestBackupTarget)
+
+	testCases := map[string]struct {
+		allowDegradedAvailability string
+		robustness                longhorn.VolumeRobustness
+		deletingReplica           bool
+		expectRestoreRequired     bool
+	}{
+		"keep restore required when healthy volume has fewer restored replicas than requested": {
+			allowDegradedAvailability: "false",
+			robustness:                longhorn.VolumeRobustnessHealthy,
+			expectRestoreRequired:     true,
+		},
+		"finish degraded restore when degraded availability is allowed": {
+			allowDegradedAvailability: "true",
+			robustness:                longhorn.VolumeRobustnessDegraded,
+			expectRestoreRequired:     false,
+		},
+		"keep restore required when degraded volume has deleting replica": {
+			allowDegradedAvailability: "true",
+			robustness:                longhorn.VolumeRobustnessDegraded,
+			deletingReplica:           true,
+			expectRestoreRequired:     true,
+		},
+	}
+
+	for name, tc := range testCases {
+		c.Logf("testing %v", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+		nIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+
+		vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+		c.Assert(err, IsNil)
+
+		setting := initSettingsNameValue(
+			string(types.SettingNameAllowVolumeCreationWithDegradedAvailability),
+			tc.allowDegradedAvailability)
+		createdSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(createdSetting)
+		c.Assert(err, IsNil)
+
+		for _, node := range []*longhorn.Node{
+			newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+			newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		} {
+			createdNode, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			err = nIndexer.Add(createdNode)
+			c.Assert(err, IsNil)
+		}
+
+		volume := newVolume(TestVolumeName, 3)
+		volume.Spec.FromBackup = testBackupURL
+		volume.Status.Robustness = tc.robustness
+		volume.Status.RestoreInitiated = true
+		volume.Status.RestoreRequired = true
+
+		engine := newEngineForVolume(volume)
+		engine.Spec.RequestedBackupRestore = TestBackupName
+		engine.Status.LastRestoredBackup = TestBackupName
+		engine.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+
+		replica1 := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+		replica2 := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+		if tc.deletingReplica {
+			now := metav1.NewTime(time.Now())
+			replica2.DeletionTimestamp = &now
+		}
+		replicas := map[string]*longhorn.Replica{
+			replica1.Name: replica1,
+			replica2.Name: replica2,
+		}
+		engine.Status.ReplicaModeMap[replica1.Name] = longhorn.ReplicaModeRW
+		engine.Status.ReplicaModeMap[replica2.Name] = longhorn.ReplicaModeRW
+
+		err = vc.checkAndFinishVolumeRestore(volume, engine, replicas)
+		c.Assert(err, IsNil)
+		c.Assert(volume.Status.RestoreRequired, Equals, tc.expectRestoreRequired)
+	}
+}
+
 func (s *TestSuite) TestVolumeBackingImageSizeIncompatibleAfterDownload(c *C) {
 	// We have to skip lister check for unit tests
 	// Because the changes written through the API won't be reflected in the listers


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#11447

#### What this PR does / why we need it:

During backup restore, the previous completion check treated a restore as complete when all remaining scheduled replicas were RW, even if a replica had been removed during restoration. This allowed a volume with fewer restored replicas than spec.numberOfReplicas to clear RestoreRequired.

For v2, this could remove the restore attachment ticket too early, detach the volume, and prevent replica replenishment/rebuild from starting.

Track the healthy restored replica count separately. Require healthy restored volumes to have spec.numberOfReplicas RW replicas before completing restore, while preserving degraded restore completion when degraded availability is enabled. Treat deleting replicas as not included.


#### Special notes for your reviewer:

#### Additional documentation or context
