### PR TITLE
feat(metrics): add setting to toggle Kubernetes Metrics Server integr…

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1685,6 +1685,16 @@ func (info *ClusterInfo) collectNodeCount() error {
 }
 
 func (info *ClusterInfo) collectResourceUsage() error {
+	enabled := true
+	if v, err := info.ds.GetSettingAsBool(types.SettingNameKubernetesMetricsServerMetricsEnabled); err != nil {
+		logrus.WithError(err).Warnf("Failed to get setting %v, defaulting to enabled", types.SettingNameKubernetesMetricsServerMetricsEnabled)
+	} else {
+		enabled = v
+	}
+	if !enabled {
+		return nil
+	}
+
 	componentMap := map[string]map[string]string{
 		"Manager":         info.ds.GetManagerLabel(),
 		"InstanceManager": types.GetInstanceManagerComponentLabel(),

--- a/metrics_collector/instance_manager_collector.go
+++ b/metrics_collector/instance_manager_collector.go
@@ -140,6 +140,16 @@ func (imc *InstanceManagerCollector) collectActualUsage(ch chan<- prometheus.Met
 		}
 	}()
 
+	enabled := true
+	if v, err := imc.ds.GetSettingAsBool(types.SettingNameKubernetesMetricsServerMetricsEnabled); err != nil {
+		imc.logger.WithError(err).Warnf("Failed to get setting %v, defaulting to enabled", types.SettingNameKubernetesMetricsServerMetricsEnabled)
+	} else {
+		enabled = v
+	}
+	if !enabled {
+		return
+	}
+
 	podMetrics, err := imc.kubeMetricsClient.MetricsV1beta1().PodMetricses(imc.namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: makeInstanceManagerLabelSelector(imc.currentNodeID),
 	})

--- a/metrics_collector/manager_collector.go
+++ b/metrics_collector/manager_collector.go
@@ -11,6 +11,7 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 )
 
 type ManagerCollector struct {
@@ -70,6 +71,16 @@ func (mc *ManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			mc.logger.WithField("error", err).Warn("Panic during collecting metrics")
 		}
 	}()
+
+	enabled := true
+	if v, err := mc.ds.GetSettingAsBool(types.SettingNameKubernetesMetricsServerMetricsEnabled); err != nil {
+		mc.logger.WithError(err).Warnf("Failed to get setting %v, defaulting to enabled", types.SettingNameKubernetesMetricsServerMetricsEnabled)
+	} else {
+		enabled = v
+	}
+	if !enabled {
+		return
+	}
 
 	// This code is running on the manager pod and os hostname always guarantees to be the manager pod name.
 	managerPodName, err := os.Hostname()

--- a/metrics_collector/node_collector.go
+++ b/metrics_collector/node_collector.go
@@ -12,6 +12,7 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -253,6 +254,16 @@ func (nc *NodeCollector) collectNodeActualCPUMemoryUsage(ch chan<- prometheus.Me
 			nc.logger.WithField("error", err).Warn("Panic during collecting metrics")
 		}
 	}()
+
+	enabled := true
+	if v, err := nc.ds.GetSettingAsBool(types.SettingNameKubernetesMetricsServerMetricsEnabled); err != nil {
+		nc.logger.WithError(err).Warnf("Failed to get setting %v, defaulting to enabled", types.SettingNameKubernetesMetricsServerMetricsEnabled)
+	} else {
+		enabled = v
+	}
+	if !enabled {
+		return
+	}
 
 	nodeMetrics, err := nc.kubeMetricsClient.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{
 		FieldSelector: "metadata.name=" + nc.currentNodeID,

--- a/types/setting.go
+++ b/types/setting.go
@@ -79,6 +79,7 @@ const (
 	SettingNameUpgradeResponderURL                                      = SettingName("upgrade-responder-url")
 	SettingNameManagerURL                                               = SettingName("manager-url")
 	SettingNameAllowCollectingLonghornUsage                             = SettingName("allow-collecting-longhorn-usage-metrics")
+	SettingNameKubernetesMetricsServerMetricsEnabled                    = SettingName("kubernetes-metrics-server-metrics-enabled")
 	SettingNameCurrentLonghornVersion                                   = SettingName("current-longhorn-version")
 	SettingNameLatestLonghornVersion                                    = SettingName("latest-longhorn-version")
 	SettingNameStableLonghornVersions                                   = SettingName("stable-longhorn-versions")
@@ -205,6 +206,7 @@ var (
 		SettingNameUpgradeResponderURL,
 		SettingNameManagerURL,
 		SettingNameAllowCollectingLonghornUsage,
+		SettingNameKubernetesMetricsServerMetricsEnabled,
 		SettingNameCurrentLonghornVersion,
 		SettingNameLatestLonghornVersion,
 		SettingNameStableLonghornVersions,
@@ -366,6 +368,7 @@ var (
 		SettingNameUpgradeResponderURL:                                      SettingDefinitionUpgradeResponderURL,
 		SettingNameManagerURL:                                               SettingDefinitionManagerURL,
 		SettingNameAllowCollectingLonghornUsage:                             SettingDefinitionAllowCollectingLonghornUsageMetrics,
+		SettingNameKubernetesMetricsServerMetricsEnabled:                    SettingDefinitionKubernetesMetricsServerMetricsEnabled,
 		SettingNameCurrentLonghornVersion:                                   SettingDefinitionCurrentLonghornVersion,
 		SettingNameLatestLonghornVersion:                                    SettingDefinitionLatestLonghornVersion,
 		SettingNameStableLonghornVersions:                                   SettingDefinitionStableLonghornVersions,
@@ -735,6 +738,21 @@ var (
 		DisplayName: "Allow Collecting Longhorn Usage Metrics",
 		Description: "Enabling this setting will allow Longhorn to provide additional usage metrics to https://metrics.longhorn.io/.\n" +
 			"This information will help us better understand how Longhorn is being used, which will ultimately contribute to future improvements.\n",
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeBool,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            "true",
+	}
+
+	SettingDefinitionKubernetesMetricsServerMetricsEnabled = SettingDefinition{
+		DisplayName: "Kubernetes Metrics Server Metrics Enabled",
+		Description: "Enabling this setting allows Longhorn to query the Kubernetes Metrics Server ('metrics.k8s.io') for pod and node resource usage. " +
+			"Disable if Metrics Server is not installed to prevent repeated scrape errors and unnecessary API traffic. " +
+			"Disabling hides metrics for: longhorn_node_cpu_usage_millicpu, longhorn_node_memory_usage_bytes, " +
+			"longhorn_instance_manager_cpu_usage_millicpu, longhorn_instance_manager_memory_usage_bytes, " +
+			"longhorn_manager_cpu_usage_millicpu, longhorn_manager_memory_usage_bytes.\n",
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeBool,
 		Required:           true,


### PR DESCRIPTION
…ation

Add kubernetes-metrics-server-metrics-enabled (Bool, default true) to let users disable metrics.k8s.io API calls on clusters without metrics-server installed.



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/13011

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
