### PR TITLE
fix(backup): guard against nil DeletingStatus entry in setInprogressDeletionMap

### DIFF
--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -1178,6 +1178,15 @@ func (bc *BackupController) setInprogressDeletionMap(backupURL string, state lon
 	bc.deletingMapLock.Lock()
 	defer bc.deletingMapLock.Unlock()
 
+	if bc.inProgressDeletingMap[backupURL] == nil {
+		// The entry was removed by the reconcile cleanup path before this
+		// update path acquired the lock. Both the deferred panic-recover and
+		// the regular error path can call this setter after reconcile
+		// observed the deletion as terminal and removed the entry. Returning
+		// here matches the existence check the reconcile read path already
+		// performs in handleBackupDeletionInBackupStore.
+		return
+	}
 	bc.inProgressDeletingMap[backupURL].State = state
 	bc.inProgressDeletingMap[backupURL].ErrorMessage = errMsg
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13245

#### What this PR does / why we need it:

Adds an existence check in `BackupController.setInprogressDeletionMap` so the setter is a no-op when the reconcile cleanup path has already removed the map entry. Without the check, the setter dereferences a nil `*DeletingStatus` and crashes the manager pod.

**The race:** Two concurrent paths both hold `deletingMapLock` but do not coordinate on entry lifetime. The reconcile path in `handleBackupDeletionInBackupStore` deletes the map entry after observing the terminal deletion state (`delete(bc.inProgressDeletingMap, backupURL)` at line 1172). Concurrently, the goroutine spawned by `startDeletingBackupInBackupStore` can call `setInprogressDeletionMap` via either (a) the deferred panic-recover at line 1093 or (b) the normal error path at line 1099, after the entry has already been removed. The mutex serialises access but does not prevent the entry from having been removed before this critical section runs. The setter currently assumes the entry exists; this PR makes that assumption explicit by mirroring the existence check the reconcile read path already performs in the same file.

The fix is `+9 -0` in a single file. The dropped state update when the entry is missing is correct: the entry's lifetime ended when reconcile cleaned it up, so no reader can observe the update.

The full root-cause analysis with the stack trace and reproduction context is in the linked issue.

#### Special notes for your reviewer:

- This mirrors the existing precedent in the same controller at line 1145 of `controller/backup_controller.go`: the reconcile read path already early-returns when `bc.inProgressDeletingMap[backupURL] == nil`. The setter is the only consumer of the map that lacks the guard; this PR closes the asymmetry.
- No new log line on the dropped update. The existing log infrastructure in the deletion lifecycle already covers observability (the reconcile path logs the terminal state). Adding a debug log here would inflate the diff without informing operators. Happy to add one if you prefer.
- No unit test. A race-driven test of two goroutines around the mutex would be flaky in CI. A non-racy test (call `setInprogressDeletionMap` on a fresh controller with an empty map, assert no panic) only exercises the new nil-check arm, not the original race. If you would prefer that shape, I can add it as a follow-up commit.
- Reproduced on three independent nodes in a production cluster on `v1.11.2`. The same code is present on master (setter at lines 1177-1183 in master file SHA `5774601d44995fe2e9b1b31922cf981328491a68`); the panic is reachable on any deployment running routine recurring-backup retention.

#### Additional documentation or context

Stack trace from our `v1.11.2` production deployment:

```text
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x22a908d]
goroutine 972544 [running]:
github.com/longhorn/longhorn-manager/controller.(*BackupController).setInprogressDeletionMap(
    0xc0007af200, {0xc00fc67f00, 0x6f}, {0x2dfe789, 0x5}, {0xc00dc0a900, 0x56})
    /app/controller/backup_controller.go:1164 +0xcd
panic({0x28e8a00?, 0x4bd0df0?})
    /usr/lib64/go/1.25/src/runtime/panic.go:783 +0x132
github.com/longhorn/longhorn-manager/controller.(*BackupController).setInprogressDeletionMap(
    0xc0007af200, {0xc00fc67f00, 0x6f}, {0x2dfe789, 0x5}, {0xc0110e2000, 0x1be5})
    /app/controller/backup_controller.go:1164 +0xcd
    /app/controller/backup_controller.go:1082 +0x14c
created by ...(*BackupController).startDeletingBackupInBackupStore in goroutine 1973
    /app/controller/backup_controller.go:1073 +0x15b
```

The full reproduction context (cluster size, recurring-job cadence, retention numbers) is in the linked umbrella issue.