### PR TITLE
fix: reconcile empty backup targets before sync gating

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -361,7 +361,7 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 		}
 	}
 
-	// start a BackupStoreTimer and keep it in a map[string]*BackupStoreTimer
+	// stopTimer mutates bsTimerMap and requires the caller to hold bsTimerMapLock.
 	stopTimer := func(backupTargetName string) {
 		_, exists := btc.bsTimerMap[backupTargetName]
 		if exists {
@@ -404,9 +404,10 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 	}
 	btc.bsTimerMapLock.Unlock()
 
-	// Check the controller should run synchronization
-	if !backupTarget.Status.LastSyncedAt.IsZero() &&
-		!backupTarget.Spec.SyncRequestedAt.After(backupTarget.Status.LastSyncedAt.Time) {
+	// Check the controller should run synchronization.
+	// An empty backup target URL must still be reconciled so the controller can
+	// clear stale availability from the previous valid configuration.
+	if !isBackupTargetSyncRequired(backupTarget) {
 		return nil
 	}
 
@@ -445,9 +446,12 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 	}
 
 	if backupTarget.Spec.BackupTargetURL == "" {
+		btc.bsTimerMapLock.Lock()
 		stopTimer(backupTarget.Name)
+		btc.bsTimerMapLock.Unlock()
 
 		backupTarget.Status.Available = false
+		backupTarget.Status.LastSyncedAt = metav1.Time{}
 		backupTarget.Status.Conditions = types.SetCondition(backupTarget.Status.Conditions,
 			longhorn.BackupTargetConditionTypeUnavailable, longhorn.ConditionStatusTrue,
 			longhorn.BackupTargetConditionReasonUnavailable, "backup target URL is empty")
@@ -506,6 +510,28 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 	}
 
 	return nil
+}
+
+func isBackupTargetSyncRequired(backupTarget *longhorn.BackupTarget) bool {
+	if backupTarget == nil {
+		return false
+	}
+
+	if backupTarget.Spec.BackupTargetURL == "" {
+		return true
+	}
+
+	// LastSyncedAt is reset to zero when the URL is cleared, so this check
+	// naturally handles the empty-to-non-empty URL transition without needing
+	// a blanket !Available bypass (which would cause repeated network calls
+	// against persistently unreachable targets on every reconcile).
+	// For unreachable targets, the BackupStoreTimer drives periodic retries
+	// via SyncRequestedAt.
+	if backupTarget.Status.LastSyncedAt.IsZero() {
+		return true
+	}
+
+	return backupTarget.Spec.SyncRequestedAt.After(backupTarget.Status.LastSyncedAt.Time)
 }
 
 func (btc *BackupTargetController) cleanUpAllBackupRelatedResources(backupTargetName string) error {

--- a/controller/backup_target_controller_test.go
+++ b/controller/backup_target_controller_test.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func TestIsBackupTargetSyncRequired(t *testing.T) {
+	now := time.Now().UTC()
+
+	testCases := map[string]struct {
+		backupTarget *longhorn.BackupTarget
+		expected     bool
+	}{
+		"nil backup target": {
+			backupTarget: nil,
+			expected:     false,
+		},
+		"empty backup target URL bypasses stale sync gate": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: "",
+					SyncRequestedAt: metav1.Time{Time: now.Add(-2 * time.Minute)},
+				},
+				Status: longhorn.BackupTargetStatus{
+					LastSyncedAt: metav1.Time{Time: now.Add(-1 * time.Minute)},
+				},
+			},
+			expected: true,
+		},
+		"stale sync request is skipped for configured target": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: TestBackupTarget,
+					SyncRequestedAt: metav1.Time{Time: now.Add(-2 * time.Minute)},
+				},
+				Status: longhorn.BackupTargetStatus{
+					Available:    true,
+					LastSyncedAt: metav1.Time{Time: now.Add(-1 * time.Minute)},
+				},
+			},
+			expected: false,
+		},
+		"newer sync request is processed": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: TestBackupTarget,
+					SyncRequestedAt: metav1.Time{Time: now},
+				},
+				Status: longhorn.BackupTargetStatus{
+					LastSyncedAt: metav1.Time{Time: now.Add(-1 * time.Minute)},
+				},
+			},
+			expected: true,
+		},
+		"unavailable target with non-empty URL defers to timer": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: TestBackupTarget,
+					SyncRequestedAt: metav1.Time{Time: now.Add(-2 * time.Minute)},
+				},
+				Status: longhorn.BackupTargetStatus{
+					Available:    false,
+					LastSyncedAt: metav1.Time{Time: now.Add(-1 * time.Minute)},
+				},
+			},
+			expected: false,
+		},
+		"first sync after URL transition from empty": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: TestBackupTarget,
+				},
+				Status: longhorn.BackupTargetStatus{
+					Available: false,
+				},
+			},
+			expected: true,
+		},
+		"available target with stale sync is skipped": {
+			backupTarget: &longhorn.BackupTarget{
+				Spec: longhorn.BackupTargetSpec{
+					BackupTargetURL: TestBackupTarget,
+					SyncRequestedAt: metav1.Time{Time: now.Add(-2 * time.Minute)},
+				},
+				Status: longhorn.BackupTargetStatus{
+					Available:    true,
+					LastSyncedAt: metav1.Time{Time: now.Add(-1 * time.Minute)},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := isBackupTargetSyncRequired(tc.backupTarget)
+			if actual != tc.expected {
+				t.Fatalf("unexpected sync requirement: got %v, want %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -21,11 +21,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"k8s.io/client-go/rest"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/client-go/rest"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
@@ -1074,7 +1074,7 @@ func (cs *ControllerServer) createCSISnapshotTypeLonghornBackup(req *csi.CreateS
 	if existBackupTarget == nil {
 		return nil, status.Errorf(codes.NotFound, "backup target %s not found", existVol.BackupTargetName)
 	}
-	if !existBackupTarget.Available {
+	if isBackupTargetUnavailableForBackup(existBackupTarget) {
 		return nil, status.Errorf(codes.Aborted, "backup target %s is not available", existVol.BackupTargetName)
 	}
 
@@ -1135,6 +1135,10 @@ func (cs *ControllerServer) createCSISnapshotTypeLonghornBackup(req *csi.CreateS
 	rsp := createSnapshotResponseForSnapshotTypeLonghornBackup(backup.VolumeName, snapshotID, snapshotCR.CreationTime,
 		existVol.Size, backup.State == string(longhorn.BackupStateCompleted))
 	return rsp, nil
+}
+
+func isBackupTargetUnavailableForBackup(backupTarget *longhornclient.BackupTarget) bool {
+	return backupTarget == nil || backupTarget.BackupTargetURL == "" || !backupTarget.Available
 }
 
 func createSnapshotResponseForSnapshotTypeLonghornSnapshot(sourceVolumeName, snapshotID string, snapshotCR *longhornclient.SnapshotCR) *csi.CreateSnapshotResponse {

--- a/csi/controller_server_test.go
+++ b/csi/controller_server_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/types"
 
+	longhornclient "github.com/longhorn/longhorn-manager/client"
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake" // nolint: staticcheck
 )
@@ -278,6 +279,50 @@ func TestGetCapacity(t *testing.T) {
 			}
 			if res != nil && res.MaximumVolumeSize.Value != test.maximumVolumeSize {
 				t.Errorf("expected maximum volume size: %d, but got: %d", test.maximumVolumeSize, res.MaximumVolumeSize.Value)
+			}
+		})
+	}
+}
+
+func TestIsBackupTargetUnavailableForBackup(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		backupTarget *longhornclient.BackupTarget
+		expected     bool
+	}{
+		{
+			name:     "nil target",
+			expected: true,
+		},
+		{
+			name: "empty url",
+			backupTarget: &longhornclient.BackupTarget{
+				BackupTargetURL: "",
+				Available:       true,
+			},
+			expected: true,
+		},
+		{
+			name: "unavailable target",
+			backupTarget: &longhornclient.BackupTarget{
+				BackupTargetURL: "s3://backupbucket@us-east-1/backupstore",
+				Available:       false,
+			},
+			expected: true,
+		},
+		{
+			name: "configured available target",
+			backupTarget: &longhornclient.BackupTarget{
+				BackupTargetURL: "s3://backupbucket@us-east-1/backupstore",
+				Available:       true,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isBackupTargetUnavailableForBackup(tc.backupTarget)
+			if actual != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, actual)
 			}
 		})
 	}

--- a/webhook/resources/backup/validator.go
+++ b/webhook/resources/backup/validator.go
@@ -69,7 +69,7 @@ func (b *backupValidator) Create(request *admission.Request, newObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "")
 	}
 
-	if !backupTarget.Status.Available {
+	if backupTarget.Spec.BackupTargetURL == "" || !backupTarget.Status.Available {
 		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
 	}
 

--- a/webhook/resources/backupbackingimage/validator.go
+++ b/webhook/resources/backupbackingimage/validator.go
@@ -71,7 +71,7 @@ func (bbi *backupBackingImageValidator) Create(request *admission.Request, newOb
 		return werror.NewInvalidError(fmt.Sprintf("failed to get backup target %s: %v", backupTargetName, err), "")
 	}
 
-	if !backupTarget.Status.Available {
+	if backupTarget.Spec.BackupTargetURL == "" || !backupTarget.Status.Available {
 		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", backupTargetName), "")
 	}
 

--- a/webhook/resources/systembackup/validator.go
+++ b/webhook/resources/systembackup/validator.go
@@ -46,7 +46,7 @@ func (v *systemBackupValidator) Create(request *admission.Request, newObj runtim
 		return werror.NewBadRequest(err.Error())
 	}
 
-	if !backupTarget.Status.Available {
+	if backupTarget.Spec.BackupTargetURL == "" || !backupTarget.Status.Available {
 		return werror.NewInvalidError(fmt.Sprintf("backup target %s is not available", types.DefaultBackupTargetName), "")
 	}
 


### PR DESCRIPTION




#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13195

#### What this PR does / why we need it:

When a backup target is reset to an empty URL, the backup target controller can skip reconciliation if status.lastSyncedAt is newer than spec.syncRequestedAt.

This leaves the previous available state behind, so the backup target can still appear available after it has been cleared.

Fix the sync gating logic by always reconciling backup targets with an empty backupTargetURL, allowing the controller to clear stale availability state and run the existing cleanup path.

#### Special notes for your reviewer:

#### Additional documentation or context
