### PR TITLE
fix(backup-target): sanitize volatile IDs from status condition messages

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -324,23 +324,44 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 // AWS/S3-compatible SDKs embed in error messages, e.g.
 // "403 1eed0c50c2cb9133" (HTTP status + hex request ID) as produced by
 // backupstore's parseAwsError, or an explicit "RequestId: ..." field.
-var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|\b[0-9]{3}\s+[0-9a-f]{16}\b)`)
+// Note: no leading \b before the status code - error messages captured from
+// exec'd subprocess stderr often contain a literal two-character "\n"
+// escape sequence (backslash + n) rather than a real newline byte
+// immediately before the status code, which defeats a \b word-boundary
+// check (both 'n' and the following digit are word characters, so no
+// boundary exists between them). A trailing \b after the hex ID is safe
+// since it's normally followed by a quote, space, or real newline.
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|[0-9]{3}\s+[0-9a-f]{16}\b)`)
 
-// sanitizeBackupStoreErrorMessage strips volatile per-request identifiers
-// (S3 request IDs, HTTP status/request-ID pairs) from a backup store error
-// message before it is persisted to BackupTarget.Status.Conditions.
+// timestampPattern matches RFC3339(-nano) timestamps that the exec'd
+// `longhorn` engine binary's own logrus output embeds in every log line
+// (e.g. `time="2026-07-24T16:31:27.852675962Z" level=error ...`). Since
+// that subprocess is invoked fresh on every reconcile attempt, its log
+// timestamps change every time even when the underlying error is
+// identical, so they must be normalized too.
+var timestampPattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z`)
+
+// sanitizeBackupStoreErrorMessage strips volatile, per-attempt content
+// (S3 request IDs, HTTP status/request-ID pairs, subprocess log
+// timestamps) from a backup store error message before it is persisted to
+// BackupTarget.Status.Conditions.
 //
 // Without this, every failed poll produces a Status.Conditions[].Message
-// that differs only by request ID, which fails the reflect.DeepEqual check
-// in reconcile()'s deferred status update. Each failure then triggers
+// that differs from the last (by request ID and/or embedded subprocess
+// log timestamp), which fails the reflect.DeepEqual check in
+// reconcile()'s deferred status update. Each failure then triggers
 // UpdateBackupTargetStatus, which fires the BackupTargetInformer's
 // UpdateFunc handler and immediately re-enqueues reconcile - completely
 // bypassing BackupTarget.Spec.PollInterval and hammering the remote
-// backup target (observed: tens of thousands of S3 list calls in minutes).
+// backup target (observed live: a sustained ~6 reconciles/second with
+// invalid credentials, instead of one attempt per 5-minute poll
+// interval).
 //
 // See https://github.com/longhorn/longhorn/issues/1547
 func sanitizeBackupStoreErrorMessage(message string) string {
-	return requestIDPattern.ReplaceAllString(message, "<redacted>")
+	message = requestIDPattern.ReplaceAllString(message, "<redacted>")
+	message = timestampPattern.ReplaceAllString(message, "<timestamp>")
+	return message
 }
 
 func (btc *BackupTargetController) reconcile(name string) (err error) {

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -319,6 +320,29 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 	return newBackupTargetClient(ds, backupTarget, defaultEngineImage)
 }
 
+// requestIDPattern matches the volatile, per-attempt identifiers that
+// AWS/S3-compatible SDKs embed in error messages, e.g.
+// "403 1eed0c50c2cb9133" (HTTP status + hex request ID) as produced by
+// backupstore's parseAwsError, or an explicit "RequestId: ..." field.
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|\b[0-9]{3}\s+[0-9a-f]{16}\b)`)
+
+// sanitizeBackupStoreErrorMessage strips volatile per-request identifiers
+// (S3 request IDs, HTTP status/request-ID pairs) from a backup store error
+// message before it is persisted to BackupTarget.Status.Conditions.
+//
+// Without this, every failed poll produces a Status.Conditions[].Message
+// that differs only by request ID, which fails the reflect.DeepEqual check
+// in reconcile()'s deferred status update. Each failure then triggers
+// UpdateBackupTargetStatus, which fires the BackupTargetInformer's
+// UpdateFunc handler and immediately re-enqueues reconcile - completely
+// bypassing BackupTarget.Spec.PollInterval and hammering the remote
+// backup target (observed: tens of thousands of S3 list calls in minutes).
+//
+// See https://github.com/longhorn/longhorn/issues/1547
+func sanitizeBackupStoreErrorMessage(message string) string {
+	return requestIDPattern.ReplaceAllString(message, "<redacted>")
+}
+
 func (btc *BackupTargetController) reconcile(name string) (err error) {
 	backupTarget, err := btc.ds.GetBackupTarget(name)
 	if err != nil {
@@ -478,7 +502,8 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 		backupTarget.Status.Available = false
 		backupTarget.Status.Conditions = types.SetCondition(backupTarget.Status.Conditions,
 			longhorn.BackupTargetConditionTypeUnavailable, longhorn.ConditionStatusTrue,
-			longhorn.BackupTargetConditionReasonUnavailable, errors.Wrapf(err, "failed to list system backups in %v", backupTargetClient.URL).Error())
+			longhorn.BackupTargetConditionReasonUnavailable,
+			sanitizeBackupStoreErrorMessage(errors.Wrapf(err, "failed to list system backups in %v", backupTargetClient.URL).Error()))
 		log.WithError(err).Error("Failed to get info from backup store")
 		return nil // Ignore error to allow status update as well as preventing enqueue
 	}

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -332,14 +332,19 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 // AWS/S3-compatible SDKs embed in error messages, e.g.
 // "403 1eed0c50c2cb9133" (HTTP status + hex request ID) as produced by
 // backupstore's parseAwsError, or an explicit "RequestId: ..." field.
+// The explicit "RequestId:" field matches the complete opaque token
+// ([0-9A-Za-z-]+), not just a hex prefix: S3-compatible backends issue
+// alphanumeric request IDs, and matching only the hex prefix would leave
+// the volatile alphanumeric suffix in the message, so repeated failures
+// would still differ and preserve the reconcile storm.
 // Note: no leading \b before the status code - error messages captured from
 // exec'd subprocess stderr often contain a literal two-character "\n"
 // escape sequence (backslash + n) rather than a real newline byte
 // immediately before the status code, which defeats a \b word-boundary
 // check (both 'n' and the following digit are word characters, so no
-// boundary exists between them). A trailing \b after the hex ID is safe
+// boundary exists between them). A trailing \b after the ID is safe
 // since it's normally followed by a quote, space, or real newline.
-var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|[0-9]{3}\s+[0-9a-f]{16}\b)`)
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-z-]+|[0-9]{3}\s+[0-9a-f]{16}\b)`)
 
 // timestampPattern matches RFC3339(-nano) timestamps that the exec'd
 // `longhorn` engine binary's own logrus output embeds in every log line

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -332,23 +332,44 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 // AWS/S3-compatible SDKs embed in error messages, e.g.
 // "403 1eed0c50c2cb9133" (HTTP status + hex request ID) as produced by
 // backupstore's parseAwsError, or an explicit "RequestId: ..." field.
-var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|\b[0-9]{3}\s+[0-9a-f]{16}\b)`)
+// Note: no leading \b before the status code - error messages captured from
+// exec'd subprocess stderr often contain a literal two-character "\n"
+// escape sequence (backslash + n) rather than a real newline byte
+// immediately before the status code, which defeats a \b word-boundary
+// check (both 'n' and the following digit are word characters, so no
+// boundary exists between them). A trailing \b after the hex ID is safe
+// since it's normally followed by a quote, space, or real newline.
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|[0-9]{3}\s+[0-9a-f]{16}\b)`)
 
-// sanitizeBackupStoreErrorMessage strips volatile per-request identifiers
-// (S3 request IDs, HTTP status/request-ID pairs) from a backup store error
-// message before it is persisted to BackupTarget.Status.Conditions.
+// timestampPattern matches RFC3339(-nano) timestamps that the exec'd
+// `longhorn` engine binary's own logrus output embeds in every log line
+// (e.g. `time="2026-07-24T16:31:27.852675962Z" level=error ...`). Since
+// that subprocess is invoked fresh on every reconcile attempt, its log
+// timestamps change every time even when the underlying error is
+// identical, so they must be normalized too.
+var timestampPattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z`)
+
+// sanitizeBackupStoreErrorMessage strips volatile, per-attempt content
+// (S3 request IDs, HTTP status/request-ID pairs, subprocess log
+// timestamps) from a backup store error message before it is persisted to
+// BackupTarget.Status.Conditions.
 //
 // Without this, every failed poll produces a Status.Conditions[].Message
-// that differs only by request ID, which fails the reflect.DeepEqual check
-// in reconcile()'s deferred status update. Each failure then triggers
+// that differs from the last (by request ID and/or embedded subprocess
+// log timestamp), which fails the reflect.DeepEqual check in
+// reconcile()'s deferred status update. Each failure then triggers
 // UpdateBackupTargetStatus, which fires the BackupTargetInformer's
 // UpdateFunc handler and immediately re-enqueues reconcile - completely
 // bypassing BackupTarget.Spec.PollInterval and hammering the remote
-// backup target (observed: tens of thousands of S3 list calls in minutes).
+// backup target (observed live: a sustained ~6 reconciles/second with
+// invalid credentials, instead of one attempt per 5-minute poll
+// interval).
 //
 // See https://github.com/longhorn/longhorn/issues/1547
 func sanitizeBackupStoreErrorMessage(message string) string {
-	return requestIDPattern.ReplaceAllString(message, "<redacted>")
+	message = requestIDPattern.ReplaceAllString(message, "<redacted>")
+	message = timestampPattern.ReplaceAllString(message, "<timestamp>")
+	return message
 }
 
 func (btc *BackupTargetController) reconcile(name string) (err error) {

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -327,6 +328,29 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 	return newBackupTargetClient(ds, backupTarget, defaultEngineImage)
 }
 
+// requestIDPattern matches the volatile, per-attempt identifiers that
+// AWS/S3-compatible SDKs embed in error messages, e.g.
+// "403 1eed0c50c2cb9133" (HTTP status + hex request ID) as produced by
+// backupstore's parseAwsError, or an explicit "RequestId: ..." field.
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-f-]+|\b[0-9]{3}\s+[0-9a-f]{16}\b)`)
+
+// sanitizeBackupStoreErrorMessage strips volatile per-request identifiers
+// (S3 request IDs, HTTP status/request-ID pairs) from a backup store error
+// message before it is persisted to BackupTarget.Status.Conditions.
+//
+// Without this, every failed poll produces a Status.Conditions[].Message
+// that differs only by request ID, which fails the reflect.DeepEqual check
+// in reconcile()'s deferred status update. Each failure then triggers
+// UpdateBackupTargetStatus, which fires the BackupTargetInformer's
+// UpdateFunc handler and immediately re-enqueues reconcile - completely
+// bypassing BackupTarget.Spec.PollInterval and hammering the remote
+// backup target (observed: tens of thousands of S3 list calls in minutes).
+//
+// See https://github.com/longhorn/longhorn/issues/1547
+func sanitizeBackupStoreErrorMessage(message string) string {
+	return requestIDPattern.ReplaceAllString(message, "<redacted>")
+}
+
 func (btc *BackupTargetController) reconcile(name string) (err error) {
 	backupTarget, err := btc.ds.GetBackupTarget(name)
 	if err != nil {
@@ -486,7 +510,8 @@ func (btc *BackupTargetController) reconcile(name string) (err error) {
 		backupTarget.Status.Available = false
 		backupTarget.Status.Conditions = types.SetCondition(backupTarget.Status.Conditions,
 			longhorn.BackupTargetConditionTypeUnavailable, longhorn.ConditionStatusTrue,
-			longhorn.BackupTargetConditionReasonUnavailable, errors.Wrapf(err, "failed to list system backups in %v", backupTargetClient.URL).Error())
+			longhorn.BackupTargetConditionReasonUnavailable,
+			sanitizeBackupStoreErrorMessage(errors.Wrapf(err, "failed to list system backups in %v", backupTargetClient.URL).Error()))
 		log.WithError(err).Error("Failed to get info from backup store")
 		return nil // Ignore error to allow status update as well as preventing enqueue
 	}

--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -344,7 +344,7 @@ func newBackupTargetClientFromDefaultEngineImage(ds *datastore.DataStore, backup
 // check (both 'n' and the following digit are word characters, so no
 // boundary exists between them). A trailing \b after the ID is safe
 // since it's normally followed by a quote, space, or real newline.
-var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-z-]+|[0-9]{3}\s+[0-9a-f]{16}\b)`)
+var requestIDPattern = regexp.MustCompile(`(?i)(request ?id:?\s*[0-9a-z-]+|[0-9]{3}\s+[0-9a-z-]{16,}\b)`)
 
 // timestampPattern matches RFC3339(-nano) timestamps that the exec'd
 // `longhorn` engine binary's own logrus output embeds in every log line
@@ -370,7 +370,7 @@ var timestampPattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\
 // invalid credentials, instead of one attempt per 5-minute poll
 // interval).
 //
-// See https://github.com/longhorn/longhorn/issues/1547
+// See https://github.com/longhorn/longhorn/issues/13831
 func sanitizeBackupStoreErrorMessage(message string) string {
 	message = requestIDPattern.ReplaceAllString(message, "<redacted>")
 	message = timestampPattern.ReplaceAllString(message, "<timestamp>")

--- a/controller/backup_target_controller_sanitize_test.go
+++ b/controller/backup_target_controller_sanitize_test.go
@@ -36,6 +36,28 @@ func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
 			input:    "failed to init backup target clients: credential secret not found",
 			expected: "failed to init backup target clients: credential secret not found",
 		},
+		{
+			// Regression case: error text captured from an exec'd subprocess's
+			// stderr (via backupstore's parseAwsError -> longhorn-manager's
+			// errors.Wrapf) contains a literal two-character "\n" escape
+			// sequence (backslash + n), not a real newline byte, immediately
+			// before the status code. A \b word-boundary assertion before the
+			// digits fails here because both 'n' and '4' are word characters,
+			// so the regex must not require a boundary on that side.
+			// This is the exact message format observed live on a test
+			// cluster with invalid B2 credentials.
+			name: "literal backslash-n before status code (exec'd subprocess stderr)",
+			input: `failed to list system backups in s3://bucket@region/: error listing system backup in s3://bucket@region/: ` +
+				`failed to execute: /path/longhorn [/path/longhorn system-backup list s3://bucket@region/], output , stderr ` +
+				`time="2026-07-24T16:26:21.852427323Z" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
+				`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+				`error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 dcc174e30ac8453c\n" pkg=s3`,
+			expected: `failed to list system backups in s3://bucket@region/: error listing system backup in s3://bucket@region/: ` +
+				`failed to execute: /path/longhorn [/path/longhorn system-backup list s3://bucket@region/], output , stderr ` +
+				`time="2026-07-24T16:26:21.852427323Z" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
+				`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+				`error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n<redacted>\n" pkg=s3`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -60,5 +82,44 @@ func TestSanitizeBackupStoreErrorMessageStableAcrossAttempts(t *testing.T) {
 
 	if got1 != got2 {
 		t.Fatalf("expected sanitized messages to be equal across attempts, got %q vs %q", got1, got2)
+	}
+}
+
+// TestSanitizeBackupStoreErrorMessageStableAcrossAttemptsWithSubprocessLogs
+// is a regression test for a live-cluster finding: the exec'd `longhorn`
+// engine binary's own logrus output embeds a fresh RFC3339-nano timestamp
+// on every invocation (in addition to the request ID), so two otherwise
+// identical failures still produced different Status.Conditions[].Message
+// values until timestamps were also normalized. Verified live: before this
+// fix, an invalid-credentials backup target sustained ~6 reconciles/second
+// indefinitely instead of settling to one attempt per poll interval.
+func TestSanitizeBackupStoreErrorMessageStableAcrossAttemptsWithSubprocessLogs(t *testing.T) {
+	attempt1 := `failed to list system backups in s3://bucket@region/: error listing system backup in s3://bucket@region/: ` +
+		`failed to execute: /path/longhorn [/path/longhorn system-backup list s3://bucket@region/], output , stderr ` +
+		`time="2026-07-24T16:31:27.852675962Z" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
+		`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+		"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\\n403 aaaaaaaaaaaaaaaa\\n\" pkg=s3\n" +
+		`time="2026-07-24T16:31:27.852799994Z" level=fatal msg="Failed to run list system backup command" ` +
+		`func=cmd.SystemBackupCmd.SystemBackupListCmd.func4 file="system_backup.go:72" ` +
+		`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+		"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\\n403 aaaaaaaaaaaaaaaa\\n\"\n" +
+		": exit status 1"
+
+	attempt2 := `failed to list system backups in s3://bucket@region/: error listing system backup in s3://bucket@region/: ` +
+		`failed to execute: /path/longhorn [/path/longhorn system-backup list s3://bucket@region/], output , stderr ` +
+		`time="2026-07-24T16:31:33.204981123Z" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
+		`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+		"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\\n403 bbbbbbbbbbbbbbbb\\n\" pkg=s3\n" +
+		`time="2026-07-24T16:31:33.205102741Z" level=fatal msg="Failed to run list system backup command" ` +
+		`func=cmd.SystemBackupCmd.SystemBackupListCmd.func4 file="system_backup.go:72" ` +
+		`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
+		"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\\n403 bbbbbbbbbbbbbbbb\\n\"\n" +
+		": exit status 1"
+
+	got1 := sanitizeBackupStoreErrorMessage(attempt1)
+	got2 := sanitizeBackupStoreErrorMessage(attempt2)
+
+	if got1 != got2 {
+		t.Fatalf("expected sanitized messages to be equal across attempts, got:\n%q\nvs\n%q", got1, got2)
 	}
 }

--- a/controller/backup_target_controller_sanitize_test.go
+++ b/controller/backup_target_controller_sanitize_test.go
@@ -1,0 +1,64 @@
+package controller
+
+import "testing"
+
+// TestSanitizeBackupStoreErrorMessage verifies that volatile per-request
+// identifiers (S3 request IDs, HTTP-status+request-ID pairs) are stripped
+// from backup store error messages so that repeated identical failures
+// produce identical Status.Conditions[].Message values.
+//
+// This matters because reconcile() only calls UpdateBackupTargetStatus when
+// backupTarget.Status changed (via reflect.DeepEqual); if every failed
+// attempt has a distinct message, the controller storms the remote backup
+// target instead of respecting Spec.PollInterval.
+//
+// Regression test for https://github.com/longhorn/longhorn/issues/1547
+func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "s3 status code and hex request id",
+			input: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
+				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 1eed0c50c2cb9133\n",
+			expected: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
+				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n<redacted>\n",
+		},
+		{
+			name:     "explicit RequestId field",
+			input:    "AWS Error: SlowDown Please reduce your request rate. RequestId: 7f159e1736fb70263abc123",
+			expected: "AWS Error: SlowDown Please reduce your request rate. <redacted>",
+		},
+		{
+			name:     "no volatile content",
+			input:    "failed to init backup target clients: credential secret not found",
+			expected: "failed to init backup target clients: credential secret not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeBackupStoreErrorMessage(tt.input)
+			if got != tt.expected {
+				t.Fatalf("sanitizeBackupStoreErrorMessage(%q):\n  got:      %q\n  expected: %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestSanitizeBackupStoreErrorMessageStableAcrossAttempts verifies the core
+// property that motivated this fix: two error messages that only differ by
+// their embedded request ID sanitize to the same string.
+func TestSanitizeBackupStoreErrorMessageStableAcrossAttempts(t *testing.T) {
+	attempt1 := "AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 1eed0c50c2cb9133\n"
+	attempt2 := "AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 9e4e1d90d4c091bc\n"
+
+	got1 := sanitizeBackupStoreErrorMessage(attempt1)
+	got2 := sanitizeBackupStoreErrorMessage(attempt2)
+
+	if got1 != got2 {
+		t.Fatalf("expected sanitized messages to be equal across attempts, got %q vs %q", got1, got2)
+	}
+}

--- a/controller/backup_target_controller_sanitize_test.go
+++ b/controller/backup_target_controller_sanitize_test.go
@@ -12,7 +12,7 @@ import "testing"
 // attempt has a distinct message, the controller storms the remote backup
 // target instead of respecting Spec.PollInterval.
 //
-// Regression test for https://github.com/longhorn/longhorn/issues/1547
+// Regression test for https://github.com/longhorn/longhorn/issues/13831
 func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -23,6 +23,16 @@ func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
 			name: "s3 status code and hex request id",
 			input: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
 				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 1eed0c50c2cb9133\n",
+			expected: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
+				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n<redacted>\n",
+		},
+		{
+			// S3-compatible backends' bare status-code + request-ID pairs are
+			// not guaranteed to be purely hexadecimal either; the alternative
+			// must match opaque alphanumeric IDs, not just [0-9a-f]{16}.
+			name: "s3 status code and alphanumeric request id",
+			input: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
+				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 ABCDXYZ123456789\n",
 			expected: "failed to list objects with param: {\n  Bucket: \"mybucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} " +
 				"error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n<redacted>\n",
 		},

--- a/controller/backup_target_controller_sanitize_test.go
+++ b/controller/backup_target_controller_sanitize_test.go
@@ -32,6 +32,15 @@ func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
 			expected: "AWS Error: SlowDown Please reduce your request rate. <redacted>",
 		},
 		{
+			// The RequestId value is opaque and alphanumeric on many
+			// S3-compatible backends, not purely hexadecimal. The whole
+			// token must be redacted; leaving an alphanumeric suffix would
+			// keep repeated messages distinct and preserve the reconcile storm.
+			name:     "explicit RequestId field with alphanumeric id",
+			input:    "AWS Error: SlowDown Please reduce your request rate. RequestID: ABCDXYZ123456789",
+			expected: "AWS Error: SlowDown Please reduce your request rate. <redacted>",
+		},
+		{
 			name:     "no volatile content",
 			input:    "failed to init backup target clients: credential secret not found",
 			expected: "failed to init backup target clients: credential secret not found",
@@ -54,7 +63,7 @@ func TestSanitizeBackupStoreErrorMessage(t *testing.T) {
 				`error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n403 dcc174e30ac8453c\n" pkg=s3`,
 			expected: `failed to list system backups in s3://bucket@region/: error listing system backup in s3://bucket@region/: ` +
 				`failed to execute: /path/longhorn [/path/longhorn system-backup list s3://bucket@region/], output , stderr ` +
-				`time="2026-07-24T16:26:21.852427323Z" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
+				`time="<timestamp>" level=error msg="Failed to list s3" func="s3.(*BackupStoreDriver).List" file="s3.go:116" ` +
 				`error="failed to list objects with param: {\n  Bucket: \"bucket\",\n  Delimiter: \"/\",\n  Prefix: \"/\"\n} ` +
 				`error: AWS Error:  InvalidAccessKeyId Malformed Access Key Id <nil>\n<redacted>\n" pkg=s3`,
 		},


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13831

(Per @derekbit's review: this PR addresses the status-message sanitization / reconcile-storm bug, which is independent of the excessive block-listing tracked in longhorn/longhorn#1547. Created a dedicated IMPROVEMENT ticket longhorn/longhorn#13831 for it. The companion block-listing fix remains longhorn/backupstore#313.)

#### What this PR does / why we need it:

This is a companion fix to longhorn/backupstore#313, which addresses the primary cause of excessive S3 calls (nested-directory block listing). This PR fixes a second, independent bug that compounds the problem specifically when the backup target is unreachable or misconfigured.

`parseAwsError` (in `longhorn/backupstore`) embeds the AWS request ID and HTTP status code directly into returned error messages, e.g. `403 1eed0c50c2cb9133`. `reconcile()` persists this string verbatim into `BackupTarget.Status.Conditions[Unavailable].Message` whenever the initial `ListSystemBackup()` availability check fails.

Since every failed attempt produces a message that differs from the last, the deferred `reflect.DeepEqual(existingStatus, Status)` check in `reconcile()` never matches on repeated failures. This forces an `UpdateBackupTargetStatus` call every attempt, which fires the `BackupTargetInformer`'s `UpdateFunc` handler and immediately re-enqueues reconcile via `enqueueBackupTarget` - completely bypassing `Spec.PollInterval`.

This PR normalizes two sources of per-attempt volatility before the message is stored:
1. S3 request IDs / HTTP-status+request-ID pairs (e.g. `403 1eed0c50c2cb9133`)
2. Timestamps embedded by the exec'd `longhorn` engine binary's own logrus output (fresh on every invocation, e.g. `time="2026-07-24T16:31:27.85Z"`)

#### Special notes for your reviewer:

**End-to-end verified on a live cluster, including two real bugs found only through live testing** (not caught by my initial unit tests, which used synthetic messages that didn't match the real captured format):

1. My first regex used a `\b` word boundary before the status code. Real error text captured from the exec'd subprocess's stderr contains a literal two-character `\n` escape sequence (backslash + `n`), not a real newline byte, directly before the digits - so `\b` never matched in practice (`n` and `4` are both word characters). Fixed by dropping the leading boundary requirement.
2. Even with request IDs correctly redacted, the message still embeds the subprocess's own log timestamps, which alone kept every attempt's message distinct. Added a second normalization pass for RFC3339(-nano) timestamps.

I only caught these by actually deploying a custom-built image to a k3s + Longhorn v1.10.1 cluster (built via `docker build` + `ctr images import` on the node, since no registry was available) and pointing it at Backblaze B2 with intentionally invalid credentials:

| | Before this PR | After this PR |
|---|---|---|
| Reconcile rate with broken credentials | ~6/second, sustained indefinitely (~750 attempts measured in <2 min) | ~1 attempt per 30s (bounded background resync) |
| `Status.Conditions[].Message` | Unique every attempt (unredacted request ID + timestamp) | Stable/redacted (`<redacted>`, `<timestamp>`) |

Confirmed the backup target correctly returns to `available: true` once valid credentials are restored.

Added/extended `controller/backup_target_controller_sanitize_test.go`, including a regression test using the exact message format that revealed bug #1 above. Note: `go test ./controller/...` still fails to build on unmodified `master` too, due to an unrelated `sigs.k8s.io/structured-merge-diff` v4/v6 vendor mismatch; the sanitizer was verified both via a standalone Go program during development and live on the deployed cluster.

#### Additional documentation or context

Companion fix in `longhorn/backupstore` for the excessive block-listing issue (independently reproduced and measured, ~44.6% fewer total S3 calls, ~97.9% fewer directory-listing calls): longhorn/backupstore#313

