### PR TITLE
fix: lazy umount LUKS device before attaching a volume to a node

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -36,6 +36,7 @@ import (
 	imutil "github.com/longhorn/longhorn-instance-manager/pkg/util"
 
 	"github.com/longhorn/longhorn-manager/constant"
+	"github.com/longhorn/longhorn-manager/csi/crypto"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/scheduler"
@@ -1898,6 +1899,20 @@ func (c *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[strin
 				// See https://github.com/longhorn/longhorn/issues/9089
 				if err := c.handleDelinquentAndStaleStateForFaultedRWXVolume(v); err != nil {
 					return err
+				}
+				// When the engine crashed unexpectedly, the LUKS device might still be mounted and the underlayer device is gone if the volume is encrypted.
+				// This can cause the subsequent attach to fail because the LUKS device is stale in use and ISCSI target can not be logged out.
+				// We can not lazy unmount the LUKS device at the CSI plugin level before sending an attaching volume request
+				// to the Longhorn server in ControllerPublishVolume because the CSI request might be received
+				// by a CSI plugin pod on the node (maybe node A) where the LUKS device is not present (maybe node B).
+				// After an unexpected engine crash, a stale LUKS device mount may still be present.
+				// Lazy unmount it here to clear stale mount state before re-attaching the volume.
+				if v.Spec.Encrypted {
+					log.Infof("Volume is encrypted, lazy unmounting crypto device for volume %v if it is still mounted", v.Name)
+					cryptoDevice := crypto.VolumeMapper(v.Name, string(v.Spec.DataEngine))
+					if err := util.LazyUnmount(cryptoDevice); err != nil {
+						return errors.Wrapf(err, "failed to lazy unmount crypto device %v for volume %v", cryptoDevice, v.Name)
+					}
 				}
 			}
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -945,3 +945,42 @@ func IsCryptsetupVerWithFixed16MiBHeaderSize() (bool, error) {
 
 	return nsexec.IsLuksFixed16MiBHeaderSize()
 }
+
+func LazyUnmount(path string) error {
+	if _, err := lhns.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		logrus.WithError(err).Warnf("Failed to stat path %s, will continue lazy unmounting it", path)
+	}
+
+	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceNet}
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
+	if err != nil {
+		return err
+	}
+
+	_, err = nsexec.Execute(nil, "umount", []string{"-l", path}, lhtypes.ExecuteDefaultTimeout)
+	if err != nil {
+		if isUnmountedError(err) {
+			// The device is already unmounted. We can safely ignore the error and treat it as a success!
+			logrus.WithError(err).Debugf("Device %s is already unmounted.", path)
+			return nil
+		}
+		return errors.Wrapf(err, "failed to unmount %s", path)
+	}
+
+	logrus.Debugf("Lazy unmounted device %s without the error.", path)
+	return nil
+}
+
+func isUnmountedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "not mounted") ||
+		strings.Contains(errMsg, "no mount point specified") ||
+		strings.Contains(errMsg, "no such file or directory")
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11510

#### What this PR does / why we need it:

We unmount the LUSK device in the volume controller that is the owner/attaching node of the volume if the engine crashed unexpectedly, and the volume was re-attached to the same node.

#### Special notes for your reviewer:

It can not do lazy unmount the LUKS device at the CSI plugin level before sending an attaching volume request to the Longhorn server in `ControllerPublishVolume` because the CSI request might be received by a CSI plugin pod on the node (maybe node A) where the LUKS device is not present (maybe node B).

And we need to unmount the LUKS device before attaching.

#### Additional documentation or context

Ran the customized e2e test case 3 times and `PASSED`
~https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7726~
~https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7744/~
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7749
