### PR TITLE
feat: restart IM pod when hugepage settings change and no instances are running

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -222,7 +222,9 @@ func (imc *InstanceManagerController) isResponsibleForSetting(obj interface{}) b
 
 	return types.SettingName(setting.Name) == types.SettingNameKubernetesClusterAutoscalerEnabled ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineCPUMask ||
-		types.SettingName(setting.Name) == types.SettingNameOrphanResourceAutoDeletion
+		types.SettingName(setting.Name) == types.SettingNameOrphanResourceAutoDeletion ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineHugepageEnabled ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineMemorySize
 }
 
 func isInstanceManagerPod(obj interface{}) bool {
@@ -657,12 +659,45 @@ func (imc *InstanceManagerController) handlePod(im *longhorn.InstanceManager) er
 		log.WithError(err).Warnf("Failed to sync date engine CPU mask to instance manager pod %v", im.Name)
 	}
 
-	isSettingSynced, isPodDeletedOrNotRunning, areInstancesRunningInPod, err := imc.areDangerZoneSettingsSyncedToIMPod(im)
+	// hugepageSettingApplied: true means the pod is safe to keep (either settings
+	// are synced, or node lacks capacity making deletion unsafe). false means settings
+	// are not synced AND node has enough capacity, so deletion is safe to proceed.
+	// hugepageSettingsSynced: true means the pod's hugepage limit and --spdk-memory-size
+	// arg match the current settings. false means they differ or could not be verified.
+	hugepageSettingApplied, hugepageSettingsSynced, err := imc.isHugepageSettingApplied(im)
+	if err != nil {
+		// Fail safe on verification errors: keep the pod deletion-blocked, but do not
+		// claim the hugepage settings are synced when capacity/sync could not be verified.
+		hugepageSettingApplied = true
+		hugepageSettingsSynced = false
+		log.WithError(err).Warnf("Failed to check hugepage setting applied state for instance manager pod %v", im.Name)
+	}
+
+	isSettingSynced, unSyncedSettings, isPodDeletedOrNotRunning, areInstancesRunningInPod, err := imc.areDangerZoneSettingsSyncedToIMPod(im)
 	if err != nil {
 		return err
 	}
 
-	isPodDeletionNotRequired := (isSettingSynced && dataEngineCPUMaskIsApplied) || areInstancesRunningInPod || isPodDeletedOrNotRunning
+	// When hugepage settings are not synced and the pod is eligible for deletion,
+	// decide whether to block or allow based on node hugepage capacity.
+	if !hugepageSettingsSynced && !isPodDeletedOrNotRunning && !areInstancesRunningInPod {
+		unSyncedSettings = append(unSyncedSettings, types.SettingNameDataEngineHugepageEnabled, types.SettingNameDataEngineMemorySize)
+
+		if hugepageSettingApplied {
+			// Node lacks sufficient hugepage capacity or capacity could not be verified.
+			// Block ALL pod deletion to avoid leaving the replacement pod unschedulable (Pending).
+			im.Status.Conditions = types.SetCondition(im.Status.Conditions, longhorn.InstanceManagerConditionTypeSettingSynced,
+				longhorn.ConditionStatusFalse, longhorn.InstanceManagerConditionReasonSettingNotSynced,
+				fmt.Sprintf("Settings %v are not synced; skipping pod deletion because sufficient hugepage capacity for rescheduling cannot be confirmed", unSyncedSettings))
+			log.Warnf("Skipping deletion of instance manager pod %v because sufficient hugepage capacity for rescheduling cannot be confirmed", im.Name)
+			return nil
+		}
+
+		im.Status.Conditions = types.SetCondition(im.Status.Conditions, longhorn.InstanceManagerConditionTypeSettingSynced,
+			longhorn.ConditionStatusFalse, longhorn.InstanceManagerConditionReasonSettingNotSynced, fmt.Sprintf("Settings %v are not synced", unSyncedSettings))
+	}
+
+	isPodDeletionNotRequired := (isSettingSynced && dataEngineCPUMaskIsApplied && hugepageSettingApplied) || areInstancesRunningInPod || isPodDeletedOrNotRunning
 	if im.Status.CurrentState != longhorn.InstanceManagerStateError &&
 		im.Status.CurrentState != longhorn.InstanceManagerStateStopped &&
 		isPodDeletionNotRequired {
@@ -673,7 +708,7 @@ func (imc *InstanceManagerController) handlePod(im *longhorn.InstanceManager) er
 		log.Warnf("Instance manager pod %v is deleted or not running, recreating the pod", im.Name)
 	} else {
 		log.Warnf("Deleting instance manager pod %v because some danger zone settings are not synced since no instances are running and the following conditions are met: "+
-			"setting is not synced (%v) or data engine CPU mask is not applied (%v)", im.Name, !isSettingSynced, !dataEngineCPUMaskIsApplied)
+			"setting is not synced (%v) or data engine CPU mask is not applied (%v) or hugepage setting is not applied (%v)", im.Name, !isSettingSynced, !dataEngineCPUMaskIsApplied, !hugepageSettingApplied)
 	}
 
 	if err := imc.cleanupInstanceManagerPod(im.Name); err != nil {
@@ -746,31 +781,31 @@ func (imc *InstanceManagerController) annotateCASafeToEvict(im *longhorn.Instanc
 	return nil
 }
 
-func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *longhorn.InstanceManager) (isSynced, isPodDeletedOrNotRunning, areInstancesRunningInPod bool, err error) {
+func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *longhorn.InstanceManager) (isSynced bool, unSyncedDangerSettings []types.SettingName, isPodDeletedOrNotRunning, areInstancesRunningInPod bool, err error) {
 	if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
-		return false, true, false, nil
+		return false, nil, true, false, nil
 	}
 
 	for _, instance := range types.ConsolidateInstances(im.Status.InstanceEngines, im.Status.InstanceEngineFrontends, im.Status.InstanceReplicas) {
 		if instance.Status.State == longhorn.InstanceStateRunning || instance.Status.State == longhorn.InstanceStateStarting {
-			return false, false, true, nil
+			return false, nil, false, true, nil
 		}
 	}
 
 	pod, err := imc.ds.GetPodRO(im.Namespace, im.Name)
 	if err != nil {
-		return false, false, false, errors.Wrapf(err, "cannot get pod for instance manager %v", im.Name)
+		return false, nil, false, false, errors.Wrapf(err, "cannot get pod for instance manager %v", im.Name)
 	}
 	if pod == nil {
-		return false, true, false, nil
+		return false, nil, true, false, nil
 	}
 
-	unSyncedDangerSettings := []types.SettingName{}
+	unSyncedDangerSettings = []types.SettingName{}
 	for settingName := range types.GetDangerZoneSettings() {
 		isSettingSynced := true
 		setting, err := imc.ds.GetSettingWithAutoFillingRO(settingName)
 		if err != nil {
-			return false, false, false, err
+			return false, nil, false, false, err
 		}
 		switch settingName {
 		case types.SettingNameTaintToleration:
@@ -796,7 +831,7 @@ func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *lon
 			isSettingSynced, err = imc.isSettingInterruptModeEnabledSynced(setting, im)
 		}
 		if err != nil {
-			return false, false, false, err
+			return false, nil, false, false, err
 		}
 		if !isSettingSynced {
 			unSyncedDangerSettings = append(unSyncedDangerSettings, settingName)
@@ -805,12 +840,12 @@ func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *lon
 	if len(unSyncedDangerSettings) > 0 {
 		im.Status.Conditions = types.SetCondition(im.Status.Conditions, longhorn.InstanceManagerConditionTypeSettingSynced,
 			longhorn.ConditionStatusFalse, longhorn.InstanceManagerConditionReasonSettingNotSynced, fmt.Sprintf("Settings %v are not synced", unSyncedDangerSettings))
-		return false, false, false, nil
+		return false, unSyncedDangerSettings, false, false, nil
 	}
 
 	im.Status.Conditions = types.SetCondition(im.Status.Conditions, longhorn.InstanceManagerConditionTypeSettingSynced,
 		longhorn.ConditionStatusTrue, "", "")
-	return true, false, false, nil
+	return true, nil, false, false, nil
 }
 
 func (imc *InstanceManagerController) isSettingTaintTolerationSynced(setting *longhorn.Setting, pod *corev1.Pod) (bool, error) {
@@ -941,6 +976,162 @@ func (imc *InstanceManagerController) isSettingInterruptModeEnabledSynced(settin
 	}
 
 	return im.Status.DataEngineStatus.V2.InterruptModeEnabled == settingValue, nil
+}
+
+// isHugepageSettingApplied checks whether hugepage-related settings are effectively
+// applied to the IM pod. It returns:
+//   - applied: true if the pod should be considered safe to keep (settings synced,
+//     or node lacks capacity making deletion unsafe)
+//   - synced: true if the pod's hugepage limit and --spdk-memory-size arg match
+//     the current settings
+//
+// applied is true (consider safe to keep) if:
+//   - The data engine is V1 (hugepages not used)
+//   - The IM is not running
+//   - The pod's hugepage limit and --spdk-memory-size arg match the current settings
+//   - The settings are NOT synced but the node lacks sufficient total hugepage
+//     capacity to reschedule the pod, making deletion unsafe
+func (imc *InstanceManagerController) isHugepageSettingApplied(im *longhorn.InstanceManager) (applied, synced bool, err error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, true, nil
+	}
+
+	if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
+		return true, true, nil
+	}
+
+	pod, err := imc.ds.GetPodRO(im.Namespace, im.Name)
+	if err != nil {
+		return false, false, errors.Wrapf(err, "cannot get pod for instance manager %v", im.Name)
+	}
+	if pod == nil {
+		return true, true, nil
+	}
+
+	limitSynced, err := imc.isSettingHugepageLimitSynced(im, pod)
+	if err != nil {
+		return false, false, err
+	}
+
+	argSynced, err := imc.isSettingMemorySizeArgSynced(im, pod)
+	if err != nil {
+		return false, false, err
+	}
+
+	if limitSynced && argSynced {
+		return true, true, nil
+	}
+
+	// Settings not synced - check if the node has enough total hugepage capacity
+	// to safely reschedule the pod after deletion.
+	nodeHasCapacity, err := imc.nodeHasEnoughHugepageTotalCapacity(im)
+	if err != nil {
+		return false, false, err
+	}
+
+	// If the node doesn't have enough total capacity, deletion would leave the
+	// IM pod unschedulable (Pending). Return applied=true to prevent deletion,
+	// but synced=false so the condition reflects the actual state.
+	return !nodeHasCapacity, false, nil
+}
+
+// isSettingHugepageLimitSynced checks whether the pod's hugepages-2Mi resource limit
+// matches the expected value derived from the hugepage-enabled and memory-size settings.
+func (imc *InstanceManagerController) isSettingHugepageLimitSynced(im *longhorn.InstanceManager, pod *corev1.Pod) (bool, error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, nil
+	}
+
+	hugepageEnabled, err := imc.ds.GetSettingAsBoolByDataEngine(types.SettingNameDataEngineHugepageEnabled, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	memorySize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineMemorySize, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	if len(pod.Spec.Containers) == 0 {
+		return false, nil
+	}
+
+	expectedHugepage := int64(0)
+	if hugepageEnabled {
+		expectedHugepage = memorySize
+	}
+	expectedHugepageQuantity := fmt.Sprintf("%dMi", expectedHugepage)
+	expectedQuantity, err := resource.ParseQuantity(expectedHugepageQuantity)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse expected hugepage quantity %q", expectedHugepageQuantity)
+	}
+	currentQuantity := pod.Spec.Containers[0].Resources.Limits[corev1.ResourceName("hugepages-2Mi")]
+	return currentQuantity.Cmp(expectedQuantity) == 0, nil
+}
+
+// isSettingMemorySizeArgSynced checks whether the pod's --spdk-memory-size argument
+// matches the current memory-size setting value.
+func (imc *InstanceManagerController) isSettingMemorySizeArgSynced(im *longhorn.InstanceManager, pod *corev1.Pod) (bool, error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, nil
+	}
+
+	memorySize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineMemorySize, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	if len(pod.Spec.Containers) == 0 {
+		return false, nil
+	}
+
+	currentMemorySize := getContainerArgValue(pod.Spec.Containers[0].Args, "--spdk-memory-size")
+	expectedMemorySize := fmt.Sprintf("%d", memorySize)
+	return currentMemorySize == expectedMemorySize, nil
+}
+
+// nodeHasEnoughHugepageTotalCapacity checks whether the node's total allocatable
+// (or capacity) hugepages meet the required memory size. It does NOT account for
+// hugepages already consumed by other pods on the node. This means a true result
+// is necessary but not sufficient for the new IM pod to be schedulable. A false
+// result, however, guarantees the pod cannot schedule and deletion should be skipped.
+func (imc *InstanceManagerController) nodeHasEnoughHugepageTotalCapacity(im *longhorn.InstanceManager) (bool, error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, nil
+	}
+
+	hugepageEnabled, err := imc.ds.GetSettingAsBoolByDataEngine(types.SettingNameDataEngineHugepageEnabled, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	if !hugepageEnabled {
+		return true, nil
+	}
+
+	memorySize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineMemorySize, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	kubeNode, err := imc.ds.GetKubernetesNodeRO(im.Spec.NodeID)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get kubernetes node %v for hugepage check", im.Spec.NodeID)
+	}
+
+	hugepagesResourceName := corev1.ResourceName("hugepages-2Mi")
+	hugepages2MiAllocatable, exists := kubeNode.Status.Allocatable[hugepagesResourceName]
+	if !exists {
+		hugepages2MiAllocatable = kubeNode.Status.Capacity[hugepagesResourceName]
+	}
+
+	requiredHugePagesQuantity := fmt.Sprintf("%dMi", memorySize)
+	requiredHugePages, err := resource.ParseQuantity(requiredHugePagesQuantity)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse required hugepages quantity for memory size %v", memorySize)
+	}
+
+	return hugepages2MiAllocatable.Cmp(requiredHugePages) >= 0, nil
 }
 
 func (imc *InstanceManagerController) syncInstanceManagerAPIVersion(im *longhorn.InstanceManager) error {

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -6,14 +6,17 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	. "gopkg.in/check.v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/longhorn/longhorn-manager/datastore"
@@ -23,8 +26,6 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
-
-	. "gopkg.in/check.v1"
 )
 
 type InstanceManagerTestCase struct {
@@ -130,6 +131,14 @@ func newDataEngineInterruptModeEnabledSetting() *longhorn.Setting {
 		},
 		Value: "{\"v2\":\"false\"}",
 	}
+}
+
+func newDataEngineHugepageEnabledSetting() *longhorn.Setting {
+	return newSetting(string(types.SettingNameDataEngineHugepageEnabled), `{"v2":"true"}`)
+}
+
+func newDataEngineMemorySizeSetting() *longhorn.Setting {
+	return newSetting(string(types.SettingNameDataEngineMemorySize), `{"v2":"1024"}`)
 }
 
 func fakeInstanceManagerVersionUpdater(im *longhorn.InstanceManager) error {
@@ -542,5 +551,294 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 			tc.expectedStatus.Conditions[i].Message = condition.Message
 		}
 		c.Assert(updatedIM.Status, DeepEquals, tc.expectedStatus)
+	}
+}
+
+// createDangerZoneSettingsForV2 creates all the danger zone settings required by areDangerZoneSettingsSyncedToIMPod
+// with V2 data engine enabled. It auto-generates settings from types.GetDangerZoneSettings() using their
+// default values, then overrides specific settings that need non-default values for V2 to function.
+// This ensures new danger zone settings are automatically included without manual maintenance.
+func createDangerZoneSettingsForV2(c *C, lhClient *lhfake.Clientset, sIndexer cache.Indexer) {
+	// Auto-populate all danger zone settings with their definition defaults.
+	for settingName := range types.GetDangerZoneSettings() {
+		definition, ok := types.GetSettingDefinition(settingName)
+		c.Assert(ok, Equals, true, Commentf("missing definition for danger zone setting %q", settingName))
+		setting := newSetting(string(settingName), definition.Default)
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Override settings that need specific values for V2 IM tests.
+	overrides := map[types.SettingName]string{
+		types.SettingNameV2DataEngine:              "true",
+		types.SettingNameDataEngineHugepageEnabled: `{"v2":"true"}`,
+		types.SettingNameDataEngineMemorySize:      `{"v2":"1024"}`,
+		types.SettingNameDataEngineCPUMask:         `{"v2":"0x1"}`,
+	}
+	for name, value := range overrides {
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Get(context.TODO(), string(name), metav1.GetOptions{})
+		c.Assert(err, IsNil)
+		setting.Value = value
+		setting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Update(setting)
+		c.Assert(err, IsNil)
+	}
+
+	// Also add non-danger-zone settings that the IM controller needs.
+	extraSettings := []*longhorn.Setting{
+		newDefaultInstanceManagerImageSetting(),
+	}
+	for _, setting := range extraSettings {
+		setting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(setting)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *TestSuite) TestHugepagePodDeletionDecision(c *C) {
+	type testCase struct {
+		nodeHugepageCapacity  string // hugepages-2Mi capacity on the kube node
+		podHugepageLimit      string // current hugepages-2Mi limit on the IM pod
+		podMemorySize         string // current --spdk-memory-size in the IM pod args
+		hugepageDisabled      bool   // if true, override hugepage-enabled setting to false
+		extraUnsyncedSetting  bool   // if true, add an extra unsynced setting (priority class)
+		expectedPodCount      int    // 0 = pod deleted without recreation, 1 = pod kept or recreated
+		expectedHugepageLimit string
+	}
+
+	testCases := map[string]testCase{
+		"hugepage mismatch, node has enough hugepages, no instances - pod should be deleted and recreated": {
+			nodeHugepageCapacity:  "2Gi",
+			podHugepageLimit:      "512Mi", // mismatches the setting value of 1024Mi
+			podMemorySize:         "512",
+			expectedPodCount:      1, // deleted then recreated (net 1)
+			expectedHugepageLimit: "1Gi",
+		},
+		"hugepage mismatch, node has insufficient hugepages, no instances - pod should NOT be deleted": {
+			nodeHugepageCapacity:  "256Mi",
+			podHugepageLimit:      "512Mi",
+			podMemorySize:         "512",
+			expectedPodCount:      1, // kept as-is
+			expectedHugepageLimit: "512Mi",
+		},
+		"hugepage mismatch + other unsynced setting, node has insufficient hugepages - pod should NOT be deleted": {
+			nodeHugepageCapacity:  "256Mi",
+			podHugepageLimit:      "512Mi",
+			podMemorySize:         "512",
+			extraUnsyncedSetting:  true,
+			expectedPodCount:      1, // guard blocks deletion; pod stays as-is
+			expectedHugepageLimit: "512Mi",
+		},
+		"hugepage matches, node has enough hugepages - pod should NOT be deleted": {
+			nodeHugepageCapacity:  "2Gi",
+			podHugepageLimit:      "1024Mi", // matches the setting value
+			podMemorySize:         "1024",
+			expectedPodCount:      1, // kept as-is
+			expectedHugepageLimit: "1Gi",
+		},
+		"memory size mismatch with hugepages disabled - pod should be deleted and recreated": {
+			nodeHugepageCapacity:  "2Gi",
+			podHugepageLimit:      "0",   // hugepages disabled, limit is 0
+			podMemorySize:         "512", // stale --spdk-memory-size, setting is 1024
+			hugepageDisabled:      true,
+			expectedPodCount:      1, // deleted then recreated (net 1)
+			expectedHugepageLimit: "0",
+		},
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+		kubeNodeIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+		lhNodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+
+		imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		createDangerZoneSettingsForV2(c, lhClient, sIndexer)
+
+		if tc.hugepageDisabled {
+			hpSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Get(context.TODO(), string(types.SettingNameDataEngineHugepageEnabled), metav1.GetOptions{})
+			c.Assert(err, IsNil)
+			hpSetting.Value = `{"v2":"false"}`
+			hpSetting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Update(context.TODO(), hpSetting, metav1.UpdateOptions{})
+			c.Assert(err, IsNil)
+			err = sIndexer.Update(hpSetting)
+			c.Assert(err, IsNil)
+		}
+
+		// If we want an extra unsynced setting, override priority class to a value that won't match the pod.
+		if tc.extraUnsyncedSetting {
+			pcSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Get(context.TODO(), string(types.SettingNamePriorityClass), metav1.GetOptions{})
+			c.Assert(err, IsNil)
+			pcSetting.Value = "system-cluster-critical"
+			pcSetting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Update(context.TODO(), pcSetting, metav1.UpdateOptions{})
+			c.Assert(err, IsNil)
+			err = sIndexer.Update(pcSetting)
+			c.Assert(err, IsNil)
+		}
+
+		// Create kubernetes node with hugepage capacity.
+		kubeNode := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode.Status.Allocatable = corev1.ResourceList{
+			"cpu":                                resource.MustParse("4"),
+			corev1.ResourceName("hugepages-2Mi"): resource.MustParse(tc.nodeHugepageCapacity),
+		}
+		kubeNode.Status.Capacity = corev1.ResourceList{
+			corev1.ResourceName("hugepages-2Mi"): resource.MustParse(tc.nodeHugepageCapacity),
+		}
+		err = kubeNodeIndexer.Add(kubeNode)
+		c.Assert(err, IsNil)
+		_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		lhNode := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+		err = lhNodeIndexer.Add(lhNode)
+		c.Assert(err, IsNil)
+		_, err = lhClient.LonghornV1beta2().Nodes(lhNode.Namespace).Create(context.TODO(), lhNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		// Create a V2 running IM with no instances.
+		im := newInstanceManager(
+			TestInstanceManagerName,
+			longhorn.InstanceManagerStateRunning,
+			TestNode1, TestNode1, TestIP1,
+			nil, nil, nil,
+			longhorn.DataEngineTypeV2,
+			TestInstanceManagerImage,
+			false,
+		)
+		// Set DataEngineStatus to match settings so CPU mask and interrupt mode are "applied".
+		im.Status.DataEngineStatus.V2.CPUMask = "0x1"
+		im.Status.DataEngineStatus.V2.InterruptModeEnabled = "false"
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+		_, err = lhClient.LonghornV1beta2().InstanceManagers(im.Namespace).Create(context.TODO(), im, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		// Create a pod with the specified hugepage limit and memory size (may or may not match the setting).
+		pod := newPod(&corev1.PodStatus{PodIP: TestIP1, Phase: corev1.PodRunning}, im.Name, im.Namespace, im.Spec.NodeID)
+		pod.Spec.Containers = []corev1.Container{{
+			Name:    "instance-manager",
+			Command: []string{"instance-manager"},
+			Args:    []string{"--spdk-memory-size", tc.podMemorySize},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{"cpu": resource.MustParse("480m")},
+				Limits: corev1.ResourceList{
+					corev1.ResourceName("hugepages-2Mi"): resource.MustParse(tc.podHugepageLimit),
+				},
+			},
+		}}
+		err = pIndexer.Add(pod)
+		c.Assert(err, IsNil)
+		_, err = kubeClient.CoreV1().Pods(im.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		err = imc.syncInstanceManager(getKey(im, c))
+		c.Assert(err, IsNil)
+
+		podList, err := kubeClient.CoreV1().Pods(im.Namespace).List(context.TODO(), metav1.ListOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(podList.Items, HasLen, tc.expectedPodCount, Commentf("test case: %v", name))
+		if tc.expectedPodCount == 1 {
+			hugepageLimit := podList.Items[0].Spec.Containers[0].Resources.Limits[corev1.ResourceName("hugepages-2Mi")]
+			c.Assert(hugepageLimit.String(), Equals, tc.expectedHugepageLimit, Commentf("test case: %v", name))
+		}
+	}
+}
+
+func (s *TestSuite) TestNodeHasEnoughHugepageTotalCapacity(c *C) {
+	type testCase struct {
+		allocatable string
+		capacity    string
+		expected    bool
+	}
+
+	testCases := map[string]testCase{
+		"prefer allocatable when present": {
+			allocatable: "512Mi",
+			capacity:    "2Gi",
+			expected:    false,
+		},
+		"fallback to capacity when allocatable missing": {
+			capacity: "2Gi",
+			expected: true,
+		},
+		"allocatable enough": {
+			allocatable: "2Gi",
+			capacity:    "512Mi",
+			expected:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+		kubeNodeIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+
+		imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		for _, setting := range []*longhorn.Setting{
+			newDataEngineHugepageEnabledSetting(),
+			newDataEngineMemorySizeSetting(),
+		} {
+			setting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			err = sIndexer.Add(setting)
+			c.Assert(err, IsNil)
+		}
+
+		kubeNode := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode.Status.Capacity = corev1.ResourceList{}
+		if tc.capacity != "" {
+			kubeNode.Status.Capacity[corev1.ResourceName("hugepages-2Mi")] = resource.MustParse(tc.capacity)
+		}
+		kubeNode.Status.Allocatable = corev1.ResourceList{}
+		if tc.allocatable != "" {
+			kubeNode.Status.Allocatable[corev1.ResourceName("hugepages-2Mi")] = resource.MustParse(tc.allocatable)
+		}
+
+		err = kubeNodeIndexer.Add(kubeNode)
+		c.Assert(err, IsNil)
+		_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		im := newInstanceManager(
+			TestInstanceManagerName,
+			longhorn.InstanceManagerStateRunning,
+			TestNode1,
+			TestNode1,
+			TestIP1,
+			nil,
+			nil,
+			nil,
+			longhorn.DataEngineTypeV2,
+			TestInstanceManagerImage,
+			false,
+		)
+
+		ok, err := imc.nodeHasEnoughHugepageTotalCapacity(im)
+		c.Assert(err, IsNil)
+		c.Assert(ok, Equals, tc.expected)
 	}
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -280,3 +280,12 @@ func isRevisionedEngineImage(image string) bool {
 	tag := image[lastColonIndex+1:]
 	return engineImageRevisionTagRegex.MatchString(tag)
 }
+
+func getContainerArgValue(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13170

#### What this PR does / why we need it:

When DataEngineHugepageEnabled or DataEngineMemorySize settings change,
the IM controller now detects the mismatch between the pod's hugepages-2Mi
resource limit / --spdk-memory-size arg and the current settings. If no
instances are running, the pod is deleted and recreated with the updated
values.

A safety guard prevents deletion when the node lacks sufficient hugepage
capacity to reschedule the replacement pod — avoiding a stuck Pending
state. On verification errors, the guard also blocks deletion (fail-safe)
until the next successful reconcile.

Non-hugepage danger-zone settings (TaintToleration, PriorityClass, etc.)
retain their existing behavior unchanged for V1 and V2 with sufficient
node capacity.

#### Special notes for your reviewer:

#### Additional documentation or context
