### PR TITLE
feat(webhook): bootstrap and rotate webhook TLS Secrets in-process

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -41,6 +41,7 @@ import (
 
 	metricscollector "github.com/longhorn/longhorn-manager/metrics_collector"
 	recoverybackend "github.com/longhorn/longhorn-manager/recovery_backend"
+	webhookcert "github.com/longhorn/longhorn-manager/webhook/cert"
 )
 
 const (
@@ -192,6 +193,12 @@ func startWebhooksByLeaderElection(ctx context.Context, kubeconfigPath, currentN
 			return err
 		}
 
+		// Pre-create webhook secrets with the static annotation so dynamiclistener
+		// starts in read-only mode. See webhook/cert.
+		if err := webhookcert.EnsureWebhookSecrets(ctx, clients.K8s, clients.Namespace); err != nil {
+			return errors.Wrap(err, "failed to bootstrap webhook secrets")
+		}
+
 		if err := webhook.StartWebhook(ctx, types.WebhookTypeAdmission, clients); err != nil {
 			return err
 		}
@@ -301,6 +308,9 @@ func startManager(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Leader-elected periodic webhook cert rotation; only the leader writes.
+	go webhookcert.RotateLoop(ctx, clients.K8s, clients.Namespace, currentNodeID)
 
 	if err := recoverybackend.StartRecoveryBackend(clients); err != nil {
 		return err

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof" // for runtime profiling
 	"os"
 	"time"
+
+	_ "net/http/pprof" // for runtime profiling
 
 	"github.com/cockroachdb/errors"
 	"github.com/gorilla/handlers"

--- a/webhook/cert/bootstrap.go
+++ b/webhook/cert/bootstrap.go
@@ -1,0 +1,403 @@
+// Package cert bootstraps and rotates the longhorn-webhook-{ca,tls} secrets.
+//
+// At scale, dynamiclistener's per-pod writers race on the secret and produce a
+// sustained 409 storm on kube-apiserver. Marking the secret with
+// listener.cattle.io/static="true" makes dynamiclistener treat it as read-only
+// on every write path; this package then owns rotation (see rotate.go).
+//
+// Rotation reuses the existing CA when it is still healthy so that only the
+// leaf Secret is updated. Updating the CA Secret triggers a non-atomic
+// caBundle/leaf swap in apiserver webhook configs that can drop handshakes
+// for a few seconds; the per-year leaf renewal path avoids it entirely.
+// CA + leaf are regenerated together only when the CA itself is unparsable
+// or near expiry.
+package cert
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rancher/dynamiclistener/factory"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+)
+
+const (
+	// Match dynamiclistener defaults: long-lived CA, yearly leaf. A long CA
+	// validity is what lets the steady-state rotation path touch only the
+	// leaf Secret.
+	caValidityDays   = 365 * 10
+	leafValidityDays = 365
+	renewWithin      = 90 * 24 * time.Hour
+	rsaKeyBits       = 2048
+
+	// Backdate NotBefore so freshly-issued certs survive minor clock skew.
+	clockSkewSlack = 5 * time.Minute
+)
+
+// EnsureWebhookSecrets brings the webhook Secrets to a healthy, static-annotated
+// state. Three-way decision:
+//
+//   - CA + leaf healthy: annotate-only.
+//   - CA healthy, leaf not: reuse the existing CA and re-issue the leaf only.
+//   - otherwise: regenerate CA + leaf together.
+//
+// Idempotent; safe to call on every leader-elected rotation tick.
+func EnsureWebhookSecrets(ctx context.Context, k8s kubernetes.Interface, namespace string) error {
+	caSec, err := getSecret(ctx, k8s, namespace, types.CaName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get secret %s/%s", namespace, types.CaName)
+	}
+	leafSec, err := getSecret(ctx, k8s, namespace, types.CertName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get secret %s/%s", namespace, types.CertName)
+	}
+
+	caCert, caKey, caHealthy := loadHealthyCA(caSec)
+	leafHealthy := caHealthy && leafIsHealthy(leafSec, caCert, namespace)
+
+	switch {
+	case caHealthy && leafHealthy:
+		if err := ensureStaticAnnotation(ctx, k8s, namespace, caSec); err != nil {
+			return errors.Wrapf(err, "failed to annotate secret %s/%s", namespace, types.CaName)
+		}
+		if err := ensureStaticAnnotation(ctx, k8s, namespace, leafSec); err != nil {
+			return errors.Wrapf(err, "failed to annotate secret %s/%s", namespace, types.CertName)
+		}
+		return nil
+
+	case caHealthy && !leafHealthy:
+		logrus.Infof("Rotating webhook leaf only (reusing existing CA) for namespace %s", namespace)
+		leafValidity := time.Duration(leafValidityDays) * 24 * time.Hour
+		leafCert, leafKey, err := generateLeaf(caCert, caKey, leafSANs(namespace), leafValidity)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate webhook leaf cert")
+		}
+		if err := upsertTLSSecret(ctx, k8s, namespace, types.CertName, leafCert, leafKey); err != nil {
+			return errors.Wrapf(err, "failed to upsert secret %s/%s", namespace, types.CertName)
+		}
+		logrus.Infof("Applied new webhook leaf (validity %dd) to namespace %s", leafValidityDays, namespace)
+		return nil
+
+	default:
+		logrus.Infof("Regenerating webhook CA and leaf for namespace %s", namespace)
+		newCACert, newCAKey, err := generateCA(time.Duration(caValidityDays) * 24 * time.Hour)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate webhook CA")
+		}
+		leafCert, leafKey, err := generateLeaf(newCACert, newCAKey, leafSANs(namespace), time.Duration(leafValidityDays)*24*time.Hour)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate webhook leaf cert")
+		}
+		// CA first so OnChange(CaName) handlers can fan out the new caBundle
+		// before the leaf swap.
+		if err := upsertTLSSecret(ctx, k8s, namespace, types.CaName, newCACert, newCAKey); err != nil {
+			return errors.Wrapf(err, "failed to upsert secret %s/%s", namespace, types.CaName)
+		}
+		if err := upsertTLSSecret(ctx, k8s, namespace, types.CertName, leafCert, leafKey); err != nil {
+			return errors.Wrapf(err, "failed to upsert secret %s/%s", namespace, types.CertName)
+		}
+		logrus.Infof("Applied new webhook CA (validity %dd) and leaf (validity %dd) to namespace %s",
+			caValidityDays, leafValidityDays, namespace)
+		return nil
+	}
+}
+
+// leafSANs covers both webhook services so either listener can terminate TLS
+// without dynamiclistener attempting an AddCN at runtime (IsStatic blocks it).
+func leafSANs(namespace string) []string {
+	return []string{
+		fmt.Sprintf("%s.%s.svc", types.AdmissionWebhookServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc", types.ConversionWebhookServiceName, namespace),
+	}
+}
+
+func getSecret(ctx context.Context, k8s kubernetes.Interface, namespace, name string) (*corev1.Secret, error) {
+	s, err := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	return s, err
+}
+
+// loadHealthyCA returns (cert, key, true) when the CA Secret parses and is
+// not nearing expiry. Any failure path returns ok=false so the caller falls
+// back to full CA + leaf regeneration.
+func loadHealthyCA(caSec *corev1.Secret) (*x509.Certificate, *rsa.PrivateKey, bool) {
+	if caSec == nil {
+		return nil, nil, false
+	}
+	caCert, caKey, err := parseCASecret(caSec)
+	if err != nil {
+		logrus.WithError(err).Warnf("Failed to parse webhook CA secret %s/%s", caSec.Namespace, caSec.Name)
+		return nil, nil, false
+	}
+	if caCert.NotAfter.Before(time.Now().Add(renewWithin)) {
+		logrus.Infof("Rotating webhook CA, expires at %s (within %s renewal window)", caCert.NotAfter, renewWithin)
+		return nil, nil, false
+	}
+	return caCert, caKey, true
+}
+
+// leafIsHealthy reports whether the leaf Secret chains to ca, has all required
+// SANs, and is not near expiry. Caller must have already verified ca is healthy.
+func leafIsHealthy(leafSec *corev1.Secret, ca *x509.Certificate, namespace string) bool {
+	if leafSec == nil {
+		return false
+	}
+	leafCert, err := parseCertSecret(leafSec)
+	if err != nil {
+		logrus.WithError(err).Warnf("Failed to parse webhook leaf secret %s/%s", leafSec.Namespace, leafSec.Name)
+		return false
+	}
+	if err := verifyChain(leafCert, ca); err != nil {
+		logrus.WithError(err).Warn("Failed to verify webhook cert chain")
+		return false
+	}
+	want := leafSANs(namespace)
+	if !certHasAllSANs(leafCert, want) {
+		logrus.Warnf("Webhook leaf SANs not all present, want %v, have %v", want, leafCert.DNSNames)
+		return false
+	}
+	if leafCert.NotAfter.Before(time.Now().Add(renewWithin)) {
+		logrus.Infof("Rotating webhook leaf, expires at %s (within %s renewal window)", leafCert.NotAfter, renewWithin)
+		return false
+	}
+	return true
+}
+
+func parseCertSecret(s *corev1.Secret) (*x509.Certificate, error) {
+	if s == nil {
+		return nil, errors.New("nil secret")
+	}
+	pemBytes := s.Data[corev1.TLSCertKey]
+	if len(pemBytes) == 0 {
+		return nil, errors.New("empty tls.crt")
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("no PEM block in tls.crt")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// parseCASecret loads both the CA cert and its RSA private key. Reusing the
+// existing key is what makes leaf-only rotation possible without invalidating
+// the apiserver-cached caBundle.
+func parseCASecret(s *corev1.Secret) (*x509.Certificate, *rsa.PrivateKey, error) {
+	cert, err := parseCertSecret(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := s.Data[corev1.TLSPrivateKeyKey]
+	if len(keyPEM) == 0 {
+		return nil, nil, errors.New("empty tls.key")
+	}
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, nil, errors.New("no PEM block in tls.key")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "parse CA private key")
+	}
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, nil, errors.New("CA private key is not RSA")
+	}
+	return cert, rsaKey, nil
+}
+
+func verifyChain(leaf, ca *x509.Certificate) error {
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	_, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	return err
+}
+
+func certHasSAN(c *x509.Certificate, want string) bool {
+	for _, dns := range c.DNSNames {
+		if dns == want {
+			return true
+		}
+	}
+	return false
+}
+
+func certHasAllSANs(c *x509.Certificate, want []string) bool {
+	for _, w := range want {
+		if !certHasSAN(c, w) {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCA(validity time.Duration) (*x509.Certificate, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		return nil, nil, err
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	notBefore := time.Now().Add(-clockSkewSlack)
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: types.CaName},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(validity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+func generateLeaf(caCert *x509.Certificate, caKey *rsa.PrivateKey, sans []string, validity time.Duration) (*x509.Certificate, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		return nil, nil, err
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	notBefore := time.Now().Add(-clockSkewSlack)
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: sans[0]},
+		DNSNames:     sans,
+		NotBefore:    notBefore,
+		NotAfter:     notBefore.Add(validity),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+func randSerial() (*big.Int, error) {
+	return rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+}
+
+func encodePEM(cert *x509.Certificate, key *rsa.PrivateKey) ([]byte, []byte, error) {
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+// upsertTLSSecret creates the Secret or updates it in place with the given
+// material and the static annotation, preserving other annotations and labels.
+func upsertTLSSecret(ctx context.Context, k8s kubernetes.Interface, namespace, name string, cert *x509.Certificate, key *rsa.PrivateKey) error {
+	certPEM, keyPEM, err := encodePEM(cert, key)
+	if err != nil {
+		return err
+	}
+
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				factory.Static: "true",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+	if _, err := k8s.CoreV1().Secrets(namespace).Create(ctx, desired, metav1.CreateOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current, err := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := current.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		updated.Annotations[factory.Static] = "true"
+		updated.Type = corev1.SecretTypeTLS
+		if updated.Data == nil {
+			updated.Data = map[string][]byte{}
+		}
+		updated.Data[corev1.TLSCertKey] = certPEM
+		updated.Data[corev1.TLSPrivateKeyKey] = keyPEM
+		_, err = k8s.CoreV1().Secrets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// ensureStaticAnnotation patches the static annotation onto an existing Secret
+// without touching cert material.
+func ensureStaticAnnotation(ctx context.Context, k8s kubernetes.Interface, namespace string, s *corev1.Secret) error {
+	if factory.IsStatic(s) {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current, err := k8s.CoreV1().Secrets(namespace).Get(ctx, s.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if factory.IsStatic(current) {
+			return nil
+		}
+		updated := current.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		updated.Annotations[factory.Static] = "true"
+		_, err = k8s.CoreV1().Secrets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		if err == nil {
+			logrus.Infof("Marked webhook secret %s/%s as static (preserving cert material)", namespace, s.Name)
+		}
+		return err
+	})
+}

--- a/webhook/cert/bootstrap_test.go
+++ b/webhook/cert/bootstrap_test.go
@@ -1,0 +1,349 @@
+package cert
+
+import (
+	"bytes"
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/rancher/dynamiclistener/factory"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+)
+
+const testNS = "longhorn-system"
+
+func TestEnsureWebhookSecrets_FreshCluster(t *testing.T) {
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("EnsureWebhookSecrets: %v", err)
+	}
+
+	caSec, err := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CA: %v", err)
+	}
+	leafSec, err := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get leaf: %v", err)
+	}
+
+	if got := caSec.Annotations[factory.Static]; got != "true" {
+		t.Errorf("CA static annotation = %q, want \"true\"", got)
+	}
+	if got := leafSec.Annotations[factory.Static]; got != "true" {
+		t.Errorf("leaf static annotation = %q, want \"true\"", got)
+	}
+	if caSec.Type != corev1.SecretTypeTLS {
+		t.Errorf("CA secret type = %q, want %q", caSec.Type, corev1.SecretTypeTLS)
+	}
+
+	caCert, err := parseCertSecret(caSec)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leafCert, err := parseCertSecret(leafSec)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if err := verifyChain(leafCert, caCert); err != nil {
+		t.Errorf("chain verify: %v", err)
+	}
+	if want := leafSANs(testNS); !certHasAllSANs(leafCert, want) {
+		t.Errorf("leaf SANs = %v, want all of %v", leafCert.DNSNames, want)
+	}
+
+	wantLeafValidity := time.Duration(leafValidityDays) * 24 * time.Hour
+	if got := leafCert.NotAfter.Sub(leafCert.NotBefore); got < wantLeafValidity-time.Hour || got > wantLeafValidity+time.Hour {
+		t.Errorf("leaf validity = %s, want ~%s", got, wantLeafValidity)
+	}
+	wantCAValidity := time.Duration(caValidityDays) * 24 * time.Hour
+	if got := caCert.NotAfter.Sub(caCert.NotBefore); got < wantCAValidity-time.Hour || got > wantCAValidity+time.Hour {
+		t.Errorf("CA validity = %s, want ~%s", got, wantCAValidity)
+	}
+}
+
+// TestEnsureWebhookSecrets_HappyPathOnlyAddsAnnotation models the
+// running-cluster scenario where dynamiclistener has already created the
+// secrets without our annotation; we must keep the cert material as-is and
+// only add the static annotation.
+func TestEnsureWebhookSecrets_HappyPathOnlyAddsAnnotation(t *testing.T) {
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("first EnsureWebhookSecrets: %v", err)
+	}
+
+	for _, name := range []string{types.CaName, types.CertName} {
+		s, err := k8s.CoreV1().Secrets(testNS).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get %s: %v", name, err)
+		}
+		delete(s.Annotations, factory.Static)
+		if _, err := k8s.CoreV1().Secrets(testNS).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("update %s: %v", name, err)
+		}
+	}
+
+	caBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("second EnsureWebhookSecrets: %v", err)
+	}
+
+	caAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if !bytes.Equal(caBefore.Data[corev1.TLSCertKey], caAfter.Data[corev1.TLSCertKey]) {
+		t.Error("CA cert was rewritten on annotation-only path")
+	}
+	if !bytes.Equal(leafBefore.Data[corev1.TLSCertKey], leafAfter.Data[corev1.TLSCertKey]) {
+		t.Error("leaf cert was rewritten on annotation-only path")
+	}
+	if !factory.IsStatic(caAfter) {
+		t.Error("CA static annotation missing after Phase 2")
+	}
+	if !factory.IsStatic(leafAfter) {
+		t.Error("leaf static annotation missing after Phase 2")
+	}
+}
+
+func TestEnsureWebhookSecrets_RotatesNearingExpiry(t *testing.T) {
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+
+	// Plant secrets whose NotAfter is within renewWithin so the next
+	// EnsureWebhookSecrets call must regenerate, not just annotate.
+	shortValidity := 10 * 24 * time.Hour
+	caCert, caKey, err := generateCA(shortValidity)
+	if err != nil {
+		t.Fatalf("generate near-expiry CA: %v", err)
+	}
+	leafCert, leafKey, err := generateLeaf(caCert, caKey, leafSANs(testNS), shortValidity)
+	if err != nil {
+		t.Fatalf("generate near-expiry leaf: %v", err)
+	}
+	mustCreateTLSSecret(t, k8s, ctx, types.CaName, caCert, caKey)
+	mustCreateTLSSecret(t, k8s, ctx, types.CertName, leafCert, leafKey)
+
+	caBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("EnsureWebhookSecrets: %v", err)
+	}
+
+	caAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if bytes.Equal(caBefore.Data[corev1.TLSCertKey], caAfter.Data[corev1.TLSCertKey]) {
+		t.Error("CA was NOT rotated despite being near expiry")
+	}
+	if bytes.Equal(leafBefore.Data[corev1.TLSCertKey], leafAfter.Data[corev1.TLSCertKey]) {
+		t.Error("leaf was NOT rotated despite being near expiry")
+	}
+
+	caAfterParsed, err := parseCertSecret(caAfter)
+	if err != nil {
+		t.Fatalf("parse rotated CA: %v", err)
+	}
+	leafAfterParsed, err := parseCertSecret(leafAfter)
+	if err != nil {
+		t.Fatalf("parse rotated leaf: %v", err)
+	}
+	if err := verifyChain(leafAfterParsed, caAfterParsed); err != nil {
+		t.Errorf("rotated chain verify: %v", err)
+	}
+	// The freshly-rotated certs must be on the full validity schedule again,
+	// not the 10-day schedule of the seed.
+	if got := leafAfterParsed.NotAfter.Sub(leafAfterParsed.NotBefore); got < shortValidity*2 {
+		t.Errorf("rotated leaf validity = %s, want > %s", got, shortValidity*2)
+	}
+}
+
+func TestEnsureWebhookSecrets_LeafReissuedOnChainMismatch(t *testing.T) {
+	// CA and leaf both exist and individually parse, but the leaf is signed
+	// by a different CA. The healthy CA Secret must be preserved (touching
+	// it would force a non-atomic apiserver caBundle/leaf swap); only the
+	// leaf is re-issued, signed by the current CA, which heals the chain.
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+	caValidity := time.Duration(caValidityDays) * 24 * time.Hour
+	leafValidity := time.Duration(leafValidityDays) * 24 * time.Hour
+
+	caA, caAKey, err := generateCA(caValidity)
+	if err != nil {
+		t.Fatalf("generate CA A: %v", err)
+	}
+	caB, caBKey, err := generateCA(caValidity)
+	if err != nil {
+		t.Fatalf("generate CA B: %v", err)
+	}
+	mismatchedLeaf, mismatchedKey, err := generateLeaf(caA, caAKey, leafSANs(testNS), leafValidity)
+	if err != nil {
+		t.Fatalf("generate mismatched leaf: %v", err)
+	}
+
+	mustCreateTLSSecret(t, k8s, ctx, types.CaName, caB, caBKey)
+	mustCreateTLSSecret(t, k8s, ctx, types.CertName, mismatchedLeaf, mismatchedKey)
+
+	caBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("EnsureWebhookSecrets: %v", err)
+	}
+
+	caAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if !bytes.Equal(caBefore.Data[corev1.TLSCertKey], caAfter.Data[corev1.TLSCertKey]) {
+		t.Error("CA was rotated; healthy CA must be preserved on chain mismatch")
+	}
+	if bytes.Equal(leafBefore.Data[corev1.TLSCertKey], leafAfter.Data[corev1.TLSCertKey]) {
+		t.Error("leaf was NOT re-issued despite chain mismatch")
+	}
+
+	caAfterParsed, err := parseCertSecret(caAfter)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leafAfterParsed, err := parseCertSecret(leafAfter)
+	if err != nil {
+		t.Fatalf("parse rotated leaf: %v", err)
+	}
+	if err := verifyChain(leafAfterParsed, caAfterParsed); err != nil {
+		t.Errorf("rotated chain verify: %v", err)
+	}
+}
+
+func TestEnsureWebhookSecrets_LeafReissuedOnMissingSAN(t *testing.T) {
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+	caValidity := time.Duration(caValidityDays) * 24 * time.Hour
+	leafValidity := time.Duration(leafValidityDays) * 24 * time.Hour
+
+	caCert, caKey, err := generateCA(caValidity)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+	wrongSAN := []string{"some.other.svc"}
+	leafCert, leafKey, err := generateLeaf(caCert, caKey, wrongSAN, leafValidity)
+	if err != nil {
+		t.Fatalf("generate wrong-SAN leaf: %v", err)
+	}
+	mustCreateTLSSecret(t, k8s, ctx, types.CaName, caCert, caKey)
+	mustCreateTLSSecret(t, k8s, ctx, types.CertName, leafCert, leafKey)
+
+	caBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("EnsureWebhookSecrets: %v", err)
+	}
+
+	caAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+	if !bytes.Equal(caBefore.Data[corev1.TLSCertKey], caAfter.Data[corev1.TLSCertKey]) {
+		t.Error("CA was rotated; healthy CA must be preserved on SAN mismatch")
+	}
+	if bytes.Equal(leafBefore.Data[corev1.TLSCertKey], leafAfter.Data[corev1.TLSCertKey]) {
+		t.Error("leaf was NOT re-issued despite SAN mismatch")
+	}
+	parsed, err := parseCertSecret(leafAfter)
+	if err != nil {
+		t.Fatalf("parse rotated leaf: %v", err)
+	}
+	if want := leafSANs(testNS); !certHasAllSANs(parsed, want) {
+		t.Errorf("rotated leaf SANs = %v, want all of %v", parsed.DNSNames, want)
+	}
+}
+
+// TestEnsureWebhookSecrets_LeafOnlyRotation_NearExpiry covers the steady-state
+// yearly rotation: CA is long-lived and healthy, leaf is within renewWithin.
+// We must re-sign a new leaf with the existing CA and leave the CA Secret
+// byte-identical so apiserver's caBundle never changes.
+func TestEnsureWebhookSecrets_LeafOnlyRotation_NearExpiry(t *testing.T) {
+	k8s := fake.NewClientset()
+	ctx := context.Background()
+
+	caCert, caKey, err := generateCA(time.Duration(caValidityDays) * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+	// Leaf valid but inside the renewWithin window.
+	shortLeafValidity := 10 * 24 * time.Hour
+	leafCert, leafKey, err := generateLeaf(caCert, caKey, leafSANs(testNS), shortLeafValidity)
+	if err != nil {
+		t.Fatalf("generate near-expiry leaf: %v", err)
+	}
+	mustCreateTLSSecret(t, k8s, ctx, types.CaName, caCert, caKey)
+	mustCreateTLSSecret(t, k8s, ctx, types.CertName, leafCert, leafKey)
+
+	caBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafBefore, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if err := EnsureWebhookSecrets(ctx, k8s, testNS); err != nil {
+		t.Fatalf("EnsureWebhookSecrets: %v", err)
+	}
+
+	caAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CaName, metav1.GetOptions{})
+	leafAfter, _ := k8s.CoreV1().Secrets(testNS).Get(ctx, types.CertName, metav1.GetOptions{})
+
+	if !bytes.Equal(caBefore.Data[corev1.TLSCertKey], caAfter.Data[corev1.TLSCertKey]) {
+		t.Error("CA cert was rotated; must stay byte-identical when only leaf is near expiry")
+	}
+	if !bytes.Equal(caBefore.Data[corev1.TLSPrivateKeyKey], caAfter.Data[corev1.TLSPrivateKeyKey]) {
+		t.Error("CA key was rotated; must stay byte-identical when only leaf is near expiry")
+	}
+	if bytes.Equal(leafBefore.Data[corev1.TLSCertKey], leafAfter.Data[corev1.TLSCertKey]) {
+		t.Error("leaf was NOT rotated despite being near expiry")
+	}
+
+	// New leaf must chain to the unchanged CA and have full validity again.
+	caParsed, err := parseCertSecret(caAfter)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leafParsed, err := parseCertSecret(leafAfter)
+	if err != nil {
+		t.Fatalf("parse rotated leaf: %v", err)
+	}
+	if err := verifyChain(leafParsed, caParsed); err != nil {
+		t.Errorf("rotated chain verify: %v", err)
+	}
+	wantLeafValidity := time.Duration(leafValidityDays) * 24 * time.Hour
+	if got := leafParsed.NotAfter.Sub(leafParsed.NotBefore); got < wantLeafValidity-time.Hour {
+		t.Errorf("rotated leaf validity = %s, want ~%s", got, wantLeafValidity)
+	}
+}
+
+func mustCreateTLSSecret(t *testing.T, k8s *fake.Clientset, ctx context.Context, name string, cert *x509.Certificate, key *rsa.PrivateKey) {
+	t.Helper()
+	certPEM, keyPEM, err := encodePEM(cert, key)
+	if err != nil {
+		t.Fatalf("encodePEM: %v", err)
+	}
+	_, err = k8s.CoreV1().Secrets(testNS).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+}

--- a/webhook/cert/rotate.go
+++ b/webhook/cert/rotate.go
@@ -1,0 +1,96 @@
+package cert
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Separate from LeaseLockNameWebhook: that lease gates a one-shot
+	// webhook init with an aggressive timeout; rotation is a long-running
+	// periodic worker that wants a calmer lease.
+	rotationLeaseName = "longhorn-webhook-cert-rotation"
+
+	// Matches dynamiclistener's 6h check cadence.
+	rotationCheckInterval = 6 * time.Hour
+
+	// Short backoff so a transient apiserver hiccup doesn't idle us for 6h.
+	rotationErrorRetryInterval = 5 * time.Minute
+)
+
+// RotateLoop runs leader-elected EnsureWebhookSecrets ticks until ctx is
+// cancelled. Single-writer is the property we care about; non-leaders pick up
+// rotated material through the existing dynamiclistener watch path with no
+// pod restart. Call once per pod with a unique identity (node or pod name).
+func RotateLoop(ctx context.Context, k8s kubernetes.Interface, namespace, identity string) {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      rotationLeaseName,
+			Namespace: namespace,
+		},
+		Client: k8s.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: identity,
+		},
+	}
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   60 * time.Second,
+		RenewDeadline:   30 * time.Second,
+		RetryPeriod:     10 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) {
+				logrus.Infof("Webhook cert rotation leader elected: %s", identity)
+				runRotationWorker(leaderCtx, k8s, namespace)
+			},
+			OnStoppedLeading: func() {
+				logrus.Infof("Webhook cert rotation leader lost: %s", identity)
+			},
+			OnNewLeader: func(id string) {
+				if id != identity {
+					logrus.Infof("Webhook cert rotation leader changed: %s", id)
+				}
+			},
+		},
+	})
+}
+
+func runRotationWorker(ctx context.Context, k8s kubernetes.Interface, namespace string) {
+	// Sync immediately on becoming leader so a near-expiry cert doesn't wait
+	// a full rotationCheckInterval after the previous leader died.
+	wait := runOnce(ctx, k8s, namespace, true)
+	// Reuse a single Timer so an in-flight tick is stopped on ctx cancel
+	// instead of leaking until it fires.
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			wait = runOnce(ctx, k8s, namespace, false)
+			t.Reset(wait)
+		}
+	}
+}
+
+func runOnce(ctx context.Context, k8s kubernetes.Interface, namespace string, initial bool) time.Duration {
+	if err := EnsureWebhookSecrets(ctx, k8s, namespace); err != nil {
+		phase := "periodic"
+		if initial {
+			phase = "initial"
+		}
+		logrus.WithError(err).Errorf("Failed %s webhook cert rotation check", phase)
+		return rotationErrorRetryInterval
+	}
+	return rotationCheckInterval
+}


### PR DESCRIPTION
At scale, dynamiclistener's per-pod writers race on the webhook secret and produce a sustained 409 storm on kube-apiserver. Pre-create the secrets with `listener.cattle.io/static="true"` so dynamiclistener treats them as read-only, and run a leader-elected loop in-process to own renewal (factory.Renew refuses static secrets).

longhorn-13012

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/13012

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
