### PR TITLE
ci: skip generated client code in Go import check

### DIFF
--- a/.github/scripts/check_go_imports.py
+++ b/.github/scripts/check_go_imports.py
@@ -326,6 +326,9 @@ def check_file(filepath: str, module_path: str) -> List[str]:
     if filepath.startswith("vendor/") or "/vendor/" in filepath:
         return errors
 
+    if filepath.startswith("k8s/pkg/client/"):
+        return errors
+
     blocks = parse_import_blocks(filepath, module_path)
 
     for groups in blocks:
@@ -362,6 +365,9 @@ def main() -> int:
             continue
 
         if filepath.startswith("vendor/") or "/vendor/" in filepath:
+            continue
+
+        if filepath.startswith("k8s/pkg/client/"):
             continue
 
         if not os.path.exists(filepath):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13356

#### What this PR does / why we need it:

The K8s code generator generates imports in a fixed format, and they should not be modified. So, they do not need to be checked.

#### Special notes for your reviewer:

#### Additional documentation or context
