### PR TITLE
fix(recurring-job): retry and propagate execution errors

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -15,6 +15,7 @@ import (
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhtyped "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2"
 )
 
 func RecurringJobCmd() *cli.Command {
@@ -58,10 +59,9 @@ func recurringJob(cmd *cli.Command) (err error) {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	recurringJob, err := lhClient.LonghornV1beta2().RecurringJobs(namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+	recurringJob, err := getRecurringJob(lhClient.LonghornV1beta2().RecurringJobs(namespace), jobName)
 	if err != nil {
-		logrus.WithError(err).Errorf("Failed to get recurring job %v.", jobName)
-		return nil
+		return err
 	}
 
 	recurringJob.Status.ExecutionCount += 1
@@ -80,4 +80,13 @@ func recurringJob(cmd *cli.Command) (err error) {
 	default:
 		return recurringjob.StartVolumeJobs(job, recurringJob)
 	}
+}
+
+func getRecurringJob(client lhtyped.RecurringJobInterface, jobName string) (*longhorn.RecurringJob, error) {
+	recurringJob, err := client.Get(context.TODO(), jobName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get recurring job %v", jobName)
+	}
+
+	return recurringJob, nil
 }

--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -9,14 +9,21 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/longhorn/longhorn-manager/app/recurringjob"
 	"github.com/longhorn/longhorn-manager/types"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	lhtyped "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/typed/longhorn/v1beta2"
 )
+
+type recurringJobGetter interface {
+	Get(context.Context, string, metav1.GetOptions) (*longhorn.RecurringJob, error)
+}
 
 func RecurringJobCmd() *cli.Command {
 	return &cli.Command{
@@ -28,7 +35,7 @@ func RecurringJobCmd() *cli.Command {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := recurringJob(cmd); err != nil {
+			if err := recurringJob(ctx, cmd); err != nil {
 				logrus.WithError(err).Fatal("Failed to do a recurring job")
 			}
 			return nil
@@ -36,7 +43,7 @@ func RecurringJobCmd() *cli.Command {
 	}
 }
 
-func recurringJob(cmd *cli.Command) (err error) {
+func recurringJob(ctx context.Context, cmd *cli.Command) (err error) {
 	logger := logrus.StandardLogger()
 
 	var managerURL = cmd.String(FlagManagerURL)
@@ -59,13 +66,13 @@ func recurringJob(cmd *cli.Command) (err error) {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	recurringJob, err := getRecurringJob(lhClient.LonghornV1beta2().RecurringJobs(namespace), jobName)
+	recurringJob, err := getRecurringJob(ctx, lhClient.LonghornV1beta2().RecurringJobs(namespace), jobName)
 	if err != nil {
 		return err
 	}
 
 	recurringJob.Status.ExecutionCount += 1
-	if _, err = lhClient.LonghornV1beta2().RecurringJobs(namespace).UpdateStatus(context.TODO(), recurringJob, metav1.UpdateOptions{}); err != nil {
+	if _, err = lhClient.LonghornV1beta2().RecurringJobs(namespace).UpdateStatus(ctx, recurringJob, metav1.UpdateOptions{}); err != nil {
 		return errors.Wrap(err, "failed to update job execution count")
 	}
 
@@ -82,11 +89,59 @@ func recurringJob(cmd *cli.Command) (err error) {
 	}
 }
 
-func getRecurringJob(client lhtyped.RecurringJobInterface, jobName string) (*longhorn.RecurringJob, error) {
-	recurringJob, err := client.Get(context.TODO(), jobName, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get recurring job %v", jobName)
+func getRecurringJob(ctx context.Context, client recurringJobGetter, jobName string) (*longhorn.RecurringJob, error) {
+	ctx, cancel := context.WithTimeout(ctx, recurringjob.InitClientTimeout)
+	defer cancel()
+
+	// Nine attempts produce about 49-59 seconds of delay for immediate failures.
+	// The context deadline also bounds the time spent inside slow requests.
+	return getRecurringJobWithBackoff(ctx, client, jobName, wait.Backoff{
+		Duration: recurringjob.InitClientRetryInterval,
+		Factor:   1.5,
+		Jitter:   0.2,
+		Steps:    9,
+	})
+}
+
+func getRecurringJobWithBackoff(ctx context.Context, client recurringJobGetter, jobName string, backoff wait.Backoff) (*longhorn.RecurringJob, error) {
+	var (
+		job      *longhorn.RecurringJob
+		lastErr  error
+		attempts int
+	)
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		attempts++
+		job, lastErr = client.Get(ctx, jobName, metav1.GetOptions{})
+		if lastErr == nil {
+			return true, nil
+		}
+		if !isRetryableRecurringJobGetError(lastErr) {
+			return false, lastErr
+		}
+		if attempts < backoff.Steps {
+			logrus.WithError(lastErr).WithField("attempt", attempts).Warnf("Failed to get recurring job %v, retrying", jobName)
+		}
+		return false, nil
+	})
+	if err == nil {
+		return job, nil
+	}
+	if wait.Interrupted(err) && lastErr != nil {
+		err = lastErr
 	}
 
-	return recurringJob, nil
+	return nil, errors.Wrapf(err, "failed to get recurring job %v", jobName)
+}
+
+func isRetryableRecurringJobGetError(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		utilnet.IsTimeout(err) ||
+		utilnet.IsConnectionRefused(err) ||
+		utilnet.IsConnectionReset(err) ||
+		utilnet.IsProbableEOF(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
 }

--- a/app/recurring_job_test.go
+++ b/app/recurring_job_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stesting "k8s.io/client-go/testing"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+func TestGetRecurringJob(t *testing.T) {
+	const (
+		namespace = "longhorn-system"
+		jobName   = "daily-backup"
+	)
+
+	t.Run("returns API errors", func(t *testing.T) {
+		expectedErr := errors.New("Kubernetes API unavailable")
+		client := lhfake.NewSimpleClientset() // nolint: staticcheck
+		client.PrependReactor("get", "recurringjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, expectedErr
+		})
+
+		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+
+		assert.Nil(t, job)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorContains(t, err, "failed to get recurring job daily-backup")
+	})
+
+	t.Run("returns a missing recurring job error", func(t *testing.T) {
+		client := lhfake.NewSimpleClientset() // nolint: staticcheck
+
+		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+
+		assert.Nil(t, job)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to get recurring job daily-backup")
+	})
+
+	t.Run("returns an existing recurring job", func(t *testing.T) {
+		expected := &longhorn.RecurringJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: namespace,
+			},
+		}
+		client := lhfake.NewSimpleClientset(expected) // nolint: staticcheck
+
+		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, job)
+	})
+}

--- a/app/recurring_job_test.go
+++ b/app/recurring_job_test.go
@@ -1,13 +1,20 @@
 package app
 
 import (
+	"context"
 	"errors"
+	"net"
+	"net/url"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stesting "k8s.io/client-go/testing"
 
@@ -28,17 +35,87 @@ func TestGetRecurringJob(t *testing.T) {
 			return true, nil, expectedErr
 		})
 
-		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+		job, err := getRecurringJob(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName)
 
 		assert.Nil(t, job)
 		assert.ErrorIs(t, err, expectedErr)
 		assert.ErrorContains(t, err, "failed to get recurring job daily-backup")
 	})
 
+	t.Run("retries a transient error and returns the job", func(t *testing.T) {
+		expected := &longhorn.RecurringJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: namespace,
+			},
+		}
+		expectedErr := &url.Error{
+			Op:  "Get",
+			URL: "https://kubernetes.default.svc",
+			Err: &net.DNSError{Err: "i/o timeout", IsTimeout: true},
+		}
+		attempts := 0
+		client := lhfake.NewSimpleClientset(expected) // nolint: staticcheck
+		client.PrependReactor("get", "recurringjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+			attempts++
+			if attempts < 3 {
+				return true, nil, expectedErr
+			}
+			return false, nil, nil
+		})
+
+		job, err := getRecurringJobWithBackoff(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName, wait.Backoff{Steps: 3})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, job)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("returns the last transient error after retries are exhausted", func(t *testing.T) {
+		expectedErr := &url.Error{
+			Op:  "Get",
+			URL: "https://kubernetes.default.svc",
+			Err: &net.DNSError{Err: "i/o timeout", IsTimeout: true},
+		}
+		attempts := 0
+		client := lhfake.NewSimpleClientset() // nolint: staticcheck
+		client.PrependReactor("get", "recurringjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+			attempts++
+			return true, nil, expectedErr
+		})
+
+		job, err := getRecurringJobWithBackoff(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName, wait.Backoff{Steps: 3})
+
+		assert.Nil(t, job)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorContains(t, err, "failed to get recurring job daily-backup")
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("does not retry a permanent API error", func(t *testing.T) {
+		expectedErr := apierrors.NewForbidden(
+			schema.GroupResource{Group: "longhorn.io", Resource: "recurringjobs"},
+			jobName,
+			errors.New("access denied"),
+		)
+		attempts := 0
+		client := lhfake.NewSimpleClientset() // nolint: staticcheck
+		client.PrependReactor("get", "recurringjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+			attempts++
+			return true, nil, expectedErr
+		})
+
+		job, err := getRecurringJobWithBackoff(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName, wait.Backoff{Steps: 3})
+
+		assert.Nil(t, job)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Equal(t, 1, attempts)
+	})
+
 	t.Run("returns a missing recurring job error", func(t *testing.T) {
 		client := lhfake.NewSimpleClientset() // nolint: staticcheck
 
-		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+		job, err := getRecurringJob(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName)
 
 		assert.Nil(t, job)
 		assert.Error(t, err)
@@ -54,9 +131,68 @@ func TestGetRecurringJob(t *testing.T) {
 		}
 		client := lhfake.NewSimpleClientset(expected) // nolint: staticcheck
 
-		job, err := getRecurringJob(client.LonghornV1beta2().RecurringJobs(namespace), jobName)
+		job, err := getRecurringJob(context.Background(), client.LonghornV1beta2().RecurringJobs(namespace), jobName)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, job)
 	})
+}
+
+func TestIsRetryableRecurringJobGetError(t *testing.T) {
+	resource := schema.GroupResource{Group: "longhorn.io", Resource: "recurringjobs"}
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"transport timeout": {
+			err:      &url.Error{Op: "Get", URL: "https://kubernetes.default.svc", Err: &net.DNSError{Err: "i/o timeout", IsTimeout: true}},
+			expected: true,
+		},
+		"connection reset": {
+			err:      &url.Error{Op: "Get", URL: "https://kubernetes.default.svc", Err: syscall.ECONNRESET},
+			expected: true,
+		},
+		"connection refused": {
+			err:      &url.Error{Op: "Get", URL: "https://kubernetes.default.svc", Err: syscall.ECONNREFUSED},
+			expected: true,
+		},
+		"API timeout": {
+			err:      apierrors.NewTimeoutError("request timed out", 1),
+			expected: true,
+		},
+		"server timeout": {
+			err:      apierrors.NewServerTimeout(resource, "get", 1),
+			expected: true,
+		},
+		"server throttling": {
+			err:      apierrors.NewTooManyRequests("slow down", 1),
+			expected: true,
+		},
+		"service unavailable": {
+			err:      apierrors.NewServiceUnavailable("unavailable"),
+			expected: true,
+		},
+		"forbidden": {
+			err:      apierrors.NewForbidden(resource, "daily-backup", errors.New("access denied")),
+			expected: false,
+		},
+		"unauthorized": {
+			err:      apierrors.NewUnauthorized("authentication failed"),
+			expected: false,
+		},
+		"not found": {
+			err:      apierrors.NewNotFound(resource, "daily-backup"),
+			expected: false,
+		},
+		"bad request": {
+			err:      apierrors.NewBadRequest("invalid request"),
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isRetryableRecurringJobGetError(test.err))
+		})
+	}
 }

--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -52,11 +52,6 @@ func StartVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob) error {
 
 	concurrentLimiter := make(chan struct{}, recurringJob.Spec.Concurrency)
 	ewg := &errgroup.Group{}
-	defer func() {
-		if wgError := ewg.Wait(); wgError != nil {
-			err = wgError
-		}
-	}()
 	for _, volumeName := range filteredVolumes {
 		startJobVolumeName := volumeName
 		ewg.Go(func() error {
@@ -64,7 +59,7 @@ func StartVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob) error {
 		})
 	}
 
-	return err
+	return ewg.Wait()
 }
 
 func startVolumeJob(job *Job, recurringJob *longhorn.RecurringJob,

--- a/app/recurringjob/volume_test.go
+++ b/app/recurringjob/volume_test.go
@@ -1,0 +1,88 @@
+package recurringjob
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhornclient "github.com/longhorn/longhorn-manager/client"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+type volumeOperationsWithGetError struct {
+	longhornclient.VolumeOperations
+	err error
+}
+
+func (o *volumeOperationsWithGetError) ById(string) (*longhornclient.Volume, error) {
+	return nil, o.err
+}
+
+func TestStartVolumeJobs(t *testing.T) {
+	const (
+		namespace  = "longhorn-system"
+		jobName    = "daily-backup"
+		volumeName = "test-volume"
+	)
+
+	newSetting := func() *longhorn.Setting {
+		return &longhorn.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(types.SettingNameAllowRecurringJobWhileVolumeDetached),
+				Namespace: namespace,
+			},
+			Value: "false",
+		}
+	}
+	newJob := func(api *longhornclient.RancherClient, objects ...runtime.Object) *Job {
+		logger := logrus.New()
+		logger.SetOutput(io.Discard)
+		return &Job{
+			api:       api,
+			lhClient:  lhfake.NewSimpleClientset(objects...), // nolint: staticcheck
+			logger:    logger,
+			name:      jobName,
+			namespace: namespace,
+		}
+	}
+	recurringJob := &longhorn.RecurringJob{
+		Spec: longhorn.RecurringJobSpec{Concurrency: 1},
+	}
+
+	t.Run("returns a volume worker error", func(t *testing.T) {
+		expectedErr := errors.New("volume API unavailable")
+		volume := &longhorn.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      volumeName,
+				Namespace: namespace,
+				Labels:    types.GetRecurringJobLabelValueMap(types.LonghornLabelRecurringJob, jobName),
+			},
+			Status: longhorn.VolumeStatus{State: longhorn.VolumeStateAttached},
+		}
+		job := newJob(&longhornclient.RancherClient{
+			Volume: &volumeOperationsWithGetError{err: expectedErr},
+		}, newSetting(), volume)
+
+		err := StartVolumeJobs(job, recurringJob)
+
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("returns nil with no selected volumes", func(t *testing.T) {
+		job := newJob(&longhornclient.RancherClient{}, newSetting())
+
+		err := StartVolumeJobs(job, recurringJob)
+
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13587

#### What this PR does / why we need it:

Recurring-job pods currently report success through two failure paths:

- An initial Kubernetes API error while reading the RecurringJob CR is logged and returned as `nil`.
- Per-volume worker errors are assigned in a deferred function after the unnamed return value has already been evaluated.

In both cases the container exits 0, Kubernetes marks the Job complete, and the configured `restartPolicy: OnFailure` and `backoffLimit: 3` cannot take effect.

This patch:

- Retries transient initial RecurringJob GET failures for up to one minute with jittered exponential backoff. Retryable failures include transport timeouts, connection reset/refused, HTTP/2 connection loss, API timeouts, throttling, and service unavailability.
- Returns permanent GET errors immediately and preserves the final error after retry exhaustion.
- Returns `errgroup.Wait()` directly after all volume workers finish.

The command action exits nonzero after an unrecoverable or exhausted failure, allowing Kubernetes to apply its existing retry policy and report an accurate Job status. The startup retry matches the reliability model introduced for Longhorn manager API initialization by longhorn-manager#5032 and longhorn/longhorn#13567.

The per-volume change restores the behavior established by longhorn/longhorn#4255 and longhorn-manager#2099 before it regressed during the recurring-job package refactor.

#### Special notes for your reviewer:

The observed startup trigger was a transient failure reaching the Kubernetes API Service. This change is transport-agnostic and does not attribute the underlying connectivity failure to a specific network component.

The retry remains inside the existing Pod network namespace. It can tolerate delayed connectivity convergence but does not repair a permanently broken per-Pod endpoint. This PR does not change `restartPolicy`; changing it from `OnFailure` to `Never` would alter retry semantics for all recurring jobs and is intentionally out of scope.

A retry of a multi-volume job can repeat work for volumes that already succeeded; that separate behavior is tracked by longhorn/longhorn#10154.

Please backport this fix to v1.12.x.

#### Additional documentation or context

Checks at `e0174a9e5`:

- Focused tests cover transient success, retry exhaustion, permanent errors, missing and successful RecurringJob lookups, retry classification, per-volume worker errors, and the no-volume success path.
- Linux `make ci` and the full race-enabled `make test` suite pass at https://github.com/christophersherman/longhorn-manager/actions/runs/30123414390. The overall workflow is red only because the fork cannot authenticate to Longhorn's Docker Hub publishing account after those steps pass.
- The branch is rebased onto current `master`.
- The two commits apply to current `v1.12.x` with a small adaptation for its older `urfave/cli` API; Linux-targeted compilation and `go vet ./app` pass there.

This PR does not address backup-store lock cleanup or the underlying network transient.