### PR TITLE
fix(node-controller): prevent disk stuck in not-ready after transient node restart

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -450,11 +450,6 @@ func (nc *NodeController) syncNode(key string) (err error) {
 		return err
 	}
 
-	// Explicitly mark all disk on this node as not ready and not schedulable when
-	// node is not ready. This ensures auto-salvage is gated during node recovery.
-	// Ref: https://github.com/longhorn/longhorn/issues/12406
-	nc.markAllDisksNotReadyWhenNodeNotReady(node)
-
 	// Set any RWX leases to non-delinquent if owned by not-ready node.
 	// Usefulness of delinquent state has passed.
 	if err = nc.clearDelinquentLeasesIfNodeNotReady(node); err != nil {
@@ -465,8 +460,20 @@ func (nc *NodeController) syncNode(key string) (err error) {
 	node.Status.Region, node.Status.Zone = types.GetRegionAndZone(kubeNode.Labels)
 
 	if nc.controllerID != node.Name {
+		// For non-owner controllers, only mark disks not-ready when the node is
+		// definitively down (K8s node gone or not ready). This prevents non-owners
+		// from interfering with the owner's disk status during transient states
+		// (e.g. manager pod restart), which could cause disks to get stuck in
+		// not-ready state.
+		// Ref: https://github.com/longhorn/longhorn/issues/12406
+		nc.markAllDisksNotReadyWhenNodeDefinitelyDown(node)
 		return nil
 	}
+
+	// Explicitly mark all disk on this node as not ready and not schedulable when
+	// node is not ready. This ensures auto-salvage is gated during node recovery.
+	// Ref: https://github.com/longhorn/longhorn/issues/12406
+	nc.markAllDisksNotReadyWhenNodeNotReady(node)
 
 	// Getting here is enough proof of life to turn on the services that might
 	// have been turned off for RWX failover.
@@ -2044,6 +2051,52 @@ func (nc *NodeController) setReadyConditionForManagerPod(node *longhorn.Node, ma
 			nc.eventRecorder, node, corev1.EventTypeWarning)
 	}
 	return nodeReady
+}
+
+// markAllDisksNotReadyWhenNodeDefinitelyDown marks all disks as not-ready and
+// not-schedulable only when the node is definitively down (Kubernetes node gone
+// or not ready). This is used by non-owner controllers to ensure disk status is
+// updated for auto-salvage gating without interfering with the owner during
+// transient states like manager pod restarts.
+func (nc *NodeController) markAllDisksNotReadyWhenNodeDefinitelyDown(node *longhorn.Node) {
+	cond := types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeReady)
+	if cond.Status == longhorn.ConditionStatusTrue {
+		return
+	}
+
+	// Only act on definitive node-down reasons. Transient reasons like
+	// ManagerPodDown will be handled by the owner once it recovers.
+	if cond.Reason != string(longhorn.NodeConditionReasonKubernetesNodeGone) &&
+		cond.Reason != string(longhorn.NodeConditionReasonKubernetesNodeNotReady) {
+		return
+	}
+
+	reason := string(longhorn.DiskConditionReasonNodeNotReady)
+	for diskName, diskStatus := range node.Status.DiskStatus {
+		diskStatus.Conditions = types.SetConditionAndRecord(
+			diskStatus.Conditions,
+			longhorn.DiskConditionTypeReady,
+			longhorn.ConditionStatusFalse,
+			reason,
+			fmt.Sprintf(
+				"Waiting for disk %v (%v) on node %v to be ready",
+				diskName, diskStatus.DiskPath, node.Name,
+			),
+			nc.eventRecorder, node, corev1.EventTypeWarning)
+
+		diskStatus.Conditions = types.SetConditionAndRecord(
+			diskStatus.Conditions,
+			longhorn.DiskConditionTypeSchedulable,
+			longhorn.ConditionStatusFalse,
+			reason,
+			fmt.Sprintf(
+				"Waiting for disk %v (%v) on node %v to be schedulable",
+				diskName, diskStatus.DiskPath, node.Name,
+			),
+			nc.eventRecorder, node, corev1.EventTypeWarning)
+
+		node.Status.DiskStatus[diskName] = diskStatus
+	}
 }
 
 func (nc *NodeController) markAllDisksNotReadyWhenNodeNotReady(node *longhorn.Node) {

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -397,6 +397,64 @@ func (s *NodeControllerSuite) TestKubeNodeDown(c *C) {
 	s.checkOrphans(c, expectation)
 }
 
+func (s *NodeControllerSuite) TestNonOwnerDoesNotMarkDisksNotReadyWhenNodeNotReady(c *C) {
+	// This test verifies that when a non-owner controller reconciles a node
+	// that is not-ready due to a transient reason (ManagerPodDown), it does NOT
+	// mark the disks as not-ready. Only definitive down states (K8s node gone/not ready)
+	// should trigger disk marking by non-owners.
+	node := newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusUnknown, "")
+
+	fixture := &NodeControllerFixture{
+		lhNodes: map[string]*longhorn.Node{
+			TestNode2: node,
+		},
+		lhSettings: map[string]*longhorn.Setting{
+			string(types.SettingNameDefaultInstanceManagerImage): newDefaultInstanceManagerImageSetting(),
+		},
+		pods: map[string]*corev1.Pod{
+			// Manager pod is failed — causes ManagerPodDown (transient)
+			TestDaemon2: newDaemonPod(corev1.PodFailed, TestDaemon2, TestNamespace, TestNode2, TestIP2, nil),
+		},
+		nodes: map[string]*corev1.Node{
+			// K8s node itself is healthy
+			TestNode2: newKubernetesNode(
+				TestNode2,
+				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				corev1.ConditionFalse,
+				corev1.ConditionFalse,
+				corev1.ConditionFalse,
+				corev1.ConditionTrue,
+			),
+		},
+	}
+
+	expectation := &NodeControllerExpectation{
+		nodeStatus: map[string]*longhorn.NodeStatus{
+			TestNode2: {
+				Conditions: []longhorn.Condition{
+					newNodeCondition(longhorn.NodeConditionTypeSchedulable, longhorn.ConditionStatusTrue, ""),
+					newNodeCondition(longhorn.NodeConditionTypeReady, longhorn.ConditionStatusFalse, longhorn.NodeConditionReasonManagerPodDown),
+				},
+			},
+		},
+	}
+
+	s.initTest(c, fixture)
+
+	err := s.controller.syncNode(getKey(node, c))
+	c.Assert(err, IsNil)
+
+	n, err := s.lhClient.LonghornV1beta2().Nodes(TestNamespace).Get(context.TODO(), node.Name, metav1.GetOptions{})
+	c.Assert(err, IsNil)
+
+	s.checkNodeConditions(c, expectation, n)
+
+	diskStatus := n.Status.DiskStatus[TestDiskID1]
+	c.Assert(types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeReady).Status, Equals, longhorn.ConditionStatusTrue)
+	c.Assert(types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeSchedulable).Status, Equals, longhorn.ConditionStatusTrue)
+}
+
 func (s *NodeControllerSuite) TestKubeNodePressure(c *C) {
 	var err error
 


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#12987

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
