### PR TITLE
fix: allow live engine upgrade for same-commit revisioned engine images

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2654,9 +2654,10 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine, log *logrus.Entry) (err 
 			return err
 		}
 
-		// Don't use image with different image name but same commit here. It
-		// will cause live replica to be removed. Volume controller should filter those.
-		if version.ClientVersion.GitCommit != version.ServerVersion.GitCommit {
+		// Revisioned engine images may keep the same engine git commit while still
+		// representing a distinct image artifact that should follow the regular
+		// upgrade flow, e.g. 1.10.2 -> 1.10.2-4.12 or 1.10.2-4.12 -> 1.10.2-4.20.
+		if version.ClientVersion.GitCommit != version.ServerVersion.GitCommit || isRevisionedEngineImage(e.Spec.Image) {
 			log.Infof("Upgrading engine from %v to %v", e.Status.CurrentImage, e.Spec.Image)
 			if err := ec.UpgradeEngineInstance(e, log); err != nil {
 				return err

--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	etypes "github.com/longhorn/longhorn-engine/pkg/types"
+
 	"github.com/longhorn/longhorn-manager/engineapi"
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
 // mockEngineClientProxy wraps EngineSimulator and overrides ReplicaRebuildVerify for test control.
@@ -146,6 +148,56 @@ func TestNeedStatusUpdate(t *testing.T) {
 			needStatusUpdate, rateLimited := tc.monitor.needStatusUpdate(tc.existingEngine, tc.engine)
 			assert.Equal(tc.expectNeedStatusUpdate, needStatusUpdate, "needStatusUpdate")
 			assert.Equal(tc.expectRateLimited, rateLimited, "rateLimited")
+		})
+	}
+}
+
+func TestShouldAllowEngineImageUpgrade(t *testing.T) {
+	shouldAllowEngineImageUpgrade := func(sourceGitCommit, targetGitCommit, targetImage string) bool {
+		return sourceGitCommit != targetGitCommit || isRevisionedEngineImage(targetImage)
+	}
+
+	tests := map[string]struct {
+		sourceGitCommit string
+		targetGitCommit string
+		targetImage     string
+		expected        bool
+	}{
+		"same commit and regular release tag is blocked": {
+			sourceGitCommit: "same-commit",
+			targetGitCommit: "same-commit",
+			targetImage:     "dp.apps.rancher.io/containers/longhorn-engine:1.10.2",
+			expected:        false,
+		},
+		"same commit and revisioned release tag is allowed": {
+			sourceGitCommit: "same-commit",
+			targetGitCommit: "same-commit",
+			targetImage:     "dp.apps.rancher.io/containers/longhorn-engine:1.10.2-4.12",
+			expected:        true,
+		},
+		"same commit and master head tag is blocked": {
+			sourceGitCommit: "same-commit",
+			targetGitCommit: "same-commit",
+			targetImage:     "longhornio/longhorn-engine:master-head",
+			expected:        false,
+		},
+		"same commit and revisioned release tag with registry port is allowed": {
+			sourceGitCommit: "same-commit",
+			targetGitCommit: "same-commit",
+			targetImage:     "registry:5000/longhorn-engine:1.10.2-1.1",
+			expected:        true,
+		},
+		"different commit and regular release tag is allowed": {
+			sourceGitCommit: "old-commit",
+			targetGitCommit: "new-commit",
+			targetImage:     "dp.apps.rancher.io/containers/longhorn-engine:1.10.3",
+			expected:        true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, shouldAllowEngineImageUpgrade(tc.sourceGitCommit, tc.targetGitCommit, tc.targetImage))
 		})
 	}
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -28,6 +30,13 @@ const (
 	podRecreateInitBackoff = 1 * time.Second
 	podRecreateMaxBackoff  = 120 * time.Second
 	backoffGCPeriod        = 12 * time.Hour
+
+	// Matches revisioned engine image tags such as 1.10.2-4.12 or 1.10.2-4.20.
+	engineImageRevisionTagPattern = `.+-\d+\.\d+$`
+)
+
+var (
+	engineImageRevisionTagRegex = regexp.MustCompile(engineImageRevisionTagPattern)
 )
 
 // newBackoff returns a flowcontrol.Backoff and starts a background GC loop.
@@ -259,4 +268,15 @@ func getCorrectedEncryptedVolumeSize(volumeSizeStr string, labels map[string]str
 		return strconv.FormatInt(correctedSize, 10), nil
 	}
 	return volumeSizeStr, nil
+}
+
+func isRevisionedEngineImage(image string) bool {
+	lastSlashIndex := strings.LastIndex(image, "/")
+	lastColonIndex := strings.LastIndex(image, ":")
+	if lastColonIndex <= lastSlashIndex {
+		return false
+	}
+
+	tag := image[lastColonIndex+1:]
+	return engineImageRevisionTagRegex.MatchString(tag)
 }

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -4139,7 +4139,7 @@ func (c *VolumeController) checkOldAndNewEngineImagesForLiveUpgrade(v *longhorn.
 		return errors.Wrapf(err, "engine live upgrade to %v, but the image wasn't ready", newImage.Spec.Image)
 	}
 
-	if oldImage.Status.GitCommit == newImage.Status.GitCommit {
+	if oldImage.Status.GitCommit == newImage.Status.GitCommit && !isRevisionedEngineImage(newImage.Spec.Image) {
 		return fmt.Errorf("engine image %v and %v are identical, delay upgrade until detach for volume", oldImage.Spec.Image, newImage.Spec.Image)
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:

Support live engine upgrade for revision-version images with unchanged GitCommit

#### Special notes for your reviewer:

#### Additional documentation or context
