### PR TITLE
fix: remove limitation in NodePublishVolume for v2 volumes

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -1137,10 +1137,6 @@ func restageRequired(volume *longhornclient.Volume,
 	mounter mount.Interface,
 	isBlock, isStorageNetworkConfigured bool) (bool, error) {
 
-	if volume.DataEngine == string(longhorn.DataEngineTypeV2) {
-		return true, fmt.Errorf("always unstage v2 volume %v", volumeID)
-	}
-
 	if isStorageNetworkConfigured && volume.AccessMode == string(longhorn.AccessModeReadWriteMany) {
 		return true, fmt.Errorf("always unstage RWX volume %v when storage network is configured", volumeID)
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#13363

#### What this PR does / why we need it:

When CSI attempts to publish v2 volumes, Longhorn forcibly restages them in the previous implementation.

#### Special notes for your reviewer:

#### Additional documentation or context
