### PR TITLE
feat: introduce CPU manager for v2 volume SPDK

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -262,11 +262,13 @@ func GetInstanceManagerCPURequirement(ds *datastore.DataStore, imName string) (*
 	}
 
 	cpuRequest := 0
+	cpuRequestVal := ""
 	switch im.Spec.DataEngine {
 	case longhorn.DataEngineTypeV1, longhorn.DataEngineTypeV2:
 		// TODO: Currently lhNode.Spec.InstanceManagerCPURequest is applied to both v1 and v2 data engines.
 		// In the future, we may want to support different CPU requests for them.
 		cpuRequest = lhNode.Spec.InstanceManagerCPURequest
+		cpuRequestVal = fmt.Sprintf("%dm", cpuRequest)
 		if cpuRequest == 0 {
 			guaranteedCPUPercentage, err := ds.GetSettingAsFloatByDataEngine(types.SettingNameGuaranteedInstanceManagerCPU, im.Spec.DataEngine)
 			if err != nil {
@@ -274,12 +276,26 @@ func GetInstanceManagerCPURequirement(ds *datastore.DataStore, imName string) (*
 			}
 			allocatableMilliCPU := float64(kubeNode.Status.Allocatable.Cpu().MilliValue())
 			cpuRequest = int(math.Round(allocatableMilliCPU * guaranteedCPUPercentage / 100.0))
+			cpuRequestVal = fmt.Sprintf("%dm", cpuRequest)
+		}
+		if types.IsDataEngineV2(im.Spec.DataEngine) {
+			spdkCoreNumber, err := ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineNumberOfCPUCores, im.Spec.DataEngine)
+			if err != nil {
+				return nil, err
+			}
+			if spdkCoreNumber > 0 {
+				if cpuRequest < int(spdkCoreNumber)*1000 {
+					cpuRequestVal = fmt.Sprintf("%d", spdkCoreNumber)
+				} else {
+					cpuRequestVal = fmt.Sprintf("%d", ((cpuRequest-1)/1000)+1)
+				}
+			}
 		}
 	default:
 		return nil, fmt.Errorf("unknown data engine %v", im.Spec.DataEngine)
 	}
 
-	return ParseResourceRequirement(fmt.Sprintf("%dm", cpuRequest))
+	return ParseResourceRequirement(cpuRequestVal)
 }
 
 func isControllerResponsibleFor(controllerID string, ds *datastore.DataStore, name, preferredOwnerID, currentOwnerID string) bool {

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -559,13 +559,22 @@ func (imc *InstanceManagerController) syncInstanceStatus(im *longhorn.InstanceMa
 	return nil
 }
 
-func (imc *InstanceManagerController) isDateEngineCPUMaskApplied(im *longhorn.InstanceManager) (bool, error) {
+func (imc *InstanceManagerController) isDateEngineCPUMaskCoreNumberApplied(im *longhorn.InstanceManager) (bool, error) {
 	if types.IsDataEngineV1(im.Spec.DataEngine) {
 		return true, nil
 	}
 
 	if im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
 		return true, nil
+	}
+
+	spdkCoreNumber, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineNumberOfCPUCores, im.Spec.DataEngine)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get %v setting for checking data engine CPU mask", types.SettingNameDataEngineNumberOfCPUCores)
+	}
+
+	if spdkCoreNumber > 0 {
+		return im.Status.DataEngineStatus.V2.CPUCoreNumber == spdkCoreNumber, nil
 	}
 
 	if im.Spec.DataEngineSpec.V2.CPUMask != "" {
@@ -653,7 +662,7 @@ func (imc *InstanceManagerController) handlePod(im *longhorn.InstanceManager) er
 		log.WithError(err).Warnf("Failed to sync log settings to instance manager pod %v", im.Name)
 	}
 
-	dataEngineCPUMaskIsApplied, err := imc.isDateEngineCPUMaskApplied(im)
+	dataEngineCPUMaskIsApplied, err := imc.isDateEngineCPUMaskCoreNumberApplied(im)
 	if err != nil {
 		log.WithError(err).Warnf("Failed to sync date engine CPU mask to instance manager pod %v", im.Name)
 	}
@@ -1874,20 +1883,31 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			logFlags = strings.ToLower(logFlagsSetting)
 		}
 
-		// CPU mask is required for SPDK.
-		cpuMask := im.Spec.DataEngineSpec.V2.CPUMask
-		if cpuMask == "" {
-			value, err := imc.ds.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineCPUMask, dataEngine)
-			if err != nil {
-				return nil, err
-			}
+		spdkCoreNumber, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineNumberOfCPUCores, im.Spec.DataEngine)
+		if err != nil {
+			return nil, err
+		}
+		dynamicCPUPinningEnabled := spdkCoreNumber != 0
 
-			cpuMask = value
+		// CPU mask is required for SPDK.
+		cpuMask := ""
+		if !dynamicCPUPinningEnabled {
+			cpuMask = im.Spec.DataEngineSpec.V2.CPUMask
 			if cpuMask == "" {
-				return nil, fmt.Errorf("failed to get CPU mask setting for data engine %v", dataEngine)
+				value, err := imc.ds.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineCPUMask, dataEngine)
+				if err != nil {
+					return nil, err
+				}
+
+				cpuMask = value
+				if cpuMask == "" {
+					return nil, fmt.Errorf("failed to get CPU mask setting for data engine %v", dataEngine)
+				}
 			}
 		}
+		// When CPU-manager-based pinning is enabled, SPDK CPUs are determined at runtime inside the IM pod (cpuMask may be empty here).
 		im.Status.DataEngineStatus.V2.CPUMask = cpuMask
+		im.Status.DataEngineStatus.V2.CPUCoreNumber = spdkCoreNumber
 
 		// Hugepage or legacy memory preallocation is required for SPDK.
 		hugepageEnabled, err := imc.ds.GetSettingAsBoolByDataEngine(types.SettingNameDataEngineHugepageEnabled, im.Spec.DataEngine)
@@ -1909,9 +1929,10 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		}
 
 		args := []string{
-			"instance-manager",
+			"start-spdk-tgt",
 			"--spdk-log", logFlags,
 			"--spdk-cpumask", cpuMask,
+			"--spdk-core-number", fmt.Sprintf("%d", spdkCoreNumber),
 			"--spdk-memory-size", fmt.Sprintf("%d", memory),
 			"--enable-spdk", "--debug",
 			"daemon",
@@ -1947,6 +1968,15 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		}
 
 		podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName("hugepages-2Mi")] = resource.MustParse(fmt.Sprintf("%vMi", hugepage))
+		if dynamicCPUPinningEnabled {
+			cpuQty, ok := podSpec.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+			if !ok {
+				cpuQty = resource.MustParse(fmt.Sprintf("%d", spdkCoreNumber))
+				podSpec.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = cpuQty
+			}
+			podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = cpuQty
+			podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("128Mi")
+		}
 
 		podSpec.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{

--- a/controller/monitor/environment_check_monitor.go
+++ b/controller/monitor/environment_check_monitor.go
@@ -2,7 +2,9 @@ package monitor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -38,7 +40,20 @@ const (
 
 	kernelConfigDir = "/host/boot/"
 	systemConfigDir = "/host/etc/"
+
+	// Path to the kubelet CPU manager state file.
+	// If running in a pod, this path should match where you mounted the host's /var/lib/kubelet
+	DefaultKubeletRootDir      = "/var/lib/kubelet"
+	DefaultCpuManagerStateFile = "/cpu_manager_state"
 )
+
+// CPUManagerState represents the structure of the kubelet's CPU manager state file.
+type CPUManagerState struct {
+	PolicyName    string                       `json:"policyName"`
+	DefaultCPUSet string                       `json:"defaultCpuSet"`
+	Entries       map[string]map[string]string `json:"entries,omitempty"`
+	Checksum      uint32                       `json:"checksum"`
+}
 
 var (
 	kernelModules       = map[string]string{"CONFIG_DM_CRYPT": "dm_crypt"}
@@ -173,6 +188,10 @@ func (m *EnvironmentCheckMonitor) environmentCheck(kubeNode *corev1.Node) *Colle
 
 	if isV2DataEngine {
 		m.checkHugePages(kubeNode, collectedData)
+	}
+
+	if err := m.syncNodeCPUManagerPolicy(collectedData); err != nil {
+		m.logger.WithError(err).Debug("Failed to sync node CPU manager policy")
 	}
 
 	return collectedData
@@ -561,4 +580,50 @@ func (m *EnvironmentCheckMonitor) syncNFSClientVersion(kubeNode *corev1.Node, co
 	}
 
 	collectedData.conditions = types.SetCondition(collectedData.conditions, longhorn.NodeConditionTypeNFSClientInstalled, longhorn.ConditionStatusTrue, "", "")
+}
+
+func (m *EnvironmentCheckMonitor) syncNodeCPUManagerPolicy(collectedData *CollectedEnvironmentCheckInfo) error {
+	kubeletCPUManagerStateFilePath := getKubeletCPUManagerStateFilePath()
+	data, err := lhns.ReadFileContent(kubeletCPUManagerStateFilePath)
+	if err != nil {
+		m.logger.WithError(err).Debugf("failed to read CPU state file %s", kubeletCPUManagerStateFilePath)
+		collectedData.conditions = types.SetCondition(collectedData.conditions,
+			longhorn.NodeConditionTypeCPUManagerPolicy, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonCPUManagerPolicyUnConfigured),
+			fmt.Sprintf("Failed to read CPU state file %s on node %s", kubeletCPUManagerStateFilePath, m.nodeName))
+		return nil
+	}
+
+	// Unmarshal the JSON data
+	var state CPUManagerState
+	if err := json.Unmarshal([]byte(data), &state); err != nil {
+		m.logger.WithError(err).Debugf("failed to parse CPU state file %s", kubeletCPUManagerStateFilePath)
+		collectedData.conditions = types.SetCondition(collectedData.conditions,
+			longhorn.NodeConditionTypeCPUManagerPolicy, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonCPUManagerPolicyUnConfigured),
+			fmt.Sprintf("Failed to parse CPU state file %s on node %s", kubeletCPUManagerStateFilePath, m.nodeName))
+		return nil
+	}
+
+	if state.PolicyName == longhorn.CpuManagerStaticPolicy {
+		collectedData.conditions = types.SetCondition(collectedData.conditions,
+			longhorn.NodeConditionTypeCPUManagerPolicy, longhorn.ConditionStatusTrue,
+			string(longhorn.NodeConditionReasonCPUManagerPolicyConfigured),
+			fmt.Sprintf("Node %v CPU manager policy is static", m.nodeName))
+	} else {
+		collectedData.conditions = types.SetCondition(collectedData.conditions,
+			longhorn.NodeConditionTypeCPUManagerPolicy, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonCPUManagerPolicyUnConfigured),
+			fmt.Sprintf("Node %v CPU manager policy is %v", m.nodeName, state.PolicyName))
+	}
+
+	return nil
+}
+
+func getKubeletCPUManagerStateFilePath() string {
+	kubeletRootDirPath := strings.TrimRight(strings.TrimSpace(os.Getenv(types.EnvKubeletRootDir)), "/")
+	if kubeletRootDirPath == "" {
+		kubeletRootDirPath = DefaultKubeletRootDir
+	}
+	return kubeletRootDirPath + DefaultCpuManagerStateFile
 }

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -707,8 +707,84 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 			}
 			return errors.Wrapf(err, "failed to get the storage class %v for setting %v", value, types.SettingNameDefaultLonghornStaticStorageClass)
 		}
+	case types.SettingNameDataEngineNumberOfCPUCores:
+		trimmed := strings.TrimSpace(value)
+
+		var values map[longhorn.DataEngineType]string
+		if err := json.Unmarshal([]byte(trimmed), &values); err != nil {
+			// Allow single values (for example, "2") the same way types.ValidateSetting does.
+			coreNumber, convErr := strconv.Atoi(trimmed)
+			if convErr != nil {
+				return errors.Wrapf(convErr, "failed to convert CPU core number setting value %q to integer", value)
+			}
+
+			if err := s.ValidateDataEngineCoreNumber(coreNumber, longhorn.DataEngineTypeV2); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		for dataEngine, v := range values {
+			coreNumber, err := strconv.Atoi(v)
+			if err != nil {
+				return errors.Wrapf(err, "failed to convert CPU core number %s for data engine %s to integer", v, dataEngine)
+			}
+			if err := s.ValidateDataEngineCoreNumber(coreNumber, dataEngine); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func (s *DataStore) ValidateDataEngineCoreNumber(coreNum int, dataEngine longhorn.DataEngineType) error {
+	switch {
+	case coreNum < 0:
+		return errors.Errorf("CPU core number for data engine %s cannot be negative", dataEngine)
+	case coreNum > 0:
+		allNodesCPUPolicyConfiged, err := s.isAllNodesCPUPolicyConfiged()
+		if err != nil {
+			return errors.Wrapf(err, "failed to check if all nodes have CPU manager policy configured")
+		}
+		if !allNodesCPUPolicyConfiged {
+			return errors.Errorf("CPU core number for data engine %s cannot be set to %d when not all nodes have CPU manager policy configured", dataEngine, coreNum)
+		}
+	case coreNum == 0:
+		allNodesCPUMaskZero, err := s.isDataEngineCPUMaskZero(dataEngine)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check if data engine CPU mask is set to 0")
+		}
+		if allNodesCPUMaskZero {
+			return errors.Errorf("CPU core number for data engine %s cannot be set to 0 when data engine CPU mask is set to 0", dataEngine)
+		}
+	}
+	return nil
+}
+
+func (s *DataStore) isAllNodesCPUPolicyConfiged() (bool, error) {
+	lhnodes, err := s.ListNodesRO()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get all nodes")
+	}
+
+	for _, node := range lhnodes {
+		waitForBackingImageCondition := types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeCPUManagerPolicy)
+		if waitForBackingImageCondition.Status != longhorn.ConditionStatusTrue {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (s *DataStore) isDataEngineCPUMaskZero(dataEngine longhorn.DataEngineType) (bool, error) {
+	value, err := s.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineCPUMask, dataEngine)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get %v setting for updating data engine CPU mask", types.SettingNameDataEngineCPUMask)
+	}
+	if value == "0" || value == "0x0" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (s *DataStore) ValidateV1DataEngineEnabled(dataEngineEnabled bool) (ims []*longhorn.InstanceManager, err error) {

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1996,6 +1996,9 @@ spec:
                 properties:
                   v2:
                     properties:
+                      cpuCoreNumber:
+                        format: int64
+                        type: integer
                       cpuMask:
                         type: string
                       interruptModeEnabled:

--- a/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
@@ -202,6 +202,8 @@ type InstanceManagerSpec struct {
 type V2DataEngineStatus struct {
 	// +optional
 	CPUMask string `json:"cpuMask"`
+	// +optional
+	CPUCoreNumber int64 `json:"cpuCoreNumber"`
 
 	// InterruptModeEnabled indicates whether the V2 data engine is running in
 	// interrupt mode (true) or polling mode (false). Set by Longhorn manager;

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -11,27 +11,30 @@ const (
 	NodeConditionTypeNFSClientInstalled  = "NFSClientInstalled"
 	NodeConditionTypeSchedulable         = "Schedulable"
 	NodeConditionTypeHugePagesAvailable  = "HugePagesAvailable"
+	NodeConditionTypeCPUManagerPolicy    = "CPUManagerPolicy"
 )
 
 const (
-	NodeConditionReasonManagerPodDown            = "ManagerPodDown"
-	NodeConditionReasonManagerPodMissing         = "ManagerPodMissing"
-	NodeConditionReasonKubernetesNodeGone        = "KubernetesNodeGone"
-	NodeConditionReasonKubernetesNodeNotReady    = "KubernetesNodeNotReady"
-	NodeConditionReasonKubernetesNodePressure    = "KubernetesNodePressure"
-	NodeConditionReasonUnknownNodeConditionTrue  = "UnknownNodeConditionTrue"
-	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
-	NodeConditionReasonMultipathdIsRunning       = "MultipathdIsRunning"
-	NodeConditionReasonUnknownOS                 = "UnknownOS"
-	NodeConditionReasonNamespaceExecutorErr      = "NamespaceExecutorErr"
-	NodeConditionReasonKernelModulesNotLoaded    = "KernelModulesNotLoaded"
-	NodeConditionReasonPackagesNotInstalled      = "PackagesNotInstalled"
-	NodeConditionReasonCheckKernelConfigFailed   = "CheckKernelConfigFailed"
-	NodeConditionReasonNFSClientIsNotFound       = "NFSClientIsNotFound"
-	NodeConditionReasonNFSClientIsMisconfigured  = "NFSClientIsMisconfigured"
-	NodeConditionReasonKubernetesNodeCordoned    = "KubernetesNodeCordoned"
-	NodeConditionReasonHugePagesNotConfigured    = "HugePagesNotConfigured"
-	NodeConditionReasonInsufficientHugePages     = "InsufficientHugePages"
+	NodeConditionReasonManagerPodDown               = "ManagerPodDown"
+	NodeConditionReasonManagerPodMissing            = "ManagerPodMissing"
+	NodeConditionReasonKubernetesNodeGone           = "KubernetesNodeGone"
+	NodeConditionReasonKubernetesNodeNotReady       = "KubernetesNodeNotReady"
+	NodeConditionReasonKubernetesNodePressure       = "KubernetesNodePressure"
+	NodeConditionReasonUnknownNodeConditionTrue     = "UnknownNodeConditionTrue"
+	NodeConditionReasonNoMountPropagationSupport    = "NoMountPropagationSupport"
+	NodeConditionReasonMultipathdIsRunning          = "MultipathdIsRunning"
+	NodeConditionReasonUnknownOS                    = "UnknownOS"
+	NodeConditionReasonNamespaceExecutorErr         = "NamespaceExecutorErr"
+	NodeConditionReasonKernelModulesNotLoaded       = "KernelModulesNotLoaded"
+	NodeConditionReasonPackagesNotInstalled         = "PackagesNotInstalled"
+	NodeConditionReasonCheckKernelConfigFailed      = "CheckKernelConfigFailed"
+	NodeConditionReasonNFSClientIsNotFound          = "NFSClientIsNotFound"
+	NodeConditionReasonNFSClientIsMisconfigured     = "NFSClientIsMisconfigured"
+	NodeConditionReasonKubernetesNodeCordoned       = "KubernetesNodeCordoned"
+	NodeConditionReasonHugePagesNotConfigured       = "HugePagesNotConfigured"
+	NodeConditionReasonInsufficientHugePages        = "InsufficientHugePages"
+	NodeConditionReasonCPUManagerPolicyConfigured   = "CPUManagerPolicyConfigured"
+	NodeConditionReasonCPUManagerPolicyUnConfigured = "CPUManagerPolicyUnConfigured"
 )
 
 const (
@@ -64,6 +67,12 @@ const (
 	ErrorReplicaScheduleReplicaAlreadyScheduled           = "replica already scheduled"
 	ErrorReplicaScheduleLonghornClientOperationFailed     = "longhorn client operation failed"
 	ErrorReplicaScheduleIncompatibleVolumeSize            = "incompatible volume size"
+)
+
+const (
+	CpuManagerStaticPolicy  = "static"
+	CpuManagerNonePolicy    = "none"
+	CpuManagerUnknownPolicy = "unknown"
 )
 
 type DiskType string

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/v2dataenginestatus.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/v2dataenginestatus.go
@@ -21,7 +21,8 @@ package v1beta2
 // V2DataEngineStatusApplyConfiguration represents a declarative configuration of the V2DataEngineStatus type for use
 // with apply.
 type V2DataEngineStatusApplyConfiguration struct {
-	CPUMask *string `json:"cpuMask,omitempty"`
+	CPUMask       *string `json:"cpuMask,omitempty"`
+	CPUCoreNumber *int64  `json:"cpuCoreNumber,omitempty"`
 	// InterruptModeEnabled indicates whether the V2 data engine is running in
 	// interrupt mode (true) or polling mode (false). Set by Longhorn manager;
 	// read-only to users.
@@ -39,6 +40,14 @@ func V2DataEngineStatus() *V2DataEngineStatusApplyConfiguration {
 // If called multiple times, the CPUMask field is set to the value of the last call.
 func (b *V2DataEngineStatusApplyConfiguration) WithCPUMask(value string) *V2DataEngineStatusApplyConfiguration {
 	b.CPUMask = &value
+	return b
+}
+
+// WithCPUCoreNumber sets the CPUCoreNumber field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CPUCoreNumber field is set to the value of the last call.
+func (b *V2DataEngineStatusApplyConfiguration) WithCPUCoreNumber(value int64) *V2DataEngineStatusApplyConfiguration {
+	b.CPUCoreNumber = &value
 	return b
 }
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -157,6 +157,7 @@ const (
 	SettingNameDataEngineHugepageEnabled                                = SettingName("data-engine-hugepage-enabled")
 	SettingNameDataEngineMemorySize                                     = SettingName("data-engine-memory-size")
 	SettingNameDataEngineCPUMask                                        = SettingName("data-engine-cpu-mask")
+	SettingNameDataEngineNumberOfCPUCores                               = SettingName("data-engine-number-of-cpu-cores")
 	SettingNameDataEngineLogLevel                                       = SettingName("data-engine-log-level")
 	SettingNameDataEngineLogFlags                                       = SettingName("data-engine-log-flags")
 	SettingNameDataEngineInterruptModeEnabled                           = SettingName("data-engine-interrupt-mode-enabled")
@@ -280,6 +281,7 @@ var (
 		SettingNameDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize,
 		SettingNameDataEngineCPUMask,
+		SettingNameDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel,
 		SettingNameDataEngineLogFlags,
 		SettingNameSnapshotDataIntegrity,
@@ -443,6 +445,7 @@ var (
 		SettingNameDataEngineHugepageEnabled:                                SettingDefinitionDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize:                                     SettingDefinitionDataEngineMemorySize,
 		SettingNameDataEngineCPUMask:                                        SettingDefinitionDataEngineCPUMask,
+		SettingNameDataEngineNumberOfCPUCores:                               SettingDefinitionDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel:                                       SettingDefinitionDataEngineLogLevel,
 		SettingNameDataEngineLogFlags:                                       SettingDefinitionDataEngineLogFlags,
 		SettingNameDataEngineInterruptModeEnabled:                           SettingDefinitionDataEngineInterruptModeEnabled,
@@ -1794,13 +1797,28 @@ var (
 
 	SettingDefinitionDataEngineCPUMask = SettingDefinition{
 		DisplayName:        "Data Engine CPU Mask",
-		Description:        "Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the assigned CPU cores do not exceed the guaranteed CPUs allocated to the V2 Data Engine Instance Manager. A minimum of 2 CPU cores is recommended. SPDK uses a busy-polling reactor model where the master reactor handles both I/O polling and management RPCs. When only a single core is assigned, heavy I/O workloads can delay or starve RPC processing, resulting in increased latency, timeout events, and operational instability. Assigning 2 or more cores allows I/O and management tasks to run on separate reactors, improving responsiveness and operational stability. Accepts either hexadecimal CPU masks (for example, 0x3 or 0xff) or CPU list format (for example, 0-1,2,5). CPU lists are automatically converted to hexadecimal masks. The default value is 0x3.",
+		Description:        "Applies only to the V2 Data Engine. If the Data Engine CPU Core Number setting is specified, this setting will be ignored. It specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the assigned CPU cores do not exceed the guaranteed CPUs allocated to the V2 Data Engine Instance Manager. A minimum of 2 CPU cores is recommended. SPDK uses a busy-polling reactor model where the master reactor handles both I/O polling and management RPCs. When only a single core is assigned, heavy I/O workloads can delay or starve RPC processing, resulting in increased latency, timeout events, and operational instability. Assigning 2 or more cores allows I/O and management tasks to run on separate reactors, improving responsiveness and operational stability. Accepts either hexadecimal CPU masks (for example, 0x3 or 0xff) or CPU list format (for example, 0-1,2,5). CPU lists are automatically converted to hexadecimal masks. The default value is 0x3.",
 		Category:           SettingCategoryDangerZone,
 		Type:               SettingTypeString,
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: true,
 		Default:            fmt.Sprintf("{%q:\"0x3\"}", longhorn.DataEngineTypeV2),
+	}
+
+	SettingDefinitionDataEngineNumberOfCPUCores = SettingDefinition{
+		DisplayName: "Data Engine Number of CPU Cores",
+		Description: "Applies only to the V2 Data Engine. It can be applied only when the kubelet CPU policy is set to static. It has higher priority than the Data Engine CPU Mask setting. Therefore, when specified, the CPU Mask setting will be ignored. " +
+			"Specifies the number of CPU cores allocated to the Storage Performance Development Kit (SPDK) target daemon. The daemon is deployed in each Instance Manager pod. Ensure that the assigned CPU cores do not exceed the guaranteed CPUs allocated to the V2 Data Engine Instance Manager. A minimum of 2 CPU cores is recommended. SPDK uses a busy-polling reactor model where the master reactor handles both I/O polling and management RPCs. When only a single core is assigned, heavy I/O workloads can delay or starve RPC processing, resulting in increased latency, timeout events, and operational instability. Assigning 2 or more cores allows I/O and management tasks to run on separate reactors, improving responsiveness and operational stability.",
+		Category:           SettingCategoryDangerZone,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: true,
+		Default:            fmt.Sprintf("{%q:\"0\"}", longhorn.DataEngineTypeV2),
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+		},
 	}
 
 	SettingDefinitionDataEngineInterruptModeEnabled = SettingDefinition{

--- a/types/types.go
+++ b/types/types.go
@@ -272,6 +272,7 @@ const (
 	EnvDataEngine     = "DATA_ENGINE"
 	EnvTZ             = "TZ"
 	EnvDistro         = "LONGHORN_DISTRO"
+	EnvKubeletRootDir = "KUBELET_ROOT_DIR"
 
 	BackupStoreTypeS3     = "s3"
 	BackupStoreTypeCIFS   = "cifs"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#13248

#### What this PR does / why we need it:

Introduce a new setting `data-engine-number-of-cpu-cores` instead of `data-engine-cpu-mask` to prevent creating IM pods failed from the CPU is pinned by other workloads.
When creating v2 instance manager pod, the CPU pinning will be managed by the K8S CPU manager with the setting `data-engine-number-of-cpu-cores` value.
And then IM pod will get pinned CPUs when starting, and send it to the SPDK process

#### Special notes for your reviewer:

#### Additional documentation or context
