### PR TITLE
fix(setting): support configurable default control path and BDF as default data path

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -311,6 +311,10 @@ func startManager(cmd *cli.Command) error {
 		return err
 	}
 
+	if err := clients.Datastore.ValidateCustomizedDefaultDataAndControlPathSettings(); err != nil {
+		return err
+	}
+
 	// Leader-elected periodic webhook cert rotation; only the leader writes.
 	go webhookcert.RotateLoop(ctx, clients.K8s, clients.Namespace, currentNodeID)
 

--- a/app/pre_upgrade.go
+++ b/app/pre_upgrade.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -114,7 +115,7 @@ func (u *preUpgrader) Run() error {
 		}
 	}()
 
-	if err = upgradeutil.CheckUpgradePath(u.namespace, u.lhClient, u.eventRecorder, true); err != nil {
+	if err = upgradeutil.CheckUpgradePath(u.namespace, u.lhClient, u.eventRecorder, true, os.Getenv(types.LonghornControlPathEnv)); err != nil {
 		return err
 	}
 

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -229,8 +229,13 @@ func getLoggerForBackingImageDataSource(logger logrus.FieldLogger, bids *longhor
 
 func (c *BackingImageDataSourceController) getEngineClientProxy(e *longhorn.Engine) (engineapi.EngineClientProxy, error) {
 	engineCollection := &engineapi.EngineCollection{}
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
 	engineCliClient, err := engineCollection.NewEngineClient(&engineapi.EngineClientRequest{
 		EngineImage: e.Status.CurrentImage,
+		ControlPath: controlPath,
 		VolumeName:  e.Spec.VolumeName,
 		IP:          e.Status.IP,
 		Port:        e.Status.Port,

--- a/controller/backing_image_data_source_controller.go
+++ b/controller/backing_image_data_source_controller.go
@@ -229,8 +229,13 @@ func getLoggerForBackingImageDataSource(logger logrus.FieldLogger, bids *longhor
 
 func (c *BackingImageDataSourceController) getEngineClientProxy(e *longhorn.Engine) (engineapi.EngineClientProxy, error) {
 	engineCollection := &engineapi.EngineCollection{}
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 	engineCliClient, err := engineCollection.NewEngineClient(&engineapi.EngineClientRequest{
 		EngineImage: e.Status.CurrentImage,
+		ControlPath: controlPath,
 		VolumeName:  e.Spec.VolumeName,
 		IP:          e.Status.IP,
 		Port:        e.Status.Port,

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -708,7 +708,11 @@ func (bc *BackupController) getEngineBinaryClient(volumeName string) (*engineapi
 	if engine == nil {
 		return nil, fmt.Errorf("cannot get the client since the engine is nil")
 	}
-	return GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage)
+	controlPath, err := bc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+	return GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage, controlPath)
 }
 
 // validateBackingImageChecksum validates backing image checksum

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -753,7 +753,7 @@ func (bc *BackupController) getEngineBinaryClient(volumeName string) (*engineapi
 	if engine == nil {
 		return nil, fmt.Errorf("cannot get the client since the engine is nil")
 	}
-	return GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage)
+	return GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage, bc.ds)
 }
 
 // validateBackingImageChecksum validates backing image checksum

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -306,8 +306,12 @@ func newBackupTargetClient(ds *datastore.DataStore, backupTarget *longhorn.Backu
 		return nil, err
 	}
 	timeout := time.Duration(executeTimeout) * time.Minute
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
 
-	return engineapi.NewBackupTargetClient(engineImage, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
+	return engineapi.NewBackupTargetClient(engineImage, controlPath, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
 }
 
 func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backupTarget *longhorn.BackupTarget) (*engineapi.BackupTargetClient, error) {

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -314,8 +314,7 @@ func newBackupTargetClient(ds *datastore.DataStore, backupTarget *longhorn.Backu
 		return nil, err
 	}
 	timeout := time.Duration(executeTimeout) * time.Minute
-
-	return engineapi.NewBackupTargetClient(engineImage, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
+	return engineapi.NewBackupTargetClient(engineImage, ds, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
 }
 
 func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backupTarget *longhorn.BackupTarget) (*engineapi.BackupTargetClient, error) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	. "gopkg.in/check.v1"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/controller"
@@ -26,8 +28,6 @@ import (
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-
-	. "gopkg.in/check.v1"
 )
 
 const (
@@ -625,11 +625,11 @@ func randomPort() int {
 	return rand.Int() % 30000
 }
 
-func fakeEngineBinaryChecker(image string) (bool, error) {
+func fakeEngineBinaryChecker(image, controlPath string) (bool, error) {
 	return true, nil
 }
 
-func fakeEngineImageUpdater(ei *longhorn.EngineImage) error {
+func fakeEngineImageUpdater(ei *longhorn.EngineImage, controlPath string) error {
 	return nil
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	. "gopkg.in/check.v1"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/controller"
@@ -22,12 +24,11 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-
-	. "gopkg.in/check.v1"
 )
 
 const (
@@ -625,11 +626,11 @@ func randomPort() int {
 	return rand.Int() % 30000
 }
 
-func fakeEngineBinaryChecker(image string) (bool, error) {
+func fakeEngineBinaryChecker(image string, ds *datastore.DataStore) (bool, error) {
 	return true, nil
 }
 
-func fakeEngineImageUpdater(ei *longhorn.EngineImage) error {
+func fakeEngineImageUpdater(ei *longhorn.EngineImage, ds *datastore.DataStore) error {
 	return nil
 }
 

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -259,7 +259,11 @@ func getLoggerForEngine(logger logrus.FieldLogger, e *longhorn.Engine) *logrus.E
 }
 
 func (ec *EngineController) getEngineClientProxy(e *longhorn.Engine, image string) (engineapi.EngineClientProxy, error) {
-	engineCliClient, err := GetBinaryClientForEngine(e, ec.engines, image)
+	controlPath, err := ec.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+	engineCliClient, err := GetBinaryClientForEngine(e, ec.engines, image, controlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1030,11 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		addressReplicaMap[address] = replica
 	}
 
-	engineCliClient, err := GetBinaryClientForEngine(engine, m.engines, engine.Status.CurrentImage)
+	controlPath, err := m.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+	engineCliClient, err := GetBinaryClientForEngine(engine, m.engines, engine.Status.CurrentImage, controlPath)
 	if err != nil {
 		return err
 	}
@@ -2031,7 +2039,7 @@ func (ec *EngineController) ReconcileEngineState(e *longhorn.Engine) error {
 	return nil
 }
 
-func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClientCollection, image string) (client *engineapi.EngineBinary, err error) {
+func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClientCollection, image, controlPath string) (client *engineapi.EngineBinary, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "cannot get client for engine %v", e.Name)
 	}()
@@ -2053,6 +2061,7 @@ func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClient
 	client, err = engines.NewEngineClient(&engineapi.EngineClientRequest{
 		VolumeName:   e.Spec.VolumeName,
 		EngineImage:  image,
+		ControlPath:  controlPath,
 		IP:           e.Status.IP,
 		Port:         e.Status.Port,
 		InstanceName: e.Name,

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -259,7 +259,7 @@ func getLoggerForEngine(logger logrus.FieldLogger, e *longhorn.Engine) *logrus.E
 }
 
 func (ec *EngineController) getEngineClientProxy(e *longhorn.Engine, image string) (engineapi.EngineClientProxy, error) {
-	engineCliClient, err := GetBinaryClientForEngine(e, ec.engines, image)
+	engineCliClient, err := GetBinaryClientForEngine(e, ec.engines, image, ec.ds)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1026,7 @@ func (m *EngineMonitor) refresh(engine *longhorn.Engine) error {
 		addressReplicaMap[address] = replica
 	}
 
-	engineCliClient, err := GetBinaryClientForEngine(engine, m.engines, engine.Status.CurrentImage)
+	engineCliClient, err := GetBinaryClientForEngine(engine, m.engines, engine.Status.CurrentImage, m.ds)
 	if err != nil {
 		return err
 	}
@@ -2068,7 +2068,7 @@ func (ec *EngineController) ReconcileEngineState(e *longhorn.Engine) error {
 	return nil
 }
 
-func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClientCollection, image string) (client *engineapi.EngineBinary, err error) {
+func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClientCollection, image string, ds *datastore.DataStore) (client *engineapi.EngineBinary, err error) {
 	defer func() {
 		err = errors.Wrapf(err, "cannot get client for engine %v", e.Name)
 	}()
@@ -2086,10 +2086,15 @@ func GetBinaryClientForEngine(e *longhorn.Engine, engines engineapi.EngineClient
 	if e.Status.IP == "" || e.Status.Port == 0 {
 		return nil, fmt.Errorf("require IP and Port")
 	}
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 
 	client, err = engines.NewEngineClient(&engineapi.EngineClientRequest{
 		VolumeName:   e.Spec.VolumeName,
 		EngineImage:  image,
+		ControlPath:  controlPath,
 		IP:           e.Status.IP,
 		Port:         e.Status.Port,
 		InstanceName: e.Name,

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -58,8 +58,8 @@ type EngineImageController struct {
 
 	// for unit test
 	nowHandler                func() string
-	engineBinaryChecker       func(string) (bool, error)
-	engineImageVersionUpdater func(*longhorn.EngineImage) error
+	engineBinaryChecker       func(string, string) (bool, error)
+	engineImageVersionUpdater func(*longhorn.EngineImage, string) error
 }
 
 func NewEngineImageController(
@@ -87,7 +87,7 @@ func NewEngineImageController(
 		ds: ds,
 
 		nowHandler:                util.Now,
-		engineBinaryChecker:       types.EngineBinaryExistOnHostForImage,
+		engineBinaryChecker:       types.EngineBinaryExistOnHostForImageWithControlPath,
 		engineImageVersionUpdater: updateEngineImageVersion,
 	}
 
@@ -321,14 +321,19 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 		return err
 	}
 
-	ok, err := ic.engineBinaryChecker(engineImage.Spec.Image)
+	controlPath, err := ic.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+
+	ok, err := ic.engineBinaryChecker(controlPath, engineImage.Spec.Image)
 	if !ok {
 		engineImage.Status.Conditions = types.SetCondition(engineImage.Status.Conditions, longhorn.EngineImageConditionTypeReady, longhorn.ConditionStatusFalse, longhorn.EngineImageConditionTypeReadyReasonDaemonSet, errors.Errorf("engine binary check failed: %v", err).Error())
 		engineImage.Status.State = longhorn.EngineImageStateDeploying
 		return nil
 	}
 
-	if err := ic.engineImageVersionUpdater(engineImage); err != nil {
+	if err := ic.engineImageVersionUpdater(engineImage, controlPath); err != nil {
 		return err
 	}
 
@@ -548,11 +553,12 @@ func (ic *EngineImageController) canDoLiveEngineImageUpgrade(v *longhorn.Volume,
 	return true
 }
 
-func updateEngineImageVersion(ei *longhorn.EngineImage) error {
+func updateEngineImageVersion(ei *longhorn.EngineImage, controlPath string) error {
 	engineCollection := &engineapi.EngineCollection{}
 	// we're getting local longhorn engine version, don't need volume etc
 	client, err := engineCollection.NewEngineClient(&engineapi.EngineClientRequest{
 		EngineImage: ei.Spec.Image,
+		ControlPath: controlPath,
 		VolumeName:  "",
 		IP:          "",
 		Port:        0,
@@ -795,6 +801,10 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 	if err != nil {
 		return nil, err
 	}
+	controlPath, err := ic.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
 
 	d := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -873,7 +883,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 							Name: "data",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: types.GetEngineBinaryDirectoryOnHostForImage(image),
+									Path: types.GetEngineBinaryDirectoryOnHostForImageWithControlPath(controlPath, image),
 								},
 							},
 						},

--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -59,8 +61,8 @@ type EngineImageController struct {
 
 	// for unit test
 	nowHandler                func() string
-	engineBinaryChecker       func(string) (bool, error)
-	engineImageVersionUpdater func(*longhorn.EngineImage) error
+	engineBinaryChecker       func(string, *datastore.DataStore) (bool, error)
+	engineImageVersionUpdater func(*longhorn.EngineImage, *datastore.DataStore) error
 }
 
 func NewEngineImageController(
@@ -88,7 +90,7 @@ func NewEngineImageController(
 		ds: ds,
 
 		nowHandler:                util.Now,
-		engineBinaryChecker:       types.EngineBinaryExistOnHostForImage,
+		engineBinaryChecker:       engineBinaryExists,
 		engineImageVersionUpdater: updateEngineImageVersion,
 	}
 
@@ -337,14 +339,14 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 		return err
 	}
 
-	ok, err := ic.engineBinaryChecker(engineImage.Spec.Image)
+	ok, err := ic.engineBinaryChecker(engineImage.Spec.Image, ic.ds)
 	if !ok {
 		engineImage.Status.Conditions = types.SetCondition(engineImage.Status.Conditions, longhorn.EngineImageConditionTypeReady, longhorn.ConditionStatusFalse, longhorn.EngineImageConditionTypeReadyReasonDaemonSet, errors.Errorf("engine binary check failed: %v", err).Error())
 		engineImage.Status.State = longhorn.EngineImageStateDeploying
 		return nil
 	}
 
-	if err := ic.engineImageVersionUpdater(engineImage); err != nil {
+	if err := ic.engineImageVersionUpdater(engineImage, ic.ds); err != nil {
 		return err
 	}
 
@@ -589,11 +591,32 @@ func (ic *EngineImageController) canDoLiveEngineImageUpgrade(v *longhorn.Volume,
 	return true
 }
 
-func updateEngineImageVersion(ei *longhorn.EngineImage) error {
+func engineBinaryExists(image string, ds *datastore.DataStore) (bool, error) {
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return false, err
+	}
+	engineBinaryPath := filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(image, controlPath), types.EngineBinaryName)
+	st, err := os.Stat(engineBinaryPath)
+	if err != nil {
+		return false, err
+	}
+	if st.IsDir() {
+		return false, fmt.Errorf("engine binary path %v is a directory", engineBinaryPath)
+	}
+	return true, nil
+}
+
+func updateEngineImageVersion(ei *longhorn.EngineImage, ds *datastore.DataStore) error {
 	engineCollection := &engineapi.EngineCollection{}
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 	// we're getting local longhorn engine version, don't need volume etc
 	client, err := engineCollection.NewEngineClient(&engineapi.EngineClientRequest{
 		EngineImage: ei.Spec.Image,
+		ControlPath: controlPath,
 		VolumeName:  "",
 		IP:          "",
 		Port:        0,
@@ -910,6 +933,10 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 
 	dsName := types.GetDaemonSetNameFromEngineImageName(ei.Name)
 	image := ei.Spec.Image
+	controlPath, err := ic.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 	podProbePeriodSeconds, podProbeTimeoutSeconds, podLivenessProbeFailureThreshold := ic.getEngineImagePodLivenessProbeParameters()
 	cmd := []string{
 		"/bin/bash",
@@ -1004,7 +1031,7 @@ func (ic *EngineImageController) createEngineImageDaemonSetSpec(ei *longhorn.Eng
 							Name: "data",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: types.GetEngineBinaryDirectoryOnHostForImage(image),
+									Path: types.GetEngineBinaryDirectoryOnHostForImage(image, controlPath),
 								},
 							},
 						},

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/longhorn/go-common-libs/multierr"
 
-	lhns "github.com/longhorn/go-common-libs/ns"
 	imapi "github.com/longhorn/longhorn-instance-manager/pkg/api"
 	imtypes "github.com/longhorn/longhorn-instance-manager/pkg/types"
 
@@ -910,18 +909,31 @@ func (imc *InstanceManagerController) isSettingPriorityClassSynced(setting *long
 	return pod.Spec.PriorityClassName == setting.Value, nil
 }
 
+func (imc *InstanceManagerController) getDefaultLogDirectoryOnHost() string {
+	controlPath, err := imc.ds.GetDefaultControlPath()
+	if err != nil {
+		imc.logger.WithError(err).Warn("Failed to get default control path, using historical default log directory")
+		return filepath.Join(types.DefaultControlPath, types.LogDirectorySubpath)
+	}
+	return filepath.Join(controlPath, types.LogDirectorySubpath)
+}
+
+func (imc *InstanceManagerController) resolveLogPath(logPath string) string {
+	logPath = filepath.Clean(logPath)
+	if !filepath.IsAbs(logPath) || logPath == string(filepath.Separator) {
+		return imc.getDefaultLogDirectoryOnHost()
+	}
+
+	return logPath
+}
+
 func (imc *InstanceManagerController) isSettingLogPathSynced(setting *longhorn.Setting, pod *corev1.Pod) (bool, error) {
 	if pod.Spec.Containers[0].VolumeMounts == nil {
 		// If there are no volume mounts, we consider it synced.
 		return true, nil
 	}
 
-	logPath := setting.Value
-	if logPath == "" {
-		logPath = types.GetDefaultLogDirectoryOnHost()
-	}
-
-	normalizedLogPath := filepath.Clean(logPath)
+	normalizedLogPath := filepath.Clean(imc.resolveLogPath(setting.Value))
 	for _, v := range pod.Spec.Volumes {
 		if v.Name == "log" {
 			if filepath.Clean(v.HostPath.Path) == normalizedLogPath {
@@ -1923,29 +1935,8 @@ func (imc *InstanceManagerController) getLogPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	if logPath == "" || logPath == string(filepath.Separator) {
-		logPath = types.GetDefaultLogDirectoryOnHost()
-	} else {
-		logPath = filepath.Clean(logPath)
-	}
-
-	parent := filepath.Dir(logPath)
-	if parent == "." || parent == string(filepath.Separator) {
-		imc.logger.Warnf("Log path %q is not a valid directory, using default log directory", logPath)
-		logPath = types.GetDefaultLogDirectoryOnHost()
-	}
-
-	if st, err := lhns.Stat(parent); err != nil {
-		imc.logger.WithError(err).Warnf("Failed to stat parent of log path %q, using default log directory", logPath)
-		logPath = types.GetDefaultLogDirectoryOnHost()
-	} else {
-		if !st.IsDir() {
-			imc.logger.Warnf("Parent of log path %q is not a directory, using default log directory", logPath)
-			logPath = types.GetDefaultLogDirectoryOnHost()
-		}
-		imc.logger.Infof("Using log path %q", logPath)
-	}
+	logPath = imc.resolveLogPath(logPath)
+	imc.logger.Infof("Using log path %q", logPath)
 
 	return logPath, nil
 }
@@ -1962,6 +1953,20 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 	if err != nil {
 		return nil, err
 	}
+
+	dataPathSetting, err := imc.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
+	if err != nil {
+		return nil, err
+	}
+	dataPath := dataPathSetting.Value
+	controlPath, err := imc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+	engineBinaryDir := filepath.Join(controlPath, types.EngineBinaryDirectorySubpath)
+	metadataDir := filepath.Join(controlPath, types.MetadataDirectorySubpath)
+	unixSocketDir := filepath.Join(controlPath, types.UnixDomainSocketDirectorySubpath)
+	unixSocketDirInContainer := filepath.Join(types.ReplicaHostPrefix, strings.TrimLeft(unixSocketDir, string(filepath.Separator)))
 
 	if types.IsDataEngineV2(dataEngine) {
 		// spdk_tgt doesn't support log level option, so we don't need to pass the log level to the instance manager.
@@ -2031,11 +2036,6 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDataEngineIobufLargePoolSize)
 		}
 
-		controlPath, err := imc.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
-		}
-
 		args := []string{
 			"start-spdk-tgt",
 			"--spdk-log", logFlags,
@@ -2048,7 +2048,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			args = append(args, "--spdk-iobuf-large-pool-size", fmt.Sprintf("%d", iobufLargePoolSize))
 		}
 		args = append(args,
-			"--longhorn-control-path", controlPath.Value,
+			"--longhorn-control-path", controlPath,
 			"--enable-spdk", "--debug",
 			"daemon",
 			"--spdk-enabled",
@@ -2158,11 +2158,11 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		},
 		{
 			Name:  types.LonghornDataPathEnv,
-			Value: types.GetLonghornDataPath(),
+			Value: dataPath,
 		},
 		{
 			Name:  types.LonghornControlPathEnv,
-			Value: types.GetLonghornControlPath(),
+			Value: controlPath,
 		},
 	}
 	if tz := os.Getenv(types.EnvTZ); tz != "" {
@@ -2191,7 +2191,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			MountPropagation: &mountPropagationHostToContainer,
 		},
 		{
-			MountPath: types.GetUnixDomainSocketDirectoryInContainer(),
+			MountPath: unixSocketDirInContainer,
 			Name:      "unix-domain-socket",
 		},
 		{
@@ -2217,7 +2217,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "engine-binaries",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetEngineBinaryDirectoryOnHost(),
+					Path: engineBinaryDir,
 				},
 			},
 		},
@@ -2225,7 +2225,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "metadata",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetMetadataDirectoryOnHost(),
+					Path: metadataDir,
 					Type: &[]corev1.HostPathType{corev1.HostPathDirectoryOrCreate}[0],
 				},
 			},
@@ -2234,7 +2234,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "unix-domain-socket",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetUnixDomainSocketDirectoryOnHost(),
+					Path: unixSocketDir,
 				},
 			},
 		},

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1985,6 +1985,11 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		return nil, errors.Wrap(err, "failed to get log path for instance manager pod")
 	}
 
+	controlPath, err := imc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
+
 	podSpec, err := imc.createGenericManagerPodSpec(im, tolerations, registrySecret, nodeSelector, dataEngine)
 	if err != nil {
 		return nil, err
@@ -2064,11 +2069,6 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDataEngineIobufSmallPoolSize)
 		}
 
-		controlPath, err := imc.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
-		}
-
 		args := []string{
 			"start-spdk-tgt",
 			"--spdk-log", logFlags,
@@ -2084,7 +2084,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			args = append(args, "--spdk-iobuf-small-pool-size", fmt.Sprintf("%d", iobufSmallPoolSize))
 		}
 		args = append(args,
-			"--longhorn-control-path", controlPath.Value,
+			"--longhorn-control-path", controlPath,
 			"--enable-spdk", "--debug",
 			"daemon",
 			"--spdk-enabled",
@@ -2193,12 +2193,8 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Value: string(dataEngine),
 		},
 		{
-			Name:  types.LonghornDataPathEnv,
-			Value: types.GetLonghornDataPath(),
-		},
-		{
 			Name:  types.LonghornControlPathEnv,
-			Value: types.GetLonghornControlPath(),
+			Value: controlPath,
 		},
 	}
 	if tz := os.Getenv(types.EnvTZ); tz != "" {
@@ -2227,7 +2223,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			MountPropagation: &mountPropagationHostToContainer,
 		},
 		{
-			MountPath: types.GetUnixDomainSocketDirectoryInContainer(),
+			MountPath: types.GetUnixDomainSocketDirectoryInContainer(controlPath),
 			Name:      "unix-domain-socket",
 		},
 		{
@@ -2253,7 +2249,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "engine-binaries",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetEngineBinaryDirectoryOnHost(),
+					Path: types.GetEngineBinaryDirectoryOnHost(controlPath),
 				},
 			},
 		},
@@ -2261,7 +2257,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "metadata",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetMetadataDirectoryOnHost(),
+					Path: types.GetMetadataDirectoryOnHost(controlPath),
 					Type: &[]corev1.HostPathType{corev1.HostPathDirectoryOrCreate}[0],
 				},
 			},
@@ -2270,7 +2266,7 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			Name: "unix-domain-socket",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: types.GetUnixDomainSocketDirectoryOnHost(),
+					Path: types.GetUnixDomainSocketDirectoryOnHost(controlPath),
 				},
 			},
 		},

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -554,6 +554,49 @@ func (s *TestSuite) TestSyncInstanceManager(c *C) {
 	}
 }
 
+func (s *TestSuite) TestIsSettingLogPathSyncedUsesNormalizedSettingLogPath(c *C) {
+	kubeClient := fake.NewSimpleClientset()                   // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                   // nolint: staticcheck
+	extensionClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionClient, informerFactories, TestNode1)
+	c.Assert(err, IsNil)
+
+	logPathSetting := &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(types.SettingNameLogPath),
+		},
+		Value: "/var/lib/longhorn/logs/",
+	}
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "log", MountPath: "/log"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "log",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/longhorn/logs",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isSynced, err := imc.isSettingLogPathSynced(logPathSetting, pod)
+	c.Assert(err, IsNil)
+	c.Assert(isSynced, Equals, true)
+}
+
 // createDangerZoneSettingsForV2 creates all the danger zone settings required by areDangerZoneSettingsSyncedToIMPod
 // with V2 data engine enabled. It auto-generates settings from types.GetDangerZoneSettings() using their
 // default values, then overrides specific settings that need non-default values for V2 to function.

--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -475,6 +476,16 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 		return nil, err
 	}
 	registrySecret := registrySecretSetting.Value
+	dataPathSetting, err := c.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
+	if err != nil {
+		return nil, err
+	}
+	dataPath := dataPathSetting.Value
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+	engineBinaryDir := filepath.Join(controlPath, types.EngineBinaryDirectorySubpath)
 
 	// for mounting inside container
 	cronJob := &batchv1.CronJob{
@@ -520,17 +531,17 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 										},
 										{
 											Name:  types.LonghornDataPathEnv,
-											Value: types.GetLonghornDataPath(),
+											Value: dataPath,
 										},
 										{
 											Name:  types.LonghornControlPathEnv,
-											Value: types.GetLonghornControlPath(),
+											Value: controlPath,
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "engine-binaries",
-											MountPath: types.GetEngineBinaryDirectoryOnHost(),
+											MountPath: engineBinaryDir,
 										},
 									},
 								},
@@ -540,7 +551,7 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 									Name: "engine-binaries",
 									VolumeSource: corev1.VolumeSource{
 										HostPath: &corev1.HostPathVolumeSource{
-											Path: types.GetEngineBinaryDirectoryOnHost(),
+											Path: engineBinaryDir,
 										},
 									},
 								},

--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -475,6 +476,11 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 		return nil, err
 	}
 	registrySecret := registrySecretSetting.Value
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
+	engineBinaryDir := filepath.Join(controlPath, types.EngineBinaryDirectorySubpath)
 
 	// for mounting inside container
 	cronJob := &batchv1.CronJob{
@@ -519,18 +525,14 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 											},
 										},
 										{
-											Name:  types.LonghornDataPathEnv,
-											Value: types.GetLonghornDataPath(),
-										},
-										{
 											Name:  types.LonghornControlPathEnv,
-											Value: types.GetLonghornControlPath(),
+											Value: controlPath,
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "engine-binaries",
-											MountPath: types.GetEngineBinaryDirectoryOnHost(),
+											MountPath: engineBinaryDir,
 										},
 									},
 								},
@@ -540,7 +542,7 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 									Name: "engine-binaries",
 									VolumeSource: corev1.VolumeSource{
 										HostPath: &corev1.HostPathVolumeSource{
-											Path: types.GetEngineBinaryDirectoryOnHost(),
+											Path: engineBinaryDir,
 										},
 									},
 								},

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -421,6 +421,11 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		return nil, err
 	}
 
+	controlPath, err := rc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+
 	r.Status.Starting = true
 	replicaName := r.Name
 	if r, err = rc.ds.UpdateReplicaStatus(r); err != nil {
@@ -429,6 +434,7 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 
 	return c.ReplicaInstanceCreate(&engineapi.ReplicaInstanceCreateRequest{
 		Replica:                       r,
+		ControlPath:                   controlPath,
 		Encrypted:                     v.Spec.Encrypted,
 		DiskName:                      diskName,
 		DataPath:                      dataPath,
@@ -646,7 +652,7 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) (err error) {
 		return err
 	}
 
-	if err := deleteUnixSocketFile(r.Spec.VolumeName); err != nil && !types.ErrorIsNotFound(err) {
+	if err := rc.deleteUnixSocketFile(r.Spec.VolumeName); err != nil && !types.ErrorIsNotFound(err) {
 		log.WithError(err).Warnf("Failed to delete unix-domain-socket file for volume %v", r.Spec.VolumeName)
 	}
 
@@ -745,8 +751,13 @@ func engineStillHasReplica(e *longhorn.Engine, r *longhorn.Replica) bool {
 	return false
 }
 
-func deleteUnixSocketFile(volumeName string) error {
-	return os.RemoveAll(filepath.Join(types.GetUnixDomainSocketDirectoryOnHost(), volumeName+filepath.Ext(".sock")))
+func (rc *ReplicaController) deleteUnixSocketFile(volumeName string) error {
+	controlPath, err := rc.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(filepath.Join(controlPath, types.UnixDomainSocketDirectorySubpath, volumeName+filepath.Ext(".sock")))
 }
 
 func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstanceProcess, error) {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -442,9 +442,14 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 	if r, err = rc.ds.UpdateReplicaStatus(r); err != nil {
 		return nil, errors.Wrapf(err, "failed to update replica %v status.starting to true before sending instance create request", replicaName)
 	}
+	controlPath, err := rc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 
 	return c.ReplicaInstanceCreate(&engineapi.ReplicaInstanceCreateRequest{
 		Replica:                       r,
+		ControlPath:                   controlPath,
 		Encrypted:                     v.Spec.Encrypted,
 		DiskName:                      diskName,
 		DataPath:                      dataPath,
@@ -662,7 +667,12 @@ func (rc *ReplicaController) DeleteInstance(obj interface{}) (err error) {
 		return err
 	}
 
-	if err := deleteUnixSocketFile(r.Spec.VolumeName); err != nil && !types.ErrorIsNotFound(err) {
+	controlPath, err := rc.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+
+	if err := deleteUnixSocketFile(r.Spec.VolumeName, controlPath); err != nil && !types.ErrorIsNotFound(err) {
 		log.WithError(err).Warnf("Failed to delete unix-domain-socket file for volume %v", r.Spec.VolumeName)
 	}
 
@@ -761,8 +771,8 @@ func engineStillHasReplica(e *longhorn.Engine, r *longhorn.Replica) bool {
 	return false
 }
 
-func deleteUnixSocketFile(volumeName string) error {
-	return os.RemoveAll(filepath.Join(types.GetUnixDomainSocketDirectoryOnHost(), volumeName+filepath.Ext(".sock")))
+func deleteUnixSocketFile(volumeName string, controlPath string) error {
+	return os.RemoveAll(filepath.Join(controlPath, types.UnixDomainSocketDirectorySubpath, volumeName+filepath.Ext(".sock")))
 }
 
 func (rc *ReplicaController) GetInstance(obj interface{}) (*longhorn.InstanceProcess, error) {

--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -773,7 +773,11 @@ func (sc *SnapshotController) handleSnapshotCreate(snapshot *longhorn.Snapshot, 
 		return err
 	}
 
-	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage)
+	controlPath, err := sc.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage, controlPath)
 	if err != nil {
 		return err
 	}
@@ -806,7 +810,11 @@ func (sc *SnapshotController) handleSnapshotCreate(snapshot *longhorn.Snapshot, 
 
 // handleSnapshotDeletion reaches out to engine process to check and delete the snapshot
 func (sc *SnapshotController) handleSnapshotDeletion(snapshot *longhorn.Snapshot, engine *longhorn.Engine) error {
-	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage)
+	controlPath, err := sc.ds.GetDefaultControlPath()
+	if err != nil {
+		return err
+	}
+	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage, controlPath)
 	if err != nil {
 		return err
 	}

--- a/controller/snapshot_controller.go
+++ b/controller/snapshot_controller.go
@@ -773,7 +773,7 @@ func (sc *SnapshotController) handleSnapshotCreate(snapshot *longhorn.Snapshot, 
 		return err
 	}
 
-	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage)
+	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage, sc.ds)
 	if err != nil {
 		return err
 	}
@@ -806,7 +806,7 @@ func (sc *SnapshotController) handleSnapshotCreate(snapshot *longhorn.Snapshot, 
 
 // handleSnapshotDeletion reaches out to engine process to check and delete the snapshot
 func (sc *SnapshotController) handleSnapshotDeletion(snapshot *longhorn.Snapshot, engine *longhorn.Engine) error {
-	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage)
+	engineCliClient, err := GetBinaryClientForEngine(engine, sc.engineClientCollection, engine.Status.CurrentImage, sc.ds)
 	if err != nil {
 		return err
 	}

--- a/controller/system_restore_controller.go
+++ b/controller/system_restore_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -384,14 +385,25 @@ func (c *SystemRestoreController) CreateSystemRestoreJob(systemRestore *longhorn
 		return nil, err
 	}
 
-	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, tolerations))
+	dataPathSetting, err := c.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
+	if err != nil {
+		return nil, err
+	}
+	dataPath := dataPathSetting.Value
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, tolerations, dataPath, controlPath))
 }
 
-func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount string, tolerations []corev1.Toleration) *batchv1.Job {
+func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount string, tolerations []corev1.Toleration, dataPath, controlPath string) *batchv1.Job {
 	backoffLimit := int32(RestoreJobBackoffLimit)
 
 	// This is required for the NFS mount to access the backup store
 	privileged := true
+	engineBinaryDir := filepath.Join(controlPath, types.EngineBinaryDirectorySubpath)
 
 	cmd := []string{
 		"longhorn-manager", "system-rollout", systemRestore.Name,
@@ -431,17 +443,17 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 								},
 								{
 									Name:  types.LonghornDataPathEnv,
-									Value: types.GetLonghornDataPath(),
+									Value: dataPath,
 								},
 								{
 									Name:  types.LonghornControlPathEnv,
-									Value: types.GetLonghornControlPath(),
+									Value: controlPath,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "engine",
-									MountPath: types.GetEngineBinaryDirectoryOnHost(),
+									MountPath: engineBinaryDir,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -454,7 +466,7 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 							Name: "engine",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: types.GetEngineBinaryDirectoryOnHost(),
+									Path: engineBinaryDir,
 								},
 							},
 						},

--- a/controller/system_restore_controller.go
+++ b/controller/system_restore_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -384,14 +385,20 @@ func (c *SystemRestoreController) CreateSystemRestoreJob(systemRestore *longhorn
 		return nil, err
 	}
 
-	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, tolerations))
+	controlPath, err := c.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
+
+	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, tolerations, controlPath))
 }
 
-func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount string, tolerations []corev1.Toleration) *batchv1.Job {
+func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount string, tolerations []corev1.Toleration, controlPath string) *batchv1.Job {
 	backoffLimit := int32(RestoreJobBackoffLimit)
 
 	// This is required for the NFS mount to access the backup store
 	privileged := true
+	engineBinaryDir := filepath.Join(controlPath, types.EngineBinaryDirectorySubpath)
 
 	cmd := []string{
 		"longhorn-manager", "system-rollout", systemRestore.Name,
@@ -430,18 +437,14 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 									Value: c.controllerID,
 								},
 								{
-									Name:  types.LonghornDataPathEnv,
-									Value: types.GetLonghornDataPath(),
-								},
-								{
 									Name:  types.LonghornControlPathEnv,
-									Value: types.GetLonghornControlPath(),
+									Value: controlPath,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "engine",
-									MountPath: types.GetEngineBinaryDirectoryOnHost(),
+									MountPath: engineBinaryDir,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -454,7 +457,7 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 							Name: "engine",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: types.GetEngineBinaryDirectoryOnHost(),
+									Path: engineBinaryDir,
 								},
 							},
 						},

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -91,7 +91,7 @@ func (s *DataStore) UpdateCustomizedSettings(defaultImages map[types.SettingName
 		return err
 	}
 
-	if err := s.createNonExistingSettingCRsWithDefaultSetting(defaultSettingCM.ResourceVersion); err != nil {
+	if err := s.createNonExistingSettingCRsWithDefaultSetting(defaultSettingCM.ResourceVersion, availableCustomizedDefaultSettings); err != nil {
 		return err
 	}
 
@@ -102,7 +102,55 @@ func (s *DataStore) UpdateCustomizedSettings(defaultImages map[types.SettingName
 	return nil
 }
 
-func (s *DataStore) createNonExistingSettingCRsWithDefaultSetting(configMapResourceVersion string) error {
+func (s *DataStore) ValidateCustomizedDefaultDataAndControlPathSettings() error {
+	defaultSettingCM, err := s.GetConfigMapRO(s.namespace, types.DefaultDefaultSettingConfigMapName)
+	if err != nil {
+		return err
+	}
+
+	customizedDefaultSettings, err := types.GetCustomizedDefaultSettings(defaultSettingCM)
+	if err != nil {
+		return err
+	}
+	nodes, err := s.ListNodesRO()
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	for _, settingName := range []types.SettingName{
+		types.SettingNameDefaultDataPath,
+		types.SettingNameDefaultControlPath,
+	} {
+		value, ok := customizedDefaultSettings[string(settingName)]
+		if !ok {
+			continue
+		}
+		if err := s.ValidateSetting(string(settingName), value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *DataStore) GetDefaultControlPath() (string, error) {
+	controlPathSetting, err := s.GetSettingExactRO(types.SettingNameDefaultControlPath)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", err
+		}
+		return types.DefaultControlPath, nil
+	}
+	if controlPathSetting.Value == "" {
+		return types.DefaultControlPath, nil
+	}
+	return controlPathSetting.Value, nil
+}
+
+func (s *DataStore) createNonExistingSettingCRsWithDefaultSetting(configMapResourceVersion string, customizedDefaultSettings map[string]string) error {
 	for _, sName := range types.SettingNameList {
 		if _, err := s.GetSettingExactRO(sName); err != nil && apierrors.IsNotFound(err) {
 			definition, ok := types.GetSettingDefinition(sName)
@@ -683,9 +731,13 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 		}
 
 	case types.SettingNameDefaultControlPath:
-		old, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
+		old, err := s.GetSettingExactRO(types.SettingNameDefaultControlPath)
 		if err != nil {
-			return err
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			old = &longhorn.Setting{Value: types.DefaultControlPath}
 		}
 
 		oldPath := filepath.Clean(strings.TrimSpace(old.Value))

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -157,6 +157,15 @@ func (s *DataStore) shouldApplyCustomizedSettingValue(name types.SettingName, va
 		return true
 	}
 
+	if name == types.SettingNameDefaultControlPath {
+		controlPath := filepath.Clean(strings.TrimSpace(value))
+		existingControlPath := filepath.Clean(strings.TrimSpace(setting.Value))
+		if existingControlPath != controlPath {
+			logrus.Warnf("Skip customized default setting %v with value %v since the existing setting value is %v", name, value, existingControlPath)
+			return false
+		}
+	}
+
 	configMapResourceVersion := ""
 	if setting.Annotations != nil {
 		configMapResourceVersion = setting.Annotations[types.GetLonghornLabelKey(types.ConfigMapResourceVersionKey)]
@@ -666,24 +675,6 @@ func (s *DataStore) ValidateSetting(name, value string) (err error) {
 			}
 		}
 
-	case types.SettingNameDefaultDataPath:
-		old, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
-		if err != nil {
-			return err
-		}
-
-		oldPath := filepath.Clean(strings.TrimSpace(old.Value))
-		newPath := filepath.Clean(strings.TrimSpace(value))
-		if oldPath != newPath {
-			nodes, err := s.ListNodesRO()
-			if err != nil {
-				return err
-			}
-			if len(nodes) != 0 {
-				return errors.Errorf("cannot change %v after Longhorn has been initialized", types.SettingNameDefaultDataPath)
-			}
-		}
-
 	case types.SettingNameDefaultControlPath:
 		old, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
 		if err != nil {
@@ -1111,6 +1102,24 @@ func (s *DataStore) GetSetting(sName types.SettingName) (*longhorn.Setting, erro
 		return nil, err
 	}
 	return resultRO.DeepCopy(), nil
+}
+
+func (s *DataStore) GetDefaultDataPath() (string, error) {
+	setting, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultDataPath)
+	if err != nil {
+		return "", err
+	}
+
+	return types.GetLonghornDataPath(setting.Value), nil
+}
+
+func (s *DataStore) GetDefaultControlPath() (string, error) {
+	setting, err := s.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
+	if err != nil {
+		return "", err
+	}
+
+	return types.GetLonghornControlPath(setting.Value), nil
 }
 
 // GetSettingValueExisted returns the value of the given setting name.

--- a/datastore/longhorn_test.go
+++ b/datastore/longhorn_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -280,6 +281,33 @@ func TestValidateSettingDefaultControlPath(t *testing.T) {
 			newValue:        "/control/longhorn",
 			expectError:     "cannot change default-control-path after Longhorn has been initialized",
 		},
+		"legacy cluster rejects control path change to customized data path": {
+			existingObjects: []runtime.Object{
+				&longhorn.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      string(types.SettingNameDefaultDataPath),
+						Namespace: testNamespace,
+					},
+					Value: "/data/longhorn",
+				},
+				newNode("node-1"),
+			},
+			newValue:    "/data/longhorn",
+			expectError: "cannot change default-control-path after Longhorn has been initialized",
+		},
+		"legacy cluster keeps historical default control path": {
+			existingObjects: []runtime.Object{
+				&longhorn.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      string(types.SettingNameDefaultDataPath),
+						Namespace: testNamespace,
+					},
+					Value: "/data/longhorn",
+				},
+				newNode("node-1"),
+			},
+			newValue: types.DefaultControlPath,
+		},
 		"block device path is rejected": {
 			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
 			newValue:        "/dev/nvme0n1",
@@ -397,6 +425,222 @@ func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
 			))
 
 			err := ds.ValidateSetting(string(types.SettingNameDefaultDataPath), tc.newValue)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+func TestUpdateCustomizedSettingsForInstallTimePathsOnUpgrade(t *testing.T) {
+	const (
+		testNamespace            = "longhorn-system"
+		configMapResourceVersion = "3113"
+	)
+
+	newNode := func(name string) *longhorn.Node {
+		return &longhorn.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+		}
+	}
+
+	newSetting := func(name types.SettingName, value string) *longhorn.Setting {
+		return &longhorn.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(name),
+				Namespace: testNamespace,
+			},
+			Value: value,
+		}
+	}
+
+	newDefaultSettingConfigMap := func(dataPath, controlPath string) *corev1.ConfigMap {
+		data := ""
+		if dataPath != "" {
+			data += fmt.Sprintf("default-data-path: %q\n", dataPath)
+		}
+		if controlPath != "" {
+			data += fmt.Sprintf("default-control-path: %q\n", controlPath)
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            types.DefaultDefaultSettingConfigMapName,
+				Namespace:       testNamespace,
+				ResourceVersion: configMapResourceVersion,
+			},
+			Data: map[string]string{
+				types.DefaultSettingYAMLFileName: data,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		existingObjects             []runtime.Object
+		defaultSettingConfigMap     *corev1.ConfigMap
+		expectedDataPathValue       string
+		expectedControlPathValue    string
+		expectControlPathToBeCreate bool
+	}{
+		"upgrade from historical default path succeeds": {
+			existingObjects: []runtime.Object{
+				newNode("node-1"),
+				newSetting(types.SettingNameDefaultDataPath, types.DefaultDataPath),
+			},
+			defaultSettingConfigMap:     newDefaultSettingConfigMap(types.DefaultDataPath, types.DefaultControlPath),
+			expectedDataPathValue:       types.DefaultDataPath,
+			expectedControlPathValue:    types.DefaultControlPath,
+			expectControlPathToBeCreate: true,
+		},
+		"upgrade from customized data path bootstraps historical control path": {
+			existingObjects: []runtime.Object{
+				newNode("node-1"),
+				newSetting(types.SettingNameDefaultDataPath, "/data/longhorn"),
+			},
+			defaultSettingConfigMap:     newDefaultSettingConfigMap("/data/longhorn", types.DefaultControlPath),
+			expectedDataPathValue:       "/data/longhorn",
+			expectedControlPathValue:    types.DefaultControlPath,
+			expectControlPathToBeCreate: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...)      // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset(tc.defaultSettingConfigMap) // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()        // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.SettingInformer.HasSynced,
+				ds.NodeInformer.HasSynced,
+				ds.ConfigMapInformer.HasSynced,
+			))
+
+			err := ds.UpdateCustomizedSettings(nil)
+			require.NoError(t, err)
+
+			dataSetting, err := ds.lhClient.LonghornV1beta2().Settings(testNamespace).Get(context.TODO(), string(types.SettingNameDefaultDataPath), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDataPathValue, dataSetting.Value)
+
+			controlSetting, err := ds.lhClient.LonghornV1beta2().Settings(testNamespace).Get(context.TODO(), string(types.SettingNameDefaultControlPath), metav1.GetOptions{})
+			if tc.expectControlPathToBeCreate {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedControlPathValue, controlSetting.Value)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateCustomizedDefaultDataAndControlPathSettings(t *testing.T) {
+	const (
+		testNamespace            = "longhorn-system"
+		configMapResourceVersion = "3113"
+	)
+
+	newNode := func(name string) *longhorn.Node {
+		return &longhorn.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+		}
+	}
+
+	newSetting := func(name types.SettingName, value string) *longhorn.Setting {
+		return &longhorn.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(name),
+				Namespace: testNamespace,
+			},
+			Value: value,
+		}
+	}
+
+	newDefaultSettingConfigMap := func(dataPath, controlPath string) *corev1.ConfigMap {
+		data := ""
+		if dataPath != "" {
+			data += fmt.Sprintf("default-data-path: %q\n", dataPath)
+		}
+		if controlPath != "" {
+			data += fmt.Sprintf("default-control-path: %q\n", controlPath)
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            types.DefaultDefaultSettingConfigMapName,
+				Namespace:       testNamespace,
+				ResourceVersion: configMapResourceVersion,
+			},
+			Data: map[string]string{
+				types.DefaultSettingYAMLFileName: data,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		existingObjects         []runtime.Object
+		defaultSettingConfigMap *corev1.ConfigMap
+		expectError             string
+	}{
+		"customized paths are allowed when unchanged": {
+			existingObjects: []runtime.Object{
+				newNode("node-1"),
+				newSetting(types.SettingNameDefaultDataPath, "/data/longhorn"),
+				newSetting(types.SettingNameDefaultControlPath, types.DefaultControlPath),
+			},
+			defaultSettingConfigMap: newDefaultSettingConfigMap("/data/longhorn", types.DefaultControlPath),
+		},
+		"rejects default data path change after initialization": {
+			existingObjects: []runtime.Object{
+				newNode("node-1"),
+				newSetting(types.SettingNameDefaultDataPath, "/data/longhorn"),
+			},
+			defaultSettingConfigMap: newDefaultSettingConfigMap(types.DefaultDataPath, types.DefaultControlPath),
+			expectError:             "cannot change default-data-path after Longhorn has been initialized",
+		},
+		"rejects default control path change after initialization": {
+			existingObjects: []runtime.Object{
+				newNode("node-1"),
+				newSetting(types.SettingNameDefaultDataPath, types.DefaultDataPath),
+				newSetting(types.SettingNameDefaultControlPath, types.DefaultControlPath),
+			},
+			defaultSettingConfigMap: newDefaultSettingConfigMap(types.DefaultDataPath, "/control/longhorn"),
+			expectError:             "cannot change default-control-path after Longhorn has been initialized",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...)      // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset(tc.defaultSettingConfigMap) // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()        // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.SettingInformer.HasSynced,
+				ds.NodeInformer.HasSynced,
+				ds.ConfigMapInformer.HasSynced,
+			))
+
+			err := ds.ValidateCustomizedDefaultDataAndControlPathSettings()
 			if tc.expectError == "" {
 				require.NoError(t, err)
 			} else {

--- a/datastore/longhorn_test.go
+++ b/datastore/longhorn_test.go
@@ -320,6 +320,65 @@ func TestValidateSettingDefaultControlPath(t *testing.T) {
 	}
 }
 
+func TestGetDefaultDataAndControlPath(t *testing.T) {
+	const testNamespace = "longhorn-system"
+
+	tests := map[string]struct {
+		existingObjects     []runtime.Object
+		expectedDataPath    string
+		expectedControlPath string
+	}{
+		"uses setting values": {
+			existingObjects: []runtime.Object{
+				&longhorn.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      string(types.SettingNameDefaultDataPath),
+						Namespace: testNamespace,
+					},
+					Value: "/data/longhorn/",
+				},
+				&longhorn.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      string(types.SettingNameDefaultControlPath),
+						Namespace: testNamespace,
+					},
+					Value: "/control/longhorn/",
+				},
+			},
+			expectedDataPath:    "/data/longhorn",
+			expectedControlPath: "/control/longhorn",
+		},
+		"falls back to historical defaults when settings are missing": {
+			expectedDataPath:    types.DefaultDataPath,
+			expectedControlPath: types.DefaultControlPath,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...) // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset()                      // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()   // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh, ds.SettingInformer.HasSynced))
+
+			dataPath, err := ds.GetDefaultDataPath()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDataPath, dataPath)
+
+			controlPath, err := ds.GetDefaultControlPath()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedControlPath, controlPath)
+		})
+	}
+}
+
 func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
 	const testNamespace = "longhorn-system"
 
@@ -367,15 +426,17 @@ func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
 			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
 			newValue:        "/data/longhorn",
 		},
-		"bare pci identifier is rejected": {
+		"bare pci identifier is allowed": {
 			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
 			newValue:        "0000:00:1e.0",
-			expectError:     "the value of default-data-path is invalid",
 		},
-		"changing path after initialization is rejected": {
+		"scsi by-id path is allowed": {
+			existingObjects: []runtime.Object{baseSetting.DeepCopy()},
+			newValue:        "/dev/disk/by-id/scsi-36001405b8f1e2d3c4b5a697887766554",
+		},
+		"changing path after initialization is allowed": {
 			existingObjects: []runtime.Object{baseSetting.DeepCopy(), newNode("node-1")},
 			newValue:        "/data/longhorn",
-			expectError:     "cannot change default-data-path after Longhorn has been initialized",
 		},
 	}
 
@@ -403,6 +464,64 @@ func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectError)
 			}
+		})
+	}
+}
+
+func TestFilterCustomizedDefaultSettingsPreservesExistingDefaultControlPath(t *testing.T) {
+	const testNamespace = "longhorn-system"
+
+	tests := map[string]struct {
+		existingControlPath string
+		customizedValue     string
+		expectAvailable     bool
+	}{
+		"skip changed control path": {
+			existingControlPath: "/var/lib/longhorn",
+			customizedValue:     "/data/longhorn",
+			expectAvailable:     false,
+		},
+		"allow same control path with normalization": {
+			existingControlPath: "/var/lib/longhorn",
+			customizedValue:     "/var/lib/longhorn/",
+			expectAvailable:     true,
+		},
+		"allow invalid control path for validation to reject": {
+			existingControlPath: "/var/lib/longhorn",
+			customizedValue:     "/dev/nvme0n1",
+			expectAvailable:     false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(&longhorn.Setting{ // nolint: staticcheck
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      string(types.SettingNameDefaultControlPath),
+					Namespace: testNamespace,
+				},
+				Value: tc.existingControlPath,
+			}) // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.SettingInformer.HasSynced,
+				ds.NodeInformer.HasSynced,
+			))
+
+			availableSettings := ds.filterCustomizedDefaultSettings(map[string]string{
+				string(types.SettingNameDefaultControlPath): tc.customizedValue,
+			}, "test-resource-version")
+
+			_, ok := availableSettings[string(types.SettingNameDefaultControlPath)]
+			require.Equal(t, tc.expectAvailable, ok)
 		})
 	}
 }

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -32,15 +32,17 @@ const (
 
 type BackupTargetClient struct {
 	Image          string
+	ControlPath    string
 	URL            string
 	Credential     map[string]string
 	ExecuteTimeout time.Duration
 }
 
 // NewBackupTargetClient returns the backup target client
-func NewBackupTargetClient(engineImage, url string, credential map[string]string, executeTimeout time.Duration) *BackupTargetClient {
+func NewBackupTargetClient(engineImage, controlPath, url string, credential map[string]string, executeTimeout time.Duration) *BackupTargetClient {
 	return &BackupTargetClient{
 		Image:          engineImage,
+		ControlPath:    controlPath,
 		URL:            url,
 		Credential:     credential,
 		ExecuteTimeout: executeTimeout,
@@ -75,12 +77,19 @@ func NewBackupTargetClientFromBackupTarget(backupTarget *longhorn.BackupTarget, 
 		return nil, err
 	}
 	timeout := time.Duration(executeTimeout) * time.Minute
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
 
-	return NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
+	return NewBackupTargetClient(defaultEngineImage, controlPath, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
 }
 
 func (btc *BackupTargetClient) LonghornEngineBinary() string {
-	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(btc.Image), "longhorn")
+	if btc.ControlPath == "" {
+		return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(btc.Image), "longhorn")
+	}
+	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImageWithControlPath(btc.ControlPath, btc.Image), "longhorn")
 }
 
 // getBackupCredentialEnv returns the environment variables as KEY=VALUE in string slice

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -32,15 +32,17 @@ const (
 
 type BackupTargetClient struct {
 	Image          string
+	ds             *datastore.DataStore
 	URL            string
 	Credential     map[string]string
 	ExecuteTimeout time.Duration
 }
 
 // NewBackupTargetClient returns the backup target client
-func NewBackupTargetClient(engineImage, url string, credential map[string]string, executeTimeout time.Duration) *BackupTargetClient {
+func NewBackupTargetClient(engineImage string, ds *datastore.DataStore, url string, credential map[string]string, executeTimeout time.Duration) *BackupTargetClient {
 	return &BackupTargetClient{
 		Image:          engineImage,
+		ds:             ds,
 		URL:            url,
 		Credential:     credential,
 		ExecuteTimeout: executeTimeout,
@@ -76,11 +78,19 @@ func NewBackupTargetClientFromBackupTarget(backupTarget *longhorn.BackupTarget, 
 	}
 	timeout := time.Duration(executeTimeout) * time.Minute
 
-	return NewBackupTargetClient(defaultEngineImage, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
+	return NewBackupTargetClient(defaultEngineImage, ds, backupTarget.Spec.BackupTargetURL, credential, timeout), nil
 }
 
-func (btc *BackupTargetClient) LonghornEngineBinary() string {
-	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(btc.Image), "longhorn")
+func (btc *BackupTargetClient) LonghornEngineBinary() (string, error) {
+	controlPath := types.DefaultControlPath
+	if btc.ds != nil {
+		settingControlPath, err := btc.ds.GetDefaultControlPath()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to get default control path")
+		}
+		controlPath = settingControlPath
+	}
+	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(btc.Image, controlPath), types.EngineBinaryName), nil
 }
 
 // getBackupCredentialEnv returns the environment variables as KEY=VALUE in string slice
@@ -139,7 +149,11 @@ func (btc *BackupTargetClient) ExecuteEngineBinary(args ...string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute(envs, btc.LonghornEngineBinary(), args, btc.ExecuteTimeout)
+	binary, err := btc.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute(envs, binary, args, btc.ExecuteTimeout)
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinaryWithTimeout(timeout time.Duration, args ...string) (string, error) {
@@ -147,7 +161,11 @@ func (btc *BackupTargetClient) ExecuteEngineBinaryWithTimeout(timeout time.Durat
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute(envs, btc.LonghornEngineBinary(), args, timeout)
+	binary, err := btc.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute(envs, binary, args, timeout)
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinaryWithoutTimeout(args ...string) (string, error) {
@@ -155,7 +173,11 @@ func (btc *BackupTargetClient) ExecuteEngineBinaryWithoutTimeout(args ...string)
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute(envs, btc.LonghornEngineBinary(), args, lhtypes.ExecuteNoTimeout)
+	binary, err := btc.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute(envs, binary, args, lhtypes.ExecuteNoTimeout)
 }
 
 // parseBackupVolumeNamesList parses a list of backup volume names into a sorted string slice

--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -35,6 +35,7 @@ type EngineCollection struct{}
 type EngineBinary struct {
 	volumeName   string
 	image        string
+	controlPath  string
 	ip           string
 	port         int
 	cURL         string
@@ -53,6 +54,7 @@ func (c *EngineCollection) NewEngineClient(request *EngineClientRequest) (*Engin
 	return &EngineBinary{
 		volumeName:   request.VolumeName,
 		image:        request.EngineImage,
+		controlPath:  request.ControlPath,
 		ip:           request.IP,
 		port:         request.Port,
 		cURL:         imutil.GetURL(request.IP, request.Port),
@@ -65,7 +67,10 @@ func (e *EngineBinary) Name() string {
 }
 
 func (e *EngineBinary) LonghornEngineBinary() string {
-	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(e.image), "longhorn")
+	if e.controlPath == "" {
+		return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(e.image), "longhorn")
+	}
+	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImageWithControlPath(e.controlPath, e.image), "longhorn")
 }
 
 func (e *EngineBinary) ExecuteEngineBinary(args ...string) (string, error) {

--- a/engineapi/engine.go
+++ b/engineapi/engine.go
@@ -35,6 +35,7 @@ type EngineCollection struct{}
 type EngineBinary struct {
 	volumeName   string
 	image        string
+	controlPath  string
 	ip           string
 	port         int
 	cURL         string
@@ -49,10 +50,14 @@ func (c *EngineCollection) NewEngineClient(request *EngineClientRequest) (*Engin
 	if request.IP != "" && request.Port == 0 {
 		return nil, fmt.Errorf("invalid empty port from request with valid IP")
 	}
+	if request.ControlPath == "" {
+		return nil, fmt.Errorf("invalid empty control path from request")
+	}
 
 	return &EngineBinary{
 		volumeName:   request.VolumeName,
 		image:        request.EngineImage,
+		controlPath:  request.ControlPath,
 		ip:           request.IP,
 		port:         request.Port,
 		cURL:         imutil.GetURL(request.IP, request.Port),
@@ -64,8 +69,8 @@ func (e *EngineBinary) Name() string {
 	return e.volumeName
 }
 
-func (e *EngineBinary) LonghornEngineBinary() string {
-	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(e.image), "longhorn")
+func (e *EngineBinary) LonghornEngineBinary() (string, error) {
+	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(e.image, e.controlPath), types.EngineBinaryName), nil
 }
 
 func (e *EngineBinary) ExecuteEngineBinary(args ...string) (string, error) {
@@ -73,7 +78,11 @@ func (e *EngineBinary) ExecuteEngineBinary(args ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute([]string{}, e.LonghornEngineBinary(), args, lhtypes.ExecuteDefaultTimeout)
+	binary, err := e.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute([]string{}, binary, args, lhtypes.ExecuteDefaultTimeout)
 }
 
 func (e *EngineBinary) ExecuteEngineBinaryWithTimeout(timeout time.Duration, args ...string) (string, error) {
@@ -81,7 +90,11 @@ func (e *EngineBinary) ExecuteEngineBinaryWithTimeout(timeout time.Duration, arg
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute([]string{}, e.LonghornEngineBinary(), args, timeout)
+	binary, err := e.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute([]string{}, binary, args, timeout)
 }
 
 func (e *EngineBinary) ExecuteEngineBinaryWithoutTimeout(envs []string, args ...string) (string, error) {
@@ -89,7 +102,11 @@ func (e *EngineBinary) ExecuteEngineBinaryWithoutTimeout(envs []string, args ...
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute(envs, e.LonghornEngineBinary(), args, lhtypes.ExecuteNoTimeout)
+	binary, err := e.LonghornEngineBinary()
+	if err != nil {
+		return "", err
+	}
+	return lhexec.NewExecutor().Execute(envs, binary, args, lhtypes.ExecuteNoTimeout)
 }
 
 func parseReplica(s string) (*Replica, error) {
@@ -221,7 +238,11 @@ func (e *EngineBinary) VersionGet(obj DataEngineObject, clientOnly bool) (*Engin
 	} else {
 		cmdline = append([]string{"--url", e.cURL}, cmdline...)
 	}
-	output, err := lhexec.NewExecutor().Execute([]string{}, e.LonghornEngineBinary(), cmdline, lhtypes.ExecuteDefaultTimeout)
+	binary, err := e.LonghornEngineBinary()
+	if err != nil {
+		return nil, err
+	}
+	output, err := lhexec.NewExecutor().Execute([]string{}, binary, cmdline, lhtypes.ExecuteDefaultTimeout)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get volume version")
 	}

--- a/engineapi/engine_binary.go
+++ b/engineapi/engine_binary.go
@@ -44,9 +44,14 @@ func GetEngineBinaryClient(ds *datastore.DataStore, volumeName, nodeID string) (
 	}
 
 	engineCollection := &EngineCollection{}
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
 	return engineCollection.NewEngineClient(&EngineClientRequest{
 		VolumeName:   e.Spec.VolumeName,
 		EngineImage:  e.Status.CurrentImage,
+		ControlPath:  controlPath,
 		IP:           e.Status.IP,
 		Port:         e.Status.Port,
 		InstanceName: e.Name,

--- a/engineapi/engine_binary.go
+++ b/engineapi/engine_binary.go
@@ -42,11 +42,16 @@ func GetEngineBinaryClient(ds *datastore.DataStore, volumeName, nodeID string) (
 		}
 		return nil, fmt.Errorf("cannot get engine client with image %v because it isn't deployed", e.Status.CurrentImage)
 	}
+	controlPath, err := ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
+	}
 
 	engineCollection := &EngineCollection{}
 	return engineCollection.NewEngineClient(&EngineClientRequest{
 		VolumeName:   e.Spec.VolumeName,
 		EngineImage:  e.Status.CurrentImage,
+		ControlPath:  controlPath,
 		IP:           e.Status.IP,
 		Port:         e.Status.Port,
 		InstanceName: e.Name,

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -373,7 +373,7 @@ func getBinaryAndArgsForEngineProcessCreation(e *longhorn.Engine,
 }
 
 func getBinaryAndArgsForReplicaProcessCreation(r *longhorn.Replica,
-	dataPath, backingImagePath string, dataLocality longhorn.DataLocality, portCount, engineCLIAPIVersion int, encrypted bool) (string, []string, error) {
+	controlPath, dataPath, backingImagePath string, dataLocality longhorn.DataLocality, portCount, engineCLIAPIVersion int, encrypted bool) (string, []string, error) {
 
 	requestSize, err := util.GetActualBackendSize(r.Spec.VolumeSize, encrypted, engineCLIAPIVersion)
 	if err != nil {
@@ -423,7 +423,7 @@ func getBinaryAndArgsForReplicaProcessCreation(r *longhorn.Replica,
 	syncAgentPortCount := portCount - 3
 	args = append(args, "--sync-agent-port-count", strconv.Itoa(syncAgentPortCount))
 
-	binary := filepath.Join(types.GetEngineBinaryDirectoryForReplicaManagerContainer(r.Spec.Image), types.EngineBinaryName)
+	binary := filepath.Join(types.GetEngineBinaryDirectoryForReplicaManagerContainerWithControlPath(controlPath, r.Spec.Image), types.EngineBinaryName)
 
 	return binary, args, nil
 }
@@ -524,6 +524,7 @@ func (c *InstanceManagerClient) EngineInstanceCreate(req *EngineInstanceCreateRe
 
 type ReplicaInstanceCreateRequest struct {
 	Replica                       *longhorn.Replica
+	ControlPath                   string
 	DiskName                      string
 	DataPath                      string
 	BackingImagePath              string
@@ -641,7 +642,7 @@ func (c *InstanceManagerClient) ReplicaInstanceCreate(req *ReplicaInstanceCreate
 	args := []string{}
 	var err error
 	if types.IsDataEngineV1(req.Replica.Spec.DataEngine) {
-		binary, args, err = getBinaryAndArgsForReplicaProcessCreation(req.Replica, req.DataPath, req.BackingImagePath, req.DataLocality, DefaultReplicaPortCountV1, req.EngineCLIAPIVersion, req.Encrypted)
+		binary, args, err = getBinaryAndArgsForReplicaProcessCreation(req.Replica, req.ControlPath, req.DataPath, req.BackingImagePath, req.DataLocality, DefaultReplicaPortCountV1, req.EngineCLIAPIVersion, req.Encrypted)
 		if err != nil {
 			return nil, err
 		}

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -88,11 +88,6 @@ func (c *InstanceManagerClient) Close() error {
 	return err
 }
 
-func GetDeprecatedInstanceManagerBinary(image string) string {
-	cname := types.GetImageCanonicalName(image)
-	return filepath.Join(types.GetEngineBinaryDirectoryOnHost(), cname, DeprecatedInstanceManagerBinaryName)
-}
-
 func CheckInstanceManagerCompatibility(imMinVersion, imVersion int) error {
 	if MinInstanceManagerAPIVersion > imVersion || CurrentInstanceManagerAPIVersion < imMinVersion {
 		return fmt.Errorf("current InstanceManager version %v-%v is not compatible with InstanceManagerAPIVersion %v and InstanceManagerAPIMinVersion %v",
@@ -377,7 +372,7 @@ func getBinaryAndArgsForEngineProcessCreation(e *longhorn.Engine,
 }
 
 func getBinaryAndArgsForReplicaProcessCreation(r *longhorn.Replica,
-	dataPath, backingImagePath string, dataLocality longhorn.DataLocality, portCount, engineCLIAPIVersion int, encrypted bool) (string, []string, error) {
+	controlPath, dataPath, backingImagePath string, dataLocality longhorn.DataLocality, portCount, engineCLIAPIVersion int, encrypted bool) (string, []string, error) {
 
 	requestSize, err := util.GetActualBackendSize(r.Spec.VolumeSize, encrypted, engineCLIAPIVersion)
 	if err != nil {
@@ -427,7 +422,10 @@ func getBinaryAndArgsForReplicaProcessCreation(r *longhorn.Replica,
 	syncAgentPortCount := portCount - 3
 	args = append(args, "--sync-agent-port-count", strconv.Itoa(syncAgentPortCount))
 
-	binary := filepath.Join(types.GetEngineBinaryDirectoryForReplicaManagerContainer(r.Spec.Image), types.EngineBinaryName)
+	if controlPath == "" {
+		return "", nil, fmt.Errorf("control path is required")
+	}
+	binary := filepath.Join(types.GetEngineBinaryDirectoryForReplicaManagerContainer(r.Spec.Image, controlPath), types.EngineBinaryName)
 
 	return binary, args, nil
 }
@@ -528,6 +526,7 @@ func (c *InstanceManagerClient) EngineInstanceCreate(req *EngineInstanceCreateRe
 
 type ReplicaInstanceCreateRequest struct {
 	Replica                       *longhorn.Replica
+	ControlPath                   string
 	DiskName                      string
 	DataPath                      string
 	BackingImagePath              string
@@ -647,7 +646,7 @@ func (c *InstanceManagerClient) ReplicaInstanceCreate(req *ReplicaInstanceCreate
 	args := []string{}
 	var err error
 	if types.IsDataEngineV1(req.Replica.Spec.DataEngine) {
-		binary, args, err = getBinaryAndArgsForReplicaProcessCreation(req.Replica, req.DataPath, req.BackingImagePath, req.DataLocality, DefaultReplicaPortCountV1, req.EngineCLIAPIVersion, req.Encrypted)
+		binary, args, err = getBinaryAndArgsForReplicaProcessCreation(req.Replica, req.ControlPath, req.DataPath, req.BackingImagePath, req.DataLocality, DefaultReplicaPortCountV1, req.EngineCLIAPIVersion, req.Encrypted)
 		if err != nil {
 			return nil, err
 		}

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -159,6 +159,7 @@ type EngineFrontendClient interface {
 type EngineClientRequest struct {
 	VolumeName   string
 	EngineImage  string
+	ControlPath  string
 	IP           string
 	Port         int
 	InstanceName string

--- a/metrics_collector/volume_collector.go
+++ b/metrics_collector/volume_collector.go
@@ -281,7 +281,11 @@ func (vc *VolumeCollector) collectMetrics(ch chan<- prometheus.Metric, v *longho
 }
 
 func (vc *VolumeCollector) getEngineClientProxy(engine *longhorn.Engine) (c engineapi.EngineClientProxy, err error) {
-	engineCliClient, err := controller.GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage)
+	controlPath, err := vc.ds.GetDefaultControlPath()
+	if err != nil {
+		return nil, err
+	}
+	engineCliClient, err := controller.GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage, controlPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get binary client for engine %v", engine.Name)
 	}

--- a/metrics_collector/volume_collector.go
+++ b/metrics_collector/volume_collector.go
@@ -281,7 +281,7 @@ func (vc *VolumeCollector) collectMetrics(ch chan<- prometheus.Metric, v *longho
 }
 
 func (vc *VolumeCollector) getEngineClientProxy(engine *longhorn.Engine) (c engineapi.EngineClientProxy, err error) {
-	engineCliClient, err := controller.GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage)
+	engineCliClient, err := controller.GetBinaryClientForEngine(engine, &engineapi.EngineCollection{}, engine.Status.CurrentImage, vc.ds)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get binary client for engine %v", engine.Name)
 	}

--- a/types/setting.go
+++ b/types/setting.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -577,12 +578,8 @@ var (
 		DisplayName: "Default Data Path",
 		Description: "Default path to use for storing data on a host. " +
 			"An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, " +
-			"whereas a path to a block device indicates a block-type disk used by the V2 Data Engine. " +
-			"Bare PCI identifiers (such as '0000:00:1e.0') are not supported here since this setting may be " +
-			"used as a host path for pod mounts. " +
-			"When this setting is a block device path, runtime and control-plane paths are configured " +
-			"separately via the 'default-control-path' setting. Note: This is an installation-time setting " +
-			"and cannot be changed after Longhorn is initialized.",
+			"while a path to a block device indicates a block-type disk used by the V2 Data Engine. " +
+			"The default value is \"/var/lib/longhorn/\".",
 		Category:           SettingCategoryGeneral,
 		Type:               SettingTypeString,
 		Required:           true,
@@ -594,7 +591,7 @@ var (
 	SettingDefinitionDefaultControlPath = SettingDefinition{
 		DisplayName: "Default Control Path",
 		Description: "Default path used for storing runtime and control-plane artifacts on a host. " +
-			"This setting must be an absolute directory path. Engine binaries, metadata, sockets, and logs " +
+			"This setting must be an absolute directory path. Engine binaries, metadata and sockets " +
 			"are stored under this path for both V1 and V2 engines. Note: This is an installation-time " +
 			"setting and cannot be changed after Longhorn is initialized.",
 		Type:               SettingTypeString,
@@ -2137,7 +2134,7 @@ var (
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            GetDefaultLogDirectoryOnHost(),
+		Default:            filepath.Join(DefaultControlPath, LogDirectorySubpath),
 	}
 
 	SettingDefinitionNodeDiskHealthMonitoring = SettingDefinition{

--- a/types/types.go
+++ b/types/types.go
@@ -508,22 +508,6 @@ func GetEngineBinaryDirectoryOnHost() string {
 	return filepath.Join(GetLonghornControlPath(), EngineBinaryDirectorySubpath)
 }
 
-// Defaults to /var/lib/longhorn/metadata when LONGHORN_CONTROL_PATH is unset.
-func GetMetadataDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), MetadataDirectorySubpath)
-}
-
-// Defaults to /var/lib/longhorn/unix-domain-socket when LONGHORN_CONTROL_PATH is unset.
-func GetUnixDomainSocketDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), UnixDomainSocketDirectorySubpath)
-}
-
-// Defaults to /host/var/lib/longhorn/unix-domain-socket inside the container.
-func GetUnixDomainSocketDirectoryInContainer() string {
-	return filepath.Join(ReplicaHostPrefix,
-		strings.TrimLeft(GetUnixDomainSocketDirectoryOnHost(), string(filepath.Separator)))
-}
-
 // Defaults to /var/lib/longhorn/logs when LONGHORN_CONTROL_PATH is unset.
 func GetDefaultLogDirectoryOnHost() string {
 	return filepath.Join(GetLonghornControlPath(), LogDirectorySubpath)
@@ -533,9 +517,13 @@ func GetImageCanonicalName(image string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(image, ":", "-"), "/", "-")
 }
 
-func GetEngineBinaryDirectoryOnHostForImage(image string) string {
+func GetEngineBinaryDirectoryOnHostForImageWithControlPath(controlPath, image string) string {
 	cname := GetImageCanonicalName(image)
-	return filepath.Join(GetEngineBinaryDirectoryOnHost(), cname)
+	return filepath.Join(controlPath, EngineBinaryDirectorySubpath, cname)
+}
+
+func GetEngineBinaryDirectoryOnHostForImage(image string) string {
+	return GetEngineBinaryDirectoryOnHostForImageWithControlPath(GetLonghornControlPath(), image)
 }
 
 func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
@@ -543,17 +531,25 @@ func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
 	return filepath.Join(EngineBinaryDirectoryInContainer, cname)
 }
 
-func GetEngineBinaryDirectoryForReplicaManagerContainer(image string) string {
+func GetEngineBinaryDirectoryForReplicaManagerContainerWithControlPath(controlPath, image string) string {
 	cname := GetImageCanonicalName(image)
 	return filepath.Join(
 		ReplicaHostPrefix,
-		strings.TrimLeft(GetEngineBinaryDirectoryOnHost(), string(filepath.Separator)),
+		strings.TrimLeft(filepath.Join(controlPath, EngineBinaryDirectorySubpath), string(filepath.Separator)),
 		cname,
 	)
 }
 
+func GetEngineBinaryDirectoryForReplicaManagerContainer(image string) string {
+	return GetEngineBinaryDirectoryForReplicaManagerContainerWithControlPath(GetLonghornControlPath(), image)
+}
+
 func EngineBinaryExistOnHostForImage(image string) (bool, error) {
-	engineBinaryPath := filepath.Join(GetEngineBinaryDirectoryOnHostForImage(image), "longhorn")
+	return EngineBinaryExistOnHostForImageWithControlPath(GetLonghornControlPath(), image)
+}
+
+func EngineBinaryExistOnHostForImageWithControlPath(controlPath, image string) (bool, error) {
+	engineBinaryPath := filepath.Join(GetEngineBinaryDirectoryOnHostForImageWithControlPath(controlPath, image), "longhorn")
 	st, err := os.Stat(engineBinaryPath)
 	if err != nil {
 		return false, err

--- a/types/types.go
+++ b/types/types.go
@@ -12,11 +12,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
 	lhns "github.com/longhorn/go-common-libs/ns"
 
@@ -503,43 +501,31 @@ func GetDefaultManagerURL() string {
 	return "http://longhorn-backend:" + strconv.Itoa(DefaultAPIPort) + "/v1"
 }
 
-// GetLonghornDataPath returns the process-scoped Longhorn data path.
-// LONGHORN_DATA_PATH is expected to be populated from the configured
-// default-data-path during installation or pod creation. This is an
-// installation-time default rather than a dynamically reloadable setting;
-// when the env var is unset, empty, or invalid, the historical default path
-// is used for backward compatibility.
-func GetLonghornDataPath() string {
-	path := strings.TrimSpace(os.Getenv(LonghornDataPathEnv))
+func GetLonghornDataPath(path string) string {
+	path = strings.TrimSpace(path)
 	if path == "" {
 		return DefaultDataPath
 	}
 	path = filepath.Clean(path)
 	if !IsValidLonghornDataPath(path) {
-		logrus.Warnf("Falling back to default data path %q because %s is unset or invalid", DefaultDataPath, LonghornDataPathEnv)
+		logrus.Warnf("Falling back to default data path %q because data path is unset or invalid", DefaultDataPath)
 		return DefaultDataPath
 	}
 	return path
 }
 
-// GetLonghornControlPath returns the process-scoped Longhorn control path.
-// LONGHORN_CONTROL_PATH is expected to be populated from the configured
-// default-control-path during installation or pod creation. This is an
-// installation-time default rather than a dynamically reloadable setting;
-// when the env var is unset, empty, or invalid, the historical default path
-// is used for backward compatibility.
-func GetLonghornControlPath() string {
-	path := strings.TrimSpace(os.Getenv(LonghornControlPathEnv))
+func GetLonghornControlPath(path string) string {
+	path = strings.TrimSpace(path)
 	if path == "" {
 		return DefaultControlPath
 	}
 	path = filepath.Clean(path)
 	if !IsValidLonghornControlPath(path) {
 		if path == "/dev" || strings.HasPrefix(path, "/dev/") {
-			logrus.Warnf("Falling back to default control path %q because %s cannot point to /dev", DefaultControlPath, LonghornControlPathEnv)
+			logrus.Warnf("Falling back to default control path %q because control path cannot point to /dev", DefaultControlPath)
 			return DefaultControlPath
 		}
-		logrus.Warnf("Falling back to default control path %q because %s is unset or invalid", DefaultControlPath, LonghornControlPathEnv)
+		logrus.Warnf("Falling back to default control path %q because control path is unset or invalid", DefaultControlPath)
 		return DefaultControlPath
 	}
 	return path
@@ -547,6 +533,9 @@ func GetLonghornControlPath() string {
 
 func IsValidLonghornDataPath(path string) bool {
 	path = filepath.Clean(strings.TrimSpace(path))
+	if IsBDF(path) {
+		return true
+	}
 	return path != "." && path != "" && path != string(filepath.Separator) && filepath.IsAbs(path)
 }
 
@@ -558,39 +547,36 @@ func IsValidLonghornControlPath(path string) bool {
 	return path != "/dev" && !strings.HasPrefix(path, "/dev/")
 }
 
-// Defaults to /var/lib/longhorn/engine-binaries when LONGHORN_CONTROL_PATH is unset.
-func GetEngineBinaryDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), EngineBinaryDirectorySubpath)
-}
-
-// Defaults to /var/lib/longhorn/metadata when LONGHORN_CONTROL_PATH is unset.
-func GetMetadataDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), MetadataDirectorySubpath)
-}
-
-// Defaults to /var/lib/longhorn/unix-domain-socket when LONGHORN_CONTROL_PATH is unset.
-func GetUnixDomainSocketDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), UnixDomainSocketDirectorySubpath)
-}
-
-// Defaults to /host/var/lib/longhorn/unix-domain-socket inside the container.
-func GetUnixDomainSocketDirectoryInContainer() string {
-	return filepath.Join(ReplicaHostPrefix,
-		strings.TrimLeft(GetUnixDomainSocketDirectoryOnHost(), string(filepath.Separator)))
-}
-
-// Defaults to /var/lib/longhorn/logs when LONGHORN_CONTROL_PATH is unset.
-func GetDefaultLogDirectoryOnHost() string {
-	return filepath.Join(GetLonghornControlPath(), LogDirectorySubpath)
-}
-
 func GetImageCanonicalName(image string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(image, ":", "-"), "/", "-")
 }
 
-func GetEngineBinaryDirectoryOnHostForImage(image string) string {
+func GetEngineBinaryDirectoryOnHost(controlPath string) string {
+	return filepath.Join(controlPath, EngineBinaryDirectorySubpath)
+}
+
+func GetMetadataDirectoryOnHost(controlPath string) string {
+	return filepath.Join(controlPath, MetadataDirectorySubpath)
+}
+
+func GetUnixDomainSocketDirectoryOnHost(controlPath string) string {
+	return filepath.Join(controlPath, UnixDomainSocketDirectorySubpath)
+}
+
+func GetPathForReplicaManagerContainer(path string) string {
+	return filepath.Join(
+		ReplicaHostPrefix,
+		strings.TrimLeft(path, string(filepath.Separator)),
+	)
+}
+
+func GetUnixDomainSocketDirectoryInContainer(controlPath string) string {
+	return GetPathForReplicaManagerContainer(GetUnixDomainSocketDirectoryOnHost(controlPath))
+}
+
+func GetEngineBinaryDirectoryOnHostForImage(image, controlPath string) string {
 	cname := GetImageCanonicalName(image)
-	return filepath.Join(GetEngineBinaryDirectoryOnHost(), cname)
+	return filepath.Join(GetEngineBinaryDirectoryOnHost(controlPath), cname)
 }
 
 func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
@@ -598,25 +584,9 @@ func GetEngineBinaryDirectoryForEngineManagerContainer(image string) string {
 	return filepath.Join(EngineBinaryDirectoryInContainer, cname)
 }
 
-func GetEngineBinaryDirectoryForReplicaManagerContainer(image string) string {
+func GetEngineBinaryDirectoryForReplicaManagerContainer(image, controlPath string) string {
 	cname := GetImageCanonicalName(image)
-	return filepath.Join(
-		ReplicaHostPrefix,
-		strings.TrimLeft(GetEngineBinaryDirectoryOnHost(), string(filepath.Separator)),
-		cname,
-	)
-}
-
-func EngineBinaryExistOnHostForImage(image string) (bool, error) {
-	engineBinaryPath := filepath.Join(GetEngineBinaryDirectoryOnHostForImage(image), "longhorn")
-	st, err := os.Stat(engineBinaryPath)
-	if err != nil {
-		return false, err
-	}
-	if st.IsDir() {
-		return false, errors.Errorf("expected %s to be a file, but it is a directory", engineBinaryPath)
-	}
-	return true, nil
+	return filepath.Join(GetPathForReplicaManagerContainer(GetEngineBinaryDirectoryOnHost(controlPath)), cname)
 }
 
 func GetBackingImageManagerName(image, diskUUID string) string {
@@ -625,6 +595,10 @@ func GetBackingImageManagerName(image, diskUUID string) string {
 
 func GetBackingImageDirectoryName(backingImageName, backingImageUUID string) string {
 	return fmt.Sprintf("%s-%s", backingImageName, backingImageUUID)
+}
+
+func GetDefaultLogDirectoryOnHost() string {
+	return filepath.Join(DefaultControlPath, LogDirectorySubpath)
 }
 
 func GetBackingImageManagerDirectoryOnHost(diskPath string) string {
@@ -1471,45 +1445,53 @@ func CreateDisksFromAnnotation(annotation string, storageReservedPercentage int6
 		if disk.Path == "" {
 			return nil, fmt.Errorf("invalid disk %+v", disk)
 		}
-		diskStat, err := lhns.GetDiskStat(disk.Path)
-		if err != nil {
-			return nil, err
+
+		if disk.StorageReserved < 0 {
+			return nil, fmt.Errorf("the storageReserved setting of disk %v is not valid, should be positive and no more than storageMaximum and storageAvailable", disk.Path)
 		}
+
+		if disk.Type == longhorn.DiskTypeBlock {
+			if disk.Name == "" {
+				disk.Name = DefaultDiskPrefix + util.RandomID()
+			}
+			if disk.DiskDriver == "" {
+				disk.DiskDriver = longhorn.DiskDriverAuto
+			}
+		} else {
+			diskStat, err := lhns.GetDiskStat(disk.Path)
+			if err != nil {
+				return nil, err
+			}
+
+			// Set to default disk name
+			if disk.Name == "" {
+				disk.Name = DefaultDiskPrefix + diskStat.DiskID
+			}
+
+			if _, exist := existDiskID[diskStat.DiskID]; exist {
+				return nil, fmt.Errorf(
+					"the disk %v is the same"+
+						"file system with %v, diskID %v",
+					disk.Path, existDiskID[diskStat.DiskID],
+					diskStat.DiskID)
+			}
+
+			existDiskID[diskStat.DiskID] = disk.Path
+
+			if disk.StorageReserved > diskStat.StorageMaximum {
+				return nil, fmt.Errorf("the storageReserved setting of disk %v is not valid, should be positive and no more than storageMaximum and storageAvailable", disk.Path)
+			}
+			if disk.StorageReserved == 0 {
+				disk.StorageReserved = diskStat.StorageMaximum * storageReservedPercentage / 100
+			}
+		}
+
 		for _, vDisk := range validDisks {
 			if vDisk.Path == disk.Path {
 				return nil, fmt.Errorf("duplicate disk path %v", disk.Path)
 			}
 		}
 
-		// Set to default disk name
-		if disk.Name == "" {
-			disk.Name = DefaultDiskPrefix + diskStat.DiskID
-		}
-
-		if _, exist := existDiskID[diskStat.DiskID]; exist {
-			return nil, fmt.Errorf(
-				"the disk %v is the same"+
-					"file system with %v, diskID %v",
-				disk.Path, existDiskID[diskStat.DiskID],
-				diskStat.DiskID)
-		}
-
-		existDiskID[diskStat.DiskID] = disk.Path
-
-		if disk.StorageReserved < 0 || disk.StorageReserved > diskStat.StorageMaximum {
-			return nil, fmt.Errorf("the storageReserved setting of disk %v is not valid, should be positive and no more than storageMaximum and storageAvailable", disk.Path)
-		}
-		if disk.StorageReserved == 0 {
-			if disk.Type == longhorn.DiskTypeBlock {
-				size, err := getBlockDeviceSize(ReplicaHostPrefix + disk.Path)
-				if err != nil {
-					return nil, err
-				}
-				disk.StorageReserved = int64(size) * storageReservedPercentage / 100
-			} else {
-				disk.StorageReserved = diskStat.StorageMaximum * storageReservedPercentage / 100
-			}
-		}
 		tags, err := util.ValidateTags(disk.Tags)
 		if err != nil {
 			return nil, err
@@ -1523,25 +1505,6 @@ func CreateDisksFromAnnotation(annotation string, storageReservedPercentage int6
 	}
 
 	return validDisks, nil
-}
-
-func getBlockDeviceSize(devicePath string) (uint64, error) {
-	file, err := os.Open(devicePath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to open block device at %s: %w", devicePath, err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			logrus.WithError(closeErr).Warnf("Failed to close block device %s", devicePath)
-		}
-	}()
-	var size uint64
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, file.Fd(), 0x80081272, uintptr(unsafe.Pointer(&size)))
-	if errno != 0 {
-		return 0, fmt.Errorf("failed to get block device size for %s: errno=%v", devicePath, errno)
-	}
-
-	return size, nil
 }
 
 func GetNodeTagsFromAnnotation(annotation string) ([]string, error) {
@@ -1584,7 +1547,7 @@ func UnmarshalToNodeTags(s string) ([]string, error) {
 }
 
 func IsBDF(addr string) bool {
-	bdfFormat := "[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}"
+	bdfFormat := "^[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}$"
 	bdfPattern := regexp.MustCompile(bdfFormat)
 	return bdfPattern.MatchString(addr)
 }
@@ -1609,10 +1572,6 @@ func IsPotentialBlockDisk(path string) bool {
 
 func CreateDefaultDisk(dataPath string, storageReservedPercentage int64) (map[string]longhorn.DiskSpec, error) {
 	if IsPotentialBlockDisk(dataPath) {
-		size, err := getBlockDeviceSize(dataPath)
-		if err != nil {
-			return nil, err
-		}
 		return map[string]longhorn.DiskSpec{
 			DefaultDiskPrefix + util.RandomID(): {
 				Type:              longhorn.DiskTypeBlock,
@@ -1620,7 +1579,7 @@ func CreateDefaultDisk(dataPath string, storageReservedPercentage int64) (map[st
 				DiskDriver:        longhorn.DiskDriverAuto,
 				AllowScheduling:   true,
 				EvictionRequested: false,
-				StorageReserved:   int64(size) * storageReservedPercentage / 100,
+				StorageReserved:   0,
 				Tags:              []string{},
 			},
 		}, nil

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -75,16 +75,22 @@ func (s *TestSuite) TestGetLonghornControlPath(c *C) {
 	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
 }
 
-func (s *TestSuite) TestContainerPathHelpersUseReplicaHostPrefix(c *C) {
+func (s *TestSuite) TestEngineBinaryDirectoryForReplicaManagerContainerUsesReplicaHostPrefix(c *C) {
 	customPath := "/control/longhorn"
 	image := "longhornio/longhorn-engine:v1.9.0"
 
 	c.Assert(os.Setenv(LonghornControlPathEnv, customPath), IsNil)
 
-	c.Assert(GetUnixDomainSocketDirectoryInContainer(), Equals,
-		filepath.Join(ReplicaHostPrefix, "control/longhorn", UnixDomainSocketDirectorySubpath))
 	c.Assert(GetEngineBinaryDirectoryForReplicaManagerContainer(image), Equals,
 		filepath.Join(ReplicaHostPrefix, "control/longhorn", EngineBinaryDirectorySubpath, GetImageCanonicalName(image)))
+}
+
+func (s *TestSuite) TestEngineBinaryDirectoryForReplicaManagerContainerWithControlPathUsesExplicitPath(c *C) {
+	controlPath := "/data/longhorn"
+	image := "longhornio/longhorn-engine:v1.9.0"
+
+	c.Assert(GetEngineBinaryDirectoryForReplicaManagerContainerWithControlPath(controlPath, image), Equals,
+		filepath.Join(ReplicaHostPrefix, "data/longhorn", EngineBinaryDirectorySubpath, GetImageCanonicalName(image)))
 }
 
 func (s *TestSuite) TestParseToleration(c *C) {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -31,62 +30,101 @@ var _ = Suite(&TestSuite{})
 
 func (s *TestSuite) SetUpTest(c *C) {
 	logrus.SetLevel(logrus.DebugLevel)
-	c.Assert(os.Unsetenv(LonghornDataPathEnv), IsNil)
-	c.Assert(os.Unsetenv(LonghornControlPathEnv), IsNil)
 }
 
 func (s *TestSuite) TearDownTest(c *C) {
-	c.Assert(os.Unsetenv(LonghornDataPathEnv), IsNil)
-	c.Assert(os.Unsetenv(LonghornControlPathEnv), IsNil)
 }
 
 func (s *TestSuite) TestGetLonghornDataPath(c *C) {
-	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+	c.Assert(GetLonghornDataPath(""), Equals, DefaultDataPath)
 
 	customPath := "/data/longhorn/"
-	c.Assert(os.Setenv(LonghornDataPathEnv, customPath), IsNil)
-	c.Assert(GetLonghornDataPath(), Equals, filepath.Clean(customPath))
+	c.Assert(GetLonghornDataPath(customPath), Equals, filepath.Clean(customPath))
 
-	c.Assert(os.Setenv(LonghornDataPathEnv, "relative/path"), IsNil)
-	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+	c.Assert(GetLonghornDataPath("relative/path"), Equals, DefaultDataPath)
 
-	c.Assert(os.Setenv(LonghornDataPathEnv, string(filepath.Separator)), IsNil)
-	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+	c.Assert(GetLonghornDataPath(string(filepath.Separator)), Equals, DefaultDataPath)
 
-	c.Assert(os.Setenv(LonghornDataPathEnv, "/dev/nvme0n1"), IsNil)
-	c.Assert(GetLonghornDataPath(), Equals, "/dev/nvme0n1")
+	c.Assert(GetLonghornDataPath("/dev/nvme0n1"), Equals, "/dev/nvme0n1")
 
-	c.Assert(os.Setenv(LonghornDataPathEnv, "0000:00:1e.0"), IsNil)
-	c.Assert(GetLonghornDataPath(), Equals, DefaultDataPath)
+	c.Assert(GetLonghornDataPath("/dev/disk/by-id/scsi-36001405b8f1e2d3c4b5a697887766554"), Equals, "/dev/disk/by-id/scsi-36001405b8f1e2d3c4b5a697887766554")
+
+	c.Assert(GetLonghornDataPath("0000:00:1e.0"), Equals, "0000:00:1e.0")
+
+	c.Assert(GetLonghornDataPath("prefix0000:00:1e.0suffix"), Equals, DefaultDataPath)
 }
 
 func (s *TestSuite) TestGetLonghornControlPath(c *C) {
-	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+	c.Assert(GetLonghornControlPath(""), Equals, DefaultControlPath)
 
 	customPath := "/control/longhorn/"
-	c.Assert(os.Setenv(LonghornControlPathEnv, customPath), IsNil)
-	c.Assert(GetLonghornControlPath(), Equals, filepath.Clean(customPath))
+	c.Assert(GetLonghornControlPath(customPath), Equals, filepath.Clean(customPath))
 
-	c.Assert(os.Setenv(LonghornControlPathEnv, "relative/path"), IsNil)
-	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+	c.Assert(GetLonghornControlPath("relative/path"), Equals, DefaultControlPath)
 
-	c.Assert(os.Setenv(LonghornControlPathEnv, string(filepath.Separator)), IsNil)
-	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+	c.Assert(GetLonghornControlPath(string(filepath.Separator)), Equals, DefaultControlPath)
 
-	c.Assert(os.Setenv(LonghornControlPathEnv, "/dev/nvme0n1"), IsNil)
-	c.Assert(GetLonghornControlPath(), Equals, DefaultControlPath)
+	c.Assert(GetLonghornControlPath("/dev/nvme0n1"), Equals, DefaultControlPath)
 }
 
-func (s *TestSuite) TestContainerPathHelpersUseReplicaHostPrefix(c *C) {
-	customPath := "/control/longhorn"
-	image := "longhornio/longhorn-engine:v1.9.0"
+func (s *TestSuite) TestCreateDefaultDiskWithBDF(c *C) {
+	const bdf = "0000:00:1e.0"
 
-	c.Assert(os.Setenv(LonghornControlPathEnv, customPath), IsNil)
+	disks, err := CreateDefaultDisk(bdf, 30)
+	c.Assert(err, IsNil)
+	c.Assert(disks, HasLen, 1)
 
-	c.Assert(GetUnixDomainSocketDirectoryInContainer(), Equals,
-		filepath.Join(ReplicaHostPrefix, "control/longhorn", UnixDomainSocketDirectorySubpath))
-	c.Assert(GetEngineBinaryDirectoryForReplicaManagerContainer(image), Equals,
-		filepath.Join(ReplicaHostPrefix, "control/longhorn", EngineBinaryDirectorySubpath, GetImageCanonicalName(image)))
+	for _, disk := range disks {
+		c.Assert(disk.Type, Equals, longhorn.DiskTypeBlock)
+		c.Assert(disk.Path, Equals, bdf)
+		c.Assert(disk.DiskDriver, Equals, longhorn.DiskDriverAuto)
+		c.Assert(disk.StorageReserved, Equals, int64(0))
+	}
+}
+
+func (s *TestSuite) TestCreateDefaultDiskWithByIDBlockDevicePath(c *C) {
+	const byIDPath = "/dev/disk/by-id/nvme-Amazon_EC2_NVMe_Instance_Storage_AWS318946B8D49D7E14D"
+
+	disks, err := CreateDefaultDisk(byIDPath, 30)
+	c.Assert(err, IsNil)
+	c.Assert(disks, HasLen, 1)
+
+	for _, disk := range disks {
+		c.Assert(disk.Type, Equals, longhorn.DiskTypeBlock)
+		c.Assert(disk.Path, Equals, byIDPath)
+		c.Assert(disk.DiskDriver, Equals, longhorn.DiskDriverAuto)
+		c.Assert(disk.StorageReserved, Equals, int64(0))
+	}
+}
+
+func (s *TestSuite) TestCreateDisksFromAnnotationWithBDFBlockDisk(c *C) {
+	const bdf = "0000:00:1e.0"
+
+	disks, err := CreateDisksFromAnnotation(fmt.Sprintf(`[{"path":%q,"diskType":"block","allowScheduling":true}]`, bdf), 30)
+	c.Assert(err, IsNil)
+	c.Assert(disks, HasLen, 1)
+
+	for diskName, disk := range disks {
+		c.Assert(strings.HasPrefix(diskName, DefaultDiskPrefix), Equals, true)
+		c.Assert(disk.Type, Equals, longhorn.DiskTypeBlock)
+		c.Assert(disk.Path, Equals, bdf)
+		c.Assert(disk.DiskDriver, Equals, longhorn.DiskDriverAuto)
+		c.Assert(disk.StorageReserved, Equals, int64(0))
+	}
+}
+
+func (s *TestSuite) TestEngineBinaryDirectoryForReplicaManagerContainerUsesControlPath(c *C) {
+	const controlPath = "/control/longhorn"
+
+	c.Assert(GetEngineBinaryDirectoryOnHost(controlPath), Equals, "/control/longhorn/engine-binaries")
+	c.Assert(GetMetadataDirectoryOnHost(controlPath), Equals, "/control/longhorn/metadata")
+	c.Assert(GetUnixDomainSocketDirectoryOnHost(controlPath), Equals, "/control/longhorn/unix-domain-socket")
+	c.Assert(GetUnixDomainSocketDirectoryInContainer(controlPath), Equals, "/host/control/longhorn/unix-domain-socket")
+	c.Assert(
+		GetEngineBinaryDirectoryForReplicaManagerContainer("longhornio/longhorn-engine:v1.9.0", controlPath),
+		Equals,
+		"/host/control/longhorn/engine-binaries/longhornio-longhorn-engine-v1.9.0",
+	)
 }
 
 func (s *TestSuite) TestParseToleration(c *C) {

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -81,7 +81,7 @@ func Upgrade(kubeconfigPath, currentNodeID, managerImage string, enableUpgradeVe
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "longhorn-upgrade"})
 
-	if err := upgradeutil.CheckUpgradePath(namespace, lhClient, eventRecorder, enableUpgradeVersionCheck); err != nil {
+	if err := upgradeutil.CheckUpgradePath(namespace, lhClient, eventRecorder, enableUpgradeVersionCheck, ""); err != nil {
 		return err
 	}
 

--- a/upgrade/util/util.go
+++ b/upgrade/util/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -199,7 +200,7 @@ func CreateOrUpdateLonghornVersionSetting(namespace string, lhClient *lhclientse
 	return nil
 }
 
-func CheckUpgradePath(namespace string, lhClient lhclientset.Interface, eventRecorder record.EventRecorder, enableUpgradeVersionCheck bool) error {
+func CheckUpgradePath(namespace string, lhClient lhclientset.Interface, eventRecorder record.EventRecorder, enableUpgradeVersionCheck bool, requestedControlPath string) error {
 	lhCurrentVersion, err := GetCurrentLonghornVersion(namespace, lhClient)
 	if err != nil {
 		return err
@@ -217,7 +218,39 @@ func CheckUpgradePath(namespace string, lhClient lhclientset.Interface, eventRec
 		return err
 	}
 
+	if err := checkDefaultControlPathUpgrade(namespace, lhClient, requestedControlPath); err != nil {
+		return err
+	}
+
 	return checkEngineUpgradePath(namespace, lhClient, emeta.GetVersion())
+}
+
+func checkDefaultControlPathUpgrade(namespace string, lhClient lhclientset.Interface, requestedControlPath string) error {
+	requestedControlPath = strings.TrimSpace(requestedControlPath)
+	if requestedControlPath == "" {
+		return nil
+	}
+
+	requestedControlPath = filepath.Clean(requestedControlPath)
+	if !types.IsValidLonghornControlPath(requestedControlPath) {
+		return fmt.Errorf("failed to upgrade since the requested %v %q is invalid", types.SettingNameDefaultControlPath, requestedControlPath)
+	}
+
+	currentControlPath := types.DefaultControlPath
+	setting, err := lhClient.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(types.SettingNameDefaultControlPath), metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to get current %v setting", types.SettingNameDefaultControlPath)
+		}
+	} else {
+		currentControlPath = types.GetLonghornControlPath(setting.Value)
+	}
+
+	if currentControlPath != requestedControlPath {
+		return fmt.Errorf("failed to upgrade since changing %v from %q to %q is not supported", types.SettingNameDefaultControlPath, currentControlPath, requestedControlPath)
+	}
+
+	return nil
 }
 
 // checkLHUpgradePath returns if the upgrade path from lhCurrentVersion to meta.Version is supported.

--- a/upgrade/util/util_test.go
+++ b/upgrade/util/util_test.go
@@ -224,6 +224,70 @@ func newCheckLHUpgradePathSupported(lhClient lhclientset.Interface) error {
 	return checkLHUpgradePath(TestNamespace, lhClient)
 }
 
+func TestCheckDefaultControlPathUpgrade(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		currentSettingValue  string
+		requestedControlPath string
+		expectError          bool
+	}{
+		{
+			name:                 "skip when requested control path is empty",
+			requestedControlPath: "",
+			expectError:          false,
+		},
+		{
+			name:                 "allow fresh install upgrade path from implicit default",
+			requestedControlPath: types.DefaultControlPath,
+			expectError:          false,
+		},
+		{
+			name:                 "reject changing implicit default control path",
+			requestedControlPath: "/data/longhorn",
+			expectError:          true,
+		},
+		{
+			name:                 "allow matching existing control path",
+			currentSettingValue:  "/data/longhorn/",
+			requestedControlPath: "/data/longhorn",
+			expectError:          false,
+		},
+		{
+			name:                 "reject changing existing control path",
+			currentSettingValue:  "/var/lib/longhorn",
+			requestedControlPath: "/data/longhorn",
+			expectError:          true,
+		},
+		{
+			name:                 "reject invalid requested control path",
+			requestedControlPath: "/dev/nvme0n1",
+			expectError:          true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset() // nolint: staticcheck
+			if tt.currentSettingValue != "" {
+				_, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), &longhorn.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: string(types.SettingNameDefaultControlPath),
+					},
+					Value: tt.currentSettingValue,
+				}, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			err := checkDefaultControlPathUpgrade(TestNamespace, lhClient, tt.requestedControlPath)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func Test(t *testing.T) { TestingT(t) }
 
 type TestSuite struct {

--- a/upgrade/v112xto1130/upgrade.go
+++ b/upgrade/v112xto1130/upgrade.go
@@ -1,10 +1,15 @@
 package v112xto1130
 
 import (
+	"context"
+
 	"github.com/cockroachdb/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
@@ -21,6 +26,36 @@ func UpgradeResources(namespace string, lhClient *lhclientset.Clientset, kubeCli
 	}
 
 	if err := upgradeRecurringJobs(namespace, lhClient, resourceMaps); err != nil {
+		return err
+	}
+
+	if err := createDefaultControlPathSetting(namespace, lhClient); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createDefaultControlPathSetting(namespace string, lhClient lhclientset.Interface) (err error) {
+	defer func() {
+		err = errors.Wrapf(err, upgradeLogPrefix+"create default control path setting failed")
+	}()
+
+	_, err = lhClient.LonghornV1beta2().Settings(namespace).Get(context.TODO(), string(types.SettingNameDefaultControlPath), metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	setting := &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(types.SettingNameDefaultControlPath),
+		},
+		Value: types.DefaultControlPath,
+	}
+	if _, err = lhClient.LonghornV1beta2().Settings(namespace).Create(context.TODO(), setting, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9083

#### What this PR does / why we need it:

1. `default-control-path` are treated as install-time settings and cannot be changed after Longhorn is initialized, including during upgrade. This avoids mixed runtime state.

2. The runtime source of truth is moved from pod `env` to `persisted settings`. This keeps install, upgrade, and reconciliation behavior consistent.

3. Align the disk creation flow so `default-data-path` now supports BDF-style block disk paths such as `0000:00:1f.0`.

#### Special notes for your reviewer:

#### Additional documentation or context
