### PR TITLE
fix(v2): gate engine frontend switchover on volume SwitchoverState

### DIFF
--- a/controller/engine_frontend_controller.go
+++ b/controller/engine_frontend_controller.go
@@ -430,7 +430,23 @@ func (efc *EngineFrontendController) syncEngineFrontend(key string) (err error) 
 		targetChanged := ef.Status.TargetIP != ef.Spec.TargetIP || ef.Status.TargetPort != ef.Spec.TargetPort
 		switchoverInProgress := ef.Status.SwitchoverPhase != longhorn.EngineFrontendSwitchoverPhaseNone
 
-		if targetChanged || switchoverInProgress {
+		// Only execute the ANA multipath switchover when the volume controller
+		// has explicitly signaled switchover intent (SwitchoverState != Empty).
+		// A target IP change without switchover intent (e.g. engine restart on
+		// the same node) is handled by NVMe multipath auto-reconnection and
+		// does not require an explicit ANA state transition.
+		var volume *longhorn.Volume
+		if targetChanged && !switchoverInProgress {
+			volume, err = efc.ds.GetVolumeRO(ef.Spec.VolumeName)
+			if err != nil && !datastore.ErrorIsNotFound(err) {
+				return errors.Wrapf(err, "failed to get volume %v for engine frontend switchover evaluation", ef.Spec.VolumeName)
+			}
+			if datastore.ErrorIsNotFound(err) {
+				log.WithField("volume", ef.Spec.VolumeName).Warn("Volume not found while evaluating engine frontend target change, skipping switchover")
+			}
+		}
+
+		if shouldExecuteEngineFrontendSwitchover(ef, volume) {
 			im, err := efc.ds.GetInstanceManager(ef.Status.InstanceManagerName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get instance manager %v for target switchover", ef.Status.InstanceManagerName)
@@ -487,6 +503,9 @@ func (efc *EngineFrontendController) syncEngineFrontend(key string) (err error) 
 				log.Infof("Successfully switched over target for engine frontend %v to %v", ef.Name, targetAddress)
 				efc.eventRecorder.Eventf(ef, corev1.EventTypeNormal, constant.EventReasonSwitchover, "Successfully switched over target to %v", targetAddress)
 			}
+		} else if targetChanged {
+			log.Debugf("Target changed (spec=%v:%v status=%v:%v) but switchover not executed (volume SwitchoverState is empty), waiting for data-plane path convergence",
+				ef.Spec.TargetIP, ef.Spec.TargetPort, ef.Status.TargetIP, ef.Status.TargetPort)
 		}
 	} // end switchover block
 
@@ -1182,6 +1201,24 @@ func getEngineFrontendTargetFromPaths(activePath string, targetPort int32, paths
 
 func isEngineFrontendTargetInitialized(targetIP string, targetPort int) bool {
 	return targetIP != "" && targetPort != 0
+}
+
+func shouldExecuteEngineFrontendSwitchover(ef *longhorn.EngineFrontend, volume *longhorn.Volume) bool {
+	if ef == nil {
+		return false
+	}
+
+	targetChanged := ef.Status.TargetIP != ef.Spec.TargetIP || ef.Status.TargetPort != ef.Spec.TargetPort
+	switchoverInProgress := ef.Status.SwitchoverPhase != longhorn.EngineFrontendSwitchoverPhaseNone
+	if switchoverInProgress {
+		return true
+	}
+
+	if !targetChanged {
+		return false
+	}
+
+	return volume != nil && volume.Status.SwitchoverState != longhorn.VolumeSwitchoverStateEmpty
 }
 
 // v2ExpansionInProgressMsg matches the SPDK engine's ErrExpansionInProgress

--- a/controller/engine_frontend_controller.go
+++ b/controller/engine_frontend_controller.go
@@ -998,6 +998,18 @@ func (m *EngineFrontendMonitor) refresh(ef *longhorn.EngineFrontend) (err error)
 		return nil
 	}
 
+	// Persist basic status (endpoint, paths, target) before proceeding to
+	// expansion-related calls. VolumeFrontendGet below may fail when engine
+	// and EF are on different nodes, and the deferred update skips writes on
+	// error. Flushing here ensures the volume controller can see the endpoint
+	// and complete the attach flow.
+	if !reflect.DeepEqual(existingEF.Status, ef.Status) {
+		if _, err := m.ds.UpdateEngineFrontendStatus(ef); err != nil {
+			return err
+		}
+		existingEF = ef.DeepCopy()
+	}
+
 	volume, err := m.ds.GetVolumeRO(ef.Spec.VolumeName)
 	if err != nil {
 		if !datastore.ErrorIsNotFound(err) {

--- a/controller/engine_frontend_controller_test.go
+++ b/controller/engine_frontend_controller_test.go
@@ -88,6 +88,94 @@ func (s *TestSuite) TestIsEngineFrontendTargetInitialized(c *C) {
 	c.Assert(isEngineFrontendTargetInitialized("10.0.0.1", 9502), Equals, true)
 }
 
+func (s *TestSuite) TestShouldExecuteEngineFrontendSwitchover(c *C) {
+	testCases := map[string]struct {
+		ef       *longhorn.EngineFrontend
+		volume   *longhorn.Volume
+		expected bool
+	}{
+		"nil engine frontend": {
+			expected: false,
+		},
+		"no target change": {
+			ef: &longhorn.EngineFrontend{
+				Spec: longhorn.EngineFrontendSpec{
+					TargetIP:   TestIP1,
+					TargetPort: TestPort1,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					TargetIP:   TestIP1,
+					TargetPort: TestPort1,
+				},
+			},
+			expected: false,
+		},
+		"target change without volume switchover intent": {
+			ef: &longhorn.EngineFrontend{
+				Spec: longhorn.EngineFrontendSpec{
+					TargetIP:   TestIP2,
+					TargetPort: TestPort1,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					TargetIP:   TestIP1,
+					TargetPort: TestPort1,
+				},
+			},
+			volume:   &longhorn.Volume{},
+			expected: false,
+		},
+		"target change without volume object": {
+			ef: &longhorn.EngineFrontend{
+				Spec: longhorn.EngineFrontendSpec{
+					TargetIP:   TestIP2,
+					TargetPort: TestPort1,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					TargetIP:   TestIP1,
+					TargetPort: TestPort1,
+				},
+			},
+			expected: false,
+		},
+		"target change with volume switchover intent": {
+			ef: &longhorn.EngineFrontend{
+				Spec: longhorn.EngineFrontendSpec{
+					TargetIP:   TestIP2,
+					TargetPort: TestPort1,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					TargetIP:   TestIP1,
+					TargetPort: TestPort1,
+				},
+			},
+			volume: &longhorn.Volume{
+				Status: longhorn.VolumeStatus{
+					SwitchoverState: longhorn.VolumeSwitchoverStateSwitchingOver,
+				},
+			},
+			expected: true,
+		},
+		"in progress switchover keeps running without volume lookup": {
+			ef: &longhorn.EngineFrontend{
+				Spec: longhorn.EngineFrontendSpec{
+					TargetIP:   TestIP2,
+					TargetPort: TestPort1,
+				},
+				Status: longhorn.EngineFrontendStatus{
+					TargetIP:        TestIP1,
+					TargetPort:      TestPort1,
+					SwitchoverPhase: longhorn.EngineFrontendSwitchoverPhasePreparing,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		c.Assert(shouldExecuteEngineFrontendSwitchover(tc.ef, tc.volume), Equals, tc.expected, Commentf("case=%s", name))
+	}
+}
+
 func (s *TestSuite) TestIsEngineFrontendEndpointRequired(c *C) {
 	c.Assert(isEngineFrontendEndpointRequired(nil), Equals, false)
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13215

#### What this PR does / why we need it:

Previously the EngineFrontend controller would trigger an ANA multipath switchover on any target IP/port change, including benign engine restarts on the same node. This could interfere with in-flight operations such as volume expansion on old-engine volumes after an upgrade.

Now the controller only executes the explicit ANA switchover when the volume controller has signaled intent via a non-empty Volume.Status.SwitchoverState. Target changes without switchover intent (e.g. engine pod restart) are left to NVMe multipath auto-reconnection.

An already in-progress switchover (SwitchoverPhase != None) continues unconditionally without requiring a volume lookup.


#### Special notes for your reviewer:

#### Additional documentation or context
