### PR TITLE
fix(v2): remove hasRecentlyHealthyExtraReplica to unblock eviction cleanup

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -51,8 +51,7 @@ var (
 	RetryInterval = 100 * time.Millisecond
 	RetryCounts   = 20
 
-	AutoSalvageTimeLimit             = 1 * time.Minute
-	RecentHealthyReplicaCleanupDelay = 1 * time.Minute
+	AutoSalvageTimeLimit = 1 * time.Minute
 
 	UnstableNodeReadyTimeThreshold = 30 * time.Minute
 )
@@ -1135,45 +1134,6 @@ func getSafeAsLastReplicaCount(rs map[string]*longhorn.Replica) int {
 	return count
 }
 
-func (c *VolumeController) hasRecentlyHealthyExtraReplica(v *longhorn.Volume, rs map[string]*longhorn.Replica) bool {
-	if !types.IsDataEngineV2(v.Spec.DataEngine) {
-		return false
-	}
-
-	healthyReplicas := make([]*longhorn.Replica, 0, len(rs))
-	for _, r := range rs {
-		if isHealthyAndActiveReplica(r, false) {
-			healthyReplicas = append(healthyReplicas, r)
-		}
-	}
-	if len(healthyReplicas) <= v.Spec.NumberOfReplicas {
-		return false
-	}
-
-	now, err := util.ParseTime(c.nowHandler())
-	if err != nil {
-		logrus.WithError(err).Warn("Failed to parse current time while checking recently healthy extra replicas")
-		return false
-	}
-
-	sort.Slice(healthyReplicas, func(i, j int) bool {
-		ti, errI := util.ParseTime(healthyReplicas[i].Spec.HealthyAt)
-		tj, errJ := util.ParseTime(healthyReplicas[j].Spec.HealthyAt)
-		if errI != nil || errJ != nil {
-			return healthyReplicas[i].Spec.HealthyAt < healthyReplicas[j].Spec.HealthyAt
-		}
-		return ti.Before(tj)
-	})
-
-	for i := v.Spec.NumberOfReplicas; i < len(healthyReplicas); i++ {
-		if util.TimestampWithinLimit(now, healthyReplicas[i].Spec.HealthyAt, RecentHealthyReplicaCleanupDelay) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func getFailedReplicaCount(rs map[string]*longhorn.Replica) int {
 	count := 0
 	for _, r := range rs {
@@ -1219,13 +1179,6 @@ func (c *VolumeController) cleanupReplicas(v *longhorn.Volume, es map[string]*lo
 	if types.IsDataEngineV2(v.Spec.DataEngine) &&
 		v.Status.State == longhorn.VolumeStateAttached &&
 		!c.areVolumeDependentResourcesOpened(v, e, rs, efs) {
-		return nil
-	}
-
-	// For v2, a newly rebuilt surplus replica can become RW a short time before the
-	// serving path is truly stable. Defer extra healthy cleanup briefly so we do not
-	// immediately discard the older known-good replica if another detach/crash follows.
-	if c.hasRecentlyHealthyExtraReplica(v, rs) {
 		return nil
 	}
 

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	. "gopkg.in/check.v1"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -20,8 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/longhorn/backupstore"
 
@@ -1863,129 +1863,6 @@ func (s *TestSuite) TestCleanupReplicasDoesNotSkipExtraHealthyCleanupForV1WhenAt
 	}
 
 	err = vc.cleanupReplicas(v, map[string]*longhorn.Engine{e.Name: e}, rs, nil)
-	c.Assert(err, IsNil)
-	c.Assert(rs, HasLen, 1)
-	c.Assert(rs[localReplica.Name], NotNil)
-	c.Assert(rs[remoteReplica.Name], IsNil)
-}
-
-func (s *TestSuite) TestCleanupReplicasSkipsExtraHealthyCleanupForRecentlyHealthyV2Replica(c *C) {
-	datastore.SkipListerCheck = true
-
-	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
-	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
-	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
-	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
-
-	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
-	c.Assert(err, IsNil)
-
-	v := newVolume(TestVolumeName, 1)
-	v.Spec.DataEngine = longhorn.DataEngineTypeV2
-	v.Spec.DataLocality = longhorn.DataLocalityBestEffort
-	v.Spec.NodeID = TestNode1
-	v.Status.State = longhorn.VolumeStateAttached
-	v.Status.CurrentNodeID = TestNode1
-	v.Status.CurrentImage = TestEngineImage
-
-	e := newEngineForVolume(v)
-	e.Spec.DataEngine = longhorn.DataEngineTypeV2
-	e.Spec.NodeID = TestNode1
-	e.Status.CurrentState = longhorn.InstanceStateRunning
-
-	baseNow, err := util.ParseTime(getTestNow())
-	c.Assert(err, IsNil)
-
-	localReplica := newReplicaForVolume(v, e, TestNode1, TestDiskID1)
-	localReplica.Spec.Active = true
-	localReplica.Spec.HealthyAt = util.FormatTimeZ(baseNow)
-	localReplica.Spec.LastHealthyAt = localReplica.Spec.HealthyAt
-	localReplica.Status.CurrentState = longhorn.InstanceStateRunning
-
-	remoteReplica := newReplicaForVolume(v, e, TestNode2, TestDiskID2)
-	remoteReplica.Spec.Active = true
-	remoteReplica.Spec.HealthyAt = util.FormatTimeZ(baseNow.Add(-2 * RecentHealthyReplicaCleanupDelay))
-	remoteReplica.Spec.LastHealthyAt = remoteReplica.Spec.HealthyAt
-	remoteReplica.Status.CurrentState = longhorn.InstanceStateRunning
-
-	ef := newEngineFrontendForVolume(v, e.Name, TestNode1, "/dev/longhorn/test")
-	ef.Status.CurrentState = longhorn.InstanceStateRunning
-	ef.Status.Endpoint = "/dev/longhorn/test"
-
-	rs := map[string]*longhorn.Replica{
-		localReplica.Name:  localReplica,
-		remoteReplica.Name: remoteReplica,
-	}
-	efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
-
-	err = vc.cleanupReplicas(v, map[string]*longhorn.Engine{e.Name: e}, rs, efs)
-	c.Assert(err, IsNil)
-	c.Assert(rs, HasLen, 2)
-	c.Assert(rs[localReplica.Name], NotNil)
-	c.Assert(rs[remoteReplica.Name], NotNil)
-}
-
-func (s *TestSuite) TestCleanupReplicasAllowsExtraHealthyCleanupAfterRecentHealthyDelay(c *C) {
-	datastore.SkipListerCheck = true
-
-	kubeClient := fake.NewSimpleClientset()
-	lhClient := lhfake.NewSimpleClientset() // nolint: staticcheck
-	extensionsClient := apiextensionsfake.NewSimpleClientset()
-	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
-
-	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
-	c.Assert(err, IsNil)
-	rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
-
-	v := newVolume(TestVolumeName, 1)
-	v.Spec.DataEngine = longhorn.DataEngineTypeV2
-	v.Spec.DataLocality = longhorn.DataLocalityBestEffort
-	v.Spec.NodeID = TestNode1
-	v.Status.State = longhorn.VolumeStateAttached
-	v.Status.CurrentNodeID = TestNode1
-	v.Status.CurrentImage = TestEngineImage
-
-	e := newEngineForVolume(v)
-	e.Spec.DataEngine = longhorn.DataEngineTypeV2
-	e.Spec.NodeID = TestNode1
-	e.Status.CurrentState = longhorn.InstanceStateRunning
-
-	baseNow, err := util.ParseTime(getTestNow())
-	c.Assert(err, IsNil)
-	vc.nowHandler = func() string {
-		return util.FormatTimeZ(baseNow.Add(RecentHealthyReplicaCleanupDelay + time.Second))
-	}
-
-	localReplica := newReplicaForVolume(v, e, TestNode1, TestDiskID1)
-	localReplica.Spec.Active = true
-	localReplica.Spec.HealthyAt = util.FormatTimeZ(baseNow)
-	localReplica.Spec.LastHealthyAt = localReplica.Spec.HealthyAt
-	localReplica.Status.CurrentState = longhorn.InstanceStateRunning
-
-	remoteReplica := newReplicaForVolume(v, e, TestNode2, TestDiskID2)
-	remoteReplica.Spec.Active = true
-	remoteReplica.Spec.HealthyAt = util.FormatTimeZ(baseNow.Add(-2 * RecentHealthyReplicaCleanupDelay))
-	remoteReplica.Spec.LastHealthyAt = remoteReplica.Spec.HealthyAt
-	remoteReplica.Status.CurrentState = longhorn.InstanceStateRunning
-
-	ef := newEngineFrontendForVolume(v, e.Name, TestNode1, "/dev/longhorn/test")
-	ef.Status.CurrentState = longhorn.InstanceStateRunning
-	ef.Status.Endpoint = "/dev/longhorn/test"
-
-	rs := map[string]*longhorn.Replica{
-		localReplica.Name:  localReplica,
-		remoteReplica.Name: remoteReplica,
-	}
-	efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
-
-	for _, replica := range []*longhorn.Replica{localReplica, remoteReplica} {
-		createdReplica, err := lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), replica, metav1.CreateOptions{})
-		c.Assert(err, IsNil)
-		err = rIndexer.Add(createdReplica)
-		c.Assert(err, IsNil)
-	}
-
-	err = vc.cleanupReplicas(v, map[string]*longhorn.Engine{e.Name: e}, rs, efs)
 	c.Assert(err, IsNil)
 	c.Assert(rs, HasLen, 1)
 	c.Assert(rs[localReplica.Name], NotNil)


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13058

#### What this PR does / why we need it:

The hasRecentlyHealthyExtraReplica function delays extra healthy replica cleanup by 1 minute for v2 volumes. During node drain/eviction, this delay prevents cleanupEvictionRequestedReplicas from removing the old evicting replica before the drain completes. After uncordon, the node controller cancels eviction (EvictionRequested=false) since the node is no longer Unschedulable, leaving a surplus replica that no cleanup path can remove.

This does not affect v1 behavior as the function was gated behind IsDataEngineV2.


#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified volume controller replica cleanup logic by removing the deferred cleanup mechanism for recently healthy replicas, eliminating unnecessary cleanup delays.
  * Updated related tests to align with the streamlined cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->