### PR TITLE
fix: skip unscheduled replicas in volume

### DIFF
--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -391,6 +391,13 @@ func (v *volumeValidator) validateExpansionSize(oldVolume *longhorn.Volume, newV
 	}
 
 	for _, replica := range replicaMap {
+		// An empty DiskID means the replica has not been scheduled to a disk yet.
+		// This can happen for newly created volumes that have never been attached.
+		// Since there is no underlying disk filesystem to check for size compatibility,
+		// it is safe to skip the validation for these unscheduled replicas.
+		if replica.Spec.DiskID == "" {
+			continue
+		}
 		diskUUID := replica.Spec.DiskID
 		node, diskName, err := v.ds.GetReadyDiskNode(diskUUID)
 		if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13355

#### What this PR does / why we need it:
For newly created volumes that have never been attached to a pod, expanding the volume fails with:

  cannot find the corresponding ready node and disk with disk UUID

  This happens because replicas for such volumes exist but have an empty `DiskID` (not yet scheduled to a disk). The `validateExpansionSize` webhook validator calls `GetReadyDiskNode` with an empty disk UUID, which fails
  since no disk matches.
#### Special notes for your reviewer:

#### Additional documentation or context
