### PR TITLE
fix(csi): use in-place upddate to prevent 0-replica window during upg…

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -15,8 +15,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/longhorn/longhorn-manager/datastore"
-	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
 const (
@@ -94,7 +95,7 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 
 func (a *AttacherDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, a.deployment, "deployment",
-		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc)
+		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc, deploymentUpdateFunc)
 }
 
 func (a *AttacherDeployment) Cleanup(kubeClient *clientset.Clientset) {
@@ -155,7 +156,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 
 func (p *ProvisionerDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, p.deployment, "deployment",
-		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc)
+		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc, deploymentUpdateFunc)
 }
 
 func (p *ProvisionerDeployment) Cleanup(kubeClient *clientset.Clientset) {
@@ -222,7 +223,7 @@ func NewResizerDeployment(namespace, serviceAccount, resizerImage, rootDir strin
 
 func (p *ResizerDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, p.deployment, "deployment",
-		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc)
+		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc, deploymentUpdateFunc)
 }
 
 func (p *ResizerDeployment) Cleanup(kubeClient *clientset.Clientset) {
@@ -279,7 +280,7 @@ func NewSnapshotterDeployment(namespace, serviceAccount, snapshotterImage, rootD
 
 func (p *SnapshotterDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, p.deployment, "deployment",
-		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc)
+		deploymentCreateFunc, deploymentDeleteFunc, deploymentGetFunc, deploymentUpdateFunc)
 }
 
 func (p *SnapshotterDeployment) Cleanup(kubeClient *clientset.Clientset) {
@@ -622,7 +623,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 
 func (p *PluginDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, p.daemonSet, "daemon set",
-		daemonSetCreateFunc, daemonSetDeleteFunc, daemonSetGetFunc)
+		daemonSetCreateFunc, daemonSetDeleteFunc, daemonSetGetFunc, nil)
 }
 
 func (p *PluginDeployment) Cleanup(kubeClient *clientset.Clientset) {
@@ -653,7 +654,7 @@ func NewCSIDriverObject(storageCapacityEnabled bool) *DriverObjectDeployment {
 
 func (d *DriverObjectDeployment) Deploy(kubeClient *clientset.Clientset) error {
 	return deploy(kubeClient, d.obj, "CSI Driver",
-		csiDriverObjectCreateFunc, csiDriverObjectDeleteFunc, csiDriverObjectGetFunc)
+		csiDriverObjectCreateFunc, csiDriverObjectDeleteFunc, csiDriverObjectGetFunc, nil)
 }
 
 func (d *DriverObjectDeployment) Cleanup(kubeClient *clientset.Clientset) {

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -166,9 +166,10 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 
 type resourceCreateFunc func(kubeClient *clientset.Clientset, obj runtime.Object) error
 type resourceDeleteFunc func(kubeClient *clientset.Clientset, name, namespace string) error
+type resourceUpdateFunc func(kubeClient *clientset.Clientset, obj runtime.Object) error
 
 func deploy(kubeClient *clientset.Clientset, obj runtime.Object, resource string,
-	createFunc resourceCreateFunc, deleteFunc resourceDeleteFunc, getFunc util.ResourceGetFunc) (err error) {
+	createFunc resourceCreateFunc, deleteFunc resourceDeleteFunc, getFunc util.ResourceGetFunc, updateFunc resourceUpdateFunc) (err error) {
 
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
@@ -205,6 +206,13 @@ func deploy(kubeClient *clientset.Clientset, obj runtime.Object, resource string
 			logrus.Infof("Detected %v %v CSI Git commit %v version %v has already been deployed",
 				resource, name, annos[AnnotationCSIGitCommit], annos[AnnotationCSIVersion])
 			return nil
+		}
+		// For Deployments, update in-place to let Kubernetes perform a rolling update,
+		// which respects maxUnavailable and avoids a 0-replica window.
+		// For other resource types (DaemonSet, CSIDriver), fall back to delete+recreate.
+		if updateFunc != nil && existingMeta.GetDeletionTimestamp() == nil {
+			logrus.Infof("Updating %s %s", resource, name)
+			return updateFunc(kubeClient, obj)
 		}
 		// otherwise clean up the old deployment
 		if err := cleanup(kubeClient, obj, resource, deleteFunc, getFunc); err != nil {
@@ -357,6 +365,24 @@ func deploymentCreateFunc(kubeClient *clientset.Clientset, obj runtime.Object) e
 		return fmt.Errorf("failed to convert back the object")
 	}
 	_, err := kubeClient.AppsV1().Deployments(o.Namespace).Create(context.TODO(), o, metav1.CreateOptions{})
+	return err
+}
+
+func deploymentUpdateFunc(kubeClient *clientset.Clientset, obj runtime.Object) error {
+	o, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return fmt.Errorf("failed to convert object to *appsv1.Deployment for update, got %T", obj)
+	}
+	_, err := util.RetryOnConflictCause(func() (interface{}, error) {
+		latest, err := kubeClient.AppsV1().Deployments(o.Namespace).Get(context.TODO(), o.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		latest.Annotations = o.Annotations
+		latest.Labels = o.Labels
+		latest.Spec = o.Spec
+		return kubeClient.AppsV1().Deployments(o.Namespace).Update(context.TODO(), latest, metav1.UpdateOptions{})
+	})
 	return err
 }
 

--- a/csi/deployment_util_test.go
+++ b/csi/deployment_util_test.go
@@ -3,8 +3,14 @@ package csi
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	longhornmeta "github.com/longhorn/longhorn-manager/meta"
 )
 
 func TestNeedToUpdatePodAntiAffinity(t *testing.T) {
@@ -176,5 +182,89 @@ func sampleHardAntiAffinityDeployment() *appsv1.Deployment {
 				AnnotationCSIPodAntiAffinityPreset: CSIPodAntiAffinityPresetHard,
 			},
 		},
+	}
+}
+
+// TestDeployUsesUpdateFuncInsteadOfDeleteRecreate verifies that deploy() calls
+// updateFunc rather than deleteFunc when updateFunc
+// is provided and an existing object is found with a different image.
+// The existing object's annotations match longhornmeta.GitCommit/Version so
+// that the update is triggered only by the image change (needToUpdateImage),
+// not by an annotation mismatch.
+func TestDeployUsesUpdateFuncInsteadOfDeleteRecreate(t *testing.T) {
+	const existingResourceVersion = "rv-42"
+
+	// existing object returned by getFunc — same annotations as the compiled binary
+	// but different image, so the update path is triggered by needToUpdateImage
+	existing := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "csi-attacher",
+			ResourceVersion: existingResourceVersion,
+			Annotations: map[string]string{
+				AnnotationCSIGitCommit: longhornmeta.GitCommit,
+				AnnotationCSIVersion:   longhornmeta.Version,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "csi-attacher", Image: "old-image:v1"},
+					},
+				},
+			},
+		},
+	}
+
+	// new object we want to deploy — different image; annotations will be overwritten
+	// by deploy() with longhornmeta.GitCommit/Version before comparison
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "csi-attacher",
+			Annotations: map[string]string{},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "csi-attacher", Image: "new-image:v2"},
+					},
+				},
+			},
+		},
+	}
+
+	createCalled := false
+	deleteCalled := false
+	updateCalled := false
+
+	fakeCreate := func(_ *clientset.Clientset, _ runtime.Object) error {
+		createCalled = true
+		return nil
+	}
+	fakeDelete := func(_ *clientset.Clientset, _, _ string) error {
+		deleteCalled = true
+		return nil
+	}
+	fakeGet := func(_ *clientset.Clientset, _, _ string) (runtime.Object, error) {
+		return existing, nil
+	}
+	fakeUpdate := func(_ *clientset.Clientset, obj runtime.Object) error {
+		updateCalled = true
+		return nil
+	}
+
+	err := deploy(nil, desired, "deployment", fakeCreate, fakeDelete, fakeGet, fakeUpdate)
+	if err != nil {
+		t.Fatalf("deploy() returned unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("expected updateFunc to be called, but it was not")
+	}
+	if deleteCalled {
+		t.Error("expected deleteFunc NOT to be called, but it was")
+	}
+	if createCalled {
+		t.Error("expected createFunc NOT to be called, but it was")
 	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue [#13105](https://github.com/longhorn/longhorn/issues/13105)

#### What this PR does / why we need it:
During upgrade, `deploy()` deleted then recreated CSI Deployments (attacher/provisioner/resizer/snapshotter), causing a guaranteed window with 0 running replicas regardless of `maxUnavailable` setting.

Fix: use `Update()` for Deployments so Kubernetes rolling update strategy is preserved and at least 1 replica stays running.
#### Special notes for your reviewer:
E2E: `Test CSI Components Rolling Update Configuration During Upgrade`  passed 2/2 runs on v1.12.x Jenkins environment.
https://ci.longhorn.io/job/public/job/v1.12.x/job/v1.12.x-longhorn-e2e-tests-sles-amd64/72/
#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CSI component deployment to support in-place updates, reducing disruption during reconciliation cycles.

* **Tests**
  * Added comprehensive tests to verify proper update behavior during deployment operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/longhorn/longhorn-manager/pull/4779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->