### PR TITLE
feat(disk): make v2 AIO block size configurable

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -488,6 +489,7 @@ type Node struct {
 
 type DiskStatus struct {
 	Conditions            map[string]longhorn.Condition `json:"conditions"`
+	ActualBlockSize       int64                         `json:"actualBlockSize"`
 	StorageAvailable      int64                         `json:"storageAvailable"`
 	StorageScheduled      int64                         `json:"storageScheduled"`
 	StorageMaximum        int64                         `json:"storageMaximum"`
@@ -509,6 +511,41 @@ type DiskInfo struct {
 
 type DiskUpdateInput struct {
 	Disks map[string]longhorn.DiskSpec `json:"disks"`
+
+	blockSizePresent map[string]bool
+}
+
+func (d *DiskUpdateInput) UnmarshalJSON(data []byte) error {
+	var input struct {
+		Disks map[string]json.RawMessage `json:"disks"`
+	}
+	if err := json.Unmarshal(data, &input); err != nil {
+		return err
+	}
+
+	d.Disks = make(map[string]longhorn.DiskSpec, len(input.Disks))
+	d.blockSizePresent = make(map[string]bool, len(input.Disks))
+	for diskName, rawDisk := range input.Disks {
+		var disk longhorn.DiskSpec
+		if err := json.Unmarshal(rawDisk, &disk); err != nil {
+			return err
+		}
+
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(rawDisk, &fields); err != nil {
+			return err
+		}
+		if rawBlockSize, exists := fields["blockSize"]; exists {
+			var blockSize *int64
+			if err := json.Unmarshal(rawBlockSize, &blockSize); err != nil {
+				return err
+			}
+			d.blockSizePresent[diskName] = blockSize != nil
+		}
+		d.Disks[diskName] = disk
+	}
+
+	return nil
 }
 
 type Event struct {
@@ -2333,6 +2370,7 @@ func toNodeResource(node *longhorn.Node, address string, apiContext *api.ApiCont
 		if node.Status.DiskStatus != nil && node.Status.DiskStatus[name] != nil {
 			di.DiskStatus = DiskStatus{
 				Conditions:                sliceToMap(node.Status.DiskStatus[name].Conditions),
+				ActualBlockSize:           node.Status.DiskStatus[name].ActualBlockSize,
 				StorageAvailable:          node.Status.DiskStatus[name].StorageAvailable,
 				StorageScheduled:          node.Status.DiskStatus[name].StorageScheduled,
 				StorageMaximum:            node.Status.DiskStatus[name].StorageMaximum,

--- a/api/model.go
+++ b/api/model.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -504,6 +505,7 @@ type Node struct {
 
 type DiskStatus struct {
 	Conditions            map[string]longhorn.Condition `json:"conditions"`
+	ActualBlockSize       int64                         `json:"actualBlockSize"`
 	StorageAvailable      int64                         `json:"storageAvailable"`
 	StorageScheduled      int64                         `json:"storageScheduled"`
 	StorageMaximum        int64                         `json:"storageMaximum"`
@@ -525,6 +527,41 @@ type DiskInfo struct {
 
 type DiskUpdateInput struct {
 	Disks map[string]longhorn.DiskSpec `json:"disks"`
+
+	blockSizePresent map[string]bool
+}
+
+func (d *DiskUpdateInput) UnmarshalJSON(data []byte) error {
+	var input struct {
+		Disks map[string]json.RawMessage `json:"disks"`
+	}
+	if err := json.Unmarshal(data, &input); err != nil {
+		return err
+	}
+
+	d.Disks = make(map[string]longhorn.DiskSpec, len(input.Disks))
+	d.blockSizePresent = make(map[string]bool, len(input.Disks))
+	for diskName, rawDisk := range input.Disks {
+		var disk longhorn.DiskSpec
+		if err := json.Unmarshal(rawDisk, &disk); err != nil {
+			return err
+		}
+
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(rawDisk, &fields); err != nil {
+			return err
+		}
+		if rawBlockSize, exists := fields["blockSize"]; exists {
+			var blockSize *int64
+			if err := json.Unmarshal(rawBlockSize, &blockSize); err != nil {
+				return err
+			}
+			d.blockSizePresent[diskName] = blockSize != nil
+		}
+		d.Disks[diskName] = disk
+	}
+
+	return nil
 }
 
 type Event struct {
@@ -798,7 +835,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("engineUpgradeInput", EngineUpgradeInput{})
 	schemas.AddType("replica", Replica{})
 	schemas.AddType("controller", Controller{})
-	schemas.AddType("diskUpdate", longhorn.DiskSpec{})
+	diskUpdateSchema(schemas.AddType("diskUpdate", longhorn.DiskSpec{}))
 	schemas.AddType("UpdateReplicaCountInput", UpdateReplicaCountInput{})
 	schemas.AddType("UpdateReplicaAutoBalanceInput", UpdateReplicaAutoBalanceInput{})
 	schemas.AddType("UpdateRebuildConcurrentSyncLimitInput", UpdateRebuildConcurrentSyncLimitInput{})
@@ -924,8 +961,14 @@ func nodeSchema(node *client.Schema) {
 
 func diskSchema(diskUpdateInput *client.Schema) {
 	disks := diskUpdateInput.ResourceFields["disks"]
-	disks.Type = "array[diskUpdate]"
+	disks.Type = "map[diskUpdate]"
 	diskUpdateInput.ResourceFields["disks"] = disks
+}
+
+func diskUpdateSchema(diskUpdate *client.Schema) {
+	blockSize := diskUpdate.ResourceFields["blockSize"]
+	blockSize.Nullable = true
+	diskUpdate.ResourceFields["blockSize"] = blockSize
 }
 
 func diskInfoSchema(diskInfo *client.Schema) {
@@ -2492,6 +2535,7 @@ func toNodeResource(node *longhorn.Node, address string, apiContext *api.ApiCont
 		if node.Status.DiskStatus != nil && node.Status.DiskStatus[name] != nil {
 			di.DiskStatus = DiskStatus{
 				Conditions:                sliceToMap(node.Status.DiskStatus[name].Conditions),
+				ActualBlockSize:           node.Status.DiskStatus[name].ActualBlockSize,
 				StorageAvailable:          node.Status.DiskStatus[name].StorageAvailable,
 				StorageScheduled:          node.Status.DiskStatus[name].StorageScheduled,
 				StorageMaximum:            node.Status.DiskStatus[name].StorageMaximum,

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,40 @@ import (
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
+
+func TestDiskUpdateInputTracksBlockSizePresence(t *testing.T) {
+	var input DiskUpdateInput
+	err := json.Unmarshal([]byte(`{
+		"disks": {
+			"omitted": {"diskType": "block", "path": "/dev/omitted"},
+			"null": {"diskType": "block", "path": "/dev/null", "blockSize": null},
+			"zero": {"diskType": "block", "path": "/dev/zero", "blockSize": 0},
+			"four-k": {"diskType": "block", "path": "/dev/four-k", "blockSize": 4096}
+		}
+	}`), &input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal disk update input: %v", err)
+	}
+
+	if input.blockSizePresent["omitted"] {
+		t.Fatal("expected omitted blockSize to remain absent")
+	}
+	if input.blockSizePresent["null"] {
+		t.Fatal("expected null blockSize to remain absent")
+	}
+	if !input.blockSizePresent["zero"] {
+		t.Fatal("expected explicit zero blockSize to be present")
+	}
+	if !input.blockSizePresent["four-k"] {
+		t.Fatal("expected explicit 4096 blockSize to be present")
+	}
+	if input.Disks["zero"].BlockSize != 0 {
+		t.Fatalf("expected explicit zero blockSize, got %d", input.Disks["zero"].BlockSize)
+	}
+	if input.Disks["four-k"].BlockSize != 4096 {
+		t.Fatalf("expected 4096 blockSize, got %d", input.Disks["four-k"].BlockSize)
+	}
+}
 
 func TestToVolumeResourceUsesEngineFrontendNodeForV2Controller(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/v1/volumes/test-volume", nil)

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -17,6 +17,94 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
+func TestDiskUpdateInputTracksBlockSizePresence(t *testing.T) {
+	var input DiskUpdateInput
+	err := json.Unmarshal([]byte(`{
+		"disks": {
+			"omitted": {"diskType": "block", "path": "/dev/omitted"},
+			"null": {"diskType": "block", "path": "/dev/null", "blockSize": null},
+			"zero": {"diskType": "block", "path": "/dev/zero", "blockSize": 0},
+			"four-k": {"diskType": "block", "path": "/dev/four-k", "blockSize": 4096}
+		}
+	}`), &input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal disk update input: %v", err)
+	}
+
+	if input.blockSizePresent["omitted"] {
+		t.Fatal("expected omitted blockSize to remain absent")
+	}
+	if input.blockSizePresent["null"] {
+		t.Fatal("expected null blockSize to remain absent")
+	}
+	if !input.blockSizePresent["zero"] {
+		t.Fatal("expected explicit zero blockSize to be present")
+	}
+	if !input.blockSizePresent["four-k"] {
+		t.Fatal("expected explicit 4096 blockSize to be present")
+	}
+	if input.Disks["zero"].BlockSize != 0 {
+		t.Fatalf("expected explicit zero blockSize, got %d", input.Disks["zero"].BlockSize)
+	}
+	if input.Disks["four-k"].BlockSize != 4096 {
+		t.Fatalf("expected 4096 blockSize, got %d", input.Disks["four-k"].BlockSize)
+	}
+}
+
+func TestGeneratedDiskUpdatePreservesBlockSizePresence(t *testing.T) {
+	zero := int64(0)
+	fourK := int64(4096)
+	payload, err := json.Marshal(lhclient.DiskUpdateInput{
+		Disks: map[string]lhclient.DiskUpdate{
+			"omitted": {BlockSize: nil},
+			"zero":    {BlockSize: &zero},
+			"four-k":  {BlockSize: &fourK},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal generated disk update: %v", err)
+	}
+
+	var input DiskUpdateInput
+	if err := json.Unmarshal(payload, &input); err != nil {
+		t.Fatalf("failed to unmarshal generated disk update: %v", err)
+	}
+
+	if input.blockSizePresent["omitted"] {
+		t.Fatal("expected nil generated blockSize to remain absent")
+	}
+	if !input.blockSizePresent["zero"] || input.Disks["zero"].BlockSize != 0 {
+		t.Fatalf("expected generated client to encode explicit zero, got presence %v and value %d",
+			input.blockSizePresent["zero"], input.Disks["zero"].BlockSize)
+	}
+	if !input.blockSizePresent["four-k"] || input.Disks["four-k"].BlockSize != 4096 {
+		t.Fatalf("expected generated client to encode 4096, got presence %v and value %d",
+			input.blockSizePresent["four-k"], input.Disks["four-k"].BlockSize)
+	}
+}
+
+func TestDiskUpdateSchemaMarksBlockSizeNullable(t *testing.T) {
+	schema := NewSchema().Schema("diskUpdate")
+	field := schema.Field("blockSize")
+	if field.Type != "int" {
+		t.Fatalf("expected blockSize schema type int, got %q", field.Type)
+	}
+	if !field.Nullable {
+		t.Fatal("expected blockSize schema field to be nullable")
+	}
+	if field.Required {
+		t.Fatal("expected blockSize schema field to remain optional")
+	}
+}
+
+func TestDiskUpdateInputSchemaUsesNamedMap(t *testing.T) {
+	schema := NewSchema().Schema("diskUpdateInput")
+	field := schema.Field("disks")
+	if field.Type != "map[diskUpdate]" {
+		t.Fatalf("expected disks schema type map[diskUpdate], got %q", field.Type)
+	}
+}
+
 func TestToVolumeResourceUsesEngineFrontendNodeForV2Controller(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/v1/volumes/test-volume", nil)
 	urlBuilder, err := rancherapi.NewUrlBuilder(req, &client.Schemas{})

--- a/api/node.go
+++ b/api/node.go
@@ -107,7 +107,7 @@ func (s *Server) DiskUpdate(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
-		return s.m.DiskUpdate(id, diskUpdate.Disks)
+		return s.m.DiskUpdate(id, diskUpdate.Disks, diskUpdate.blockSizePresent)
 	})
 	if err != nil {
 		return err

--- a/client/disk_update_test.go
+++ b/client/disk_update_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDiskUpdateBlockSizeJSONPresence(t *testing.T) {
+	zero := int64(0)
+	fiveTwelve := int64(512)
+	fourK := int64(4096)
+	testCases := map[string]struct {
+		blockSize *int64
+		present   bool
+		value     int64
+	}{
+		"omitted": {
+			blockSize: nil,
+		},
+		"explicit zero": {
+			blockSize: &zero,
+			present:   true,
+		},
+		"512": {
+			blockSize: &fiveTwelve,
+			present:   true,
+			value:     512,
+		},
+		"4096": {
+			blockSize: &fourK,
+			present:   true,
+			value:     4096,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(DiskUpdate{BlockSize: testCase.blockSize})
+			if err != nil {
+				t.Fatalf("failed to marshal disk update: %v", err)
+			}
+
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(data, &fields); err != nil {
+				t.Fatalf("failed to inspect disk update JSON: %v", err)
+			}
+			rawBlockSize, present := fields["blockSize"]
+			if present != testCase.present {
+				t.Fatalf("expected blockSize presence %v, got %v in %s", testCase.present, present, data)
+			}
+			if !present {
+				return
+			}
+
+			var value int64
+			if err := json.Unmarshal(rawBlockSize, &value); err != nil {
+				t.Fatalf("failed to decode blockSize: %v", err)
+			}
+			if value != testCase.value {
+				t.Fatalf("expected blockSize %d, got %d", testCase.value, value)
+			}
+
+			var roundTrip DiskUpdate
+			if err := json.Unmarshal(data, &roundTrip); err != nil {
+				t.Fatalf("failed to round-trip disk update: %v", err)
+			}
+			if roundTrip.BlockSize == nil || *roundTrip.BlockSize != testCase.value {
+				t.Fatalf("expected round-trip blockSize %d, got %v", testCase.value, roundTrip.BlockSize)
+			}
+		})
+	}
+}

--- a/client/generated_disk_info.go
+++ b/client/generated_disk_info.go
@@ -7,7 +7,11 @@ const (
 type DiskInfo struct {
 	Resource `yaml:"-"`
 
+	ActualBlockSize int64 `json:"actualBlockSize,omitempty" yaml:"actual_block_size,omitempty"`
+
 	AllowScheduling bool `json:"allowScheduling,omitempty" yaml:"allow_scheduling,omitempty"`
+
+	BlockSize int64 `json:"blockSize,omitempty" yaml:"block_size,omitempty"`
 
 	Conditions map[string]interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 

--- a/client/generated_disk_update.go
+++ b/client/generated_disk_update.go
@@ -9,6 +9,8 @@ type DiskUpdate struct {
 
 	AllowScheduling bool `json:"allowScheduling,omitempty" yaml:"allow_scheduling,omitempty"`
 
+	BlockSize int64 `json:"blockSize,omitempty" yaml:"block_size,omitempty"`
+
 	DiskDriver string `json:"diskDriver,omitempty" yaml:"disk_driver,omitempty"`
 
 	DiskType string `json:"diskType,omitempty" yaml:"disk_type,omitempty"`

--- a/client/generated_disk_update.go
+++ b/client/generated_disk_update.go
@@ -9,6 +9,8 @@ type DiskUpdate struct {
 
 	AllowScheduling bool `json:"allowScheduling,omitempty" yaml:"allow_scheduling,omitempty"`
 
+	BlockSize *int64 `json:"blockSize,omitempty" yaml:"block_size,omitempty"`
+
 	DiskDriver string `json:"diskDriver,omitempty" yaml:"disk_driver,omitempty"`
 
 	DiskType string `json:"diskType,omitempty" yaml:"disk_type,omitempty"`

--- a/client/generated_disk_update_input.go
+++ b/client/generated_disk_update_input.go
@@ -7,7 +7,7 @@ const (
 type DiskUpdateInput struct {
 	Resource `yaml:"-"`
 
-	Disks []DiskUpdate `json:"disks,omitempty" yaml:"disks,omitempty"`
+	Disks map[string]DiskUpdate `json:"disks,omitempty" yaml:"disks,omitempty"`
 }
 
 type DiskUpdateInputCollection struct {

--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -77,7 +77,7 @@ type CollectedDiskInfo struct {
 type GetDiskStatHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*lhtypes.DiskStat, error)
 type GetDiskHealthHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, time.Time, *DiskServiceClient, logrus.FieldLogger) (map[string]longhorn.HealthData, time.Time, error)
 type GetDiskConfigHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*util.DiskConfig, error)
-type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, *DiskServiceClient, *datastore.DataStore) (*util.DiskConfig, error)
+type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, int64, int64, *DiskServiceClient, *datastore.DataStore) (*util.DiskConfig, error)
 type GetReplicaDataStoresHandler func(longhorn.DiskType, *longhorn.Node, string, string, string, string, *DiskServiceClient) (map[string]string, error)
 
 func NewDiskMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, nodeName string, syncCallback func(key string)) (*DiskMonitor, error) {
@@ -302,9 +302,11 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 
 			diskUUID := ""
 			diskDriver := disk.DiskDriver
+			actualBlockSize := int64(0)
 			if node.Status.DiskStatus != nil {
 				if diskStatus, ok := node.Status.DiskStatus[diskName]; ok {
 					diskUUID = diskStatus.DiskUUID
+					actualBlockSize = diskStatus.ActualBlockSize
 					if diskStatus.DiskDriver != "" {
 						diskDriver = diskStatus.DiskDriver
 					}
@@ -316,7 +318,7 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			//   The handling of all disks containing the same fsid will be done in NodeController.
 			// Block-type disk
 			//   Create a bdev lvstore
-			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, diskUUID, disk.Path, string(diskDriver), diskServiceClient, m.ds)
+			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, diskUUID, disk.Path, string(diskDriver), disk.BlockSize, actualBlockSize, diskServiceClient, m.ds)
 			if err != nil {
 				errs.Append("errors", errors.Wrap(err, "failed to generate disk config"))
 

--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -80,7 +80,7 @@ type CollectedDiskInfo struct {
 type GetDiskStatHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*lhtypes.DiskStat, error)
 type GetDiskHealthHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, time.Time, *DiskServiceClient, logrus.FieldLogger) (map[string]longhorn.HealthData, time.Time, error)
 type GetDiskConfigHandler func(longhorn.DiskType, string, string, longhorn.DiskDriver, *DiskServiceClient) (*util.DiskConfig, error)
-type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, *DiskServiceClient, *datastore.DataStore) (*util.DiskConfig, error)
+type GenerateDiskConfigHandler func(longhorn.DiskType, string, string, string, string, int64, int64, *DiskServiceClient, *datastore.DataStore) (*util.DiskConfig, error)
 type GetReplicaDataStoresHandler func(longhorn.DiskType, *longhorn.Node, string, string, string, string, *DiskServiceClient) (map[string]string, error)
 
 func NewDiskMonitor(logger logrus.FieldLogger, ds *datastore.DataStore, nodeName string, syncCallback func(key string)) (*DiskMonitor, error) {
@@ -260,10 +260,12 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 
 		diskDriver := longhorn.DiskDriverNone
 		recordedDiskUUID := ""
+		actualBlockSize := int64(0)
 		if node.Status.DiskStatus != nil {
 			if diskStatus, ok := node.Status.DiskStatus[diskName]; ok && diskStatus != nil {
 				diskDriver = diskStatus.DiskDriver
 				recordedDiskUUID = diskStatus.DiskUUID
+				actualBlockSize = diskStatus.ActualBlockSize
 			}
 		}
 		// The recorded driver wins over the spec so that a re-creation reuses the
@@ -316,7 +318,8 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			//   The handling of all disks containing the same fsid will be done in NodeController.
 			// Block-type disk
 			//   Create a bdev lvstore
-			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path, string(requestedDiskDriver), diskServiceClient, m.ds)
+			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path,
+				string(requestedDiskDriver), disk.BlockSize, actualBlockSize, diskServiceClient, m.ds)
 			if err != nil {
 				errs.Append("errors", errors.Wrap(err, "failed to generate disk config"))
 
@@ -333,8 +336,16 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 				diskName, disk.Path, node.Name, diskConfig.Message)
 
 			previousMessage := diskConfig.Message
+			retryActualBlockSize := actualBlockSize
+			if retryActualBlockSize == 0 && disk.BlockSize == 0 && recordedDiskUUID != "" && diskConfig.DiskUUID == recordedDiskUUID {
+				// An Error-state disk retains the parameters of its failed creation.
+				// Reuse that size only for the same recorded disk; it is not persisted as
+				// observed geometry until the disk reaches Ready and DiskStat succeeds.
+				retryActualBlockSize = diskConfig.BlockSize
+			}
 
-			retriedDiskConfig, retryErr := m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path, string(requestedDiskDriver), diskServiceClient, m.ds)
+			retriedDiskConfig, retryErr := m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path,
+				string(requestedDiskDriver), disk.BlockSize, retryActualBlockSize, diskServiceClient, m.ds)
 			if retryErr != nil {
 				errs.Append("errors", errors.Wrap(retryErr, "failed to retry disk creation"))
 			} else {

--- a/controller/monitor/disk_monitor_test.go
+++ b/controller/monitor/disk_monitor_test.go
@@ -98,18 +98,26 @@ func TestCollectDiskDataRetriesFailedBlockDisk(t *testing.T) {
 	failureMessage := "unsupported disk driver vfio-pci for disk path 0000:05:00.0"
 	generateCalls := 0
 	generatedUUID, generatedDriver := "", ""
+	generatedBlockSize := int64(0)
 
 	m := newTestDiskMonitor(t,
 		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
 			return &util.DiskConfig{
-				DiskName: diskName,
-				State:    string(spdkdisk.DiskStateError),
-				Message:  failureMessage,
+				DiskName:  diskName,
+				DiskUUID:  testBlockDiskUUID,
+				State:     string(spdkdisk.DiskStateError),
+				BlockSize: 512,
+				Message:   failureMessage,
 			}, nil
 		},
-		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 			generateCalls++
 			generatedUUID, generatedDriver = diskUUID, diskDriver
+			resolvedBlockSize, err := resolveDiskBlockSize(blockSize, actualBlockSize, diskUUID != "")
+			if err != nil {
+				return nil, err
+			}
+			generatedBlockSize = resolvedBlockSize
 			// The disk service only reports the state when a creation is started.
 			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
 		},
@@ -122,6 +130,7 @@ func TestCollectDiskDataRetriesFailedBlockDisk(t *testing.T) {
 	// lvstore of the previous attempt or re-resolves a driver that is already known.
 	assert.Equal(testBlockDiskUUID, generatedUUID)
 	assert.Equal(string(longhorn.DiskDriverNvme), generatedDriver)
+	assert.Equal(int64(512), generatedBlockSize)
 
 	diskInfo, ok := diskInfoMap[testBlockDiskName]
 	assert.True(ok)
@@ -129,6 +138,69 @@ func TestCollectDiskDataRetriesFailedBlockDisk(t *testing.T) {
 	// A retry restarts from the creating state with no message, so the reason of the
 	// previous failure has to be carried over; otherwise it is never reported.
 	assert.Contains(diskInfo.Condition.Message, failureMessage)
+}
+
+func TestCollectDiskDataDoesNotTrustErrorBlockSizeFromDifferentDisk(t *testing.T) {
+	assert := require.New(t)
+
+	diskCreateCalls := 0
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName:  diskName,
+				DiskUUID:  "different-disk-uuid",
+				State:     string(spdkdisk.DiskStateError),
+				BlockSize: 4096,
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			resolvedBlockSize, err := resolveDiskBlockSize(blockSize, actualBlockSize, diskUUID != "")
+			if err != nil {
+				return nil, err
+			}
+			diskCreateCalls++
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating), BlockSize: resolvedBlockSize}, nil
+		},
+	)
+
+	diskInfo := m.collectDiskData(newTestBlockDiskNode())[testBlockDiskName]
+
+	assert.Equal(0, diskCreateCalls)
+	assert.NotNil(diskInfo.Condition)
+	assert.Contains(diskInfo.Condition.Message, "cannot determine the block size of initialized disk")
+}
+
+func TestCollectDiskDataUsesCorrectedRequestedSizeForErrorDisk(t *testing.T) {
+	assert := require.New(t)
+
+	generatedBlockSize := int64(0)
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName:  diskName,
+				DiskUUID:  testBlockDiskUUID,
+				State:     string(spdkdisk.DiskStateError),
+				BlockSize: 512,
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			resolvedBlockSize, err := resolveDiskBlockSize(blockSize, actualBlockSize, diskUUID != "")
+			if err != nil {
+				return nil, err
+			}
+			generatedBlockSize = resolvedBlockSize
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating), BlockSize: resolvedBlockSize}, nil
+		},
+	)
+
+	node := newTestBlockDiskNode()
+	disk := node.Spec.Disks[testBlockDiskName]
+	disk.BlockSize = 4096
+	node.Spec.Disks[testBlockDiskName] = disk
+
+	m.collectDiskData(node)
+
+	assert.Equal(int64(4096), generatedBlockSize)
 }
 
 // TestCollectDiskDataKeepsReportingFailureAcrossCollections covers the steady state
@@ -150,7 +222,7 @@ func TestCollectDiskDataKeepsReportingFailureAcrossCollections(t *testing.T) {
 				Message:  failureMessage,
 			}, nil
 		},
-		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 			generateCalls++
 			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
 		},
@@ -184,7 +256,7 @@ func TestCollectDiskDataDoesNotRetryReadyBlockDisk(t *testing.T) {
 				State:      string(spdkdisk.DiskStateReady),
 			}, nil
 		},
-		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 			generateCalls++
 			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
 		},
@@ -213,7 +285,7 @@ func TestCollectDiskDataToleratesNilDiskStatus(t *testing.T) {
 				State:      string(spdkdisk.DiskStateReady),
 			}, nil
 		},
-		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
 		},
 	)

--- a/controller/monitor/disk_utils.go
+++ b/controller/monitor/disk_utils.go
@@ -344,15 +344,36 @@ func getBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskPath string
 }
 
 // GenerateDiskConfig generates a disk config for the given directory
-func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	switch diskType {
 	case longhorn.DiskTypeFilesystem:
 		return generateFilesystemTypeDiskConfig(diskName, diskPath, ds)
 	case longhorn.DiskTypeBlock:
-		return generateBlockTypeDiskConfig(client, diskName, diskUUID, diskPath, diskDriver, defaultBlockSize)
+		resolvedBlockSize, err := resolveDiskBlockSize(blockSize, actualBlockSize, diskUUID != "")
+		if err != nil {
+			return nil, err
+		}
+		return generateBlockTypeDiskConfig(client, diskName, diskUUID, diskPath, diskDriver, resolvedBlockSize)
 	default:
 		return nil, fmt.Errorf("unknown disk type %v", diskType)
 	}
+}
+
+func resolveDiskBlockSize(blockSize, actualBlockSize int64, initialized bool) (int64, error) {
+	if actualBlockSize != 0 {
+		if blockSize != 0 && blockSize != actualBlockSize {
+			return 0, fmt.Errorf("configured block size %v does not match actual block size %v", blockSize, actualBlockSize)
+		}
+		return actualBlockSize, nil
+	}
+	if blockSize != 0 {
+		return blockSize, nil
+	}
+	if initialized {
+		return 0, fmt.Errorf("cannot determine the block size of initialized disk")
+	}
+
+	return defaultBlockSize, nil
 }
 
 func generateFilesystemTypeDiskConfig(diskName, diskPath string, ds *datastore.DataStore) (*util.DiskConfig, error) {

--- a/controller/monitor/disk_utils.go
+++ b/controller/monitor/disk_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -340,20 +341,48 @@ func getBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskPath string
 		DiskUUID:   info.UUID,
 		DiskDriver: longhorn.DiskDriver(info.Driver),
 		State:      info.State,
+		BlockSize:  info.BlockSize,
 		Message:    info.Message,
 	}, nil
 }
 
 // GenerateDiskConfig generates a disk config for the given directory
-func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+func generateDiskConfig(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	switch diskType {
 	case longhorn.DiskTypeFilesystem:
 		return generateFilesystemTypeDiskConfig(diskName, diskPath, ds)
 	case longhorn.DiskTypeBlock:
-		return generateBlockTypeDiskConfig(client, diskName, diskUUID, diskPath, diskDriver, defaultBlockSize)
+		resolvedBlockSize, err := resolveDiskBlockSize(blockSize, actualBlockSize, diskUUID != "")
+		if err != nil {
+			return nil, err
+		}
+		return generateBlockTypeDiskConfig(client, diskName, diskUUID, diskPath, diskDriver, resolvedBlockSize)
 	default:
 		return nil, fmt.Errorf("unknown disk type %v", diskType)
 	}
+}
+
+func resolveDiskBlockSize(blockSize, actualBlockSize int64, initialized bool) (int64, error) {
+	if blockSize != 0 && !types.IsSupportedV2BlockSize(blockSize) {
+		return 0, fmt.Errorf("configured block size %v is not supported", blockSize)
+	}
+	if actualBlockSize != 0 && !types.IsSupportedV2BlockSize(actualBlockSize) {
+		return 0, fmt.Errorf("actual block size %v is not supported", actualBlockSize)
+	}
+	if actualBlockSize != 0 {
+		if blockSize != 0 && blockSize != actualBlockSize {
+			return 0, fmt.Errorf("configured block size %v does not match actual block size %v", blockSize, actualBlockSize)
+		}
+		return actualBlockSize, nil
+	}
+	if blockSize != 0 {
+		return blockSize, nil
+	}
+	if initialized {
+		return 0, fmt.Errorf("cannot determine the block size of initialized disk")
+	}
+
+	return defaultBlockSize, nil
 }
 
 func generateFilesystemTypeDiskConfig(diskName, diskPath string, ds *datastore.DataStore) (*util.DiskConfig, error) {
@@ -432,6 +461,7 @@ func generateBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskUUID, 
 		DiskUUID:   info.UUID,
 		DiskDriver: longhorn.DiskDriver(info.Driver),
 		State:      info.State,
+		BlockSize:  info.BlockSize,
 		Message:    info.Message,
 	}, nil
 }

--- a/controller/monitor/disk_utils_test.go
+++ b/controller/monitor/disk_utils_test.go
@@ -1,0 +1,68 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveDiskBlockSize(t *testing.T) {
+	testCases := map[string]struct {
+		blockSize       int64
+		actualBlockSize int64
+		initialized     bool
+		expected        int64
+		expectError     bool
+	}{
+		"unset uses default": {
+			blockSize: 0,
+			expected:  defaultBlockSize,
+		},
+		"explicit 512 is preserved": {
+			blockSize: 512,
+			expected:  512,
+		},
+		"explicit 4096 is preserved": {
+			blockSize: 4096,
+			expected:  4096,
+		},
+		"initialized legacy disk uses actual size": {
+			actualBlockSize: 4096,
+			initialized:     true,
+			expected:        4096,
+		},
+		"matching explicit and actual size is preserved": {
+			blockSize:       4096,
+			actualBlockSize: 4096,
+			initialized:     true,
+			expected:        4096,
+		},
+		"explicit and actual size mismatch fails closed": {
+			blockSize:       512,
+			actualBlockSize: 4096,
+			initialized:     true,
+			expectError:     true,
+		},
+		"mismatch fails closed before UUID status is recorded": {
+			blockSize:       4096,
+			actualBlockSize: 512,
+			expectError:     true,
+		},
+		"initialized disk without an observed size is not guessed": {
+			initialized: true,
+			expectError: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := resolveDiskBlockSize(testCase.blockSize, testCase.actualBlockSize, testCase.initialized)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/controller/monitor/disk_utils_test.go
+++ b/controller/monitor/disk_utils_test.go
@@ -1,0 +1,77 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveDiskBlockSize(t *testing.T) {
+	testCases := map[string]struct {
+		blockSize       int64
+		actualBlockSize int64
+		initialized     bool
+		expected        int64
+		expectError     bool
+	}{
+		"unset uses default": {
+			blockSize: 0,
+			expected:  defaultBlockSize,
+		},
+		"explicit 512 is preserved": {
+			blockSize: 512,
+			expected:  512,
+		},
+		"explicit 4096 is preserved": {
+			blockSize: 4096,
+			expected:  4096,
+		},
+		"initialized legacy disk uses actual size": {
+			actualBlockSize: 4096,
+			initialized:     true,
+			expected:        4096,
+		},
+		"matching explicit and actual size is preserved": {
+			blockSize:       4096,
+			actualBlockSize: 4096,
+			initialized:     true,
+			expected:        4096,
+		},
+		"explicit and actual size mismatch fails closed": {
+			blockSize:       512,
+			actualBlockSize: 4096,
+			initialized:     true,
+			expectError:     true,
+		},
+		"mismatch fails closed before UUID status is recorded": {
+			blockSize:       4096,
+			actualBlockSize: 512,
+			expectError:     true,
+		},
+		"initialized disk without an observed size is not guessed": {
+			initialized: true,
+			expectError: true,
+		},
+		"unsupported configured size fails closed": {
+			blockSize:   1024,
+			expectError: true,
+		},
+		"unsupported actual size fails closed": {
+			actualBlockSize: 1024,
+			initialized:     true,
+			expectError:     true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := resolveDiskBlockSize(testCase.blockSize, testCase.actualBlockSize, testCase.initialized)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/controller/monitor/fake_disk_monitor.go
+++ b/controller/monitor/fake_disk_monitor.go
@@ -108,7 +108,7 @@ func fakeGetDiskConfig(diskType longhorn.DiskType, name, path string, diskDriver
 	}
 }
 
-func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	return &util.DiskConfig{
 		DiskName: name,
 		DiskUUID: TestDiskID1,

--- a/controller/monitor/fake_disk_monitor.go
+++ b/controller/monitor/fake_disk_monitor.go
@@ -79,7 +79,7 @@ func fakeGetDiskStat(diskType longhorn.DiskType, name, directory string, diskDri
 			Driver:      "",
 			FreeBlocks:  0,
 			TotalBlocks: 0,
-			BlockSize:   0,
+			BlockSize:   defaultBlockSize,
 
 			StorageMaximum:   0,
 			StorageAvailable: 0,
@@ -108,7 +108,7 @@ func fakeGetDiskConfig(diskType longhorn.DiskType, name, path string, diskDriver
 	}
 }
 
-func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+func fakeGenerateDiskConfig(diskType longhorn.DiskType, name, uuid, path, diskDriver string, blockSize, actualBlockSize int64, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
 	return &util.DiskConfig{
 		DiskName: name,
 		DiskUUID: TestDiskID1,

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -828,6 +828,18 @@ func (nc *NodeController) findNotReadyAndReadyDiskMaps(node *longhorn.Node, coll
 			}
 		}
 
+		diskSpec := node.Spec.Disks[diskName]
+		if diskSpec.Type == longhorn.DiskTypeBlock && diskSpec.BlockSize != 0 && diskInfo.DiskStat != nil && diskInfo.DiskStat.BlockSize != diskSpec.BlockSize {
+			node.Status.DiskStatus[diskName].ActualBlockSize = diskInfo.DiskStat.BlockSize
+			notReadyDiskInfoMap[diskID][diskName] =
+				monitor.NewDiskInfo(diskInfo.DiskName, diskInfo.DiskUUID, diskInfo.Path, diskInfo.DiskDriver,
+					diskInfo.NodeOrDiskEvicted, diskInfo.DiskStat, diskInfo.OrphanedReplicaDataStores,
+					diskInfo.InstanceManagerName, string(longhorn.DiskConditionReasonDiskBlockSizeMismatch),
+					fmt.Sprintf("Disk %v(%v) on node %v is not ready: configured block size %v does not match actual block size %v",
+						diskName, diskInfo.Path, node.Name, diskSpec.BlockSize, diskInfo.DiskStat.BlockSize))
+			continue
+		}
+
 		diskIDDiskGroupMap[diskID][diskName] = diskInfo
 	}
 
@@ -896,6 +908,9 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 			diskStatus.StorageAvailable = usableStorage
 			diskStatus.StorageMaximum = diskInfoMap[diskName].DiskStat.StorageMaximum
 			diskStatus.InstanceManagerName = diskInfoMap[diskName].InstanceManagerName
+			if diskStatus.Type == longhorn.DiskTypeBlock {
+				diskStatus.ActualBlockSize = diskInfoMap[diskName].DiskStat.BlockSize
+			}
 
 			if monitorDiskHealth {
 				diskStatus.HealthData = info.HealthData

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -830,6 +830,29 @@ func (nc *NodeController) findNotReadyAndReadyDiskMaps(node *longhorn.Node, coll
 			}
 		}
 
+		diskSpec := node.Spec.Disks[diskName]
+		if diskSpec.Type == longhorn.DiskTypeBlock && diskInfo.DiskStat != nil {
+			node.Status.DiskStatus[diskName].ActualBlockSize = diskInfo.DiskStat.BlockSize
+			if !types.IsSupportedV2BlockSize(diskInfo.DiskStat.BlockSize) {
+				notReadyDiskInfoMap[diskID][diskName] =
+					monitor.NewDiskInfo(diskInfo.DiskName, diskInfo.DiskUUID, diskInfo.Path, diskInfo.DiskDriver,
+						diskInfo.NodeOrDiskEvicted, diskInfo.DiskStat, diskInfo.OrphanedReplicaDataStores,
+						diskInfo.InstanceManagerName, string(longhorn.DiskConditionReasonDiskBlockSizeUnsupported),
+						fmt.Sprintf("Disk %v(%v) on node %v is not ready: actual block size %v is not supported",
+							diskName, diskInfo.Path, node.Name, diskInfo.DiskStat.BlockSize))
+				continue
+			}
+		}
+		if diskSpec.Type == longhorn.DiskTypeBlock && diskSpec.BlockSize != 0 && diskInfo.DiskStat != nil && diskInfo.DiskStat.BlockSize != diskSpec.BlockSize {
+			notReadyDiskInfoMap[diskID][diskName] =
+				monitor.NewDiskInfo(diskInfo.DiskName, diskInfo.DiskUUID, diskInfo.Path, diskInfo.DiskDriver,
+					diskInfo.NodeOrDiskEvicted, diskInfo.DiskStat, diskInfo.OrphanedReplicaDataStores,
+					diskInfo.InstanceManagerName, string(longhorn.DiskConditionReasonDiskBlockSizeMismatch),
+					fmt.Sprintf("Disk %v(%v) on node %v is not ready: configured block size %v does not match actual block size %v",
+						diskName, diskInfo.Path, node.Name, diskSpec.BlockSize, diskInfo.DiskStat.BlockSize))
+			continue
+		}
+
 		diskIDDiskGroupMap[diskID][diskName] = diskInfo
 	}
 
@@ -898,6 +921,9 @@ func (nc *NodeController) updateReadyDiskStatusReadyCondition(node *longhorn.Nod
 			diskStatus.StorageAvailable = usableStorage
 			diskStatus.StorageMaximum = diskInfoMap[diskName].DiskStat.StorageMaximum
 			diskStatus.InstanceManagerName = diskInfoMap[diskName].InstanceManagerName
+			if diskStatus.Type == longhorn.DiskTypeBlock {
+				diskStatus.ActualBlockSize = diskInfoMap[diskName].DiskStat.BlockSize
+			}
 
 			if monitorDiskHealth {
 				diskStatus.HealthData = info.HealthData

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -22,6 +22,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
 
+	lhtypes "github.com/longhorn/go-common-libs/types"
+
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
@@ -647,6 +649,106 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 	}
 
 	s.checkOrphans(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestUpdateReadyBlockDiskStatusRecordsActualBlockSize(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {
+					DiskUUID: "disk-uuid",
+					Type:     longhorn.DiskTypeBlock,
+				},
+			},
+		},
+	}
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskUUID: "disk-uuid",
+			DiskStat: &lhtypes.DiskStat{BlockSize: 4096},
+		},
+	}
+
+	s.controller.updateReadyDiskStatusReadyCondition(node, diskInfoMap, false)
+
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(4096))
+}
+
+func (s *NodeControllerSuite) TestBlockDiskBlockSizeMismatchIsNotReady(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				diskName: {
+					Type:      longhorn.DiskTypeBlock,
+					BlockSize: 4096,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskName: diskName,
+			DiskUUID: "disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    "disk-id",
+				BlockSize: 512,
+			},
+		},
+	}
+
+	notReady, ready := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady["disk-id"][diskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskBlockSizeMismatch))
+	c.Assert(ready["disk-id"], HasLen, 0)
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(512))
+}
+
+func (s *NodeControllerSuite) TestBlockDiskUUIDMismatchDoesNotOverwriteActualBlockSize(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				diskName: {
+					Type:      longhorn.DiskTypeBlock,
+					BlockSize: 4096,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {
+					DiskUUID:        "recorded-disk-uuid",
+					ActualBlockSize: 4096,
+				},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskName: diskName,
+			DiskUUID: "replacement-disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    "disk-id",
+				BlockSize: 512,
+			},
+		},
+	}
+
+	notReady, _ := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady["disk-id"][diskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskFilesystemChanged))
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(4096))
 }
 
 func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -22,6 +22,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
 
+	lhtypes "github.com/longhorn/go-common-libs/types"
+
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
@@ -647,6 +649,201 @@ func (s *NodeControllerSuite) TestUpdateDiskStatus(c *C) {
 	}
 
 	s.checkOrphans(c, expectation)
+}
+
+func (s *NodeControllerSuite) TestUpdateReadyBlockDiskStatusRecordsActualBlockSize(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {
+					DiskUUID: "disk-uuid",
+					Type:     longhorn.DiskTypeBlock,
+				},
+			},
+		},
+	}
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskUUID: "disk-uuid",
+			DiskStat: &lhtypes.DiskStat{BlockSize: 4096},
+		},
+	}
+
+	s.controller.updateReadyDiskStatusReadyCondition(node, diskInfoMap, false)
+
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(4096))
+}
+
+func (s *NodeControllerSuite) TestBlockDiskBlockSizeMismatchIsNotReady(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				diskName: {
+					Type:      longhorn.DiskTypeBlock,
+					BlockSize: 4096,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskName: diskName,
+			DiskUUID: "disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    "disk-id",
+				BlockSize: 512,
+			},
+		},
+	}
+
+	notReady, ready := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady["disk-id"][diskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskBlockSizeMismatch))
+	c.Assert(ready["disk-id"], HasLen, 0)
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(512))
+}
+
+func (s *NodeControllerSuite) TestBlockDiskUnsupportedBlockSizeIsNotReady(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				diskName: {Type: longhorn.DiskTypeBlock},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskName: diskName,
+			DiskUUID: "disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    "disk-id",
+				BlockSize: 1024,
+			},
+		},
+	}
+
+	notReady, ready := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady["disk-id"][diskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskBlockSizeUnsupported))
+	c.Assert(ready["disk-id"], HasLen, 0)
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(1024))
+}
+
+func (s *NodeControllerSuite) TestDuplicateBlockDiskRecordsActualBlockSizeBeforeNotReadyFiltering(c *C) {
+	const (
+		readyDiskName     = "ready-block-disk"
+		duplicateDiskName = "duplicate-block-disk"
+		diskID            = "shared-disk-id"
+	)
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				readyDiskName: {
+					Type: longhorn.DiskTypeBlock,
+				},
+				duplicateDiskName: {
+					Type: longhorn.DiskTypeBlock,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				readyDiskName: {
+					DiskUUID: "ready-disk-uuid",
+					Conditions: []longhorn.Condition{
+						newNodeCondition(longhorn.DiskConditionTypeReady, longhorn.ConditionStatusTrue, ""),
+					},
+				},
+				duplicateDiskName: {
+					DiskUUID: "duplicate-disk-uuid",
+				},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		readyDiskName: {
+			DiskName: readyDiskName,
+			DiskUUID: "ready-disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    diskID,
+				BlockSize: 4096,
+			},
+		},
+		duplicateDiskName: {
+			DiskName: duplicateDiskName,
+			DiskUUID: "duplicate-disk-uuid",
+			Path:     "/dev/loop1",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    diskID,
+				BlockSize: 4096,
+			},
+		},
+	}
+
+	notReady, ready := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady[diskID][duplicateDiskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskFilesystemChanged))
+	c.Assert(ready[diskID], HasLen, 1)
+	c.Assert(ready[diskID][readyDiskName], NotNil)
+	c.Assert(node.Status.DiskStatus[duplicateDiskName].ActualBlockSize, Equals, int64(4096))
+}
+
+func (s *NodeControllerSuite) TestBlockDiskUUIDMismatchDoesNotOverwriteActualBlockSize(c *C) {
+	const diskName = "block-disk"
+	node := &longhorn.Node{
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				diskName: {
+					Type:      longhorn.DiskTypeBlock,
+					BlockSize: 4096,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				diskName: {
+					DiskUUID:        "recorded-disk-uuid",
+					ActualBlockSize: 4096,
+				},
+			},
+		},
+	}
+	node.Name = "node-1"
+	diskInfoMap := map[string]*monitor.CollectedDiskInfo{
+		diskName: {
+			DiskName: diskName,
+			DiskUUID: "replacement-disk-uuid",
+			Path:     "/dev/loop0",
+			DiskStat: &lhtypes.DiskStat{
+				DiskID:    "disk-id",
+				BlockSize: 512,
+			},
+		},
+	}
+
+	notReady, _ := s.controller.findNotReadyAndReadyDiskMaps(node, diskInfoMap)
+
+	c.Assert(notReady["disk-id"][diskName].Condition.Reason, Equals, string(longhorn.DiskConditionReasonDiskFilesystemChanged))
+	c.Assert(node.Status.DiskStatus[diskName].ActualBlockSize, Equals, int64(4096))
 }
 
 func (s *NodeControllerSuite) TestCleanDiskStatus(c *C) {

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2480,6 +2480,17 @@ spec:
                   properties:
                     allowScheduling:
                       type: boolean
+                    blockSize:
+                      description: |-
+                        BlockSize is the block size in bytes for an AIO-backed block disk. Supported values are 512 and 4096.
+                        A value of 0 uses the default block size of 512 bytes.
+                        The effective block size is immutable after the disk is initialized.
+                      enum:
+                      - 0
+                      - 512
+                      - 4096
+                      format: int64
+                      type: integer
                     diskDriver:
                       enum:
                       - ""
@@ -2555,6 +2566,11 @@ spec:
               diskStatus:
                 additionalProperties:
                   properties:
+                    actualBlockSize:
+                      description: ActualBlockSize is the block size in bytes reported
+                        by an initialized block disk.
+                      format: int64
+                      type: integer
                     conditions:
                       items:
                         properties:

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2495,6 +2495,17 @@ spec:
                   properties:
                     allowScheduling:
                       type: boolean
+                    blockSize:
+                      description: |-
+                        BlockSize is the block size in bytes for an AIO-backed block disk. Supported values are 512 and 4096.
+                        A value of 0 uses the default block size of 512 bytes.
+                        The effective block size is immutable after the disk is initialized.
+                      enum:
+                      - 0
+                      - 512
+                      - 4096
+                      format: int64
+                      type: integer
                     diskDriver:
                       enum:
                       - ""
@@ -2570,6 +2581,11 @@ spec:
               diskStatus:
                 additionalProperties:
                   properties:
+                    actualBlockSize:
+                      description: ActualBlockSize is the block size in bytes reported
+                        by an initialized block disk.
+                      format: int64
+                      type: integer
                     conditions:
                       items:
                         properties:

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -42,6 +42,7 @@ const (
 
 const (
 	DiskConditionReasonDiskPressure           = "DiskPressure"
+	DiskConditionReasonDiskBlockSizeMismatch  = "DiskBlockSizeMismatch"
 	DiskConditionReasonDiskFilesystemChanged  = "DiskFilesystemChanged"
 	DiskConditionReasonNoDiskInfo             = "NoDiskInfo"
 	DiskConditionReasonDiskNotReady           = "DiskNotReady"
@@ -166,6 +167,12 @@ type DiskSpec struct {
 	// +kubebuilder:validation:Enum="";auto;aio;nvme
 	// +optional
 	DiskDriver DiskDriver `json:"diskDriver"`
+	// BlockSize is the block size in bytes for an AIO-backed block disk. Supported values are 512 and 4096.
+	// A value of 0 uses the default block size of 512 bytes.
+	// The effective block size is immutable after the disk is initialized.
+	// +kubebuilder:validation:Enum=0;512;4096
+	// +optional
+	BlockSize int64 `json:"blockSize"`
 	// +optional
 	AllowScheduling bool `json:"allowScheduling"`
 	// +optional
@@ -202,6 +209,9 @@ type DiskStatus struct {
 	Type DiskType `json:"diskType"`
 	// +optional
 	DiskDriver DiskDriver `json:"diskDriver"`
+	// ActualBlockSize is the block size in bytes reported by an initialized block disk.
+	// +optional
+	ActualBlockSize int64 `json:"actualBlockSize"`
 	// +optional
 	FSType string `json:"filesystemType"`
 	// +optional

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -41,12 +41,14 @@ const (
 )
 
 const (
-	DiskConditionReasonDiskPressure           = "DiskPressure"
-	DiskConditionReasonDiskFilesystemChanged  = "DiskFilesystemChanged"
-	DiskConditionReasonNoDiskInfo             = "NoDiskInfo"
-	DiskConditionReasonDiskNotReady           = "DiskNotReady"
-	DiskConditionReasonDiskServiceUnreachable = "DiskServiceUnreachable"
-	DiskConditionReasonNodeNotReady           = "NodeNotReady"
+	DiskConditionReasonDiskPressure             = "DiskPressure"
+	DiskConditionReasonDiskBlockSizeMismatch    = "DiskBlockSizeMismatch"
+	DiskConditionReasonDiskBlockSizeUnsupported = "DiskBlockSizeUnsupported"
+	DiskConditionReasonDiskFilesystemChanged    = "DiskFilesystemChanged"
+	DiskConditionReasonNoDiskInfo               = "NoDiskInfo"
+	DiskConditionReasonDiskNotReady             = "DiskNotReady"
+	DiskConditionReasonDiskServiceUnreachable   = "DiskServiceUnreachable"
+	DiskConditionReasonNodeNotReady             = "NodeNotReady"
 )
 
 const (
@@ -167,6 +169,12 @@ type DiskSpec struct {
 	// +kubebuilder:validation:Enum="";auto;aio;nvme
 	// +optional
 	DiskDriver DiskDriver `json:"diskDriver"`
+	// BlockSize is the block size in bytes for an AIO-backed block disk. Supported values are 512 and 4096.
+	// A value of 0 uses the default block size of 512 bytes.
+	// The effective block size is immutable after the disk is initialized.
+	// +kubebuilder:validation:Enum=0;512;4096
+	// +optional
+	BlockSize int64 `json:"blockSize"`
 	// +optional
 	AllowScheduling bool `json:"allowScheduling"`
 	// +optional
@@ -203,6 +211,9 @@ type DiskStatus struct {
 	Type DiskType `json:"diskType"`
 	// +optional
 	DiskDriver DiskDriver `json:"diskDriver"`
+	// ActualBlockSize is the block size in bytes reported by an initialized block disk.
+	// +optional
+	ActualBlockSize int64 `json:"actualBlockSize"`
 	// +optional
 	FSType string `json:"filesystemType"`
 	// +optional

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/diskspec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/diskspec.go
@@ -25,13 +25,17 @@ import (
 // DiskSpecApplyConfiguration represents a declarative configuration of the DiskSpec type for use
 // with apply.
 type DiskSpecApplyConfiguration struct {
-	Type              *longhornv1beta2.DiskType   `json:"diskType,omitempty"`
-	Path              *string                     `json:"path,omitempty"`
-	DiskDriver        *longhornv1beta2.DiskDriver `json:"diskDriver,omitempty"`
-	AllowScheduling   *bool                       `json:"allowScheduling,omitempty"`
-	EvictionRequested *bool                       `json:"evictionRequested,omitempty"`
-	StorageReserved   *int64                      `json:"storageReserved,omitempty"`
-	Tags              []string                    `json:"tags,omitempty"`
+	Type       *longhornv1beta2.DiskType   `json:"diskType,omitempty"`
+	Path       *string                     `json:"path,omitempty"`
+	DiskDriver *longhornv1beta2.DiskDriver `json:"diskDriver,omitempty"`
+	// BlockSize is the block size in bytes for an AIO-backed block disk. Supported values are 512 and 4096.
+	// A value of 0 uses the default block size of 512 bytes.
+	// The effective block size is immutable after the disk is initialized.
+	BlockSize         *int64   `json:"blockSize,omitempty"`
+	AllowScheduling   *bool    `json:"allowScheduling,omitempty"`
+	EvictionRequested *bool    `json:"evictionRequested,omitempty"`
+	StorageReserved   *int64   `json:"storageReserved,omitempty"`
+	Tags              []string `json:"tags,omitempty"`
 }
 
 // DiskSpecApplyConfiguration constructs a declarative configuration of the DiskSpec type for use with
@@ -61,6 +65,14 @@ func (b *DiskSpecApplyConfiguration) WithPath(value string) *DiskSpecApplyConfig
 // If called multiple times, the DiskDriver field is set to the value of the last call.
 func (b *DiskSpecApplyConfiguration) WithDiskDriver(value longhornv1beta2.DiskDriver) *DiskSpecApplyConfiguration {
 	b.DiskDriver = &value
+	return b
+}
+
+// WithBlockSize sets the BlockSize field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the BlockSize field is set to the value of the last call.
+func (b *DiskSpecApplyConfiguration) WithBlockSize(value int64) *DiskSpecApplyConfiguration {
+	b.BlockSize = &value
 	return b
 }
 

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/diskstatus.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/diskstatus.go
@@ -26,17 +26,19 @@ import (
 // DiskStatusApplyConfiguration represents a declarative configuration of the DiskStatus type for use
 // with apply.
 type DiskStatusApplyConfiguration struct {
-	Conditions                []ConditionApplyConfiguration           `json:"conditions,omitempty"`
-	StorageAvailable          *int64                                  `json:"storageAvailable,omitempty"`
-	StorageScheduled          *int64                                  `json:"storageScheduled,omitempty"`
-	StorageMaximum            *int64                                  `json:"storageMaximum,omitempty"`
-	ScheduledReplica          map[string]int64                        `json:"scheduledReplica,omitempty"`
-	ScheduledBackingImage     map[string]int64                        `json:"scheduledBackingImage,omitempty"`
-	DiskUUID                  *string                                 `json:"diskUUID,omitempty"`
-	DiskName                  *string                                 `json:"diskName,omitempty"`
-	DiskPath                  *string                                 `json:"diskPath,omitempty"`
-	Type                      *longhornv1beta2.DiskType               `json:"diskType,omitempty"`
-	DiskDriver                *longhornv1beta2.DiskDriver             `json:"diskDriver,omitempty"`
+	Conditions            []ConditionApplyConfiguration `json:"conditions,omitempty"`
+	StorageAvailable      *int64                        `json:"storageAvailable,omitempty"`
+	StorageScheduled      *int64                        `json:"storageScheduled,omitempty"`
+	StorageMaximum        *int64                        `json:"storageMaximum,omitempty"`
+	ScheduledReplica      map[string]int64              `json:"scheduledReplica,omitempty"`
+	ScheduledBackingImage map[string]int64              `json:"scheduledBackingImage,omitempty"`
+	DiskUUID              *string                       `json:"diskUUID,omitempty"`
+	DiskName              *string                       `json:"diskName,omitempty"`
+	DiskPath              *string                       `json:"diskPath,omitempty"`
+	Type                  *longhornv1beta2.DiskType     `json:"diskType,omitempty"`
+	DiskDriver            *longhornv1beta2.DiskDriver   `json:"diskDriver,omitempty"`
+	// ActualBlockSize is the block size in bytes reported by an initialized block disk.
+	ActualBlockSize           *int64                                  `json:"actualBlockSize,omitempty"`
 	FSType                    *string                                 `json:"filesystemType,omitempty"`
 	InstanceManagerName       *string                                 `json:"instanceManagerName,omitempty"`
 	HealthData                map[string]HealthDataApplyConfiguration `json:"healthData,omitempty"`
@@ -151,6 +153,14 @@ func (b *DiskStatusApplyConfiguration) WithType(value longhornv1beta2.DiskType) 
 // If called multiple times, the DiskDriver field is set to the value of the last call.
 func (b *DiskStatusApplyConfiguration) WithDiskDriver(value longhornv1beta2.DiskDriver) *DiskStatusApplyConfiguration {
 	b.DiskDriver = &value
+	return b
+}
+
+// WithActualBlockSize sets the ActualBlockSize field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActualBlockSize field is set to the value of the last call.
+func (b *DiskStatusApplyConfiguration) WithActualBlockSize(value int64) *DiskStatusApplyConfiguration {
+	b.ActualBlockSize = &value
 	return b
 }
 

--- a/manager/node.go
+++ b/manager/node.go
@@ -99,13 +99,13 @@ func (m *VolumeManager) ListNodesSorted() ([]*longhorn.Node, error) {
 	return nodes, nil
 }
 
-func (m *VolumeManager) DiskUpdate(name string, updateDisks map[string]longhorn.DiskSpec) (*longhorn.Node, error) {
+func (m *VolumeManager) DiskUpdate(name string, updateDisks map[string]longhorn.DiskSpec, blockSizePresent map[string]bool) (*longhorn.Node, error) {
 	node, err := m.ds.GetNode(name)
 	if err != nil {
 		return nil, err
 	}
 
-	node.Spec.Disks = updateDisks
+	node.Spec.Disks = mergeOmittedDiskBlockSizes(node, updateDisks, blockSizePresent)
 
 	node, err = m.ds.UpdateNode(node)
 	if err != nil {
@@ -113,6 +113,18 @@ func (m *VolumeManager) DiskUpdate(name string, updateDisks map[string]longhorn.
 	}
 	logrus.Infof("Updated node disks of %v to %+v", name, node.Spec.Disks)
 	return node, nil
+}
+
+func mergeOmittedDiskBlockSizes(node *longhorn.Node, updateDisks map[string]longhorn.DiskSpec, blockSizePresent map[string]bool) map[string]longhorn.DiskSpec {
+	mergedDisks := make(map[string]longhorn.DiskSpec, len(updateDisks))
+	for diskName, updateDisk := range updateDisks {
+		currentDisk, exists := node.Spec.Disks[diskName]
+		if exists && currentDisk.Type == longhorn.DiskTypeBlock && currentDisk.BlockSize != 0 && !blockSizePresent[diskName] {
+			updateDisk.BlockSize = currentDisk.BlockSize
+		}
+		mergedDisks[diskName] = updateDisk
+	}
+	return mergedDisks
 }
 
 func (m *VolumeManager) DeleteNode(name string) error {

--- a/manager/node_test.go
+++ b/manager/node_test.go
@@ -1,0 +1,71 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func TestMergeOmittedDiskBlockSizes(t *testing.T) {
+	testCases := map[string]struct {
+		currentBlockSize int64
+		updatedBlockSize int64
+		blockSizePresent bool
+		diskUUID         string
+		expected         int64
+	}{
+		"older client omission preserves initialized disk": {
+			currentBlockSize: 4096,
+			diskUUID:         "disk-uuid",
+			expected:         4096,
+		},
+		"older client omission preserves uninitialized disk": {
+			currentBlockSize: 4096,
+			expected:         4096,
+		},
+		"explicit zero may clear uninitialized requested size": {
+			currentBlockSize: 4096,
+			blockSizePresent: true,
+			expected:         0,
+		},
+		"explicit update is preserved": {
+			currentBlockSize: 512,
+			updatedBlockSize: 4096,
+			blockSizePresent: true,
+			expected:         4096,
+		},
+		"omission keeps zero default": {
+			expected: 0,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			node := &longhorn.Node{
+				Spec: longhorn.NodeSpec{
+					Disks: map[string]longhorn.DiskSpec{
+						"disk-1": {Type: longhorn.DiskTypeBlock, BlockSize: testCase.currentBlockSize},
+					},
+				},
+				Status: longhorn.NodeStatus{
+					DiskStatus: map[string]*longhorn.DiskStatus{
+						"disk-1": {DiskUUID: testCase.diskUUID},
+					},
+				},
+			}
+			updates := map[string]longhorn.DiskSpec{
+				"disk-1": {BlockSize: testCase.updatedBlockSize},
+			}
+			blockSizePresent := map[string]bool{
+				"disk-1": testCase.blockSizePresent,
+			}
+
+			merged := mergeOmittedDiskBlockSizes(node, updates, blockSizePresent)
+
+			assert.Equal(t, testCase.expected, merged["disk-1"].BlockSize)
+			assert.Equal(t, testCase.updatedBlockSize, updates["disk-1"].BlockSize, "merge must not mutate retry input")
+		})
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1405,7 +1405,7 @@ func UnmarshalToNodeTags(s string) ([]string, error) {
 }
 
 func IsBDF(addr string) bool {
-	bdfFormat := "[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}"
+	bdfFormat := "^[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}$"
 	bdfPattern := regexp.MustCompile(bdfFormat)
 	return bdfPattern.MatchString(addr)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1510,6 +1510,11 @@ func IsPotentialBlockDisk(path string) bool {
 	return false
 }
 
+// IsSupportedV2BlockSize reports whether Longhorn supports the logical block size for V2 data paths.
+func IsSupportedV2BlockSize(blockSize int64) bool {
+	return blockSize == 512 || blockSize == 4096
+}
+
 func CreateDefaultDisk(dataPath string, storageReservedPercentage int64) (map[string]longhorn.DiskSpec, error) {
 	if IsPotentialBlockDisk(dataPath) {
 		return map[string]longhorn.DiskSpec{

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -75,6 +75,19 @@ func (s *TestSuite) TestGetLonghornControlPath(c *C) {
 	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
 }
 
+func (s *TestSuite) TestUnmarshalToDisksPreservesBlockSize(c *C) {
+	disks, err := UnmarshalToDisks(`[{"name":"disk-1","path":"/dev/nvme0n1","diskType":"block","diskDriver":"aio","blockSize":4096}]`)
+	c.Assert(err, IsNil)
+	c.Assert(disks, HasLen, 1)
+	c.Assert(disks[0].BlockSize, Equals, int64(4096))
+}
+
+func (s *TestSuite) TestIsBDFMatchesOnlyPCIAddresses(c *C) {
+	c.Assert(IsBDF("0000:00:1f.3"), Equals, true)
+	c.Assert(IsBDF("/dev/disk/by-path/pci-0000:00:1f.3-nvme-1"), Equals, false)
+	c.Assert(IsBDF("0000:00:1f.3-extra"), Equals, false)
+}
+
 func (s *TestSuite) TestContainerPathHelpersUseReplicaHostPrefix(c *C) {
 	customPath := "/control/longhorn"
 	image := "longhornio/longhorn-engine:v1.9.0"

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -31,6 +31,13 @@ func (s *TestSuite) SetUpTest(c *C) {
 	logrus.SetLevel(logrus.DebugLevel)
 }
 
+func (s *TestSuite) TestUnmarshalToDisksPreservesBlockSize(c *C) {
+	disks, err := UnmarshalToDisks(`[{"name":"disk-1","path":"/dev/nvme0n1","diskType":"block","diskDriver":"aio","blockSize":4096}]`)
+	c.Assert(err, IsNil)
+	c.Assert(disks, HasLen, 1)
+	c.Assert(disks[0].BlockSize, Equals, int64(4096))
+}
+
 func (s *TestSuite) TestParseToleration(c *C) {
 	type testCase struct {
 		input string

--- a/util/util.go
+++ b/util/util.go
@@ -651,6 +651,8 @@ type DiskConfig struct {
 	DiskUUID   string              `json:"diskUUID"`
 	DiskDriver longhorn.DiskDriver `json:"diskDriver"`
 	State      string              `json:"state"`
+	// BlockSize is reported by the V2 disk service and is never persisted.
+	BlockSize int64 `json:"-"`
 	// Message is never persisted; it only carries the reason of the current state.
 	Message string `json:"-"`
 }

--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -63,6 +63,10 @@ func (n *nodeValidator) Create(request *admission.Request, newObj runtime.Object
 	}
 
 	for name, disk := range node.Spec.Disks {
+		if err := validateDiskBlockSize(name, disk); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+
 		if !v2DataEngineEnabled {
 			if disk.Type == longhorn.DiskTypeBlock {
 				return werror.NewInvalidError(fmt.Sprintf("disk %v type %v is not supported since v2 data engine is disabled", name, disk.Type), "")
@@ -171,6 +175,10 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 
 	// Validate Disks StorageReserved, Tags and Type
 	for name, disk := range newNode.Spec.Disks {
+		if err := validateDiskBlockSize(name, disk); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+
 		if disk.StorageReserved < 0 {
 			return werror.NewInvalidError(fmt.Sprintf("update disk on node %v error: The storageReserved setting of disk %v(%v) is not valid, should be positive and no more than storageMaximum and storageAvailable",
 				newNode.Name, name, disk.Path), "")
@@ -215,8 +223,71 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 			}
 		}
 	}
+	if err := validateDiskBlockSizeUpdate(oldNode, newNode); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
 
 	return nil
+}
+
+func validateDiskBlockSize(diskName string, disk longhorn.DiskSpec) error {
+	if disk.BlockSize == 0 {
+		return nil
+	}
+	if disk.BlockSize != 512 && disk.BlockSize != 4096 {
+		return fmt.Errorf("disk %v block size %v is invalid; supported values are 0, 512, and 4096", diskName, disk.BlockSize)
+	}
+
+	if disk.Type != longhorn.DiskTypeBlock {
+		return fmt.Errorf("disk %v type %v does not support a configurable block size", diskName, disk.Type)
+	}
+
+	if disk.DiskDriver != longhorn.DiskDriverNone && disk.DiskDriver != longhorn.DiskDriverAuto && disk.DiskDriver != longhorn.DiskDriverAio {
+		return fmt.Errorf("disk %v driver %v does not support a configurable block size", diskName, disk.DiskDriver)
+	}
+	if disk.DiskDriver == longhorn.DiskDriverAuto && types.IsBDF(disk.Path) {
+		return fmt.Errorf("disk %v uses a PCI address with the auto driver, which does not support a configurable block size", diskName)
+	}
+
+	return nil
+}
+
+func validateDiskBlockSizeUpdate(oldNode, newNode *longhorn.Node) error {
+	for diskName, oldDisk := range oldNode.Spec.Disks {
+		newDisk, exists := newNode.Spec.Disks[diskName]
+		if !exists || oldDisk.Type != longhorn.DiskTypeBlock {
+			continue
+		}
+		if oldDisk.BlockSize == newDisk.BlockSize {
+			continue
+		}
+
+		oldDiskStatus, exists := oldNode.Status.DiskStatus[diskName]
+		if !exists || oldDiskStatus == nil || oldDiskStatus.DiskUUID == "" {
+			continue
+		}
+
+		if oldDiskStatus.ActualBlockSize == 0 {
+			if oldDisk.BlockSize == 0 &&
+				types.GetCondition(oldDiskStatus.Conditions, longhorn.DiskConditionTypeReady).Status != longhorn.ConditionStatusTrue {
+				continue
+			}
+			return fmt.Errorf("update disk on node %v error: The actual block size of initialized disk %v(%v) is not available", newNode.Name, diskName, oldDisk.Path)
+		}
+		if effectiveDiskBlockSize(newDisk.BlockSize) != oldDiskStatus.ActualBlockSize {
+			return fmt.Errorf("update disk on node %v error: The block size of initialized disk %v(%v) is not allowed to change", newNode.Name, diskName, oldDisk.Path)
+		}
+	}
+
+	return nil
+}
+
+func effectiveDiskBlockSize(blockSize int64) int64 {
+	if blockSize == 0 {
+		return 512
+	}
+
+	return blockSize
 }
 
 func validateNodeDiskPaths(nodeName string, disks map[string]longhorn.DiskSpec) error {

--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -64,6 +64,10 @@ func (n *nodeValidator) Create(request *admission.Request, newObj runtime.Object
 	}
 
 	for name, disk := range node.Spec.Disks {
+		if err := validateDiskBlockSize(name, disk); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+
 		if !v2DataEngineEnabled {
 			if disk.Type == longhorn.DiskTypeBlock {
 				return werror.NewInvalidError(fmt.Sprintf("disk %v type %v is not supported since v2 data engine is disabled", name, disk.Type), "")
@@ -196,6 +200,10 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 
 	// Validate Disks StorageReserved, Tags and Type
 	for name, disk := range newNode.Spec.Disks {
+		if err := validateDiskBlockSize(name, disk); err != nil {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+
 		if disk.StorageReserved < 0 {
 			return werror.NewInvalidError(fmt.Sprintf("update disk on node %v error: The storageReserved setting of disk %v(%v) is not valid, should be positive and no more than storageMaximum and storageAvailable",
 				newNode.Name, name, disk.Path), "")
@@ -243,8 +251,71 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 			}
 		}
 	}
+	if err := validateDiskBlockSizeUpdate(oldNode, newNode); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
 
 	return nil
+}
+
+func validateDiskBlockSize(diskName string, disk longhorn.DiskSpec) error {
+	if disk.BlockSize == 0 {
+		return nil
+	}
+	if !types.IsSupportedV2BlockSize(disk.BlockSize) {
+		return fmt.Errorf("disk %v block size %v is invalid; supported values are 0, 512, and 4096", diskName, disk.BlockSize)
+	}
+
+	if disk.Type != longhorn.DiskTypeBlock {
+		return fmt.Errorf("disk %v type %v does not support a configurable block size", diskName, disk.Type)
+	}
+
+	if disk.DiskDriver != longhorn.DiskDriverNone && disk.DiskDriver != longhorn.DiskDriverAuto && disk.DiskDriver != longhorn.DiskDriverAio {
+		return fmt.Errorf("disk %v driver %v does not support a configurable block size", diskName, disk.DiskDriver)
+	}
+	if disk.DiskDriver == longhorn.DiskDriverAuto && types.IsBDF(disk.Path) {
+		return fmt.Errorf("disk %v uses a PCI address with the auto driver, which does not support a configurable block size", diskName)
+	}
+
+	return nil
+}
+
+func validateDiskBlockSizeUpdate(oldNode, newNode *longhorn.Node) error {
+	for diskName, oldDisk := range oldNode.Spec.Disks {
+		newDisk, exists := newNode.Spec.Disks[diskName]
+		if !exists || oldDisk.Type != longhorn.DiskTypeBlock {
+			continue
+		}
+		if oldDisk.BlockSize == newDisk.BlockSize {
+			continue
+		}
+
+		oldDiskStatus, exists := oldNode.Status.DiskStatus[diskName]
+		if !exists || oldDiskStatus == nil || oldDiskStatus.DiskUUID == "" {
+			continue
+		}
+
+		if oldDiskStatus.ActualBlockSize == 0 {
+			if oldDisk.BlockSize == 0 &&
+				types.GetCondition(oldDiskStatus.Conditions, longhorn.DiskConditionTypeReady).Status != longhorn.ConditionStatusTrue {
+				continue
+			}
+			return fmt.Errorf("update disk on node %v error: The actual block size of initialized disk %v(%v) is not available", newNode.Name, diskName, oldDisk.Path)
+		}
+		if effectiveDiskBlockSize(newDisk.BlockSize) != oldDiskStatus.ActualBlockSize {
+			return fmt.Errorf("update disk on node %v error: The block size of initialized disk %v(%v) is not allowed to change", newNode.Name, diskName, oldDisk.Path)
+		}
+	}
+
+	return nil
+}
+
+func effectiveDiskBlockSize(blockSize int64) int64 {
+	if blockSize == 0 {
+		return 512
+	}
+
+	return blockSize
 }
 
 func validateNodeDiskPaths(nodeName string, disks map[string]longhorn.DiskSpec) error {

--- a/webhook/resources/node/validator_test.go
+++ b/webhook/resources/node/validator_test.go
@@ -54,3 +54,167 @@ func TestFilepathCleanWithBDF(t *testing.T) {
 	cleaned := filepath.Clean(input)
 	assert.Equal(t, "00:1f.3", cleaned, "filepath.Clean should not alter BDF paths")
 }
+
+func TestValidateDiskBlockSize(t *testing.T) {
+	testCases := map[string]struct {
+		disk        longhorn.DiskSpec
+		expectError bool
+	}{
+		"unset filesystem block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeFilesystem},
+		},
+		"unset block disk block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAuto},
+		},
+		"512 byte AIO block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 512},
+		},
+		"4096 byte block size with auto driver": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+		},
+		"4096 byte block size before driver defaulting": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverNone, BlockSize: 4096},
+		},
+		"filesystem with explicit block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeFilesystem, BlockSize: 4096},
+			expectError: true,
+		},
+		"NVMe driver with explicit block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverNvme, BlockSize: 4096},
+			expectError: true,
+		},
+		"1024 byte AIO block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 1024},
+			expectError: true,
+		},
+		"auto driver with PCI address": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, Path: "0000:00:1f.3", DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+			expectError: true,
+		},
+		"auto driver with stable device path": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, Path: "/dev/disk/by-path/pci-0000:00:1f.3-nvme-1", DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+		},
+		"non-power-of-two block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 513},
+			expectError: true,
+		},
+		"negative block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: -1},
+			expectError: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateDiskBlockSize("disk-1", testCase.disk)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateDiskBlockSizeUpdate(t *testing.T) {
+	testCases := map[string]struct {
+		oldBlockSize    int64
+		newBlockSize    int64
+		diskUUID        string
+		actualBlockSize int64
+		readyStatus     longhorn.ConditionStatus
+		expectError     bool
+	}{
+		"unset and 512 are equivalent": {
+			oldBlockSize:    0,
+			newBlockSize:    512,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+		},
+		"512 and unset are equivalent": {
+			oldBlockSize:    512,
+			newBlockSize:    0,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+		},
+		"legacy 4096 byte disk can record its actual block size": {
+			oldBlockSize:    0,
+			newBlockSize:    4096,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 4096,
+		},
+		"initialized disk block size is immutable": {
+			oldBlockSize:    512,
+			newBlockSize:    4096,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+			expectError:     true,
+		},
+		"legacy initialized not-ready disk with unknown actual block size can be asserted": {
+			oldBlockSize: 0,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			readyStatus:  longhorn.ConditionStatusFalse,
+		},
+		"legacy initialized ready disk with unknown actual block size cannot be asserted": {
+			oldBlockSize: 0,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			readyStatus:  longhorn.ConditionStatusTrue,
+			expectError:  true,
+		},
+		"explicit initialized disk with unknown actual block size cannot change": {
+			oldBlockSize: 512,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			expectError:  true,
+		},
+		"uninitialized disk block size may change": {
+			oldBlockSize: 512,
+			newBlockSize: 4096,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			oldNode := &longhorn.Node{
+				Spec: longhorn.NodeSpec{
+					Disks: map[string]longhorn.DiskSpec{
+						"disk-1": {
+							Type:      longhorn.DiskTypeBlock,
+							Path:      "/dev/nvme0n1",
+							BlockSize: testCase.oldBlockSize,
+						},
+					},
+				},
+				Status: longhorn.NodeStatus{
+					DiskStatus: map[string]*longhorn.DiskStatus{
+						"disk-1": {
+							DiskUUID:        testCase.diskUUID,
+							ActualBlockSize: testCase.actualBlockSize,
+							Conditions: []longhorn.Condition{
+								{
+									Type:   longhorn.DiskConditionTypeReady,
+									Status: testCase.readyStatus,
+								},
+							},
+						},
+					},
+				},
+			}
+			oldNode.Name = "node-1"
+
+			newNode := oldNode.DeepCopy()
+			newDisk := newNode.Spec.Disks["disk-1"]
+			newDisk.BlockSize = testCase.newBlockSize
+			newNode.Spec.Disks["disk-1"] = newDisk
+
+			err := validateDiskBlockSizeUpdate(oldNode, newNode)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/webhook/resources/node/validator_test.go
+++ b/webhook/resources/node/validator_test.go
@@ -217,6 +217,67 @@ func TestNodeValidatorUpdateLostKubernetesNode(t *testing.T) {
 	}
 }
 
+func TestValidateDiskBlockSize(t *testing.T) {
+	testCases := map[string]struct {
+		disk        longhorn.DiskSpec
+		expectError bool
+	}{
+		"unset filesystem block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeFilesystem},
+		},
+		"unset block disk block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAuto},
+		},
+		"512 byte AIO block size": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 512},
+		},
+		"4096 byte block size with auto driver": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+		},
+		"4096 byte block size before driver defaulting": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverNone, BlockSize: 4096},
+		},
+		"filesystem with explicit block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeFilesystem, BlockSize: 4096},
+			expectError: true,
+		},
+		"NVMe driver with explicit block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverNvme, BlockSize: 4096},
+			expectError: true,
+		},
+		"1024 byte AIO block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 1024},
+			expectError: true,
+		},
+		"auto driver with PCI address": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, Path: "0000:00:1f.3", DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+			expectError: true,
+		},
+		"auto driver with stable device path": {
+			disk: longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, Path: "/dev/disk/by-path/pci-0000:00:1f.3-nvme-1", DiskDriver: longhorn.DiskDriverAuto, BlockSize: 4096},
+		},
+		"non-power-of-two block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: 513},
+			expectError: true,
+		},
+		"negative block size": {
+			disk:        longhorn.DiskSpec{Type: longhorn.DiskTypeBlock, DiskDriver: longhorn.DiskDriverAio, BlockSize: -1},
+			expectError: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateDiskBlockSize("disk-1", testCase.disk)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func newNodeValidatorForTest(kubeClient *kubefake.Clientset) *nodeValidator {
 	lhClient := lhfake.NewClientset()
 	extensionsClient := apiextensionsfake.NewSimpleClientset()
@@ -246,4 +307,107 @@ func newNodeValidatorUpdate() (*longhorn.Node, *longhorn.Node) {
 		},
 	}
 	return oldNode, oldNode.DeepCopy()
+}
+
+func TestValidateDiskBlockSizeUpdate(t *testing.T) {
+	testCases := map[string]struct {
+		oldBlockSize    int64
+		newBlockSize    int64
+		diskUUID        string
+		actualBlockSize int64
+		readyStatus     longhorn.ConditionStatus
+		expectError     bool
+	}{
+		"unset and 512 are equivalent": {
+			oldBlockSize:    0,
+			newBlockSize:    512,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+		},
+		"512 and unset are equivalent": {
+			oldBlockSize:    512,
+			newBlockSize:    0,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+		},
+		"legacy 4096 byte disk can record its actual block size": {
+			oldBlockSize:    0,
+			newBlockSize:    4096,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 4096,
+		},
+		"initialized disk block size is immutable": {
+			oldBlockSize:    512,
+			newBlockSize:    4096,
+			diskUUID:        "disk-uuid",
+			actualBlockSize: 512,
+			expectError:     true,
+		},
+		"legacy initialized not-ready disk with unknown actual block size can be asserted": {
+			oldBlockSize: 0,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			readyStatus:  longhorn.ConditionStatusFalse,
+		},
+		"legacy initialized ready disk with unknown actual block size cannot be asserted": {
+			oldBlockSize: 0,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			readyStatus:  longhorn.ConditionStatusTrue,
+			expectError:  true,
+		},
+		"explicit initialized disk with unknown actual block size cannot change": {
+			oldBlockSize: 512,
+			newBlockSize: 4096,
+			diskUUID:     "disk-uuid",
+			expectError:  true,
+		},
+		"uninitialized disk block size may change": {
+			oldBlockSize: 512,
+			newBlockSize: 4096,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			oldNode := &longhorn.Node{
+				Spec: longhorn.NodeSpec{
+					Disks: map[string]longhorn.DiskSpec{
+						"disk-1": {
+							Type:      longhorn.DiskTypeBlock,
+							Path:      "/dev/nvme0n1",
+							BlockSize: testCase.oldBlockSize,
+						},
+					},
+				},
+				Status: longhorn.NodeStatus{
+					DiskStatus: map[string]*longhorn.DiskStatus{
+						"disk-1": {
+							DiskUUID:        testCase.diskUUID,
+							ActualBlockSize: testCase.actualBlockSize,
+							Conditions: []longhorn.Condition{
+								{
+									Type:   longhorn.DiskConditionTypeReady,
+									Status: testCase.readyStatus,
+								},
+							},
+						},
+					},
+				},
+			}
+			oldNode.Name = "node-1"
+
+			newNode := oldNode.DeepCopy()
+			newDisk := newNode.Spec.Disks["disk-1"]
+			newDisk.BlockSize = testCase.newBlockSize
+			newNode.Spec.Disks["disk-1"] = newDisk
+
+			err := validateDiskBlockSizeUpdate(oldNode, newNode)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#10745

LEP: longhorn/longhorn#13584

#### What this PR does / why we need it:

I ran into this with a 4Kn NVMe device used as an AIO-backed V2 disk. The manager always sends a 512-byte block size to the disk service. SPDK detects the device's 4096-byte logical block size, rejects the smaller value, and the disk never becomes ready.

This patch adds the disk-side foundation for configurable logical block sizes:

- `DiskSpec.blockSize` accepts 512 or 4096 for an AIO-backed block disk. Leaving it unset keeps the current 512-byte default.
- `DiskStatus.actualBlockSize` records what an initialized V2 block disk reports, including non-AIO disks whose size comes from hardware.
- An initialized legacy disk with an unset spec reuses its observed size after an instance-manager restart instead of being forced back to 512.
- An explicit requested/actual mismatch, unknown initialized geometry, or unsupported observed size keeps the disk NotReady.
- The webhook prevents effective size changes after initialization and handles stable `/dev/disk/by-path/...` device names correctly.
- Older REST disk-map updates preserve an existing nonzero value when `blockSize` is omitted, while an explicit JSON value remains distinguishable.
- The disk-update action schema now matches its map-shaped wire API, so the generated client can preserve disk names and explicit zero values.
- The default-disks-config annotation, CRD, apply configuration, and generated clients carry the new fields.

The default remains 512. This preserves the behavior introduced by longhorn/longhorn#10053 and longhorn-manager#3403.

#### Special notes for your reviewer:

This remains a draft because configuring disks alone is not a complete safety contract. SPDK RAID cannot combine base devices with different logical block sizes, while the current replica and EC shard schedulers do not model that property.

The LEP proposes an immutable V2 volume block size, exact matching against observed disk status, and enforcement across initial placement, rebuild, failed-replica reuse, eviction, auto-balance, clone, backup/restore, DR, and EC shards. It also covers API/UI compatibility and upgrade behavior.

Current master retries creation for a V2 block disk in `Error`, reusing its recorded UUID and driver. This branch carries the block size through that retry, reuses Error-state request metadata only for the same recorded UUID, and otherwise fails closed. The remaining implementation must also pin an observed legacy AIO size into the spec so a cold instance-manager restart cannot lose the only known geometry.

V2 backing-image support has been removed since v1.12 and is not reintroduced by this work.

#### Additional documentation or context

Checks at `fa70f34ac`:

- `make ci` and the full race-enabled `make test` pass in the fork workflow: https://github.com/christophersherman/longhorn-manager/actions/runs/33912195103
- Focused Linux tests, race tests, Linux/amd64 `go vet`, `gofmt`, and `git diff --check` pass.
- The workflow's later image-publish job cannot log in to Docker Hub because the fork does not have the repository's publish credentials.
- A synthetic 4Kn loop device reported a 4096-byte logical sector through `blockdev`; 4096-byte direct I/O succeeded and 512-byte direct I/O was rejected. This validates the planned E2E fixture, not the Longhorn data path itself.

Physical 4Kn hardware, mixed-size scheduling, restart/rebuild, and full cluster E2E tests remain pending on the LEP and companion implementation.
