### PR TITLE
feat: add setting to gate live engine upgrade on image tag change

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2654,10 +2654,19 @@ func (ec *EngineController) Upgrade(e *longhorn.Engine, log *logrus.Entry) (err 
 			return err
 		}
 
-		// Revisioned engine images may keep the same engine git commit while still
-		// representing a distinct image artifact that should follow the regular
-		// upgrade flow, e.g. 1.10.2 -> 1.10.2-4.12 or 1.10.2-4.12 -> 1.10.2-4.20.
-		if version.ClientVersion.GitCommit != version.ServerVersion.GitCommit || isRevisionedEngineImage(e.Spec.Image) {
+		// Engine images may keep the same git commit while still representing a
+		// distinct image artifact (revisioned tag) that can follow the regular upgrade flow
+		// when the allow-live-engine-upgrade-on-same-image-commit setting is enabled,
+		// e.g. 1.10.2 -> 1.10.2-4.12 or 1.10.2-4.12 -> 1.10.2-4.20.
+		shouldUpgrade := version.ClientVersion.GitCommit != version.ServerVersion.GitCommit
+		if !shouldUpgrade && isRevisionedEngineImage(e.Spec.Image) {
+			allowSameCommitUpgrade, err := ec.ds.GetSettingAsBool(types.SettingNameAllowLiveEngineUpgradeOnSameImageCommit)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get setting %v", types.SettingNameAllowLiveEngineUpgradeOnSameImageCommit)
+			}
+			shouldUpgrade = allowSameCommitUpgrade
+		}
+		if shouldUpgrade {
 			log.Infof("Upgrading engine from %v to %v", e.Status.CurrentImage, e.Spec.Image)
 			if err := ec.UpgradeEngineInstance(e, log); err != nil {
 				return err

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -4150,8 +4150,15 @@ func (c *VolumeController) checkOldAndNewEngineImagesForLiveUpgrade(v *longhorn.
 		return errors.Wrapf(err, "engine live upgrade to %v, but the image wasn't ready", newImage.Spec.Image)
 	}
 
-	if oldImage.Status.GitCommit == newImage.Status.GitCommit && !isRevisionedEngineImage(newImage.Spec.Image) {
-		return fmt.Errorf("engine image %v and %v are identical, delay upgrade until detach for volume", oldImage.Spec.Image, newImage.Spec.Image)
+	if oldImage.Status.GitCommit == newImage.Status.GitCommit {
+		allowSameCommitUpgrade, err := c.ds.GetSettingAsBool(types.SettingNameAllowLiveEngineUpgradeOnSameImageCommit)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get setting %v", types.SettingNameAllowLiveEngineUpgradeOnSameImageCommit)
+		}
+		if !allowSameCommitUpgrade || !isRevisionedEngineImage(newImage.Spec.Image) {
+			return fmt.Errorf("engine images %v and %v share the same git commit (setting %v=%v, revisioned=%v), delay upgrade until detach for volume",
+				oldImage.Spec.Image, newImage.Spec.Image, types.SettingNameAllowLiveEngineUpgradeOnSameImageCommit, allowSameCommitUpgrade, isRevisionedEngineImage(newImage.Spec.Image))
+		}
 	}
 
 	if oldImage.Status.ControllerAPIVersion > newImage.Status.ControllerAPIVersion ||

--- a/types/setting.go
+++ b/types/setting.go
@@ -180,6 +180,7 @@ const (
 	SettingNameNodeDiskHealthMonitoring                                 = SettingName("node-disk-health-monitoring")
 	SettingNameCSIAllowedTopologyKeys                                   = SettingName("csi-allowed-topology-keys")
 	SettingNameCSIStorageCapacityTracking                               = SettingName("csi-storage-capacity-tracking")
+	SettingNameAllowLiveEngineUpgradeOnSameImageCommit                  = SettingName("allow-live-engine-upgrade-on-same-image-commit")
 
 	// The settings are deprecated and Longhorn won't create Setting Resources for these parameters.
 	// TODO: Remove these settings in the future releases.
@@ -307,6 +308,7 @@ var (
 		SettingNameSnapshotHeavyTaskConcurrentLimit,
 		SettingNameCSIAllowedTopologyKeys,
 		SettingNameCSIStorageCapacityTracking,
+		SettingNameAllowLiveEngineUpgradeOnSameImageCommit,
 	}
 )
 
@@ -468,6 +470,7 @@ var (
 		SettingNameSnapshotHeavyTaskConcurrentLimit:                         SettingDefinitionSnapshotHeavyTaskConcurrentLimit,
 		SettingNameCSIAllowedTopologyKeys:                                   SettingDefinitionCSIAllowedTopologyKeys,
 		SettingNameCSIStorageCapacityTracking:                               SettingDefinitionCSIStorageCapacityTracking,
+		SettingNameAllowLiveEngineUpgradeOnSameImageCommit:                  SettingDefinitionAllowLiveEngineUpgradeOnSameImageCommit,
 	}
 
 	SettingDefinitionAllowRecurringJobWhileVolumeDetached = SettingDefinition{
@@ -2042,6 +2045,21 @@ var (
 		DisplayName: "CSI Storage Capacity Tracking",
 		Description: "Controls CSI storage capacity tracking, which allows the kube-scheduler to filter " +
 			"nodes that cannot fit the requested volume.",
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeBool,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            "false",
+	}
+
+	SettingDefinitionAllowLiveEngineUpgradeOnSameImageCommit = SettingDefinition{
+		DisplayName: "Allow Live Engine Upgrade On Same Image Commit",
+		Description: "This setting allows live engine upgrades between engine images that share the same git commit but differ in image tag " +
+			"(e.g. 1.10.2 to 1.10.2-4.12 or 1.10.2-4.12 to 1.10.2-4.20). " +
+			"Normally, when the image tag differs the automatic upgrade path governed by concurrent-automatic-engine-upgrade-per-node-limit handles the live upgrade. " +
+			"This setting covers the edge case where the git commit is identical across both images. " +
+			"When disabled, such upgrades are delayed until the volume is detached.",
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeBool,
 		Required:           true,


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Commit a6b529e19 introduced support for live engine upgrades between engine images that share the same git commit but differ in image tag (e.g. 1.10.2 -> 1.10.2-4.12). This behavior is now gated behind a new setting "allow-live-engine-upgrade-on-image-tag-change" (default: false).

When disabled, the system retains the original behavior: same-commit images are treated as identical and upgrades are delayed until detach. When enabled, tag-only changes on matching version patterns are allowed to proceed as live upgrades.


#### Special notes for your reviewer:

#### Additional documentation or context
