### PR TITLE
fix: keep running replica rebuilds from being blocked

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2686,6 +2686,19 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 		rs[r.Name] = r
 	}
 
+	// This function also runs while the volume is already Attached, to pick up replicas added or
+	// rebuilt afterward (see the "This is a stable state" call site in
+	// reconcileAttachDetachStateMachine). In that steady state, don't let one replica that is still
+	// starting/rebuilding block OTHER, already Running, sibling replicas from being (re-)added to
+	// e.Spec.ReplicaAddressMap below: that field is fully overwritten every call, so bailing out here
+	// would silently drop already-healthy replicas until every sibling becomes Running at the same
+	// time. That may never happen when rebuilds are serialized one at a time per volume/per node,
+	// leaving replacement replicas permanently un-dialed by the engine after a mass replica
+	// replacement event (https://github.com/longhorn/longhorn/issues/13571). Only wait for every
+	// replica to become Running when the engine itself hasn't started yet, since starting it for the
+	// first time with an incomplete replica set would be wrong.
+	engineAlreadyRunning := e.Status.CurrentState == longhorn.InstanceStateRunning
+
 	replicaAddressMap := map[string]string{}
 	for _, r := range rs {
 		// Ignore unscheduled replicas
@@ -2710,8 +2723,19 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 		if r.Status.CurrentState == longhorn.InstanceStateError {
 			continue
 		}
-		// wait for all potentially healthy replicas become running
 		if r.Status.CurrentState != longhorn.InstanceStateRunning {
+			if engineAlreadyRunning {
+				// The engine is already up. Keep this replica's existing address (if any) instead of
+				// waiting for it to become Running, so a still-starting or briefly-flapping replica
+				// does not block its running siblings from being kept in the map, while also not
+				// dropping a still-connected replica that would then be removed as unknown.
+				if addr, ok := e.Spec.ReplicaAddressMap[r.Name]; ok {
+					replicaAddressMap[r.Name] = addr
+				}
+				continue
+			}
+			// Initial attach: wait for all potentially healthy replicas to become running before
+			// starting the engine.
 			return nil
 		}
 		if r.Status.IP == "" {

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1097,6 +1097,88 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	}
 	testCases["replica rebuilding - reuse failed replica"] = tc
 
+	// volume attached, add running replica address while sibling replica is still starting
+	tc = generateVolumeTestCaseTemplate()
+	tc.volume.Spec.NodeID = TestNode1
+	tc.volume.Spec.NumberOfReplicas = 3
+	tc.volume.Status.CurrentImage = TestEngineImage
+	tc.volume.Status.CurrentNodeID = TestNode1
+	tc.volume.Status.State = longhorn.VolumeStateAttached
+	tc.volume.Status.Robustness = longhorn.VolumeRobustnessDegraded
+	tc.volume.Status.LastDegradedAt = "2014-01-02T00:00:00Z"
+	var currentEngine *longhorn.Engine
+	for _, e := range tc.engines {
+		currentEngine = e
+		break
+	}
+	thirdReplica := newReplicaForVolume(tc.volume, currentEngine, TestNode1, TestDiskID1)
+	tc.replicas[thirdReplica.Name] = thirdReplica
+	var healthyReplica *longhorn.Replica
+	var runningReplica *longhorn.Replica
+	var stoppedReplica *longhorn.Replica
+	for _, e := range tc.engines {
+		e.Spec.NodeID = TestNode1
+		e.Spec.DesireState = longhorn.InstanceStateRunning
+		e.Spec.Image = TestEngineImage
+		e.Status.CurrentState = longhorn.InstanceStateRunning
+		e.Status.CurrentImage = TestEngineImage
+		e.Status.CurrentSize = TestVolumeSize
+		e.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{}
+		e.Status.ReplicaTransitionTimeMap = map[string]string{}
+	}
+	for _, r := range tc.replicas {
+		if healthyReplica == nil {
+			healthyReplica = r
+			r.Spec.DesireState = longhorn.InstanceStateRunning
+			r.Spec.HealthyAt = getTestNow()
+			r.Spec.LastHealthyAt = r.Spec.HealthyAt
+			r.Status.CurrentState = longhorn.InstanceStateRunning
+			r.Status.IP = randomIP()
+			r.Status.StorageIP = r.Status.IP
+			r.Status.Port = randomPort()
+			for _, e := range tc.engines {
+				e.Spec.ReplicaAddressMap[r.Name] = imutil.GetURL(r.Status.StorageIP, r.Status.Port)
+				e.Status.ReplicaModeMap[r.Name] = longhorn.ReplicaModeRW
+				e.Status.ReplicaTransitionTimeMap[r.Name] = r.Spec.LastHealthyAt
+			}
+			continue
+		}
+		if runningReplica == nil {
+			runningReplica = r
+			r.Spec.DesireState = longhorn.InstanceStateRunning
+			r.Spec.HealthyAt = ""
+			r.Spec.LastHealthyAt = getTestNow()
+			r.Spec.RebuildRetryCount = 1
+			r.Status.CurrentState = longhorn.InstanceStateRunning
+			r.Status.IP = randomIP()
+			r.Status.StorageIP = r.Status.IP
+			r.Status.Port = randomPort()
+			continue
+		}
+		stoppedReplica = r
+		r.Spec.HealthyAt = ""
+		r.Spec.LastHealthyAt = getTestNow()
+		r.Spec.RebuildRetryCount = 1
+		r.Status.CurrentState = longhorn.InstanceStateStopped
+		// This replica is already in the engine's replica address map but is momentarily not
+		// Running (so it carries no live IP). Its existing address must be preserved (not dropped),
+		// otherwise the engine monitor would later treat it as an unknown replica and remove a
+		// still-connected replica.
+		for _, e := range tc.engines {
+			e.Spec.ReplicaAddressMap[r.Name] = imutil.GetURL("10.234.0.99", 10000)
+		}
+	}
+	tc.copyCurrentToExpect()
+	for _, e := range tc.expectEngines {
+		e.Spec.ReplicaAddressMap[runningReplica.Name] = imutil.GetURL(runningReplica.Status.StorageIP, runningReplica.Status.Port)
+	}
+	for _, r := range tc.expectReplicas {
+		if r.Name == stoppedReplica.Name {
+			r.Spec.DesireState = longhorn.InstanceStateRunning
+		}
+	}
+	testCases["volume attached - add running replica address while sibling is not running"] = tc
+
 	// replica rebuilding - delay replica replenishment
 	tc = generateVolumeTestCaseTemplate()
 	tc.volume.Spec.NodeID = TestNode1


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13571

#### What this PR does / why we need it:

openVolumeDependentResources rebuilds the entire engine ReplicaAddressMap while the volume is already attached so newly added or rebuilt replicas can be picked up by the running engine.

Before this change, one replica that was not yet Running caused the function to return early. This preserved the initial attach safety behavior, but it also blocked already Running sibling replicas from being added to the engine's ReplicaAddressMap during steady-state reconcile. Since the engine only dials replicas listed in that map, those running replacements could remain undialed, never finish rebuilding, and keep rebuild concurrency slots occupied.

When the engine is already Running, preserve any existing address for a not-yet-Running replica and continue processing the rest of the replicas. This keeps existing connected replicas from being dropped as unknown while allowing newly Running sibling replicas to be added to the map. Initial attach behavior is unchanged: if the engine is not yet Running, Longhorn still waits for all potentially healthy replicas before starting the engine.

Add a regression test covering an attached degraded volume where a Running replacement replica must be added while another sibling replica is not Running.

#### Special notes for your reviewer:

#### Additional documentation or context
