### PR TITLE
refactor(setting_controller): move LONGHORN_DISTRO collection to cluster scope

### DIFF
--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1561,6 +1561,8 @@ const (
 	ClusterInfoNamespaceUID = util.StructName("LonghornNamespaceUid")
 	ClusterInfoNodeCount    = util.StructName("LonghornNodeCount")
 
+	ClusterInfoLonghornDistro = util.StructName("LonghornDistro")
+
 	ClusterInfoBackingImageCount      = util.StructName("LonghornBackingImageCount")
 	ClusterInfoOrphanCount            = util.StructName("LonghornOrphanCount")
 	ClusterInfoVolumeAvgActualSize    = util.StructName("LonghornVolumeAverageActualSizeBytes")
@@ -1597,7 +1599,6 @@ const (
 	ClusterInfoHostArch          = util.StructName("HostArch")
 	ClusterInfoHostKernelRelease = util.StructName("HostKernelRelease")
 	ClusterInfoHostOsDistro      = util.StructName("HostOsDistro")
-	ClusterInfoLonghornDistro    = util.StructName("LonghornDistro")
 
 	ClusterInfoLonghornImageRegistry = util.StructName("LonghornImageRegistry")
 
@@ -1666,6 +1667,8 @@ func (info *ClusterInfo) collectClusterScope() {
 	if err := info.collectBackupTargetInfo(); err != nil {
 		info.logger.WithError(err).Warn("Failed to collect Longhorn backup target info")
 	}
+
+	info.collectLonghornDistro()
 }
 
 func (info *ClusterInfo) collectNamespace() error {
@@ -2068,8 +2071,6 @@ func (info *ClusterInfo) collectBackupTargetInfo() error {
 }
 
 func (info *ClusterInfo) collectNodeScope() {
-	info.collectLonghornDistro()
-
 	if err := info.collectHostArch(); err != nil {
 		info.logger.WithError(err).Warn("Failed to collect host architecture")
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13252

#### What this PR does / why we need it:

LONGHORN_DISTRO is an environment variable set on the manager pod and is identical across all nodes in the cluster. Collecting it per-node is redundant. Move collectLonghornDistro() from collectNodeScope() to collectClusterScope() and relocate the ClusterInfoLonghornDistro constant to the cluster-scoped constants block accordingly.


#### Special notes for your reviewer:

#### Additional documentation or context
