### PR TITLE
feat: tune host RPS to keep SPDK reactor cores off the network path

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1018,9 +1018,9 @@ func (imc *InstanceManagerController) resolveCPUIsolationEnabled(im *longhorn.In
 // setting) matches what the V2 instance-manager pod was started with. The pod
 // always receives --longhorn-control-path (so we can reconcile stale state
 // across restarts even after toggling off); the actual toggle is the presence
-// of --enable-irq-affinity AND --enable-workqueue-affinity in the pod's args.
-// Both flags are set together, so the effective state is "enabled" only when
-// both are present.
+// of --enable-irq-affinity, --enable-workqueue-affinity, AND --enable-rps in the
+// pod's args. All flags are set together, so the effective state is "enabled"
+// only when all are present.
 func (imc *InstanceManagerController) isSettingCPUIsolationEnabledSynced(setting *longhorn.Setting, im *longhorn.InstanceManager, pod *corev1.Pod) (bool, error) {
 	if types.IsDataEngineV1(im.Spec.DataEngine) {
 		return true, nil
@@ -1036,15 +1036,18 @@ func (imc *InstanceManagerController) isSettingCPUIsolationEnabledSynced(setting
 
 	hasIRQFlag := false
 	hasWorkqueueFlag := false
+	hasRPSFlag := false
 	for _, a := range pod.Spec.Containers[0].Args {
 		switch a {
 		case "--enable-irq-affinity":
 			hasIRQFlag = true
 		case "--enable-workqueue-affinity":
 			hasWorkqueueFlag = true
+		case "--enable-rps":
+			hasRPSFlag = true
 		}
 	}
-	hasEnabled := hasIRQFlag && hasWorkqueueFlag
+	hasEnabled := hasIRQFlag && hasWorkqueueFlag && hasRPSFlag
 	return wantEnabled == hasEnabled, nil
 }
 
@@ -2065,7 +2068,10 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			return nil, err
 		}
 		if cpuIsolationEnabled {
-			args = append(args, "--enable-irq-affinity", "--enable-workqueue-affinity")
+			// RPS steering shares the CPU-isolation toggle: the start-spdk-tgt script
+			// steers host IRQ, workqueue, and RX softirq (RPS) away from the SPDK
+			// reactor cores together.
+			args = append(args, "--enable-irq-affinity", "--enable-workqueue-affinity", "--enable-rps")
 		}
 
 		if !hugepageEnabled {

--- a/types/setting.go
+++ b/types/setting.go
@@ -1890,8 +1890,8 @@ var (
 
 	SettingDefinitionDataEngineCPUIsolationEnabled = SettingDefinition{
 		DisplayName: "Enable Host CPU Isolation for Data Engine",
-		Description: "Applies only to the V2 Data Engine. Steers host hardware IRQs *and* unbound kernel workqueue workers away from the CPUs used by the Storage Performance Development Kit (SPDK) target daemon, " +
-			"so that interrupt handling and deferred kernel work do not preempt SPDK polling reactors. \n\n" +
+		Description: "Applies only to the V2 Data Engine. Steers host hardware IRQs, unbound kernel workqueue workers, *and* network Receive Packet Steering (RPS) away from the CPUs used by the Storage Performance Development Kit (SPDK) target daemon, " +
+			"so that interrupt handling, deferred kernel work, and network softirq processing do not preempt SPDK polling reactors. \n\n" +
 			"  - When applying the setting, Longhorn will try to restart all V2 instance-manager pods if all volumes are detached and eventually restart the instance manager pod without instances running on the instance manager. \n\n" +
 			"  - This value can be overridden per Instance Manager via `Spec.DataEngineSpec.V2.CPUIsolationEnabled` " +
 			"(set to `\"true\"` or `\"false\"` on a specific instance manager to force the value on that node; leave empty to inherit this setting). \n\n",


### PR DESCRIPTION
Add an opt-in node network tuning component in longhorn-manager that configures host Receive Packet Steering (RPS) on the physical interfaces so RX softirq processing is steered away from the CPU cores occupied by the SPDK target reactor. This prevents kernel network processing from stealing CPU from the busy-polling reactor cores, which can degrade V2 volume I/O under network load.

- New opt-in setting `data-engine-host-network-tuning` (default false).
- New controller/networktuning package: builds the RPS complement mask from the CPU mask the running V2 Instance Manager actually applied (Status.CPUMask) and writes it to every rx queue of the host physical interfaces via the host mount+net namespaces.
- Wired into InstanceManagerController: node-local, only for a running V2 Instance Manager, re-applied when the applied mask changes, and best-effort so it never fails the sync. Skips dynamic CPU-manager pinning (empty applied mask), where the cores are not known here.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13483

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
