### PR TITLE
fix(csi): reconcile CSI sidecar replica count on existing deployments

### DIFF
--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -201,7 +201,8 @@ func deploy(kubeClient *clientset.Clientset, obj runtime.Object, resource string
 			annos[AnnotationCSIVersion] == existingAnnos[AnnotationCSIVersion] &&
 			existingMeta.GetDeletionTimestamp() == nil &&
 			!needToUpdateImage(existing, obj) &&
-			!needToUpdatePodAntiAffinity(existing, obj) {
+			!needToUpdatePodAntiAffinity(existing, obj) &&
+			!needToUpdateReplicas(existing, obj) {
 			// deployment of correct version already deployed
 			logrus.Infof("Detected %v %v CSI Git commit %v version %v has already been deployed",
 				resource, name, annos[AnnotationCSIGitCommit], annos[AnnotationCSIVersion])
@@ -322,6 +323,26 @@ func needToUpdatePodAntiAffinity(existingObj, newObj runtime.Object) bool {
 	}
 
 	return existingPreset != newPreset
+}
+
+func needToUpdateReplicas(existingObj, newObj runtime.Object) bool {
+	existingDeployment, ok := existingObj.(*appsv1.Deployment)
+	if !ok {
+		return false
+	}
+	newDeployment, ok := newObj.(*appsv1.Deployment)
+	if !ok {
+		return false
+	}
+
+	if newDeployment.Spec.Replicas == nil {
+		return false
+	}
+	if existingDeployment.Spec.Replicas == nil {
+		return true
+	}
+
+	return *existingDeployment.Spec.Replicas != *newDeployment.Spec.Replicas
 }
 
 func cleanup(kubeClient *clientset.Clientset, obj runtime.Object, resource string,

--- a/csi/deployment_util_test.go
+++ b/csi/deployment_util_test.go
@@ -268,3 +268,132 @@ func TestDeployUsesUpdateFuncInsteadOfDeleteRecreate(t *testing.T) {
 		t.Error("expected createFunc NOT to be called, but it was")
 	}
 }
+
+func TestNeedToUpdateReplicas(t *testing.T) {
+	deploymentWithReplicas := func(r *int32) *appsv1.Deployment {
+		return &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: r}}
+	}
+	two := int32(2)
+	three := int32(3)
+
+	for _, test := range []struct {
+		testName string
+		existing runtime.Object
+		new      runtime.Object
+		expected bool
+	}{
+		{
+			testName: "Should update when existing has more replicas than desired",
+			existing: deploymentWithReplicas(&three),
+			new:      deploymentWithReplicas(&two),
+			expected: true,
+		},
+		{
+			testName: "Should not update when replica counts match",
+			existing: deploymentWithReplicas(&three),
+			new:      deploymentWithReplicas(&three),
+			expected: false,
+		},
+		{
+			testName: "Should not update when desired replica count is nil",
+			existing: deploymentWithReplicas(&three),
+			new:      deploymentWithReplicas(nil),
+			expected: false,
+		},
+		{
+			testName: "Should update when existing replica count is nil but desired is set",
+			existing: deploymentWithReplicas(nil),
+			new:      deploymentWithReplicas(&two),
+			expected: true,
+		},
+		{
+			testName: "Should not update for non-Deployment objects",
+			existing: &appsv1.DaemonSet{},
+			new:      &appsv1.DaemonSet{},
+			expected: false,
+		},
+	} {
+		t.Run(test.testName, func(t *testing.T) {
+			res := needToUpdateReplicas(test.existing, test.new)
+			if res != test.expected {
+				t.Errorf("expected result: %v, but got: %v", test.expected, res)
+			}
+		})
+	}
+}
+
+func TestDeployUpdatesOnReplicaCountChange(t *testing.T) {
+	two := int32(2)
+	three := int32(3)
+
+	existing := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "csi-attacher",
+			Annotations: map[string]string{
+				AnnotationCSIGitCommit: longhornmeta.GitCommit,
+				AnnotationCSIVersion:   longhornmeta.Version,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &three,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "csi-attacher", Image: "same-image:v1"},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "csi-attacher",
+			Annotations: map[string]string{},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &two,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "csi-attacher", Image: "same-image:v1"},
+					},
+				},
+			},
+		},
+	}
+
+	createCalled := false
+	deleteCalled := false
+	updateCalled := false
+
+	fakeCreate := func(_ *clientset.Clientset, _ runtime.Object) error {
+		createCalled = true
+		return nil
+	}
+	fakeDelete := func(_ *clientset.Clientset, _, _ string) error {
+		deleteCalled = true
+		return nil
+	}
+	fakeGet := func(_ *clientset.Clientset, _, _ string) (runtime.Object, error) {
+		return existing, nil
+	}
+	fakeUpdate := func(_ *clientset.Clientset, _ runtime.Object) error {
+		updateCalled = true
+		return nil
+	}
+
+	err := deploy(nil, desired, "deployment", fakeCreate, fakeDelete, fakeGet, fakeUpdate)
+	if err != nil {
+		t.Fatalf("deploy() returned unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("expected updateFunc to be called on replica count change, but it was not")
+	}
+	if deleteCalled {
+		t.Error("expected deleteFunc NOT to be called, but it was")
+	}
+	if createCalled {
+		t.Error("expected createFunc NOT to be called, but it was")
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13461

#### What this PR does / why we need it:

The csi.*ReplicaCount Helm values only took effect when a CSI deployment was first created. deploy() short-circuited on a git-commit/version/image/anti-affinity match and never compared spec.replicas, so changing the count on a running cluster was a silent no-op. Add needToUpdateReplicas (Deployment-only, nil-safe) to the skip condition so a replica-count-only change is reconciled through the existing rolling-update path.

#### Special notes for your reviewer:

#### Additional documentation or context
