### PR TITLE
Avoid no-op backup compression method updates

### DIFF
--- a/manager/volume.go
+++ b/manager/volume.go
@@ -960,6 +960,11 @@ func (m *VolumeManager) UpdateBackupCompressionMethod(name string, value string)
 		return nil, err
 	}
 
+	if v.Spec.BackupCompressionMethod == longhorn.BackupCompressionMethod(value) {
+		logrus.Debugf("Volume %v already has backup compression method set to %v", v.Name, value)
+		return v, nil
+	}
+
 	oldValue := v.Spec.BackupCompressionMethod
 	v.Spec.BackupCompressionMethod = longhorn.BackupCompressionMethod(value)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13460

#### What this PR does / why we need it:

`UpdateBackupCompressionMethod` currently updates the Volume even when the requested backup compression method already matches `Spec.BackupCompressionMethod`.

This PR adds an early return for that unchanged-value case, matching the neighboring volume setting helpers such as `UpdateReplicaAutoBalance`, `UpdateRebuildConcurrentSyncLimit`, and `UpdateVolumeBackupTarget`.

#### Special notes for your reviewer:

This is intentionally scoped to `UpdateBackupCompressionMethod`.

#### Additional documentation or context

Validation:

```text
GOCACHE=/tmp/longhorn-go-build-cache CGO_ENABLED=0 go test ./manager
```