### PR TITLE
fix: detect and delete stale engine frontend instances with empty IM frontend

### DIFF
--- a/constant/events.go
+++ b/constant/events.go
@@ -75,4 +75,6 @@ const (
 	EventReasonMigrationFailed = "MigrationFailed"
 
 	EventReasonOrphanCleanupCompleted = "OrphanCleanupCompleted"
+
+	EventReasonStaleInstance = "StaleInstance"
 )

--- a/controller/engine_frontend_controller.go
+++ b/controller/engine_frontend_controller.go
@@ -53,6 +53,9 @@ type EngineFrontendController struct {
 
 	instanceHandler *InstanceHandler
 
+	// nil means use DeleteInstance; set in tests.
+	deleteInstanceHandler func(obj interface{}) error
+
 	proxyConnCounter util.Counter
 
 	backoff *flowcontrol.Backoff
@@ -368,6 +371,32 @@ func (efc *EngineFrontendController) syncEngineFrontend(key string) (err error) 
 	// Use instance handler to reconcile state
 	if err := efc.instanceHandler.ReconcileInstanceState(ef, &ef.Spec.InstanceSpec, &ef.Status.InstanceStatus); err != nil {
 		return err
+	}
+
+	// Delete stale EF instances recovered with an empty frontend in the IM.
+	if ef.Status.CurrentState == longhorn.InstanceStateRunning &&
+		ef.Spec.DesireState == longhorn.InstanceStateRunning &&
+		isEngineFrontendEndpointRequired(ef) {
+		var (
+			im    *longhorn.InstanceManager
+			imErr error
+		)
+		if ef.Status.InstanceManagerName != "" {
+			im, imErr = efc.ds.GetInstanceManagerRO(ef.Status.InstanceManagerName)
+		} else {
+			im, imErr = efc.ds.GetInstanceManagerByInstanceRO(ef)
+		}
+		if imErr != nil {
+			log.WithError(imErr).Warn("Failed to get instance manager for stale engine frontend detection, skipping")
+		} else if shouldDeleteStaleRunningEngineFrontend(ef, im) {
+			log.Warnf("EngineFrontend %v is running in IM with empty frontend (spec expects %v), deleting stale instance to trigger re-creation", ef.Name, ef.Spec.Frontend)
+			efc.eventRecorder.Eventf(ef, corev1.EventTypeWarning, constant.EventReasonStaleInstance,
+				"Deleting stale instance: IM reports empty frontend but spec expects %v", ef.Spec.Frontend)
+			if err := efc.deleteEngineFrontendInstance(ef); err != nil {
+				return errors.Wrapf(err, "failed to delete stale engine frontend instance %v", ef.Name)
+			}
+			return nil
+		}
 	}
 
 	statusTargetInitialized := isEngineFrontendTargetInitialized(ef.Status.TargetIP, ef.Status.TargetPort)
@@ -1077,6 +1106,27 @@ func isEngineFrontendEndpointRequired(ef *longhorn.EngineFrontend) bool {
 		return false
 	}
 	return !ef.Spec.DisableFrontend && ef.Spec.Frontend != longhorn.VolumeFrontendEmpty
+}
+
+// Caller must ensure isEngineFrontendEndpointRequired(ef) before calling.
+func shouldDeleteStaleRunningEngineFrontend(ef *longhorn.EngineFrontend, im *longhorn.InstanceManager) bool {
+	if ef == nil || im == nil {
+		return false
+	}
+
+	instance, exists := im.Status.InstanceEngineFrontends[ef.Name]
+	if !exists {
+		return false
+	}
+
+	return instance.Status.State == longhorn.InstanceStateRunning && instance.Status.Frontend == ""
+}
+
+func (efc *EngineFrontendController) deleteEngineFrontendInstance(ef *longhorn.EngineFrontend) error {
+	if efc.deleteInstanceHandler != nil {
+		return efc.deleteInstanceHandler(ef)
+	}
+	return efc.DeleteInstance(ef)
 }
 
 func syncEngineFrontendPathStatus(ef *longhorn.EngineFrontend, instance *longhorn.InstanceProcess) {

--- a/controller/engine_frontend_controller_test.go
+++ b/controller/engine_frontend_controller_test.go
@@ -7,13 +7,15 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "gopkg.in/check.v1"
 
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/longhorn/longhorn-manager/constant"
 	"github.com/longhorn/longhorn-manager/datastore"
@@ -23,8 +25,6 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
-
-	. "gopkg.in/check.v1"
 )
 
 func (s *TestSuite) TestShouldExpandEngineFrontend(c *C) {
@@ -101,6 +101,105 @@ func (s *TestSuite) TestIsEngineFrontendEndpointRequired(c *C) {
 	ef.Spec.DisableFrontend = false
 	ef.Spec.Frontend = longhorn.VolumeFrontendEmpty
 	c.Assert(isEngineFrontendEndpointRequired(ef), Equals, false)
+}
+
+func (s *TestSuite) TestShouldDeleteStaleRunningEngineFrontend(c *C) {
+	testCases := map[string]struct {
+		ef       *longhorn.EngineFrontend
+		im       *longhorn.InstanceManager
+		expected bool
+	}{
+		"nil engine frontend": {
+			im:       &longhorn.InstanceManager{},
+			expected: false,
+		},
+		"nil instance manager": {
+			ef: &longhorn.EngineFrontend{
+				ObjectMeta: metav1.ObjectMeta{Name: "ef-1"},
+			},
+			expected: false,
+		},
+		"delete stale running empty frontend instance": {
+			ef: &longhorn.EngineFrontend{
+				ObjectMeta: metav1.ObjectMeta{Name: "ef-1"},
+				Spec: longhorn.EngineFrontendSpec{
+					InstanceSpec: longhorn.InstanceSpec{
+						DesireState: longhorn.InstanceStateRunning,
+					},
+					Frontend: longhorn.VolumeFrontendBlockDev,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					InstanceStatus: longhorn.InstanceStatus{
+						CurrentState: longhorn.InstanceStateRunning,
+					},
+				},
+			},
+			im: &longhorn.InstanceManager{
+				Status: longhorn.InstanceManagerStatus{
+					InstanceEngineFrontends: map[string]longhorn.InstanceProcess{
+						"ef-1": {
+							Status: longhorn.InstanceProcessStatus{
+								State:    longhorn.InstanceStateRunning,
+								Frontend: "",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		"keep running instance when IM reports frontend": {
+			ef: &longhorn.EngineFrontend{
+				ObjectMeta: metav1.ObjectMeta{Name: "ef-1"},
+			},
+			im: &longhorn.InstanceManager{
+				Status: longhorn.InstanceManagerStatus{
+					InstanceEngineFrontends: map[string]longhorn.InstanceProcess{
+						"ef-1": {
+							Status: longhorn.InstanceProcessStatus{
+								State:    longhorn.InstanceStateRunning,
+								Frontend: string(longhorn.VolumeFrontendBlockDev),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"keep instance when frontend process does not exist": {
+			ef: &longhorn.EngineFrontend{
+				ObjectMeta: metav1.ObjectMeta{Name: "ef-1"},
+			},
+			im: &longhorn.InstanceManager{
+				Status: longhorn.InstanceManagerStatus{
+					InstanceEngineFrontends: map[string]longhorn.InstanceProcess{},
+				},
+			},
+			expected: false,
+		},
+		"keep non-running IM instance": {
+			ef: &longhorn.EngineFrontend{
+				ObjectMeta: metav1.ObjectMeta{Name: "ef-1"},
+			},
+			im: &longhorn.InstanceManager{
+				Status: longhorn.InstanceManagerStatus{
+					InstanceEngineFrontends: map[string]longhorn.InstanceProcess{
+						"ef-1": {
+							Status: longhorn.InstanceProcessStatus{
+								State:    longhorn.InstanceStateStarting,
+								Frontend: "",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		c.Assert(shouldDeleteStaleRunningEngineFrontend(tc.ef, tc.im), Equals, tc.expected, Commentf("case=%s", name))
+	}
 }
 
 func (s *TestSuite) TestSyncEngineFrontendPathStatus(c *C) {
@@ -287,6 +386,138 @@ func (s *TestSuite) TestSyncEngineFrontendInitializesIncompleteTargetStatus(c *C
 	c.Assert(updatedEF.Status.CurrentState, Equals, longhorn.InstanceStateSuspended)
 	_, exists := efc.engineFrontendMonitorMap[ef.Name]
 	c.Assert(exists, Equals, false)
+}
+
+func (s *TestSuite) TestSyncEngineFrontendDeletesStaleRunningInstance(c *C) {
+	datastore.SkipListerCheck = true
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, 0)
+
+	efc, err := newTestEngineFrontendController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	c.Assert(err, IsNil)
+
+	fakeRecorder := record.NewFakeRecorder(10)
+	efc.eventRecorder = fakeRecorder
+
+	deleted := false
+	efc.deleteInstanceHandler = func(obj interface{}) error {
+		ef, ok := obj.(*longhorn.EngineFrontend)
+		c.Assert(ok, Equals, true)
+		c.Assert(ef.Name, Equals, "stale-engine-frontend")
+		deleted = true
+		return nil
+	}
+
+	settingIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+	volumeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Volumes().Informer().GetIndexer()
+	efIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineFrontends().Informer().GetIndexer()
+	imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+	kubeNodeIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+	podIndexer := informerFactories.KubeNamespaceFilteredInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+
+	defaultEngineImageSetting := newSetting(string(types.SettingNameDefaultEngineImage), TestEngineImage)
+	v2DataEngineSetting := newSetting(string(types.SettingNameV2DataEngine), "true")
+	for _, setting := range []*longhorn.Setting{defaultEngineImageSetting, v2DataEngineSetting} {
+		createdSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(settingIndexer.Add(createdSetting), IsNil)
+	}
+
+	volume := newVolume(TestVolumeName, 1)
+	volume.Spec.DataEngine = longhorn.DataEngineTypeV2
+	volume.Spec.Frontend = longhorn.VolumeFrontendBlockDev
+	volume.Status.CurrentImage = TestEngineImage
+	createdVolume, err := lhClient.LonghornV1beta2().Volumes(TestNamespace).Create(context.TODO(), volume, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(volumeIndexer.Add(createdVolume), IsNil)
+
+	kubeNode := newKubernetesNode(TestOwnerID1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+	createdKubeNode, err := kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(kubeNodeIndexer.Add(createdKubeNode), IsNil)
+
+	imPod := newPod(&corev1.PodStatus{Phase: corev1.PodRunning, PodIP: TestIP1}, TestInstanceManagerName, TestNamespace, TestOwnerID1)
+	createdPod, err := kubeClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), imPod, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(podIndexer.Add(createdPod), IsNil)
+
+	ef := &longhorn.EngineFrontend{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-engine-frontend",
+			Namespace: TestNamespace,
+		},
+		Spec: longhorn.EngineFrontendSpec{
+			InstanceSpec: longhorn.InstanceSpec{
+				VolumeName:  volume.Name,
+				VolumeSize:  volume.Spec.Size,
+				NodeID:      TestOwnerID1,
+				Image:       TestEngineImage,
+				DesireState: longhorn.InstanceStateRunning,
+				DataEngine:  longhorn.DataEngineTypeV2,
+			},
+			Frontend:   longhorn.VolumeFrontendBlockDev,
+			EngineName: "test-engine",
+			TargetIP:   TestIP2,
+			TargetPort: TestPort1,
+		},
+		Status: longhorn.EngineFrontendStatus{
+			InstanceStatus: longhorn.InstanceStatus{
+				OwnerID:             TestOwnerID1,
+				InstanceManagerName: TestInstanceManagerName,
+				CurrentState:        longhorn.InstanceStateRunning,
+				Started:             true,
+			},
+		},
+	}
+
+	instanceManager := newInstanceManager(
+		TestInstanceManagerName,
+		longhorn.InstanceManagerStateRunning,
+		TestOwnerID1,
+		TestOwnerID1,
+		TestIP1,
+		nil,
+		map[string]longhorn.InstanceProcess{
+			ef.Name: {
+				Spec: longhorn.InstanceProcessSpec{
+					Name:       ef.Name,
+					DataEngine: longhorn.DataEngineTypeV2,
+				},
+				Status: longhorn.InstanceProcessStatus{
+					State:    longhorn.InstanceStateRunning,
+					Frontend: "",
+					UUID:     "test-uuid",
+				},
+			},
+		},
+		nil,
+		longhorn.DataEngineTypeV2,
+		TestInstanceManagerImage,
+		false,
+	)
+	createdIM, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), instanceManager, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(imIndexer.Add(createdIM), IsNil)
+
+	createdEF, err := lhClient.LonghornV1beta2().EngineFrontends(TestNamespace).Create(context.TODO(), ef, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(efIndexer.Add(createdEF), IsNil)
+
+	err = efc.syncEngineFrontend(TestNamespace + "/" + ef.Name)
+	c.Assert(err, IsNil)
+	c.Assert(deleted, Equals, true)
+
+	select {
+	case event := <-fakeRecorder.Events:
+		c.Assert(strings.Contains(event, corev1.EventTypeWarning), Equals, true)
+		c.Assert(strings.Contains(event, constant.EventReasonStaleInstance), Equals, true)
+		c.Assert(strings.Contains(event, "Deleting stale instance"), Equals, true)
+	default:
+		c.Fatal("expected stale instance event to be recorded")
+	}
 }
 
 func (s *TestSuite) TestGetReplicaRebuildCandidate(c *C) {


### PR DESCRIPTION


#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13084

#### What this PR does / why we need it:

When an EngineFrontend is recovered from a persisted record left over from a DisableFrontend phase, the IM may report it as running with an empty frontend. This mismatch causes the volume to remain stuck because the controller treats the instance as healthy while no actual frontend is serving I/O.

Add a defense-in-depth check in syncEngineFrontend that compares the IM-reported frontend against the spec. If the spec requires a real frontend but the IM has an empty one, delete the stale instance so it can be re-created with the correct frontend type.

#### Special notes for your reviewer:

#### Additional documentation or context
