### PR TITLE
feat: add data-engine-iobuf-large-pool-size setting

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -221,6 +221,7 @@ func (imc *InstanceManagerController) isResponsibleForSetting(obj interface{}) b
 
 	return types.SettingName(setting.Name) == types.SettingNameKubernetesClusterAutoscalerEnabled ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineCPUMask ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineIobufLargePoolSize ||
 		types.SettingName(setting.Name) == types.SettingNameOrphanResourceAutoDeletion ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineHugepageEnabled ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineMemorySize
@@ -837,6 +838,8 @@ func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *lon
 			}
 		case types.SettingNameDataEngineInterruptModeEnabled:
 			isSettingSynced, err = imc.isSettingInterruptModeEnabledSynced(setting, im)
+		case types.SettingNameDataEngineIobufLargePoolSize:
+			isSettingSynced, err = imc.isSettingIobufLargePoolSizeSynced(im, pod)
 		}
 		if err != nil {
 			return false, nil, false, false, err
@@ -1140,6 +1143,32 @@ func (imc *InstanceManagerController) nodeHasEnoughHugepageTotalCapacity(im *lon
 	}
 
 	return hugepages2MiAllocatable.Cmp(requiredHugePages) >= 0, nil
+}
+
+// isSettingIobufLargePoolSizeSynced checks whether the pod's --spdk-iobuf-large-pool-size
+// argument matches the current setting. A value not greater than SPDK's default
+// (types.SpdkDefaultIobufLargePoolSize) means the flag is omitted from the pod args, so an
+// absent flag is considered synced; this prevents recreating existing pods that predate the setting.
+func (imc *InstanceManagerController) isSettingIobufLargePoolSizeSynced(im *longhorn.InstanceManager, pod *corev1.Pod) (bool, error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, nil
+	}
+
+	if len(pod.Spec.Containers) == 0 {
+		return false, nil
+	}
+
+	iobufLargePoolSize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineIobufLargePoolSize, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	expected := ""
+	if iobufLargePoolSize > types.SpdkDefaultIobufLargePoolSize {
+		expected = fmt.Sprintf("%d", iobufLargePoolSize)
+	}
+	current := getContainerArgValue(pod.Spec.Containers[0].Args, "--spdk-iobuf-large-pool-size")
+	return current == expected, nil
 }
 
 func (imc *InstanceManagerController) syncInstanceManagerAPIVersion(im *longhorn.InstanceManager) error {
@@ -1928,16 +1957,32 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			hugepage = memory
 		}
 
+		// iobuf large pool size (large_pool_count) for the SPDK target. A value not
+		// greater than SPDK's built-in default (types.SpdkDefaultIobufLargePoolSize) is
+		// a no-op, so the flag is omitted and behavior is unchanged. A larger value is
+		// consumed by the instance-manager launch wrapper, which generates an SPDK
+		// startup JSON config (the iobuf pool can only be sized during spdk_tgt startup).
+		iobufLargePoolSize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineIobufLargePoolSize, dataEngine)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDataEngineIobufLargePoolSize)
+		}
+
 		args := []string{
 			"start-spdk-tgt",
 			"--spdk-log", logFlags,
 			"--spdk-cpumask", cpuMask,
 			"--spdk-core-number", fmt.Sprintf("%d", spdkCoreNumber),
 			"--spdk-memory-size", fmt.Sprintf("%d", memory),
+		}
+		// Must precede "daemon" so the launch wrapper consumes it as an SPDK option.
+		if iobufLargePoolSize > types.SpdkDefaultIobufLargePoolSize {
+			args = append(args, "--spdk-iobuf-large-pool-size", fmt.Sprintf("%d", iobufLargePoolSize))
+		}
+		args = append(args,
 			"--enable-spdk", "--debug",
 			"daemon",
 			"--spdk-enabled",
-			"--listen", fmt.Sprintf("0.0.0.0:%d", engineapi.InstanceManagerProcessManagerServiceDefaultPort)}
+			"--listen", fmt.Sprintf("0.0.0.0:%d", engineapi.InstanceManagerProcessManagerServiceDefaultPort))
 
 		interruptMode, err := imc.ds.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineInterruptModeEnabled, dataEngine)
 		if err != nil {

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -281,6 +281,9 @@ func isRevisionedEngineImage(image string) bool {
 	return engineImageRevisionTagRegex.MatchString(tag)
 }
 
+// getContainerArgValue returns the value following the given flag in a container's
+// args (e.g. for flag "--spdk-iobuf-large-pool-size" it returns the next element).
+// It returns an empty string if the flag is absent or has no following value.
 func getContainerArgValue(args []string, flag string) string {
 	for i, arg := range args {
 		if arg == flag && i+1 < len(args) {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -690,6 +690,26 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 			return fmt.Errorf("%s should be between 2 and 250", name)
 		}
 
+	case types.SettingNameDataEngineIobufLargePoolSize:
+		definition, ok := types.GetSettingDefinition(types.SettingNameDataEngineIobufLargePoolSize)
+		if !ok {
+			return fmt.Errorf("setting %v is not found", types.SettingNameDataEngineIobufLargePoolSize)
+		}
+		values, err := types.ParseDataEngineSpecificSetting(definition, value)
+		if err != nil {
+			return err
+		}
+		// A value of 0 keeps SPDK's default; only a value greater than the default
+		// actually changes the pool. Reject the in-between range so it does not silently
+		// become a no-op.
+		for dataEngine, v := range values {
+			size := v.(int64)
+			if size > 0 && size <= types.SpdkDefaultIobufLargePoolSize {
+				return fmt.Errorf("%v for data engine %v must be 0 (keep the SPDK default) or greater than %v; values in between are no-ops",
+					name, dataEngine, types.SpdkDefaultIobufLargePoolSize)
+			}
+		}
+
 	case types.SettingNameDefaultLonghornStaticStorageClass:
 		definition, ok := types.GetSettingDefinition(types.SettingNameDefaultLonghornStaticStorageClass)
 		if !ok {

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -690,26 +690,6 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 			return fmt.Errorf("%s should be between 2 and 250", name)
 		}
 
-	case types.SettingNameDataEngineIobufLargePoolSize:
-		definition, ok := types.GetSettingDefinition(types.SettingNameDataEngineIobufLargePoolSize)
-		if !ok {
-			return fmt.Errorf("setting %v is not found", types.SettingNameDataEngineIobufLargePoolSize)
-		}
-		values, err := types.ParseDataEngineSpecificSetting(definition, value)
-		if err != nil {
-			return err
-		}
-		// A value of 0 keeps SPDK's default; only a value greater than the default
-		// actually changes the pool. Reject the in-between range so it does not silently
-		// become a no-op.
-		for dataEngine, v := range values {
-			size := v.(int64)
-			if size > 0 && size <= types.SpdkDefaultIobufLargePoolSize {
-				return fmt.Errorf("%v for data engine %v must be 0 (keep the SPDK default) or greater than %v; values in between are no-ops",
-					name, dataEngine, types.SpdkDefaultIobufLargePoolSize)
-			}
-		}
-
 	case types.SettingNameDefaultLonghornStaticStorageClass:
 		definition, ok := types.GetSettingDefinition(types.SettingNameDefaultLonghornStaticStorageClass)
 		if !ok {

--- a/types/setting.go
+++ b/types/setting.go
@@ -63,6 +63,11 @@ const (
 
 	ValueFloatRangeMinimum = "minimum"
 	ValueFloatRangeMaximum = "maximum"
+
+	// SpdkDefaultIobufLargePoolSize is SPDK's built-in default large_pool_count. A
+	// data-engine-iobuf-large-pool-size value not greater than this is a no-op (SPDK
+	// keeps its default), so only a larger value is passed through to override it.
+	SpdkDefaultIobufLargePoolSize = 1024
 )
 
 type SettingName string
@@ -156,6 +161,7 @@ const (
 	SettingNameV2DataEngine                                             = SettingName("v2-data-engine")
 	SettingNameDataEngineHugepageEnabled                                = SettingName("data-engine-hugepage-enabled")
 	SettingNameDataEngineMemorySize                                     = SettingName("data-engine-memory-size")
+	SettingNameDataEngineIobufLargePoolSize                             = SettingName("data-engine-iobuf-large-pool-size")
 	SettingNameDataEngineCPUMask                                        = SettingName("data-engine-cpu-mask")
 	SettingNameDataEngineNumberOfCPUCores                               = SettingName("data-engine-number-of-cpu-cores")
 	SettingNameDataEngineLogLevel                                       = SettingName("data-engine-log-level")
@@ -280,6 +286,7 @@ var (
 		SettingNameV2DataEngine,
 		SettingNameDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize,
+		SettingNameDataEngineIobufLargePoolSize,
 		SettingNameDataEngineCPUMask,
 		SettingNameDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel,
@@ -444,6 +451,7 @@ var (
 		SettingNameV2DataEngine:                                             SettingDefinitionV2DataEngine,
 		SettingNameDataEngineHugepageEnabled:                                SettingDefinitionDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize:                                     SettingDefinitionDataEngineMemorySize,
+		SettingNameDataEngineIobufLargePoolSize:                             SettingDefinitionDataEngineIobufLargePoolSize,
 		SettingNameDataEngineCPUMask:                                        SettingDefinitionDataEngineCPUMask,
 		SettingNameDataEngineNumberOfCPUCores:                               SettingDefinitionDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel:                                       SettingDefinitionDataEngineLogLevel,
@@ -1792,6 +1800,25 @@ var (
 		Default:            fmt.Sprintf("{%q:\"2048\"}", longhorn.DataEngineTypeV2),
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: 0,
+		},
+	}
+
+	SettingDefinitionDataEngineIobufLargePoolSize = SettingDefinition{
+		DisplayName: "Data Engine iobuf Large Pool Size",
+		Description: "Applies only to the V2 Data Engine. Sets the SPDK iobuf large buffer pool size (`large_pool_count`) on the Instance Manager's SPDK target. The Instance Manager passes the value to spdk_tgt at startup through a generated JSON configuration file (`--json`); the iobuf pool can only be sized at startup, not changed at runtime. \n\n" +
+			"  - `0` (default): keep SPDK's built-in default (1024); behavior is unchanged. \n\n" +
+			"  - A larger value relieves NVMe-oF TCP large-buffer exhaustion (the `large_pool` `retry` / `NEED_BUFFER` stalls) under heavy mixed read/write workloads whose I/O size exceeds the iobuf small buffer size (8 KiB), e.g. 16 KiB database pages. Values not greater than 1024 keep the SPDK default. \n\n" +
+			"  - Larger values consume more hugepage memory: each large buffer is 132 KiB, so the large pool uses `large_pool_count x 132 KiB` (1024 -> 132 MiB, 4096 -> 528 MiB, 16384 -> ~2 GiB). This comes out of the SPDK target's fixed `Data Engine Memory Size` budget, so raise that setting accordingly or fewer volumes will fit per node. \n\n" +
+			"  - Changing this setting recreates Instance Manager pods that have no running instances, so the new pool size takes effect.",
+		Category:           SettingCategoryDangerZone,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: true,
+		Default:            fmt.Sprintf("{%q:\"0\"}", longhorn.DataEngineTypeV2),
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+			ValueIntRangeMaximum: 65536,
 		},
 	}
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -1806,7 +1806,7 @@ var (
 	SettingDefinitionDataEngineIobufLargePoolSize = SettingDefinition{
 		DisplayName: "Data Engine iobuf Large Pool Size",
 		Description: "Applies only to the V2 Data Engine. Sets the SPDK iobuf large buffer pool size (`large_pool_count`) on the Instance Manager's SPDK target. The Instance Manager passes the value to spdk_tgt at startup through a generated JSON configuration file (`--json`); the iobuf pool can only be sized at startup, not changed at runtime. \n\n" +
-			"  - `0` (default): keep SPDK's built-in default (1024); behavior is unchanged. \n\n" +
+			"  - `1024` (default): SPDK's built-in default `large_pool_count`; behavior is unchanged. \n\n" +
 			"  - A larger value relieves NVMe-oF TCP large-buffer exhaustion (the `large_pool` `retry` / `NEED_BUFFER` stalls) under heavy mixed read/write workloads whose I/O size exceeds the iobuf small buffer size (8 KiB), e.g. 16 KiB database pages. Values not greater than 1024 keep the SPDK default. \n\n" +
 			"  - Larger values consume more hugepage memory: each large buffer is 132 KiB, so the large pool uses `large_pool_count x 132 KiB` (1024 -> 132 MiB, 4096 -> 528 MiB, 16384 -> ~2 GiB). This comes out of the SPDK target's fixed `Data Engine Memory Size` budget, so raise that setting accordingly or fewer volumes will fit per node. \n\n" +
 			"  - Changing this setting recreates Instance Manager pods that have no running instances, so the new pool size takes effect.",
@@ -1815,10 +1815,9 @@ var (
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: true,
-		Default:            fmt.Sprintf("{%q:\"0\"}", longhorn.DataEngineTypeV2),
+		Default:            fmt.Sprintf("{%q:\"%v\"}", longhorn.DataEngineTypeV2, SpdkDefaultIobufLargePoolSize),
 		ValueIntRange: map[string]int{
-			ValueIntRangeMinimum: 0,
-			ValueIntRangeMaximum: 65536,
+			ValueIntRangeMinimum: SpdkDefaultIobufLargePoolSize,
 		},
 	}
 


### PR DESCRIPTION
Dynamic V2 setting that sizes the SPDK iobuf large buffer pool (large_pool_count) via the instance-manager startup JSON config, to relieve NVMe-oF TCP large-buffer exhaustion.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13322

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
