### PR TITLE
fix(v2): do not clear Spec.NodeID during volume deletion to prevent SPDK bdev orphan

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -413,7 +413,6 @@ func (c *VolumeController) syncVolume(key string) (err error) {
 			for _, ef := range engineFrontends {
 				if ef.DeletionTimestamp == nil {
 					ef.Spec.DesireState = longhorn.InstanceStateStopped
-					ef.Spec.NodeID = ""
 					if err := c.deleteEngineFrontend(ef, engineFrontends); err != nil {
 						return err
 					}
@@ -440,7 +439,6 @@ func (c *VolumeController) syncVolume(key string) (err error) {
 			if e.DeletionTimestamp == nil {
 				if types.IsDataEngineV2(volume.Spec.DataEngine) {
 					e.Spec.DesireState = longhorn.InstanceStateStopped
-					e.Spec.NodeID = ""
 					if err := c.deleteEngine(e, engines); err != nil {
 						return err
 					}
@@ -478,7 +476,6 @@ func (c *VolumeController) syncVolume(key string) (err error) {
 			if r.DeletionTimestamp == nil {
 				if types.IsDataEngineV2(volume.Spec.DataEngine) {
 					r.Spec.DesireState = longhorn.InstanceStateStopped
-					r.Spec.NodeID = ""
 					if err := c.deleteReplica(r, replicas); err != nil {
 						return err
 					}


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13198

#### What this PR does / why we need it:

Remove the Spec.NodeID = "" assignments for engine frontends, engines,
and replicas in the v2 volume deletion path.

Setting DesireState=Stopped is sufficient to prevent ReconcileInstanceState
from re-creating instances, since only the DesireState=Running case calls
createInstance(). Clearing NodeID is redundant and removes the fallback
path in DeleteInstance() that uses NodeID to locate the Instance Manager
when Status.InstanceManagerName is empty (cleared by
syncStatusWithInstanceManager after the instance stops). Without NodeID,
DeleteInstance skips the actual SPDK instance deletion, leaving the lvol
bdev as an orphaned resource in spdk_tgt.


#### Special notes for your reviewer:

#### Additional documentation or context
