### PR TITLE
fix(scheduler): prevent unschedulable replicas during disk pressure auto-balance

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -3433,6 +3433,20 @@ func (c *VolumeController) checkReplicaDiskPressuredSchedulableCandidates(volume
 		return errors.Errorf("%v setting is 0, skip auto-balance replicas in disk pressure", types.SettingNameReplicaAutoBalanceDiskPressurePercentage)
 	}
 
+	allowEmptyDiskSelectorVolume, err := c.ds.GetSettingAsBool(types.SettingNameAllowEmptyDiskSelectorVolume)
+	if err != nil {
+		return err
+	}
+
+	var biDiskSelector []string
+	if volume.Spec.BackingImage != "" {
+		bi, err := c.ds.GetBackingImageRO(volume.Spec.BackingImage)
+		if err != nil {
+			return err
+		}
+		biDiskSelector = bi.Spec.DiskSelector
+	}
+
 	nodes, err := c.ds.ListNodesRO()
 	if err != nil {
 		return err
@@ -3468,7 +3482,7 @@ func (c *VolumeController) checkReplicaDiskPressuredSchedulableCandidates(volume
 			continue
 		}
 
-		if !diskSpec.AllowScheduling {
+		if eligible, _, _ := c.scheduler.IsDiskEligibleForVolume(diskSpec, diskStatus, volume, allowEmptyDiskSelectorVolume, biDiskSelector); !eligible {
 			continue
 		}
 

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -547,18 +547,9 @@ func (rcs *ReplicaScheduler) filterNodeDisksForReplica(node *longhorn.Node, disk
 			continue
 		}
 
-		isV1EngineFilesystemDisk := types.IsDataEngineV1(volume.Spec.DataEngine) && diskSpec.Type == longhorn.DiskTypeFilesystem
-		isV2EngineBlockDisk := types.IsDataEngineV2(volume.Spec.DataEngine) && diskSpec.Type == longhorn.DiskTypeBlock
-		if !isV1EngineFilesystemDisk && !isV2EngineBlockDisk {
-			logrus.Debugf("Volume %v is not compatible with disk %v", volume.Name, diskName)
-			continue
-		}
-
-		if !datastore.IsSupportedVolumeSize(volume.Spec.DataEngine, diskStatus.FSType, volume.Spec.Size) {
-			logrus.Debugf("Volume %v size %v is not compatible with the file system %v of the disk %v", volume.Name, volume.Spec.Size, diskStatus.Type, diskName)
-			errs.Append(longhorn.ErrorReplicaScheduleIncompatibleVolumeSize,
-				fmt.Errorf("volume %v size %v is not compatible with the file system %v of the disk %v",
-					volume.Name, volume.Spec.Size, diskStatus.Type, diskName))
+		if eligible, reason, msg := rcs.IsDiskEligibleForVolume(diskSpec, diskStatus, volume, allowEmptyDiskSelectorVolume, biDiskSelector); !eligible {
+			errs.Append(reason,
+				fmt.Errorf("disk %v on node %v: %v", diskName, node.Name, msg))
 			continue
 		}
 
@@ -588,25 +579,6 @@ func (rcs *ReplicaScheduler) filterNodeDisksForReplica(node *longhorn.Node, disk
 				errs.Append(longhorn.ErrorReplicaScheduleInsufficientStorage,
 					fmt.Errorf("disk %v on node %v does not have enough storage available for replica %v with size %v",
 						diskName, node.Name, volume.Name, volume.Spec.Size))
-				continue
-			}
-		}
-
-		// Check if the Disk's Tags are valid.
-		if !types.IsSelectorsInTags(diskSpec.Tags, volume.Spec.DiskSelector, allowEmptyDiskSelectorVolume) {
-			errs.Append(longhorn.ErrorReplicaScheduleTagsNotFulfilled,
-				fmt.Errorf("disk %v on node %v does not match the disk selector %v for volume %v",
-					diskName, node.Name, volume.Spec.DiskSelector, volume.Name))
-			continue
-		}
-
-		if volume.Spec.BackingImage != "" {
-			// If the disks don't match the tags of the backing image of this volume,
-			// don't schedule the replica on it because it will hang there
-			if !types.IsSelectorsInTags(diskSpec.Tags, biDiskSelector, allowEmptyDiskSelectorVolume) {
-				errs.Append(longhorn.ErrorReplicaScheduleTagsNotFulfilled,
-					fmt.Errorf("disk %v on node %v does not match the disk selector %v for backing image %v of volume %v",
-						diskName, node.Name, biDiskSelector, volume.Spec.BackingImage, volume.Name))
 				continue
 			}
 		}
@@ -1282,6 +1254,58 @@ func (rcs *ReplicaScheduler) ValidateDiskAvailableForExpansion(requiredBytes int
 	}
 
 	return nil
+}
+
+// IsDiskEligibleForVolume validates whether a disk meets the basic eligibility
+// requirements for hosting a replica of the given volume. This consolidates the
+// common checks shared between the replica scheduling path and the disk-pressure
+// auto-balance candidate evaluation.
+//
+// biDiskSelector is the backing image's DiskSelector (if any). Callers should
+// fetch it once per volume evaluation via GetBackingImageRO and pass it in to
+// avoid repeated lister lookups inside per-disk loops.
+//
+// Returns:
+//   - eligible: whether the disk passes all checks.
+//   - reason: an ErrorReplicaSchedule* constant categorizing the failure (empty when eligible).
+//   - message: a human-readable explanation of the failure (empty when eligible).
+func (rcs *ReplicaScheduler) IsDiskEligibleForVolume(diskSpec longhorn.DiskSpec, diskStatus *longhorn.DiskStatus, volume *longhorn.Volume, allowEmptyDiskSelectorVolume bool, biDiskSelector []string) (eligible bool, reason string, message string) {
+	if !diskSpec.AllowScheduling || diskSpec.EvictionRequested {
+		return false, longhorn.ErrorReplicaScheduleDiskUnavailable, "disk does not allow scheduling or eviction is requested"
+	}
+
+	// Validate disk type compatibility with the volume's data engine.
+	isV1EngineFilesystemDisk := types.IsDataEngineV1(volume.Spec.DataEngine) && diskSpec.Type == longhorn.DiskTypeFilesystem
+	isV2EngineBlockDisk := types.IsDataEngineV2(volume.Spec.DataEngine) && diskSpec.Type == longhorn.DiskTypeBlock
+	if !isV1EngineFilesystemDisk && !isV2EngineBlockDisk {
+		return false, longhorn.ErrorReplicaScheduleDiskUnavailable,
+			fmt.Sprintf("disk type %v is not compatible with data engine %v", diskSpec.Type, volume.Spec.DataEngine)
+	}
+
+	if !datastore.IsSupportedVolumeSize(volume.Spec.DataEngine, diskStatus.FSType, volume.Spec.Size) {
+		return false, longhorn.ErrorReplicaScheduleIncompatibleVolumeSize,
+			fmt.Sprintf("volume size %v is not compatible with file system %v", volume.Spec.Size, diskStatus.FSType)
+	}
+
+	// Check volume disk selector tags.
+	if !types.IsSelectorsInTags(diskSpec.Tags, volume.Spec.DiskSelector, allowEmptyDiskSelectorVolume) {
+		return false, longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+			fmt.Sprintf("disk tags %v do not match volume disk selector %v", diskSpec.Tags, volume.Spec.DiskSelector)
+	}
+
+	// Check backing image disk selector tags (only when a backing image is in use).
+	// Gate on volume.Spec.BackingImage rather than len(biDiskSelector) to preserve
+	// the allow-empty-disk-selector-volume semantics: when a backing image has an
+	// empty DiskSelector and the setting is false, disks with tags must be rejected
+	// to stay consistent with backing image distribution logic.
+	if volume.Spec.BackingImage != "" {
+		if !types.IsSelectorsInTags(diskSpec.Tags, biDiskSelector, allowEmptyDiskSelectorVolume) {
+			return false, longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+				fmt.Sprintf("disk tags %v do not match backing image disk selector %v", diskSpec.Tags, biDiskSelector)
+		}
+	}
+
+	return true, "", ""
 }
 
 func (rcs *ReplicaScheduler) IsSchedulableToDiskConsiderDiskPressure(diskPressurePercentage, size, requiredStorage int64, info *DiskSchedulingInfo) bool {

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -22,8 +24,6 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
-
-	. "gopkg.in/check.v1"
 )
 
 const (
@@ -2136,6 +2136,207 @@ func (s *TestSuite) TestSelectBestDisk(c *C) {
 		} else {
 			c.Assert(err, IsNil)
 			c.Assert(disk, NotNil)
+		}
+	}
+}
+
+func (s *TestSuite) TestIsDiskEligibleForVolume(c *C) {
+	rcs := &ReplicaScheduler{} // No datastore calls needed; all inputs are passed in.
+
+	baseDiskSpec := longhorn.DiskSpec{
+		Type:            longhorn.DiskTypeFilesystem,
+		Path:            TestDefaultDataPath,
+		AllowScheduling: true,
+		Tags:            []string{"primary"},
+	}
+	baseDiskStatus := &longhorn.DiskStatus{
+		StorageAvailable: TestDiskAvailableSize,
+		StorageMaximum:   TestDiskSize,
+		FSType:           "ext4",
+	}
+	baseVolume := &longhorn.Volume{
+		Spec: longhorn.VolumeSpec{
+			Size:         TestVolumeSize,
+			DataEngine:   longhorn.DataEngineTypeV1,
+			DiskSelector: []string{"primary"},
+		},
+	}
+
+	tests := []struct {
+		name                      string
+		diskSpec                  longhorn.DiskSpec
+		diskStatus                *longhorn.DiskStatus
+		volume                    *longhorn.Volume
+		allowEmptyDiskSelectorVol bool
+		biDiskSelector            []string
+		expect                    bool
+		expectReason              string
+	}{
+		{
+			name:       "Eligible - tags match, no backing image selector",
+			diskSpec:   baseDiskSpec,
+			diskStatus: baseDiskStatus,
+			volume:     baseVolume,
+			expect:     true,
+		},
+		{
+			name: "Ineligible - volume diskSelector mismatch",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"secondary"},
+			},
+			diskStatus:   baseDiskStatus,
+			volume:       baseVolume,
+			expect:       false,
+			expectReason: longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+		},
+		{
+			name: "Ineligible - AllowScheduling disabled",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: false,
+				Tags:            []string{"primary"},
+			},
+			diskStatus:   baseDiskStatus,
+			volume:       baseVolume,
+			expect:       false,
+			expectReason: longhorn.ErrorReplicaScheduleDiskUnavailable,
+		},
+		{
+			name: "Ineligible - EvictionRequested",
+			diskSpec: longhorn.DiskSpec{
+				Type:              longhorn.DiskTypeFilesystem,
+				Path:              TestDefaultDataPath,
+				AllowScheduling:   true,
+				EvictionRequested: true,
+				Tags:              []string{"primary"},
+			},
+			diskStatus:   baseDiskStatus,
+			volume:       baseVolume,
+			expect:       false,
+			expectReason: longhorn.ErrorReplicaScheduleDiskUnavailable,
+		},
+		{
+			name: "Ineligible - disk type mismatch (block disk for v1 engine)",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeBlock,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"primary"},
+			},
+			diskStatus:   baseDiskStatus,
+			volume:       baseVolume,
+			expect:       false,
+			expectReason: longhorn.ErrorReplicaScheduleDiskUnavailable,
+		},
+		{
+			name:       "Ineligible - backing image diskSelector mismatch",
+			diskSpec:   baseDiskSpec,
+			diskStatus: baseDiskStatus,
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{
+					Size:         TestVolumeSize,
+					DataEngine:   longhorn.DataEngineTypeV1,
+					DiskSelector: []string{"primary"},
+					BackingImage: "test-bi",
+				},
+			},
+			biDiskSelector: []string{"special-bi-tag"},
+			expect:         false,
+			expectReason:   longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+		},
+		{
+			name: "Eligible - backing image diskSelector matches disk tags",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"primary", "special-bi-tag"},
+			},
+			diskStatus: baseDiskStatus,
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{
+					Size:         TestVolumeSize,
+					DataEngine:   longhorn.DataEngineTypeV1,
+					DiskSelector: []string{"primary"},
+					BackingImage: "test-bi",
+				},
+			},
+			biDiskSelector: []string{"special-bi-tag"},
+			expect:         true,
+		},
+		{
+			name: "Ineligible - backing image with empty diskSelector, allowEmpty=false, disk has tags",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"primary"},
+			},
+			diskStatus: baseDiskStatus,
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{
+					Size:         TestVolumeSize,
+					DataEngine:   longhorn.DataEngineTypeV1,
+					DiskSelector: []string{"primary"},
+					BackingImage: "test-bi",
+				},
+			},
+			biDiskSelector:            []string{},
+			allowEmptyDiskSelectorVol: false,
+			expect:                    false,
+			expectReason:              longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+		},
+		{
+			name: "Eligible - empty volume diskSelector with allowEmptyDiskSelectorVolume=true",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"anything"},
+			},
+			diskStatus: baseDiskStatus,
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{
+					Size:         TestVolumeSize,
+					DataEngine:   longhorn.DataEngineTypeV1,
+					DiskSelector: []string{},
+				},
+			},
+			allowEmptyDiskSelectorVol: true,
+			expect:                    true,
+		},
+		{
+			name: "Ineligible - empty volume diskSelector with allowEmptyDiskSelectorVolume=false and disk has tags",
+			diskSpec: longhorn.DiskSpec{
+				Type:            longhorn.DiskTypeFilesystem,
+				Path:            TestDefaultDataPath,
+				AllowScheduling: true,
+				Tags:            []string{"anything"},
+			},
+			diskStatus: baseDiskStatus,
+			volume: &longhorn.Volume{
+				Spec: longhorn.VolumeSpec{
+					Size:         TestVolumeSize,
+					DataEngine:   longhorn.DataEngineTypeV1,
+					DiskSelector: []string{},
+				},
+			},
+			allowEmptyDiskSelectorVol: false,
+			expect:                    false,
+			expectReason:              longhorn.ErrorReplicaScheduleTagsNotFulfilled,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Logf("Running scenario: %s", tt.name)
+		result, reason, _ := rcs.IsDiskEligibleForVolume(tt.diskSpec, tt.diskStatus, tt.volume, tt.allowEmptyDiskSelectorVol, tt.biDiskSelector)
+		c.Assert(result, Equals, tt.expect, Commentf("scenario: %s", tt.name))
+		if !tt.expect {
+			c.Assert(reason, Equals, tt.expectReason, Commentf("scenario: %s reason", tt.name))
 		}
 	}
 }


### PR DESCRIPTION


#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13152

#### What this PR does / why we need it:


Validate volume.Spec.DiskSelector when checking schedulable candidates for disk pressure auto-balance.

This prevents Longhorn from selecting disks with mismatched tags as valid migration targets and creating unschedulable placeholder replicas.

#### Special notes for your reviewer:

#### Additional documentation or context
