### PR TITLE
feat: support CPU list format for V2 Data Engine CPU Mask setting

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -29,12 +29,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
+	lhtypes "github.com/longhorn/go-common-libs/types"
+	lhutils "github.com/longhorn/go-common-libs/utils"
+
 	"github.com/longhorn/longhorn-manager/csi/crypto"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
-	lhtypes "github.com/longhorn/go-common-libs/types"
-	lhutils "github.com/longhorn/go-common-libs/utils"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
@@ -403,6 +404,10 @@ func (s *DataStore) applyCustomizedDefaultSettingsToDefinitions(customizedDefaul
 			if err != nil {
 				return err
 			}
+			value, err = NormalizeSettingValue(sName, value)
+			if err != nil {
+				return err
+			}
 			logrus.Infof("Setting %v default value is updated to a customized value %v (raw value %v)", sName, value, raw)
 			definition.Default = value
 			types.SetSettingDefinition(sName, definition)
@@ -447,6 +452,35 @@ func GetSettingValidValue(definition types.SettingDefinition, value string) (str
 	}
 
 	return convertDataEngineValuesToJSONString(values)
+}
+
+// NormalizeSettingValue applies setting-specific normalization to a value that
+// has already been validated and converted to JSON format by GetSettingValidValue.
+// For example, it converts CPU list format to hex mask for the DataEngineCPUMask setting.
+func NormalizeSettingValue(name types.SettingName, value string) (string, error) {
+	if name != types.SettingNameDataEngineCPUMask {
+		return value, nil
+	}
+
+	var values map[longhorn.DataEngineType]string
+	if err := json.Unmarshal([]byte(value), &values); err != nil {
+		return "", fmt.Errorf("failed to unmarshal CPU mask setting value %q: %v", value, err)
+	}
+
+	for dataEngine, v := range values {
+		normalized, err := types.NormalizeCPUMask(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to normalize CPU mask for data engine %s: %v", dataEngine, err)
+		}
+		values[dataEngine] = normalized
+	}
+
+	jsonBytes, err := json.Marshal(values)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal normalized CPU mask setting value: %v", err)
+	}
+
+	return string(jsonBytes), nil
 }
 
 func convertDataEngineValuesToJSONString(values map[longhorn.DataEngineType]any) (string, error) {

--- a/types/setting.go
+++ b/types/setting.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"slices"
 	"strconv"
 	"strings"
@@ -41,6 +42,11 @@ const (
 	BackupBlockSize2Mi           = 2 * BackupBlockSizeMi
 	BackupBlockSize16Mi          = 16 * BackupBlockSizeMi
 	BackupBlockSizeInvalid int64 = -1
+
+	// maxCPU is the maximum supported CPU number.
+	// This is a reasonable upper bound to prevent resource exhaustion from malicious input
+	// while supporting modern high-core-count servers.
+	maxCPU = 1023
 )
 
 type SettingType string
@@ -1785,7 +1791,7 @@ var (
 
 	SettingDefinitionDataEngineCPUMask = SettingDefinition{
 		DisplayName:        "Data Engine CPU Mask",
-		Description:        "Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine. The default value is 0x1.\n\n",
+		Description:        "Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine. Accepts hex mask format (e.g., 0x1, 0xff) or CPU list format (e.g., 1-3,5,7). CPU list format is automatically converted to hex mask. The default value is 0x1.\n\n",
 		Category:           SettingCategoryDangerZone,
 		Type:               SettingTypeString,
 		Required:           true,
@@ -2822,6 +2828,11 @@ func validateSettingString(name SettingName, definition SettingDefinition, value
 			if _, err := UnmarshalOrphanResourceTypes(strValue); err != nil {
 				return errors.Wrapf(err, "the value of %v is invalid", name)
 			}
+
+		case SettingNameDataEngineCPUMask:
+			if _, err := NormalizeCPUMask(strValue); err != nil {
+				return errors.Wrapf(err, "the value of %v is invalid", name)
+			}
 		}
 	}
 
@@ -2857,4 +2868,147 @@ func parseSettingSingleString(definition SettingDefinition, value string) (map[l
 	}
 
 	return values, nil
+}
+
+// CPUListToHexMask converts a CPU list format string (e.g., "1-3,5,7") to a hex mask (e.g., "0xae").
+// Supported formats:
+//   - Individual CPUs: "1,2,3"
+//   - Ranges: "0-3"
+//   - Mixed: "1-3,5,7"
+//   - Parenthesized groups: "(1-3),(5)"
+func CPUListToHexMask(cpuList string) (string, error) {
+	mask, err := parseCPUListToMask(cpuList)
+	if err != nil {
+		return "", err
+	}
+	if mask.Sign() == 0 {
+		return "", fmt.Errorf("CPU list is empty")
+	}
+
+	return "0x" + mask.Text(16), nil
+}
+
+// parseCPUListToMask parses a CPU list string and builds the bitmask directly
+// using math/big.Int to support arbitrary CPU counts. Each CPU number is
+// validated immediately against the valid range (0-maxCPU), so malicious inputs
+// like "0-1000000000" fail fast without large allocations.
+func parseCPUListToMask(cpuList string) (*big.Int, error) {
+	// Remove parentheses — they are optional grouping in DPDK lcores format
+	cpuList = strings.ReplaceAll(cpuList, "(", "")
+	cpuList = strings.ReplaceAll(cpuList, ")", "")
+	cpuList = strings.TrimSpace(cpuList)
+
+	if cpuList == "" {
+		return nil, fmt.Errorf("CPU list is empty")
+	}
+
+	mask := new(big.Int)
+	parts := strings.Split(cpuList, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("invalid CPU list %q: empty CPU entry", cpuList)
+		}
+
+		if strings.Contains(part, "-") {
+			rangeParts := strings.SplitN(part, "-", 2)
+			start, err := strconv.Atoi(strings.TrimSpace(rangeParts[0]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU number %q in range %q", rangeParts[0], part)
+			}
+			end, err := strconv.Atoi(strings.TrimSpace(rangeParts[1]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU number %q in range %q", rangeParts[1], part)
+			}
+			if start < 0 || start > maxCPU {
+				return nil, fmt.Errorf("CPU number %d is out of valid range (0-%d)", start, maxCPU)
+			}
+			if end < 0 || end > maxCPU {
+				return nil, fmt.Errorf("CPU number %d is out of valid range (0-%d)", end, maxCPU)
+			}
+			if start > end {
+				return nil, fmt.Errorf("invalid CPU range %q: start (%d) > end (%d)", part, start, end)
+			}
+			for i := start; i <= end; i++ {
+				mask.SetBit(mask, i, 1)
+			}
+		} else {
+			cpu, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU number %q", part)
+			}
+			if cpu < 0 || cpu > maxCPU {
+				return nil, fmt.Errorf("CPU number %d is out of valid range (0-%d)", cpu, maxCPU)
+			}
+			mask.SetBit(mask, cpu, 1)
+		}
+	}
+
+	return mask, nil
+}
+
+func isHexDigit(c rune) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// IsHexCPUMask checks if the value is a hex CPU mask format (e.g., "0x1", "0xff").
+func IsHexCPUMask(value string) bool {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "0x") && !strings.HasPrefix(value, "0X") {
+		return false
+	}
+	hexPart := value[2:]
+	if hexPart == "" {
+		return false
+	}
+	for _, c := range hexPart {
+		if !isHexDigit(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// NormalizeCPUMask normalizes the CPU mask value. If it's already a hex mask, it is
+// validated to be non-zero and returned as-is. If it's a CPU list format (e.g., "1-3,5"),
+// it's converted to a hex mask.
+func NormalizeCPUMask(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("CPU mask value is empty")
+	}
+
+	// Handle values with 0x/0X prefix explicitly as hex masks
+	if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+		hexPart := value[2:]
+		if hexPart == "" {
+			return "", fmt.Errorf("invalid hex CPU mask %q: missing hex digits after prefix", value)
+		}
+		// Each hex digit represents 4 bits; maxCPU+1 bits requires at most (maxCPU+1)/4 hex digits.
+		// Reject overly long inputs early to avoid expensive big.Int parsing.
+		maxHexDigits := (maxCPU + 1) / 4
+		if len(hexPart) > maxHexDigits {
+			return "", fmt.Errorf("CPU mask %q exceeds maximum supported CPU %d", value, maxCPU)
+		}
+		for _, c := range hexPart {
+			if !isHexDigit(c) {
+				return "", fmt.Errorf("invalid hex CPU mask %q: contains non-hex character %q", value, string(c))
+			}
+		}
+		mask := new(big.Int)
+		_, ok := mask.SetString(hexPart, 16)
+		if !ok {
+			return "", fmt.Errorf("invalid hex CPU mask %q", value)
+		}
+		if mask.Sign() == 0 {
+			return "", fmt.Errorf("CPU mask %q is zero, at least one CPU must be selected", value)
+		}
+		if mask.BitLen() > maxCPU+1 {
+			return "", fmt.Errorf("CPU mask %q exceeds maximum supported CPU %d", value, maxCPU)
+		}
+		return value, nil
+	}
+
+	// Try to parse as CPU list and convert to hex mask
+	return CPUListToHexMask(value)
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -3,13 +3,14 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
-
 	. "gopkg.in/check.v1"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -349,5 +350,197 @@ func (s *TestSuite) TestValidateManagerURL(c *C) {
 		} else {
 			c.Assert(err, NotNil, Commentf("Expected error for test case: %s", testName))
 		}
+	}
+}
+
+func (s *TestSuite) TestCPUListToHexMask(c *C) {
+	type testCase struct {
+		input       string
+		expected    string
+		expectError bool
+	}
+	testCases := map[string]testCase{
+		"single cpu 0": {
+			input:    "0",
+			expected: "0x1",
+		},
+		"single cpu 1": {
+			input:    "1",
+			expected: "0x2",
+		},
+		"single cpu 7": {
+			input:    "7",
+			expected: "0x80",
+		},
+		"range 0-3": {
+			input:    "0-3",
+			expected: "0xf",
+		},
+		"range 1-3": {
+			input:    "1-3",
+			expected: "0xe",
+		},
+		"comma separated": {
+			input:    "1,2,3",
+			expected: "0xe",
+		},
+		"mixed range and individual": {
+			input:    "1-3,5,7",
+			expected: "0xae",
+		},
+		"parenthesized group": {
+			input:    "(0-3)",
+			expected: "0xf",
+		},
+		"multiple parenthesized groups": {
+			input:    "(1-3),(5)",
+			expected: "0x2e",
+		},
+		"high cpu numbers": {
+			input:    "32,63",
+			expected: "0x8000000100000000",
+		},
+		"cpu beyond 64": {
+			input:    "64,127",
+			expected: "0x80000000000000010000000000000000",
+		},
+		"large range 0-127": {
+			input:    "0-127",
+			expected: "0xffffffffffffffffffffffffffffffff",
+		},
+		"empty string": {
+			input:       "",
+			expectError: true,
+		},
+		"leading comma": {
+			input:       ",1",
+			expectError: true,
+		},
+		"trailing comma": {
+			input:       "1,",
+			expectError: true,
+		},
+		"empty middle entry": {
+			input:       "1,,3",
+			expectError: true,
+		},
+		"whitespace-only middle entry": {
+			input:       "1,   ,3",
+			expectError: true,
+		},
+		"invalid format": {
+			input:       "abc",
+			expectError: true,
+		},
+		"invalid range reversed": {
+			input:       "5-3",
+			expectError: true,
+		},
+		"cpu number too high": {
+			input:       "1024",
+			expectError: true,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		result, err := CPUListToHexMask(testCase.input)
+		if testCase.expectError {
+			c.Assert(err, NotNil, Commentf("Expected error for test case: %s", testName))
+		} else {
+			c.Assert(err, IsNil, Commentf(TestErrErrorFmt, testName, err))
+			c.Assert(result, Equals, testCase.expected, Commentf(TestErrResultFmt, testName))
+		}
+	}
+}
+
+func (s *TestSuite) TestNormalizeCPUMask(c *C) {
+	type testCase struct {
+		input       string
+		expected    string
+		expectError bool
+	}
+	testCases := map[string]testCase{
+		"hex mask lowercase": {
+			input:    "0xff",
+			expected: "0xff",
+		},
+		"hex mask uppercase": {
+			input:    "0xFF",
+			expected: "0xFF",
+		},
+		"hex mask single": {
+			input:    "0x1",
+			expected: "0x1",
+		},
+		"cpu list single": {
+			input:    "0",
+			expected: "0x1",
+		},
+		"cpu list range": {
+			input:    "0-3",
+			expected: "0xf",
+		},
+		"cpu list mixed": {
+			input:    "1-3,5",
+			expected: "0x2e",
+		},
+		"cpu list beyond 64": {
+			input:    "64,65",
+			expected: "0x30000000000000000",
+		},
+		"hex mask zero": {
+			input:       "0x0",
+			expectError: true,
+		},
+		"hex mask large": {
+			input:    "0xffffffffffffffffffffffffffffffff",
+			expected: "0xffffffffffffffffffffffffffffffff",
+		},
+		"hex mask exceeds max cpu": {
+			input:       "0x" + strings.Repeat("f", 257), // 1028 bits, exceeds maxCPU (1023)
+			expectError: true,
+		},
+		"empty string": {
+			input:       "",
+			expectError: true,
+		},
+		"invalid hex": {
+			input:       "0xZZ",
+			expectError: true,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		result, err := NormalizeCPUMask(testCase.input)
+		if testCase.expectError {
+			c.Assert(err, NotNil, Commentf("Expected error for test case: %s", testName))
+		} else {
+			c.Assert(err, IsNil, Commentf(TestErrErrorFmt, testName, err))
+			c.Assert(result, Equals, testCase.expected, Commentf(TestErrResultFmt, testName))
+		}
+	}
+}
+
+func (s *TestSuite) TestIsHexCPUMask(c *C) {
+	type testCase struct {
+		input    string
+		expected bool
+	}
+	testCases := map[string]testCase{
+		"valid 0x1":      {input: "0x1", expected: true},
+		"valid 0xff":     {input: "0xff", expected: true},
+		"valid 0xFF":     {input: "0xFF", expected: true},
+		"valid 0X1":      {input: "0X1", expected: true},
+		"just 0x":        {input: "0x", expected: false},
+		"no prefix":      {input: "ff", expected: false},
+		"cpu list":       {input: "1-3,5", expected: false},
+		"decimal number": {input: "123", expected: false},
+		"empty":          {input: "", expected: false},
+		"invalid hex":    {input: "0xGG", expected: false},
+	}
+
+	for testName, testCase := range testCases {
+		result := IsHexCPUMask(testCase.input)
+		c.Assert(result, Equals, testCase.expected, Commentf(TestErrResultFmt, testName))
 	}
 }

--- a/webhook/resources/setting/mutator.go
+++ b/webhook/resources/setting/mutator.go
@@ -63,6 +63,11 @@ func (s *settingMutator) mutate(newObj runtime.Object) (admission.PatchOps, erro
 		return nil, werror.NewInvalidError(fmt.Sprintf("failed to get valid value for setting %s: %v", setting.Name, err), "value")
 	}
 
+	value, err = datastore.NormalizeSettingValue(types.SettingName(setting.Name), value)
+	if err != nil {
+		return nil, werror.NewInvalidError(fmt.Sprintf("failed to normalize value for setting %s: %v", setting.Name, err), "value")
+	}
+
 	var patchOps admission.PatchOps
 
 	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/value", "value": %q}`, value))


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13166

#### What this PR does / why we need it:

Support CPU list format for V2 Data Engine CPU Mask setting with automatic conversion to hex mask



#### Special notes for your reviewer:

#### Additional documentation or context
