### PR TITLE
fix: remove encrypted dm device when engine crashed unexpectedly for v2 encrypted volumes

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1913,6 +1913,14 @@ func (c *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[strin
 					if err := util.LazyUnmount(cryptoDevice); err != nil {
 						return errors.Wrapf(err, "failed to lazy unmount crypto device %v for volume %v", cryptoDevice, v.Name)
 					}
+					if types.IsDataEngineV2(longhorn.DataEngineType(v.Spec.DataEngine)) {
+						// For v2 data engine, the dm-encrypted device will block the removing of the linear dm device that Longhorn creates for the volume on SPDK engine side.
+						// so we remove the encrypted dm device directly here to clear the stale state.
+						// And linear dm device will be removed on SPDK engine side when restarting the initiator.
+						if err := util.RemoveDMDevice(cryptoDevice); err != nil {
+							return errors.Wrapf(err, "failed to remove dm-crypt device %v for volume %v", cryptoDevice, v.Name)
+						}
+					}
 				}
 			}
 		}

--- a/csi/crypto/crypto.go
+++ b/csi/crypto/crypto.go
@@ -10,13 +10,14 @@ import (
 
 	lhns "github.com/longhorn/go-common-libs/ns"
 	lhtypes "github.com/longhorn/go-common-libs/types"
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 
 	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
 const (
-	mapperFilePathPrefix = "/dev/mapper"
+	MapperFilePathPrefix = "/dev/mapper"
 	mapperV2VolumeSuffix = "-encrypted"
 
 	CryptoKeyDefaultCipher = "aes-xts-plain64"
@@ -107,9 +108,9 @@ func VolumeMapper(volume, dataEngine string) string {
 		// v2 volume will use a dm device as default to control IO path when attaching.
 		// This dm device will be created with the same name as the volume name.
 		// The encrypted volume will be created with the volume name with "-encrypted" suffix to resolve the naming conflict.
-		return path.Join(mapperFilePathPrefix, getEncryptVolumeName(volume, dataEngine))
+		return path.Join(MapperFilePathPrefix, getEncryptVolumeName(volume, dataEngine))
 	}
-	return path.Join(mapperFilePathPrefix, volume)
+	return path.Join(MapperFilePathPrefix, volume)
 }
 
 // EncryptVolume encrypts provided device with LUKS.
@@ -248,7 +249,7 @@ func isDeviceEncrypted(devicePath string) (bool, error) {
 // and if so what the device is and the mapper name as used by LUKS.
 // If not, just returns the original device and an empty string.
 func DeviceEncryptionStatus(devicePath string) (mappedDevice, mapper string, err error) {
-	if !strings.HasPrefix(devicePath, mapperFilePathPrefix) {
+	if !strings.HasPrefix(devicePath, MapperFilePathPrefix) {
 		return devicePath, "", nil
 	}
 
@@ -258,7 +259,7 @@ func DeviceEncryptionStatus(devicePath string) (mappedDevice, mapper string, err
 		return devicePath, "", err
 	}
 
-	volume := strings.TrimPrefix(devicePath, mapperFilePathPrefix+"/")
+	volume := strings.TrimPrefix(devicePath, MapperFilePathPrefix+"/")
 	stdout, err := nsexec.LuksStatus(volume, lhtypes.LuksTimeout)
 	if err != nil {
 		logrus.WithError(err).Warnf("Device %s is not an active LUKS device", devicePath)

--- a/util/util.go
+++ b/util/util.go
@@ -46,6 +46,7 @@ import (
 	lhio "github.com/longhorn/go-common-libs/io"
 	lhns "github.com/longhorn/go-common-libs/ns"
 	lhtypes "github.com/longhorn/go-common-libs/types"
+	lhspdkutil "github.com/longhorn/go-spdk-helper/pkg/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
@@ -982,5 +983,34 @@ func isUnmountedError(err error) bool {
 	errMsg := strings.ToLower(err.Error())
 	return strings.Contains(errMsg, "not mounted") ||
 		strings.Contains(errMsg, "no mount point specified") ||
+		strings.Contains(errMsg, "no such file or directory")
+}
+
+func RemoveDMDevice(devicePath string) error {
+	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceIpc}
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
+	if err != nil {
+		return err
+	}
+
+	if err := lhspdkutil.DmsetupRemove(devicePath, true, true, nsexec); err != nil {
+		if isIgnorableDMRemoveError(err) {
+			logrus.WithError(err).Debugf("Dm device %s is already removed.", devicePath)
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func isIgnorableDMRemoveError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "no such device or address") ||
+		strings.Contains(errMsg, "not found") ||
 		strings.Contains(errMsg, "no such file or directory")
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

longhorn/longhorn#11510

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7811/
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7897/
