### PR TITLE
fix(migration): prevent initiate volume live migration if target node not ready

### DIFF
--- a/controller/volume_attachment_controller.go
+++ b/controller/volume_attachment_controller.go
@@ -454,9 +454,31 @@ func (vac *VolumeAttachmentController) handleVolumeMigrationStart(va *longhorn.V
 	// Found one csi attachmentTicket that is requesting volume to attach to the current node
 
 	if attachmentTicket := getCSIAttachmentTicketNotRequestingNode(vol.Spec.NodeID, va, vol); attachmentTicket != nil {
+		log := getLoggerForMigratingLHVolumeAttachment(vac.logger, va, vol)
+
+		// Require the target node to be fully Ready before starting migration.
+		// If migration is initiated while the target node is still recovering (e.g.,
+		// after a node restart), controllers across the cluster may transiently observe
+		// inconsistent node readiness, causing rapid engine CR ownership flapping.
+		// During that window, the volume controller's cleanup logic can misidentify the
+		// engine actively serving I/O as an "extra" and delete it, causing immediate I/O
+		// failure for the workload. Deferring migration until Ready=True ensures the
+		// node's controllers are stable before a migration engine is created.
+		targetNode, err := vac.ds.GetNodeRO(attachmentTicket.NodeID)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to get node %v for migration readiness check", attachmentTicket.NodeID)
+			vac.enqueueVolumeAttachmentAfter(va, 10*time.Second)
+			return
+		}
+		readyCond := types.GetCondition(targetNode.Status.Conditions, longhorn.NodeConditionTypeReady)
+		if readyCond.Status != longhorn.ConditionStatusTrue {
+			log.Infof("Pending migration attachment ticket %v: target node %v not ready (reason: %v)", attachmentTicket.ID, attachmentTicket.NodeID, readyCond.Reason)
+			vac.enqueueVolumeAttachmentAfter(va, 10*time.Second)
+			return
+		}
+
 		// Found one csi attachmentTicket that is requesting volume to attach to a different node
 		vol.Spec.MigrationNodeID = attachmentTicket.NodeID
-		log := getLoggerForMigratingLHVolumeAttachment(vac.logger, va, vol)
 		log.Info("Starting migration")
 	}
 }

--- a/controller/volume_attachment_controller_test.go
+++ b/controller/volume_attachment_controller_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	. "gopkg.in/check.v1"
+
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -19,13 +21,12 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
-
-	. "gopkg.in/check.v1"
 )
 
 type volumeAttachmentTestCase struct {
 	volAttachment *longhorn.VolumeAttachment
 	vol           *longhorn.Volume
+	nodes         []*longhorn.Node
 
 	expectedVolAttachment *longhorn.VolumeAttachment
 	expectedVol           *longhorn.Volume
@@ -513,6 +514,7 @@ func (s *TestSuite) runVolumeAttachmentTestCase(c *C, tc *volumeAttachmentTestCa
 
 	volumeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Volumes().Informer().GetIndexer()
 	volumeAttachmentIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().VolumeAttachments().Informer().GetIndexer()
+	nodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
 
 	vac, err := NewLonghornVolumeAttachmentController(logger, ds, scheme.Scheme, kubeClient, TestOwnerID1, TestNamespace)
 	c.Assert(err, IsNil)
@@ -537,6 +539,13 @@ func (s *TestSuite) runVolumeAttachmentTestCase(c *C, tc *volumeAttachmentTestCa
 	err = volumeAttachmentIndexer.Add(volAttachment)
 	c.Assert(err, IsNil)
 
+	for _, n := range tc.nodes {
+		createdNode, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), n, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = nodeIndexer.Add(createdNode)
+		c.Assert(err, IsNil)
+	}
+
 	////////////////////////////////////
 	// main test func
 	err = vac.syncHandler(getKey(volAttachment, c))
@@ -558,6 +567,130 @@ func (s *TestSuite) runVolumeAttachmentTestCase(c *C, tc *volumeAttachmentTestCa
 	}
 	c.Assert(retVolAttachment.Status, DeepEquals, tc.expectedVolAttachment.Status)
 
+}
+
+func (s *TestSuite) TestVolumeMigrationStartNodeReadiness(c *C) {
+	testCases := map[string]*volumeAttachmentTestCase{}
+
+	// shared builder: migratable vol attached to TestNode1, CSI tickets for both nodes
+	makeMigrationTC := func() *volumeAttachmentTestCase {
+		tc := generateVolumeAttachmentTestCaseTemplate(TestVolumeName)
+		tc.vol.Spec.Migratable = true
+		tc.vol.Spec.AccessMode = longhorn.AccessModeReadWriteMany
+		tc.vol.Spec.NodeID = TestNode1
+		tc.vol.Status.State = longhorn.VolumeStateAttached
+		tc.vol.Status.CurrentNodeID = TestNode1
+		tc.volAttachment.Spec.AttachmentTickets = map[string]*longhorn.AttachmentTicket{
+			"csi-node1": {
+				ID:         "csi-node1",
+				Type:       longhorn.AttacherTypeCSIAttacher,
+				NodeID:     TestNode1,
+				Parameters: map[string]string{},
+			},
+			"csi-node2": {
+				ID:         "csi-node2",
+				Type:       longhorn.AttacherTypeCSIAttacher,
+				NodeID:     TestNode2,
+				Parameters: map[string]string{},
+			},
+		}
+		return tc
+	}
+
+	// shared expected ticket statuses: csi-node1 satisfied, csi-node2 not (migration not
+	// confirmed by VolumeController yet, so CurrentMigrationNodeID is still "")
+	expectedTicketStatuses := func() map[string]*longhorn.AttachmentTicketStatus {
+		return map[string]*longhorn.AttachmentTicketStatus{
+			"csi-node1": {
+				ID:        "csi-node1",
+				Satisfied: true,
+				Conditions: types.SetConditionWithoutTimestamp([]longhorn.Condition{},
+					longhorn.AttachmentStatusConditionTypeSatisfied, longhorn.ConditionStatusTrue, "", ""),
+			},
+			"csi-node2": {
+				ID:        "csi-node2",
+				Satisfied: false,
+				Conditions: types.SetConditionWithoutTimestamp([]longhorn.Condition{},
+					longhorn.AttachmentStatusConditionTypeSatisfied, longhorn.ConditionStatusFalse, "",
+					fmt.Sprintf("the volume is currently attached to different node %v ", TestNode1)),
+			},
+		}
+	}
+
+	///////////////////////////////////////////////////////////////////
+	// Case A: target node not found in etcd -> IsNodeDownOrDeletedOrMissingManager=true -> blocked
+	tc := makeMigrationTC()
+	tc.nodes = []*longhorn.Node{
+		newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		// TestNode2 intentionally absent
+	}
+	tc.copyCurrentToExpect()
+	tc.expectedVol.Spec.MigrationNodeID = ""
+	tc.expectedVolAttachment.Status.AttachmentTicketStatuses = expectedTicketStatuses()
+	testCases["migration blocked: target node absent"] = tc
+	///////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////
+	// Case B: target node Ready=False, Reason=ManagerPodMissing -> blocked
+	tc = makeMigrationTC()
+	tc.nodes = []*longhorn.Node{
+		newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		newNode(TestNode2, TestNamespace, false, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonManagerPodMissing)),
+	}
+	tc.copyCurrentToExpect()
+	tc.expectedVol.Spec.MigrationNodeID = ""
+	tc.expectedVolAttachment.Status.AttachmentTicketStatuses = expectedTicketStatuses()
+	testCases["migration blocked: target node ManagerPodMissing"] = tc
+	///////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////
+	// Case C: target node Ready=False, Reason=KubernetesNodeNotReady -> blocked
+	tc = makeMigrationTC()
+	tc.nodes = []*longhorn.Node{
+		newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		newNode(TestNode2, TestNamespace, false, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonKubernetesNodeNotReady)),
+	}
+	tc.copyCurrentToExpect()
+	tc.expectedVol.Spec.MigrationNodeID = ""
+	tc.expectedVolAttachment.Status.AttachmentTicketStatuses = expectedTicketStatuses()
+	testCases["migration blocked: target node KubernetesNodeNotReady"] = tc
+	///////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////
+	// Case D: target node Ready=False, Reason=ManagerPodDown (not in IsNodeDownOrDeletedOrMissingManager).
+	// IsNodeDownOrDeletedOrMissingManager returns false, so only the Ready=True gate blocks this.
+	// This test will FAIL before the Ready=True gate is added and PASS after.
+	tc = makeMigrationTC()
+	tc.nodes = []*longhorn.Node{
+		newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		newNode(TestNode2, TestNamespace, false, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonManagerPodDown)),
+	}
+	tc.copyCurrentToExpect()
+	tc.expectedVol.Spec.MigrationNodeID = ""
+	tc.expectedVolAttachment.Status.AttachmentTicketStatuses = expectedTicketStatuses()
+	testCases["migration blocked: target node Ready=False transitional (ManagerPodDown)"] = tc
+	///////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////
+	// Case E: target node Ready=True -> migration proceeds
+	tc = makeMigrationTC()
+	tc.nodes = []*longhorn.Node{
+		newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+		newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusTrue, ""),
+	}
+	tc.copyCurrentToExpect()
+	tc.expectedVol.Spec.MigrationNodeID = TestNode2
+	tc.expectedVolAttachment.Status.AttachmentTicketStatuses = expectedTicketStatuses()
+	testCases["migration proceeds: target node Ready=True"] = tc
+	///////////////////////////////////////////////////////////////////
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+		s.runVolumeAttachmentTestCase(c, tc)
+	}
 }
 
 func newVolumeAttachment(name string) *longhorn.VolumeAttachment {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13109

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/13109#issuecomment-4677392901

#### Special notes for your reviewer:

#### Additional documentation or context
