### PR TITLE
fix(api): use frontend node to select attached v2 engine

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1549,7 +1549,7 @@ func toVolumeResource(v *longhorn.Volume, vefs []*longhorn.EngineFrontend, ves [
 			UnmapMarkSnapChainRemovedEnabled: e.Status.UnmapMarkSnapChainRemovedEnabled,
 		})
 
-		if e.Spec.NodeID == v.Status.CurrentNodeID {
+		if controllerNodeID == v.Status.CurrentNodeID {
 			ve = e
 		}
 		rs := e.Status.RestoreStatus


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13029

#### What this PR does / why we need it:

For v2 volumes, toVolumeResource() merged EngineFrontend node information into the controller response, but still selected the attached engine by comparing volume.Status.CurrentNodeID with engine.Spec.NodeID.

When the frontend node and engine node differ, the API picks no attached engine for replica mode lookup, so replicas[].mode stays empty and the UI renders replica cards as gray even though the replicas are running.

Fix this by selecting the engine with the resolved controller node ID (after applying EngineFrontend overrides), so replica modes are populated from the attached engine correctly.

#### Special notes for your reviewer:

#### Additional documentation or context
