### PR TITLE
fix: align runtime paths with default-data-path

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -914,7 +914,7 @@ func (imc *InstanceManagerController) isSettingLogPathSynced(setting *longhorn.S
 
 	logPath := setting.Value
 	if logPath == "" {
-		logPath = types.DefaultLogDirectoryOnHost
+		logPath = types.GetDefaultLogDirectoryOnHost()
 	}
 
 	normalizedLogPath := filepath.Clean(logPath)
@@ -1861,7 +1861,7 @@ func (imc *InstanceManagerController) getLogPath() (string, error) {
 	}
 
 	if logPath == "" || logPath == string(filepath.Separator) {
-		logPath = types.DefaultLogDirectoryOnHost
+		logPath = types.GetDefaultLogDirectoryOnHost()
 	} else {
 		logPath = filepath.Clean(logPath)
 	}
@@ -1869,16 +1869,16 @@ func (imc *InstanceManagerController) getLogPath() (string, error) {
 	parent := filepath.Dir(logPath)
 	if parent == "." || parent == string(filepath.Separator) {
 		imc.logger.Warnf("Log path %q is not a valid directory, using default log directory", logPath)
-		logPath = types.DefaultLogDirectoryOnHost
+		logPath = types.GetDefaultLogDirectoryOnHost()
 	}
 
 	if st, err := lhns.Stat(parent); err != nil {
 		imc.logger.WithError(err).Warnf("Failed to stat parent of log path %q, using default log directory", logPath)
-		logPath = types.DefaultLogDirectoryOnHost
+		logPath = types.GetDefaultLogDirectoryOnHost()
 	} else {
 		if !st.IsDir() {
 			imc.logger.Warnf("Parent of log path %q is not a directory, using default log directory", logPath)
-			logPath = types.DefaultLogDirectoryOnHost
+			logPath = types.GetDefaultLogDirectoryOnHost()
 		}
 		imc.logger.Infof("Using log path %q", logPath)
 	}
@@ -2075,6 +2075,14 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name:  types.EnvDataEngine,
 			Value: string(dataEngine),
 		},
+		{
+			Name:  types.LonghornDataPathEnv,
+			Value: types.GetLonghornDataPath(),
+		},
+		{
+			Name:  types.LonghornControlPathEnv,
+			Value: types.GetLonghornControlPath(),
+		},
 	}
 	if tz := os.Getenv(types.EnvTZ); tz != "" {
 		podEnv = append(podEnv, corev1.EnvVar{
@@ -2102,7 +2110,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			MountPropagation: &mountPropagationHostToContainer,
 		},
 		{
-			MountPath: types.UnixDomainSocketDirectoryInContainer,
+			MountPath: types.GetUnixDomainSocketDirectoryInContainer(),
 			Name:      "unix-domain-socket",
 		},
 		{
@@ -2128,7 +2136,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "engine-binaries",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.EngineBinaryDirectoryOnHost,
+					Path: types.GetEngineBinaryDirectoryOnHost(),
 				},
 			},
 		},
@@ -2136,7 +2144,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "metadata",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.MetadataDirectoryOnHost,
+					Path: types.GetMetadataDirectoryOnHost(),
 					Type: &[]corev1.HostPathType{corev1.HostPathDirectoryOrCreate}[0],
 				},
 			},
@@ -2145,7 +2153,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "unix-domain-socket",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.UnixDomainSocketDirectoryOnHost,
+					Path: types.GetUnixDomainSocketDirectoryOnHost(),
 				},
 			},
 		},

--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -518,11 +518,19 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 												},
 											},
 										},
+										{
+											Name:  types.LonghornDataPathEnv,
+											Value: types.GetLonghornDataPath(),
+										},
+										{
+											Name:  types.LonghornControlPathEnv,
+											Value: types.GetLonghornControlPath(),
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "engine-binaries",
-											MountPath: types.EngineBinaryDirectoryOnHost,
+											MountPath: types.GetEngineBinaryDirectoryOnHost(),
 										},
 									},
 								},
@@ -532,7 +540,7 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 									Name: "engine-binaries",
 									VolumeSource: corev1.VolumeSource{
 										HostPath: &corev1.HostPathVolumeSource{
-											Path: types.EngineBinaryDirectoryOnHost,
+											Path: types.GetEngineBinaryDirectoryOnHost(),
 										},
 									},
 								},

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -745,7 +745,7 @@ func engineStillHasReplica(e *longhorn.Engine, r *longhorn.Replica) bool {
 }
 
 func deleteUnixSocketFile(volumeName string) error {
-	return os.RemoveAll(filepath.Join(types.UnixDomainSocketDirectoryOnHost, volumeName+filepath.Ext(".sock")))
+	return os.RemoveAll(filepath.Join(types.GetUnixDomainSocketDirectoryOnHost(), volumeName+filepath.Ext(".sock")))
 }
 
 func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstanceProcess, error) {

--- a/controller/system_restore_controller.go
+++ b/controller/system_restore_controller.go
@@ -429,11 +429,19 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 									Name:  "NODE_NAME",
 									Value: c.controllerID,
 								},
+								{
+									Name:  types.LonghornDataPathEnv,
+									Value: types.GetLonghornDataPath(),
+								},
+								{
+									Name:  types.LonghornControlPathEnv,
+									Value: types.GetLonghornControlPath(),
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "engine",
-									MountPath: types.EngineBinaryDirectoryOnHost,
+									MountPath: types.GetEngineBinaryDirectoryOnHost(),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -446,7 +454,7 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 							Name: "engine",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: types.EngineBinaryDirectoryOnHost,
+									Path: types.GetEngineBinaryDirectoryOnHost(),
 								},
 							},
 						},

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -660,6 +661,42 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 			_, err = s.ValidateV2DataEngineEnabled(dataEngineEnabled)
 			if err != nil {
 				return err
+			}
+		}
+
+	case types.SettingNameDefaultDataPath:
+		old, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
+		if err != nil {
+			return err
+		}
+
+		oldPath := filepath.Clean(strings.TrimSpace(old.Value))
+		newPath := filepath.Clean(strings.TrimSpace(value))
+		if oldPath != newPath {
+			nodes, err := s.ListNodesRO()
+			if err != nil {
+				return err
+			}
+			if len(nodes) != 0 {
+				return errors.Errorf("cannot change %v after Longhorn has been initialized", types.SettingNameDefaultDataPath)
+			}
+		}
+
+	case types.SettingNameDefaultControlPath:
+		old, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
+		if err != nil {
+			return err
+		}
+
+		oldPath := filepath.Clean(strings.TrimSpace(old.Value))
+		newPath := filepath.Clean(strings.TrimSpace(value))
+		if oldPath != newPath {
+			nodes, err := s.ListNodesRO()
+			if err != nil {
+				return err
+			}
+			if len(nodes) != 0 {
+				return errors.Errorf("cannot change %v after Longhorn has been initialized", types.SettingNameDefaultControlPath)
 			}
 		}
 

--- a/datastore/longhorn_test.go
+++ b/datastore/longhorn_test.go
@@ -15,6 +15,7 @@ import (
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -239,4 +240,169 @@ func TestGetVolumeCurrentEngineFrontendReturnsErrorWhenMissing(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, ef)
 	require.Contains(t, err.Error(), "cannot find the current engine frontend")
+}
+
+func TestValidateSettingDefaultControlPath(t *testing.T) {
+	const testNamespace = "longhorn-system"
+
+	baseSetting := &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      string(types.SettingNameDefaultControlPath),
+			Namespace: testNamespace,
+		},
+		Value: types.DefaultControlPath,
+	}
+
+	newNode := func(name string) *longhorn.Node {
+		return &longhorn.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		existingObjects []runtime.Object
+		newValue        string
+		expectError     string
+	}{
+		"same path with trailing slash normalization is allowed": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/var/lib/longhorn/",
+		},
+		"changing path before initialization is allowed": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/control/longhorn",
+		},
+		"changing path after initialization is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy(), newNode("node-1")},
+			newValue:        "/control/longhorn",
+			expectError:     "cannot change default-control-path after Longhorn has been initialized",
+		},
+		"block device path is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/dev/nvme0n1",
+			expectError:     "the value of default-control-path is invalid",
+		},
+		"root path is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/",
+			expectError:     "the value of default-control-path is invalid",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...) // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset()                      // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()   // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.SettingInformer.HasSynced,
+				ds.NodeInformer.HasSynced,
+			))
+
+			err := ds.ValidateSetting(string(types.SettingNameDefaultControlPath), tc.newValue)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
+	const testNamespace = "longhorn-system"
+
+	baseSetting := &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      string(types.SettingNameDefaultDataPath),
+			Namespace: testNamespace,
+		},
+		Value: "/var/lib/longhorn",
+	}
+
+	newNode := func(name string) *longhorn.Node {
+		return &longhorn.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		existingObjects []runtime.Object
+		newValue        string
+		expectError     string
+	}{
+		"relative path is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "relative/path",
+			expectError:     "the value of default-data-path is invalid",
+		},
+		"root path is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/",
+			expectError:     "the value of default-data-path is invalid",
+		},
+		"same path with trailing slash normalization is allowed": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/var/lib/longhorn/",
+		},
+		"same path with whitespace normalization is allowed (even after initialization)": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy(), newNode("node-1")},
+			newValue:        " /var/lib/longhorn/ ",
+		},
+		"changing path before initialization is allowed": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/data/longhorn",
+		},
+		"bare pci identifier is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "0000:00:1e.0",
+			expectError:     "the value of default-data-path is invalid",
+		},
+		"changing path after initialization is rejected": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy(), newNode("node-1")},
+			newValue:        "/data/longhorn",
+			expectError:     "cannot change default-data-path after Longhorn has been initialized",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...) // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset()                      // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()   // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.SettingInformer.HasSynced,
+				ds.NodeInformer.HasSynced,
+			))
+
+			err := ds.ValidateSetting(string(types.SettingNameDefaultDataPath), tc.newValue)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
 }

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -76,7 +76,7 @@ func (c *InstanceManagerClient) Close() error {
 
 func GetDeprecatedInstanceManagerBinary(image string) string {
 	cname := types.GetImageCanonicalName(image)
-	return filepath.Join(types.EngineBinaryDirectoryOnHost, cname, DeprecatedInstanceManagerBinaryName)
+	return filepath.Join(types.GetEngineBinaryDirectoryOnHost(), cname, DeprecatedInstanceManagerBinaryName)
 }
 
 func CheckInstanceManagerCompatibility(imMinVersion, imVersion int) error {

--- a/types/setting.go
+++ b/types/setting.go
@@ -76,6 +76,7 @@ const (
 	SettingNameAllowRecurringJobWhileVolumeDetached                     = SettingName("allow-recurring-job-while-volume-detached")
 	SettingNameCreateDefaultDiskLabeledNodes                            = SettingName("create-default-disk-labeled-nodes")
 	SettingNameDefaultDataPath                                          = SettingName("default-data-path")
+	SettingNameDefaultControlPath                                       = SettingName("default-control-path")
 	SettingNameDefaultEngineImage                                       = SettingName("default-engine-image")
 	SettingNameDefaultInstanceManagerImage                              = SettingName("default-instance-manager-image")
 	SettingNameDefaultBackingImageManagerImage                          = SettingName("default-backing-image-manager-image")
@@ -206,6 +207,7 @@ var (
 		SettingNameAllowRecurringJobWhileVolumeDetached,
 		SettingNameCreateDefaultDiskLabeledNodes,
 		SettingNameDefaultDataPath,
+		SettingNameDefaultControlPath,
 		SettingNameDefaultEngineImage,
 		SettingNameDefaultInstanceManagerImage,
 		SettingNameDefaultBackingImageManagerImage,
@@ -371,6 +373,7 @@ var (
 		SettingNameAllowRecurringJobWhileVolumeDetached:                     SettingDefinitionAllowRecurringJobWhileVolumeDetached,
 		SettingNameCreateDefaultDiskLabeledNodes:                            SettingDefinitionCreateDefaultDiskLabeledNodes,
 		SettingNameDefaultDataPath:                                          SettingDefinitionDefaultDataPath,
+		SettingNameDefaultControlPath:                                       SettingDefinitionDefaultControlPath,
 		SettingNameDefaultEngineImage:                                       SettingDefinitionDefaultEngineImage,
 		SettingNameDefaultInstanceManagerImage:                              SettingDefinitionDefaultInstanceManagerImage,
 		SettingNameDefaultBackingImageManagerImage:                          SettingDefinitionDefaultBackingImageManagerImage,
@@ -558,14 +561,34 @@ var (
 	}
 
 	SettingDefinitionDefaultDataPath = SettingDefinition{
-		DisplayName:        "Default Data Path",
-		Description:        "Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine.",
+		DisplayName: "Default Data Path",
+		Description: "Default path to use for storing data on a host. " +
+			"An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, " +
+			"whereas a path to a block device indicates a block-type disk used by the V2 Data Engine. " +
+			"Bare PCI identifiers (such as '0000:00:1e.0') are not supported here since this setting may be " +
+			"used as a host path for pod mounts. " +
+			"When this setting is a block device path, runtime and control-plane paths are configured " +
+			"separately via the 'default-control-path' setting. Note: This is an installation-time setting " +
+			"and cannot be changed after Longhorn is initialized.",
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeString,
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            "/var/lib/longhorn/",
+		Default:            DefaultDataPath,
+	}
+
+	SettingDefinitionDefaultControlPath = SettingDefinition{
+		DisplayName: "Default Control Path",
+		Description: "Default path used for storing runtime and control-plane artifacts on a host. " +
+			"This setting must be an absolute directory path. Engine binaries, metadata, sockets, and logs " +
+			"are stored under this path for both V1 and V2 engines. Note: This is an installation-time " +
+			"setting and cannot be changed after Longhorn is initialized.",
+		Type:               SettingTypeString,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: false,
+		Default:            DefaultControlPath,
 	}
 
 	SettingDefinitionDefaultEngineImage = SettingDefinition{
@@ -2040,7 +2063,7 @@ var (
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            DefaultLogDirectoryOnHost,
+		Default:            GetDefaultLogDirectoryOnHost(),
 	}
 
 	SettingDefinitionNodeDiskHealthMonitoring = SettingDefinition{
@@ -2894,6 +2917,14 @@ func validateSettingString(name SettingName, definition SettingDefinition, value
 		case SettingNameDataEngineCPUMask:
 			if _, err := NormalizeCPUMask(strValue); err != nil {
 				return errors.Wrapf(err, "the value of %v is invalid", name)
+			}
+		case SettingNameDefaultDataPath:
+			if !IsValidLonghornDataPath(strValue) {
+				return fmt.Errorf("the value of %v is invalid", name)
+			}
+		case SettingNameDefaultControlPath:
+			if !IsValidLonghornControlPath(strValue) {
+				return fmt.Errorf("the value of %v is invalid", name)
 			}
 		}
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -107,16 +107,17 @@ const (
 	DefaultRecoveryBackendServerPort = 9503
 
 	EngineBinaryDirectoryInContainer = "/engine-binaries/"
-	EngineBinaryDirectoryOnHost      = "/var/lib/longhorn/engine-binaries/"
 	MetadataDirectoryInContainer     = "/metadata/"
-	MetadataDirectoryOnHost          = "/var/lib/longhorn/metadata/"
 	ReplicaHostPrefix                = "/host"
 	EngineBinaryName                 = "longhorn"
-
-	UnixDomainSocketDirectoryInContainer = "/host/var/lib/longhorn/unix-domain-socket/"
-	UnixDomainSocketDirectoryOnHost      = "/var/lib/longhorn/unix-domain-socket/"
-
-	DefaultLogDirectoryOnHost = "/var/lib/longhorn/logs/"
+	DefaultDataPath                  = "/var/lib/longhorn"
+	DefaultControlPath               = "/var/lib/longhorn"
+	LonghornDataPathEnv              = "LONGHORN_DATA_PATH"
+	LonghornControlPathEnv           = "LONGHORN_CONTROL_PATH"
+	EngineBinaryDirectorySubpath     = "engine-binaries"
+	MetadataDirectorySubpath         = "metadata"
+	UnixDomainSocketDirectorySubpath = "unix-domain-socket"
+	LogDirectorySubpath              = "logs"
 
 	BackingImageManagerDirectory = "/backing-images/"
 	BackingImageFileName         = "backing"
@@ -404,13 +405,94 @@ func GetDefaultManagerURL() string {
 	return "http://longhorn-backend:" + strconv.Itoa(DefaultAPIPort) + "/v1"
 }
 
+// GetLonghornDataPath returns the process-scoped Longhorn data path.
+// LONGHORN_DATA_PATH is expected to be populated from the configured
+// default-data-path during installation or pod creation. This is an
+// installation-time default rather than a dynamically reloadable setting;
+// when the env var is unset, empty, or invalid, the historical default path
+// is used for backward compatibility.
+func GetLonghornDataPath() string {
+	path := strings.TrimSpace(os.Getenv(LonghornDataPathEnv))
+	if path == "" {
+		return DefaultDataPath
+	}
+	path = filepath.Clean(path)
+	if !IsValidLonghornDataPath(path) {
+		logrus.Warnf("Falling back to default data path %q because %s is unset or invalid", DefaultDataPath, LonghornDataPathEnv)
+		return DefaultDataPath
+	}
+	return path
+}
+
+// GetLonghornControlPath returns the process-scoped Longhorn control path.
+// LONGHORN_CONTROL_PATH is expected to be populated from the configured
+// default-control-path during installation or pod creation. This is an
+// installation-time default rather than a dynamically reloadable setting;
+// when the env var is unset, empty, or invalid, the historical default path
+// is used for backward compatibility.
+func GetLonghornControlPath() string {
+	path := strings.TrimSpace(os.Getenv(LonghornControlPathEnv))
+	if path == "" {
+		return DefaultControlPath
+	}
+	path = filepath.Clean(path)
+	if !IsValidLonghornControlPath(path) {
+		if path == "/dev" || strings.HasPrefix(path, "/dev/") {
+			logrus.Warnf("Falling back to default control path %q because %s cannot point to /dev", DefaultControlPath, LonghornControlPathEnv)
+			return DefaultControlPath
+		}
+		logrus.Warnf("Falling back to default control path %q because %s is unset or invalid", DefaultControlPath, LonghornControlPathEnv)
+		return DefaultControlPath
+	}
+	return path
+}
+
+func IsValidLonghornDataPath(path string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	return path != "." && path != "" && path != string(filepath.Separator) && filepath.IsAbs(path)
+}
+
+func IsValidLonghornControlPath(path string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "." || path == "" || path == string(filepath.Separator) || !filepath.IsAbs(path) {
+		return false
+	}
+	return path != "/dev" && !strings.HasPrefix(path, "/dev/")
+}
+
+// Defaults to /var/lib/longhorn/engine-binaries when LONGHORN_CONTROL_PATH is unset.
+func GetEngineBinaryDirectoryOnHost() string {
+	return filepath.Join(GetLonghornControlPath(), EngineBinaryDirectorySubpath)
+}
+
+// Defaults to /var/lib/longhorn/metadata when LONGHORN_CONTROL_PATH is unset.
+func GetMetadataDirectoryOnHost() string {
+	return filepath.Join(GetLonghornControlPath(), MetadataDirectorySubpath)
+}
+
+// Defaults to /var/lib/longhorn/unix-domain-socket when LONGHORN_CONTROL_PATH is unset.
+func GetUnixDomainSocketDirectoryOnHost() string {
+	return filepath.Join(GetLonghornControlPath(), UnixDomainSocketDirectorySubpath)
+}
+
+// Defaults to /host/var/lib/longhorn/unix-domain-socket inside the container.
+func GetUnixDomainSocketDirectoryInContainer() string {
+	return filepath.Join(ReplicaHostPrefix,
+		strings.TrimLeft(GetUnixDomainSocketDirectoryOnHost(), string(filepath.Separator)))
+}
+
+// Defaults to /var/lib/longhorn/logs when LONGHORN_CONTROL_PATH is unset.
+func GetDefaultLogDirectoryOnHost() string {
+	return filepath.Join(GetLonghornControlPath(), LogDirectorySubpath)
+}
+
 func GetImageCanonicalName(image string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(image, ":", "-"), "/", "-")
 }
 
 func GetEngineBinaryDirectoryOnHostForImage(image string) string {
 	cname := GetImageCanonicalName(image)
-	return filepath.Join(EngineBinaryDirectoryOnHost, cname)
+	return filepath.Join(GetEngineBinaryDirectoryOnHost(), cname)
 }
 
 func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
@@ -420,7 +502,11 @@ func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
 
 func GetEngineBinaryDirectoryForReplicaManagerContainer(image string) string {
 	cname := GetImageCanonicalName(image)
-	return filepath.Join(filepath.Join(ReplicaHostPrefix, EngineBinaryDirectoryOnHost), cname)
+	return filepath.Join(
+		ReplicaHostPrefix,
+		strings.TrimLeft(GetEngineBinaryDirectoryOnHost(), string(filepath.Separator)),
+		cname,
+	)
 }
 
 func EngineBinaryExistOnHostForImage(image string) (bool, error) {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,6 +29,62 @@ var _ = Suite(&TestSuite{})
 
 func (s *TestSuite) SetUpTest(c *C) {
 	logrus.SetLevel(logrus.DebugLevel)
+	c.Assert(os.Unsetenv(LonghornDataPathEnv), IsNil)
+	c.Assert(os.Unsetenv(LonghornControlPathEnv), IsNil)
+}
+
+func (s *TestSuite) TearDownTest(c *C) {
+	c.Assert(os.Unsetenv(LonghornDataPathEnv), IsNil)
+	c.Assert(os.Unsetenv(LonghornControlPathEnv), IsNil)
+}
+
+func (s *TestSuite) TestGetLonghornDataPath(c *C) {
+	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+
+	customPath := "/data/longhorn/"
+	c.Assert(os.Setenv(LonghornDataPathEnv, customPath), IsNil)
+	c.Assert(GetLonghornDataPath(), Equals, filepath.Clean(customPath))
+
+	c.Assert(os.Setenv(LonghornDataPathEnv, "relative/path"), IsNil)
+	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+
+	c.Assert(os.Setenv(LonghornDataPathEnv, string(filepath.Separator)), IsNil)
+	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+
+	c.Assert(os.Setenv(LonghornDataPathEnv, "/dev/nvme0n1"), IsNil)
+	c.Assert(GetLonghornDataPath(), Equals, "/dev/nvme0n1")
+
+	c.Assert(os.Setenv(LonghornDataPathEnv, "0000:00:1e.0"), IsNil)
+	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+}
+
+func (s *TestSuite) TestGetLonghornControlPath(c *C) {
+	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+
+	customPath := "/control/longhorn/"
+	c.Assert(os.Setenv(LonghornControlPathEnv, customPath), IsNil)
+	c.Assert(GetLonghornControlPath(), Equals, filepath.Clean(customPath))
+
+	c.Assert(os.Setenv(LonghornControlPathEnv, "relative/path"), IsNil)
+	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+
+	c.Assert(os.Setenv(LonghornControlPathEnv, string(filepath.Separator)), IsNil)
+	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+
+	c.Assert(os.Setenv(LonghornControlPathEnv, "/dev/nvme0n1"), IsNil)
+	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+}
+
+func (s *TestSuite) TestContainerPathHelpersUseReplicaHostPrefix(c *C) {
+	customPath := "/control/longhorn"
+	image := "longhornio/longhorn-engine:v1.9.0"
+
+	c.Assert(os.Setenv(LonghornControlPathEnv, customPath), IsNil)
+
+	c.Assert(GetUnixDomainSocketDirectoryInContainer(), Equals,
+		filepath.Join(ReplicaHostPrefix, "control/longhorn", UnixDomainSocketDirectorySubpath))
+	c.Assert(GetEngineBinaryDirectoryForReplicaManagerContainer(image), Equals,
+		filepath.Join(ReplicaHostPrefix, "control/longhorn", EngineBinaryDirectorySubpath, GetImageCanonicalName(image)))
 }
 
 func (s *TestSuite) TestParseToleration(c *C) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9083

#### What this PR does / why we need it:

This PR introduces `default-control-path` to separate Longhorn runtime/control-plane paths from `default-data-path`.

Previously, engine binaries, metadata, unix domain sockets, and logs still relied on `/var/lib/longhorn`, which could cause issues in environments where `/var` is mounted with `noexec`. With this change, those runtime artifacts are resolved from `default-control-path`, while `default-data-path` continues to represent the data path.

This PR also introduces `LONGHORN_CONTROL_PATH` and makes both `default-data-path` and `default-control-path` immutable after Longhorn has been initialized.

#### Special notes for your reviewer:

- default-data-path and default-control-path are installation-time settings.
- The chart writes them into the default setting ConfigMap and passes them to pods through `LONGHORN_DATA_PATH` and `LONGHORN_CONTROL_PATH`.
- Longhorn processes read these env vars at startup to determine data/runtime path resolution.

#### Additional documentation or context
