### PR TITLE
fix(recurring-job): correct system backup retention to protect successful backups

### DIFF
--- a/app/recurringjob/systembackup.go
+++ b/app/recurringjob/systembackup.go
@@ -106,7 +106,18 @@ func (job *SystemBackupJob) cleanup() {
 		return
 	}
 
-	expiredSystemBackups := filterExpiredItems(systemBackupsToNameWithTimestamps(systemBackupList), job.retain)
+	// Only consider system backups that have reached a state eligible for
+	// retention (Ready or Error). Skipping the others means a backup that is
+	// still in flight is never deleted mid-creation, and does not count toward
+	// the retain quota.
+	retainableSystemBackups := make([]longhorn.SystemBackup, 0, len(systemBackupList.Items))
+	for _, systemBackup := range systemBackupList.Items {
+		if isSystemBackupEligibleForRetention(systemBackup.Status.State) {
+			retainableSystemBackups = append(retainableSystemBackups, systemBackup)
+		}
+	}
+
+	expiredSystemBackups := filterExpiredItems(systemBackupsToNameWithTimestamps(retainableSystemBackups), job.retain)
 	for _, systemBackupName := range expiredSystemBackups {
 		job.logger.Infof("Deleting system backup %v", systemBackupName)
 		err = job.DeleteSystemBackup(systemBackupName)
@@ -114,6 +125,17 @@ func (job *SystemBackupJob) cleanup() {
 			job.logger.WithError(err).Warnf("Failed to delete system backup %v", systemBackupName)
 		}
 	}
+}
+
+// isSystemBackupEligibleForRetention reports whether a SystemBackup should be
+// considered by retention cleanup. Only the completed terminal states Ready and
+// Error participate: in-flight backups (Syncing, Generating, Uploading, ...) are
+// skipped so a backup that is still being created is never deleted, and Deleting
+// backups are already on their way out. (The controller's systemBackupInFinalState
+// additionally treats Deleting as final; retention deliberately does not, to
+// avoid counting or re-deleting it.)
+func isSystemBackupEligibleForRetention(state longhorn.SystemBackupState) bool {
+	return state == longhorn.SystemBackupStateReady || state == longhorn.SystemBackupStateError
 }
 
 func (job *SystemBackupJob) waitForSystemBackupToStates(expectedStates []longhorn.SystemBackupState) (err error) {

--- a/app/recurringjob/systembackup_test.go
+++ b/app/recurringjob/systembackup_test.go
@@ -1,0 +1,193 @@
+package recurringjob
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	testNamespace       = "longhorn-system"
+	testSystemBackupJob = "daily-system-backup"
+)
+
+// systemBackupRecurringJobLabels returns the label set the system-backup
+// RecurringJob stamps on the SystemBackup CRs it creates. cleanup() lists by
+// this exact label (see (*Job).ListSystemBackup), so seeded fixtures must carry
+// it to be considered for retention.
+func systemBackupRecurringJobLabels(jobName string) map[string]string {
+	return map[string]string{
+		types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJob, string(longhorn.RecurringJobTypeSystemBackup)): jobName,
+	}
+}
+
+// newLabeledSystemBackup builds a SystemBackup owned by jobName (carrying the
+// recurring-job label) in testNamespace, reusing the shared fixture builder.
+func newLabeledSystemBackup(name, jobName string, creationTime, statusCreatedAt time.Time, state longhorn.SystemBackupState) *longhorn.SystemBackup {
+	sb := newSystemBackup(name, creationTime, statusCreatedAt, state)
+	sb.Namespace = testNamespace
+	sb.Labels = systemBackupRecurringJobLabels(jobName)
+	return &sb
+}
+
+// newSystemBackupJobForTest wires a SystemBackupJob to a fake Longhorn clientset
+// seeded with the given SystemBackups. This exercises the real cleanup() path
+// (ListSystemBackup -> filter retention-eligible states ->
+// systemBackupsToNameWithTimestamps -> filterExpiredItems -> DeleteSystemBackup)
+// without needing a cluster.
+func newSystemBackupJobForTest(retain int, objs ...*longhorn.SystemBackup) *SystemBackupJob {
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		runtimeObjs = append(runtimeObjs, o)
+	}
+	lhClient := lhfake.NewSimpleClientset(runtimeObjs...) // nolint: staticcheck
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	return &SystemBackupJob{
+		Job: &Job{
+			lhClient:  lhClient,
+			logger:    logger,
+			name:      testSystemBackupJob,
+			namespace: testNamespace,
+			retain:    retain,
+		},
+		logger: logrus.NewEntry(logger),
+	}
+}
+
+// remainingSystemBackupNames returns the names of SystemBackups still present in
+// the fake cluster after a cleanup pass.
+func remainingSystemBackupNames(t *testing.T, job *SystemBackupJob) []string {
+	t.Helper()
+	list, err := job.lhClient.LonghornV1beta2().SystemBackups(testNamespace).List(context.TODO(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	names := make([]string, 0, len(list.Items))
+	for _, sb := range list.Items {
+		names = append(names, sb.Name)
+	}
+	return names
+}
+
+func TestSystemBackupJobCleanup(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	t.Run("prunes_error_backup_before_ready", func(t *testing.T) {
+		// longhorn/longhorn#13203, resolved per @derekbit's guidance: only Ready
+		// and Error are eligible for retention, and an Error backup (zero
+		// Status.CreatedAt) sorts first, so it is pruned before any successful
+		// Ready backup. With retain=2 and two Ready + one newest Error, the Error
+		// CR is removed and both Ready CRs are kept.
+		oldReady := newLabeledSystemBackup("daily-old-ready", testSystemBackupJob,
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		midReady := newLabeledSystemBackup("daily-mid-ready", testSystemBackupJob,
+			base.Add(24*time.Hour), base.Add(24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+		newError := newLabeledSystemBackup("daily-new-error", testSystemBackupJob,
+			base.Add(48*time.Hour), time.Time{}, longhorn.SystemBackupStateError)
+
+		job := newSystemBackupJobForTest(2, oldReady, midReady, newError)
+
+		job.cleanup()
+
+		assert.ElementsMatch(t, []string{"daily-old-ready", "daily-mid-ready"},
+			remainingSystemBackupNames(t, job),
+			"the Error CR is pruned before either Ready CR; successful backups are kept")
+	})
+
+	t.Run("skips_in_flight_system_backups", func(t *testing.T) {
+		// In-flight backups (anything not Ready/Error) must never be deleted, and
+		// must not count toward retain. With retain=1 and two Ready + one
+		// Generating, retention applies only to the two terminal Ready CRs (the
+		// oldest is pruned); the Generating CR is left untouched.
+		oldReady := newLabeledSystemBackup("daily-old-ready", testSystemBackupJob,
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		newReady := newLabeledSystemBackup("daily-new-ready", testSystemBackupJob,
+			base.Add(24*time.Hour), base.Add(24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+		inFlight := newLabeledSystemBackup("daily-in-flight", testSystemBackupJob,
+			base.Add(48*time.Hour), time.Time{}, longhorn.SystemBackupStateGenerating)
+
+		job := newSystemBackupJobForTest(1, oldReady, newReady, inFlight)
+
+		job.cleanup()
+
+		assert.ElementsMatch(t, []string{"daily-new-ready", "daily-in-flight"},
+			remainingSystemBackupNames(t, job),
+			"in-flight CR is skipped (kept, not counted); only the oldest terminal "+
+				"Ready CR is pruned under retain=1")
+	})
+
+	t.Run("repeated_failures_do_not_evict_ready_backups", func(t *testing.T) {
+		// Safety property behind dropping the creationTimestamp fallback: during a
+		// backup-target outage, consecutive failed runs produce Error CRs. They
+		// must be pruned before successful backups so retention never erodes the
+		// usable (Ready) backups. retain=2 with two Ready + two Error keeps both
+		// Ready CRs and prunes both Error CRs.
+		ready1 := newLabeledSystemBackup("daily-ready-1", testSystemBackupJob,
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		ready2 := newLabeledSystemBackup("daily-ready-2", testSystemBackupJob,
+			base.Add(24*time.Hour), base.Add(24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+		error1 := newLabeledSystemBackup("daily-error-1", testSystemBackupJob,
+			base.Add(48*time.Hour), time.Time{}, longhorn.SystemBackupStateError)
+		error2 := newLabeledSystemBackup("daily-error-2", testSystemBackupJob,
+			base.Add(72*time.Hour), time.Time{}, longhorn.SystemBackupStateError)
+
+		job := newSystemBackupJobForTest(2, ready1, ready2, error1, error2)
+
+		job.cleanup()
+
+		assert.ElementsMatch(t, []string{"daily-ready-1", "daily-ready-2"},
+			remainingSystemBackupNames(t, job),
+			"both Error CRs are pruned; successful Ready backups are never evicted by failures")
+	})
+
+	t.Run("ignores_system_backups_owned_by_other_jobs", func(t *testing.T) {
+		// cleanup() lists by the recurring-job label, so CRs created by a
+		// different recurring job must never be pruned by this job — even when
+		// this job's retain would otherwise expire them.
+		ownOld := newLabeledSystemBackup("own-old", testSystemBackupJob,
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		ownNew := newLabeledSystemBackup("own-new", testSystemBackupJob,
+			base.Add(24*time.Hour), base.Add(24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+		otherJob := newLabeledSystemBackup("other-job-old", "weekly-system-backup",
+			base.Add(-24*time.Hour), base.Add(-24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+
+		job := newSystemBackupJobForTest(1, ownOld, ownNew, otherJob)
+
+		job.cleanup()
+
+		assert.ElementsMatch(t, []string{"own-new", "other-job-old"},
+			remainingSystemBackupNames(t, job),
+			"with retain=1 only this job's oldest CR (own-old) is pruned; another "+
+				"job's CR (other-job-old) is left untouched")
+	})
+
+	t.Run("no_deletion_when_within_retain", func(t *testing.T) {
+		// retain >= number of owned terminal CRs: nothing is expired. The Error CR
+		// with a zero Status.CreatedAt must not trip an accidental deletion here.
+		ready := newLabeledSystemBackup("a-ready", testSystemBackupJob,
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		errored := newLabeledSystemBackup("b-error", testSystemBackupJob,
+			base.Add(24*time.Hour), time.Time{}, longhorn.SystemBackupStateError)
+
+		job := newSystemBackupJobForTest(2, ready, errored)
+
+		job.cleanup()
+
+		assert.ElementsMatch(t, []string{"a-ready", "b-error"}, remainingSystemBackupNames(t, job),
+			"retain=2 with two owned CRs must delete nothing")
+	})
+}

--- a/app/recurringjob/type.go
+++ b/app/recurringjob/type.go
@@ -15,7 +15,7 @@ import (
 // Job is a base job that contains the necessary clients, configuration, and general information.
 type Job struct {
 	api      *longhornclient.RancherClient // Rancher client used to interact with the Longhorn API.
-	lhClient *lhclientset.Clientset        // Kubernetes clientset for Longhorn resources.
+	lhClient lhclientset.Interface         // Longhorn clientset (interface so a fake can be injected in tests).
 
 	eventRecorder record.EventRecorder // Used to record events related to the job.
 	logger        *logrus.Logger       // Log messages related to the job.

--- a/app/recurringjob/util.go
+++ b/app/recurringjob/util.go
@@ -64,7 +64,7 @@ func filterExpiredItems(nts []NameWithTimestamp, retainCount int) []string {
 }
 
 func snapshotCRsToNameWithTimestamps(snapshotCRs []longhornclient.SnapshotCR) []NameWithTimestamp {
-	result := []NameWithTimestamp{}
+	result := make([]NameWithTimestamp, 0, len(snapshotCRs))
 	for _, snapshotCR := range snapshotCRs {
 		t, err := time.Parse(time.RFC3339, snapshotCR.CrCreationTime)
 		if err != nil {
@@ -110,7 +110,7 @@ func filterVolumesForJob(allowDetached bool, volumes []longhorn.Volume, filterNa
 	}
 }
 
-func getVolumesBySelector(recurringJobType, recurringJobName, namespace string, client *lhclientset.Clientset) ([]longhorn.Volume, error) {
+func getVolumesBySelector(recurringJobType, recurringJobName, namespace string, client lhclientset.Interface) ([]longhorn.Volume, error) {
 	logger := logrus.StandardLogger()
 
 	label := fmt.Sprintf("%s=%s",
@@ -126,7 +126,7 @@ func getVolumesBySelector(recurringJobType, recurringJobName, namespace string, 
 	return volumes.Items, nil
 }
 
-func getSettingAsBoolean(name types.SettingName, namespace string, client *lhclientset.Clientset) (bool, error) {
+func getSettingAsBoolean(name types.SettingName, namespace string, client lhclientset.Interface) (bool, error) {
 	obj, err := client.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(name), metav1.GetOptions{})
 	if err != nil {
 		return false, err
@@ -156,9 +156,16 @@ func sliceStringSafely(s string, begin, end int) string {
 	return s[begin:end]
 }
 
-func systemBackupsToNameWithTimestamps(systemBackupList *longhorn.SystemBackupList) []NameWithTimestamp {
-	result := []NameWithTimestamp{}
-	for _, systemBackup := range systemBackupList.Items {
+// systemBackupsToNameWithTimestamps maps SystemBackups to NameWithTimestamp by
+// Status.CreatedAt for retention sorting. Callers must pre-filter to the states
+// eligible for retention (see (*SystemBackupJob).cleanup). Status.CreatedAt is
+// only written on the successful upload path, so SystemBackups in Error state
+// carry a zero timestamp; that zero intentionally sorts ahead of successful
+// (Ready) backups in filterExpiredItems, so failed backups are pruned before
+// successful ones (longhorn/longhorn#13203).
+func systemBackupsToNameWithTimestamps(systemBackups []longhorn.SystemBackup) []NameWithTimestamp {
+	result := make([]NameWithTimestamp, 0, len(systemBackups))
+	for _, systemBackup := range systemBackups {
 		result = append(result, NameWithTimestamp{
 			Name:      systemBackup.Name,
 			Timestamp: systemBackup.Status.CreatedAt.Time,

--- a/app/recurringjob/util_test.go
+++ b/app/recurringjob/util_test.go
@@ -1,0 +1,142 @@
+package recurringjob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func newSystemBackup(name string, creationTime time.Time, statusCreatedAt time.Time, state longhorn.SystemBackupState) longhorn.SystemBackup {
+	return longhorn.SystemBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.NewTime(creationTime),
+		},
+		Status: longhorn.SystemBackupStatus{
+			State:     state,
+			CreatedAt: metav1.NewTime(statusCreatedAt),
+		},
+	}
+}
+
+func TestSystemBackupsToNameWithTimestamps(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	t.Run("uses_status_created_at", func(t *testing.T) {
+		// Ready backups have Status.CreatedAt populated by the controller; the
+		// returned timestamps should match Status.CreatedAt for each entry.
+		systemBackups := []longhorn.SystemBackup{
+			newSystemBackup("daily-1", base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady),
+			newSystemBackup("daily-2", base.Add(24*time.Hour), base.Add(24*time.Hour+6*time.Minute), longhorn.SystemBackupStateReady),
+		}
+
+		got := systemBackupsToNameWithTimestamps(systemBackups)
+
+		assert.Len(t, got, 2)
+		byName := map[string]time.Time{}
+		for _, n := range got {
+			byName[n.Name] = n.Timestamp
+		}
+		assert.Equal(t, base.Add(8*time.Minute), byName["daily-1"])
+		assert.Equal(t, base.Add(24*time.Hour+6*time.Minute), byName["daily-2"])
+	})
+
+	t.Run("error_backup_keeps_zero_timestamp", func(t *testing.T) {
+		// Status.CreatedAt is only set on the successful upload path, so an Error
+		// backup carries a zero timestamp. We deliberately do not fall back to
+		// metadata.creationTimestamp: the zero value sorts ahead of successful
+		// (Ready) backups in filterExpiredItems, so failed backups are pruned
+		// first and never evict a successful one (longhorn/longhorn#13203).
+		errored := newSystemBackup("daily-stuck", base, time.Time{}, longhorn.SystemBackupStateError)
+
+		got := systemBackupsToNameWithTimestamps([]longhorn.SystemBackup{errored})
+
+		if assert.Len(t, got, 1) {
+			assert.True(t, got[0].Timestamp.IsZero(),
+				"Error backup must keep a zero timestamp so it sorts (and prunes) ahead of Ready backups")
+		}
+	})
+
+	t.Run("error_is_pruned_before_ready", func(t *testing.T) {
+		// With retain=2 and two Ready + one Error, the Error backup (zero
+		// Status.CreatedAt) sorts first and is the one pruned; both successful
+		// Ready backups are retained.
+		oldReady := newSystemBackup("daily-old-ready",
+			base, base.Add(8*time.Minute), longhorn.SystemBackupStateReady)
+		midReady := newSystemBackup("daily-mid-ready",
+			base.Add(24*time.Hour), base.Add(24*time.Hour+8*time.Minute), longhorn.SystemBackupStateReady)
+		newError := newSystemBackup("daily-new-error",
+			base.Add(48*time.Hour), time.Time{}, longhorn.SystemBackupStateError)
+
+		expired := filterExpiredItems(systemBackupsToNameWithTimestamps(
+			[]longhorn.SystemBackup{oldReady, midReady, newError}), 2)
+
+		assert.Equal(t, []string{"daily-new-error"}, expired,
+			"the Error backup is pruned before either Ready backup")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		assert.Empty(t, systemBackupsToNameWithTimestamps(nil))
+	})
+}
+
+func TestFilterExpiredItems(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	t.Run("retains_n_newest", func(t *testing.T) {
+		nts := []NameWithTimestamp{
+			{Name: "a", Timestamp: base},
+			{Name: "b", Timestamp: base.Add(24 * time.Hour)},
+			{Name: "c", Timestamp: base.Add(48 * time.Hour)},
+			{Name: "d", Timestamp: base.Add(72 * time.Hour)},
+		}
+
+		expired := filterExpiredItems(nts, 2)
+
+		// Expect the two oldest (a, b) to be pruned; c and d retained.
+		assert.ElementsMatch(t, []string{"a", "b"}, expired)
+	})
+
+	t.Run("retain_count_equals_len_returns_empty", func(t *testing.T) {
+		nts := []NameWithTimestamp{
+			{Name: "a", Timestamp: base},
+			{Name: "b", Timestamp: base.Add(24 * time.Hour)},
+		}
+
+		expired := filterExpiredItems(nts, 2)
+
+		assert.Empty(t, expired)
+	})
+
+	t.Run("retain_count_greater_than_len_returns_empty", func(t *testing.T) {
+		nts := []NameWithTimestamp{
+			{Name: "a", Timestamp: base},
+		}
+
+		expired := filterExpiredItems(nts, 5)
+
+		assert.Empty(t, expired)
+	})
+
+	t.Run("zero_timestamp_sorts_first", func(t *testing.T) {
+		// A zero time.Time sorts before any real timestamp, so an entry with a
+		// zero Timestamp is always treated as the oldest and pruned first. For
+		// system backups this is intentional: Error backups carry a zero
+		// Status.CreatedAt and must be pruned ahead of successful (Ready) ones.
+		nts := []NameWithTimestamp{
+			{Name: "newest-real", Timestamp: base.Add(48 * time.Hour)},
+			{Name: "older-real", Timestamp: base},
+			{Name: "zero-time", Timestamp: time.Time{}},
+		}
+
+		expired := filterExpiredItems(nts, 2)
+
+		// Zero timestamp sorts to position 0 — gets pruned.
+		assert.Equal(t, []string{"zero-time"}, expired)
+	})
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13203

#### What this PR does / why we need it:

The `system-backup` `RecurringJob`'s retention (`cleanup()`) sorts `SystemBackup` CRs by `Status.CreatedAt`, but the controller only writes that field on the successful upload path (`controller/system_backup_controller.go` ~L566). CRs in `Error` state — and CRs still in flight when `ListSystemBackup` runs — have the zero value `time.Time{}` (year 1), which sorts to the front of `filterExpiredItems`, so retention pruned the wrong CRs.

This PR makes retention state-aware:

- **Skip in-flight backups.** `cleanup()` only considers CRs in a terminal state (`Ready` or `Error`). A backup still being created (`Syncing`/`Generating`/`Uploading`/…) is never deleted and does not count toward the `retain` quota.
- **Prune failed backups before successful ones.** `Error` CRs keep their zero `Status.CreatedAt` and sort ahead of `Ready` CRs, so they are pruned first. A run of failures (e.g. a backup-target outage) can no longer evict good backups.

#### Special notes for your reviewer:

- Implements @derekbit's suggestion to skip non-`Ready`/`Error` states in `cleanup()`. The earlier `creationTimestamp` fallback was dropped in favor of this, since it could let accumulating `Error` CRs evict successful backups during a sustained outage.
- `isSystemBackupEligibleForRetention` treats only `Ready`/`Error` as eligible — unlike the controller's `systemBackupInFinalState`, it excludes `Deleting` (those are already on their way out).
- The recurring-job Longhorn client is made an interface so `cleanup()` is testable against a fake clientset.

#### Testing

`app/recurringjob/` unit tests, incl. `TestSystemBackupJobCleanup` driving the real `cleanup()` against a fake clientset:
- `prunes_error_backup_before_ready`, `skips_in_flight_system_backups`, `repeated_failures_do_not_evict_ready_backups`, plus label-scoping and within-retain cases.

```
$ go test ./app/recurringjob/
ok  	github.com/longhorn/longhorn-manager/app/recurringjob
```
