### PR TITLE
fix: close leaked HTTP response bodies in polling paths

### DIFF
--- a/controller/support_bundle_controller.go
+++ b/controller/support_bundle_controller.go
@@ -556,6 +556,11 @@ func (c *SupportBundleController) getSupportBundleStatusFromManager(url string) 
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.WithError(closeErr).Warn("Failed to close support bundle manager response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -105,16 +105,30 @@ func isServiceAvailable(webhookType string, endpoint string, timeout time.Durati
 		resp, err := cli.Get(endpoint)
 		if err != nil {
 			logrus.WithError(err).Warnf("Failed to check endpoint %v", endpoint)
-		} else if resp.StatusCode == 200 {
-			running = true
-			break
 		} else {
-			bodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				logrus.Warnf("Endpoint return %d not 200: cannot read the body", resp.StatusCode)
+			func() {
+				defer func() {
+					if closeErr := resp.Body.Close(); closeErr != nil {
+						logrus.WithError(closeErr).Warnf("Failed to close response body for endpoint %v", endpoint)
+					}
+				}()
+
+				if resp.StatusCode == http.StatusOK {
+					running = true
+					return
+				}
+
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					logrus.Warnf("Endpoint return %d not 200: cannot read the body", resp.StatusCode)
+				}
+				bodyString := string(bodyBytes)
+				logrus.Warnf("Endpoint return %d not 200: %v", resp.StatusCode, bodyString)
+			}()
+
+			if running {
+				break
 			}
-			bodyString := string(bodyBytes)
-			logrus.Warnf("Endpoint return %d not 200: %v", resp.StatusCode, bodyString)
 		}
 		time.Sleep(2 * time.Second)
 	}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13115

#### What this PR does / why we need it:

Add missing response body cleanup in two long-running HTTP polling paths:

- close the support bundle manager status response body after decode
- close webhook readiness probe response bodies on both success and error paths

Without these closes, repeated polling/retry loops can retain HTTP connections and file descriptors over time.



#### Special notes for your reviewer:

#### Additional documentation or context
