### PR TITLE
fix: ublk volume attaching

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2560,6 +2560,11 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			// so we have the TargetIP available.
 			// For DR volumes (frontend disabled or empty), bypass the Port check
 			// because the engine may not expose a port when the frontend is off.
+			// For UBLK, also bypass the Port check: UBLK is a local block device
+			// exposed via ublk_drv, so the engine never reports a TCP port and
+			// e.Status.Port stays 0 even when the engine is healthy. Without this
+			// the UBLK EngineFrontend would never start and the volume would hang
+			// in attaching.
 			if e.Status.CurrentState == longhorn.InstanceStateRunning && e.Status.IP != "" &&
 				(e.Status.Port != 0 || v.Status.FrontendDisabled || v.Spec.Frontend == longhorn.VolumeFrontendEmpty || v.Spec.Frontend == longhorn.VolumeFrontendUblk) {
 				ef.Spec.NodeID = v.Spec.NodeID

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2561,7 +2561,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			// For DR volumes (frontend disabled or empty), bypass the Port check
 			// because the engine may not expose a port when the frontend is off.
 			if e.Status.CurrentState == longhorn.InstanceStateRunning && e.Status.IP != "" &&
-				(e.Status.Port != 0 || v.Status.FrontendDisabled || v.Spec.Frontend == longhorn.VolumeFrontendEmpty) {
+				(e.Status.Port != 0 || v.Status.FrontendDisabled || v.Spec.Frontend == longhorn.VolumeFrontendEmpty || v.Spec.Frontend == longhorn.VolumeFrontendUblk) {
 				ef.Spec.NodeID = v.Spec.NodeID
 				ef.Spec.Frontend = v.Spec.Frontend
 				ef.Spec.UblkQueueDepth = v.Spec.UblkQueueDepth


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue [#11977](https://github.com/longhorn/longhorn/issues/11977)

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
Fixes the V2 UBLK volume attach hang on kernel 6.17. Root cause: the EngineFrontend start gate in volume_controller.go required a non-zero engine port; UBLK never exposes one, so the EngineFrontend stayed stopped. Adds VolumeFrontendUblk to the bypass. Validated by rebuilding longhorn-manager only and confirming repeated UBLK attaches; NVMe unaffected.

ref: longhorn/longhorn#11977