### PR TITLE
fix(replica): mark replica as failed on broken node

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2757,11 +2757,28 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 				return err
 			}
 
-			if v.Status.State != longhorn.VolumeStateAttached || nodeDeleted {
-				msg := fmt.Sprintf("Replica %v is marked as failed because the volume %v is not attached and the instance manager is unable to launch the replica", r.Name, v.Name)
-				if nodeDeleted {
-					msg = fmt.Sprintf("Replica %v is marked as failed since the node %v is deleted.", r.Name, r.Spec.NodeID)
-				}
+			nodeDownOrDeleted, err := c.ds.IsNodeDownOrDeleted(r.Spec.NodeID)
+			if err != nil {
+				return err
+			}
+
+			neverStartedRebuild := r.Status.Starting &&
+				!r.Status.Started &&
+				r.Status.CurrentState == longhorn.InstanceStateStopped &&
+				r.Spec.HealthyAt == "" &&
+				r.Spec.LastHealthyAt == ""
+
+			failedReason := ""
+			switch {
+			case v.Status.State != longhorn.VolumeStateAttached:
+				failedReason = fmt.Sprintf("the volume %v is not attached and the instance manager is unable to launch the replica", v.Name)
+			case nodeDeleted:
+				failedReason = fmt.Sprintf("the node %v is deleted", r.Spec.NodeID)
+			case neverStartedRebuild && nodeDownOrDeleted:
+				failedReason = fmt.Sprintf("the replica is initializing on a node %v that is down or deleted", r.Spec.NodeID)
+			}
+			if failedReason != "" {
+				msg := fmt.Sprintf("Replica %v is marked as failed because %v", r.Name, failedReason)
 				log.WithField("replica", r.Name).Warn(msg)
 				if r.Spec.FailedAt == "" {
 					setReplicaFailedAt(r, c.nowHandler())
@@ -2867,7 +2884,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			ef.Spec.VolumeSize = v.Spec.Size
 			// Always propagate the target size to the EF so the EF
 			// monitor can detect that expansion is needed and trigger
-			// EngineFrontendExpand (which expands replicas → engine →
+			// EngineFrontendExpand (which expands replicas -> engine ->
 			// frontend).  The createEngineFrontend function already
 			// creates the SPDK EF at the pre-expansion size, so
 			// ef.Status.CurrentSize will correctly reflect the actual
@@ -3211,7 +3228,7 @@ func (c *VolumeController) closeVolumeDependentResources(v *longhorn.Volume, e *
 			}
 		}
 		if len(healthyReplicas) > v.Spec.NumberOfReplicas {
-			// Sort by HealthyAt ascending — oldest (most trusted) first.
+			// Sort by HealthyAt ascending - oldest (most trusted) first.
 			sort.Slice(healthyReplicas, func(i, j int) bool {
 				ti, _ := time.Parse(time.RFC3339, healthyReplicas[i].Spec.HealthyAt)
 				tj, _ := time.Parse(time.RFC3339, healthyReplicas[j].Spec.HealthyAt)

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1985,7 +1985,7 @@ func (c *VolumeController) ReconcileVolumeState(v *longhorn.Volume, es map[strin
 				}
 				// For a linked-clone replica, also verify its source replica is healthy.
 				// If it is still rebuilding or failed, the CoW chain may not be accessible
-				// yet — skip this candidate and retry on the next reconcile.
+				// yet - skip this candidate and retry on the next reconcile.
 				if r.Spec.LinkedCloneSrcReplicaName != "" {
 					srcReplica, srcRepErr := c.ds.GetReplicaRO(r.Spec.LinkedCloneSrcReplicaName)
 					if srcRepErr != nil {
@@ -2807,6 +2807,14 @@ func isVolumeOfflineUpgrade(v *longhorn.Volume) bool {
 	return v.Status.State == longhorn.VolumeStateDetached && v.Status.CurrentImage != v.Spec.Image
 }
 
+func isReplicaNeverStarted(r *longhorn.Replica) bool {
+	return (r.Status.Starting || r.Spec.DesireState == longhorn.InstanceStateRunning) &&
+		!r.Status.Started &&
+		r.Status.CurrentState == longhorn.InstanceStateStopped &&
+		r.Spec.HealthyAt == "" &&
+		r.Spec.LastHealthyAt == ""
+}
+
 func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *longhorn.Engine, rs map[string]*longhorn.Replica, efs map[string]*longhorn.EngineFrontend, log *logrus.Entry) error {
 	if isVolumeOfflineUpgrade(v) {
 		log.Info("Waiting for offline volume upgrade to finish")
@@ -2826,6 +2834,10 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 		if err != nil {
 			return err
 		}
+
+		neverStarted := isReplicaNeverStarted(r)
+
+		failedReason := ""
 		if canIMLaunchReplica {
 			if r.Spec.FailedAt == "" && r.Spec.Image == v.Status.CurrentImage {
 				if r.Status.CurrentState == longhorn.InstanceStateStopped {
@@ -2845,17 +2857,27 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 				return err
 			}
 
-			if v.Status.State != longhorn.VolumeStateAttached || nodeDeleted {
-				msg := fmt.Sprintf("Replica %v is marked as failed because the volume %v is not attached and the instance manager is unable to launch the replica", r.Name, v.Name)
-				if nodeDeleted {
-					msg = fmt.Sprintf("Replica %v is marked as failed since the node %v is deleted.", r.Name, r.Spec.NodeID)
-				}
-				log.WithField("replica", r.Name).Warn(msg)
-				if r.Spec.FailedAt == "" {
-					setReplicaFailedAt(r, c.nowHandler())
-				}
-				r.Spec.DesireState = longhorn.InstanceStateStopped
+			nodeDownOrDeleted, err := c.ds.IsNodeDownOrDeleted(r.Spec.NodeID)
+			if err != nil {
+				return err
 			}
+
+			switch {
+			case nodeDeleted:
+				failedReason = fmt.Sprintf("the node %v is deleted", r.Spec.NodeID)
+			case v.Status.State != longhorn.VolumeStateAttached:
+				failedReason = fmt.Sprintf("the volume %v is not attached and the instance manager is unable to launch the replica", v.Name)
+			case neverStarted && nodeDownOrDeleted:
+				failedReason = fmt.Sprintf("the replica never started on node %v that is down or deleted", r.Spec.NodeID)
+			}
+		}
+		if failedReason != "" {
+			msg := fmt.Sprintf("Marked replica %v as failed because %v", r.Name, failedReason)
+			log.WithField("replica", r.Name).Warn(msg)
+			if r.Spec.FailedAt == "" {
+				setReplicaFailedAt(r, c.nowHandler())
+			}
+			r.Spec.DesireState = longhorn.InstanceStateStopped
 		}
 		rs[r.Name] = r
 	}
@@ -2886,6 +2908,9 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 		}
 		// wait for all potentially healthy replicas become running
 		if r.Status.CurrentState != longhorn.InstanceStateRunning {
+			if v.Status.State == longhorn.VolumeStateAttached && IsRebuildingReplica(r) && isReplicaNeverStarted(r) {
+				continue
+			}
 			return nil
 		}
 		if r.Status.IP == "" {
@@ -2955,7 +2980,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 			ef.Spec.VolumeSize = v.Spec.Size
 			// Always propagate the target size to the EF so the EF
 			// monitor can detect that expansion is needed and trigger
-			// EngineFrontendExpand (which expands replicas → engine →
+			// EngineFrontendExpand (which expands replicas -> engine ->
 			// frontend).  The createEngineFrontend function already
 			// creates the SPDK EF at the pre-expansion size, so
 			// ef.Status.CurrentSize will correctly reflect the actual
@@ -3301,7 +3326,7 @@ func (c *VolumeController) closeVolumeDependentResources(v *longhorn.Volume, e *
 			}
 		}
 		if len(healthyReplicas) > v.Spec.NumberOfReplicas {
-			// Sort by HealthyAt ascending — oldest (most trusted) first.
+			// Sort by HealthyAt ascending - oldest (most trusted) first.
 			sort.Slice(healthyReplicas, func(i, j int) bool {
 				ti, _ := time.Parse(time.RFC3339, healthyReplicas[i].Spec.HealthyAt)
 				tj, _ := time.Parse(time.RFC3339, healthyReplicas[j].Spec.HealthyAt)
@@ -5200,7 +5225,7 @@ func (c *VolumeController) syncLinkedCloneReplicaSourceFields(v *longhorn.Volume
 //  1. Rebuild retry count exhausted (RebuildRetryCount >= FailedReplicaMaxRetryCount)
 //  2. Stale timeout exceeded (FailedAt older than StaleReplicaTimeout)
 //  3. The replica was created more than StaleReplicaTimeout after the earliest
-//     healthy replica's HealthyAt — indicating the system has been stuck in the
+//     healthy replica's HealthyAt - indicating the system has been stuck in the
 //     replenish-and-fail loop for too long.
 //
 // If ALL non-healthy replicas satisfy at least one condition, the clone should
@@ -5232,7 +5257,7 @@ func (c *VolumeController) shouldCompleteLinkedCloneDespiteDegraded(v *longhorn.
 			continue
 		}
 		if r.Spec.HealthyAt != "" && r.Spec.FailedAt == "" {
-			// Healthy replica — skip.
+			// Healthy replica - skip.
 			continue
 		}
 		hasNonHealthyReplica = true
@@ -5260,7 +5285,7 @@ func (c *VolumeController) shouldCompleteLinkedCloneDespiteDegraded(v *longhorn.
 			continue
 		}
 
-		// This replica does not meet any condition — not ready to give up.
+		// This replica does not meet any condition - not ready to give up.
 		return false
 	}
 	return hasNonHealthyReplica

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1147,6 +1147,111 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	s.runTestCases(c, testCases)
 }
 
+func (s *TestSuite) TestOpenVolumeDependentResourcesFailsNeverStartedReplicaOnDownNode(c *C) {
+	testCases := []struct {
+		name               string
+		currentState       longhorn.InstanceState
+		lastHealthyAt      string
+		expectFailed       bool
+		expectDesiredState longhorn.InstanceState
+	}{
+		{
+			name:               "stopped never-started replica",
+			currentState:       longhorn.InstanceStateStopped,
+			expectFailed:       true,
+			expectDesiredState: longhorn.InstanceStateStopped,
+		},
+		{
+			name:               "stopped previously healthy replica",
+			currentState:       longhorn.InstanceStateStopped,
+			lastHealthyAt:      getTestNow(),
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+		{
+			name:               "replica process still starting",
+			currentState:       longhorn.InstanceStateStarting,
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Logf("testing %v", tc.name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+		c.Assert(err, IsNil)
+
+		nodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+		err = nodeIndexer.Add(newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""))
+		c.Assert(err, IsNil)
+		err = nodeIndexer.Add(newNode(TestNode2, TestNamespace, true, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonKubernetesNodeNotReady)))
+		c.Assert(err, IsNil)
+
+		instanceManager := newInstanceManager(
+			TestInstanceManagerName+"-"+TestNode1, longhorn.InstanceManagerStateRunning,
+			TestOwnerID1, TestNode1, TestIP1,
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			longhorn.DataEngineTypeV1,
+			TestInstanceManagerImage,
+			false,
+		)
+		instanceManagerIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+		err = instanceManagerIndexer.Add(instanceManager)
+		c.Assert(err, IsNil)
+
+		volume := newVolume(TestVolumeName, 2)
+		volume.Spec.NodeID = TestNode1
+		volume.Status.CurrentNodeID = TestNode1
+		volume.Status.CurrentImage = TestEngineImage
+		volume.Status.State = longhorn.VolumeStateAttached
+
+		engine := newEngineForVolume(volume)
+		engine.Spec.NodeID = TestNode1
+		engine.Spec.DesireState = longhorn.InstanceStateRunning
+
+		healthyReplica := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+		healthyReplica.Spec.DesireState = longhorn.InstanceStateRunning
+		healthyReplica.Spec.HealthyAt = getTestNow()
+		healthyReplica.Spec.LastHealthyAt = getTestNow()
+		healthyReplica.Status.CurrentState = longhorn.InstanceStateRunning
+		healthyReplica.Status.Started = true
+		healthyReplica.Status.InstanceManagerName = instanceManager.Name
+		healthyReplica.Status.IP = TestIP1
+		healthyReplica.Status.StorageIP = TestIP1
+		healthyReplica.Status.Port = 10000
+
+		candidate := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+		candidate.Spec.DesireState = longhorn.InstanceStateRunning
+		candidate.Spec.LastHealthyAt = tc.lastHealthyAt
+		candidate.Status.CurrentState = tc.currentState
+		candidate.Status.Starting = true
+
+		replicas := map[string]*longhorn.Replica{
+			healthyReplica.Name: healthyReplica,
+			candidate.Name:      candidate,
+		}
+
+		err = vc.openVolumeDependentResources(volume, engine, replicas, nil, getLoggerForVolume(vc.logger, volume))
+		c.Assert(err, IsNil)
+
+		if tc.expectFailed {
+			c.Assert(candidate.Spec.FailedAt, Equals, getTestNow())
+			c.Assert(candidate.Spec.LastFailedAt, Equals, getTestNow())
+		} else {
+			c.Assert(candidate.Spec.FailedAt, Equals, "")
+			c.Assert(candidate.Spec.LastFailedAt, Equals, "")
+		}
+		c.Assert(candidate.Spec.DesireState, Equals, tc.expectDesiredState)
+	}
+}
+
 func (s *TestSuite) TestTooManySnapshotsThresholdBehavior(c *C) {
 	// Ensure lister skip for unit tests
 	datastore.SkipListerCheck = true
@@ -2061,7 +2166,7 @@ func setupSwitchoverTestInfra(c *C) (
 	v.Status.CurrentEngineNodeID = TestNode1
 	v.Status.Robustness = longhorn.VolumeRobustnessHealthy
 
-	// Current (old) engine — running on node1
+	// Current (old) engine - running on node1
 	currentEngine = newEngineForVolume(v)
 	currentEngine.Spec.DataEngine = longhorn.DataEngineTypeV2
 	currentEngine.Spec.Active = true
@@ -2072,7 +2177,7 @@ func setupSwitchoverTestInfra(c *C) (
 	currentEngine.Status.StorageIP = "10.1.0.1"
 	currentEngine.Status.Port = 8501
 
-	// Migration engine — running on node2
+	// Migration engine - running on node2
 	migrationEngine = newEngineForVolume(v)
 	migrationEngine.Spec.DataEngine = longhorn.DataEngineTypeV2
 	migrationEngine.Spec.Active = false
@@ -2083,7 +2188,7 @@ func setupSwitchoverTestInfra(c *C) (
 	migrationEngine.Status.StorageIP = "10.1.0.2"
 	migrationEngine.Status.Port = 8502
 
-	// Replica — assigned to the current engine, and also used for migration.
+	// Replica - assigned to the current engine, and also used for migration.
 	replica = newReplicaForVolume(v, currentEngine, TestNode1, TestDiskID1)
 	replica.Spec.DesireState = longhorn.InstanceStateRunning
 	replica.Status.CurrentState = longhorn.InstanceStateRunning
@@ -2099,7 +2204,7 @@ func setupSwitchoverTestInfra(c *C) (
 		replica.Name: imutil.GetURL(replica.Status.StorageIP, replica.Status.Port),
 	}
 
-	// EF — Spec already points to migration engine target (from a prior cycle).
+	// EF - Spec already points to migration engine target (from a prior cycle).
 	ef = newEngineFrontendForVolume(v, currentEngine.Name, TestNode1, "")
 	ef.Spec.TargetIP = migrationEngine.Status.StorageIP
 	ef.Spec.TargetPort = migrationEngine.Status.Port
@@ -2131,7 +2236,7 @@ func (s *TestSuite) TestProcessEngineSwitchoverKeepsOldEngineRunningUntilTargetS
 	err := vc.processEngineSwitchover(v, es, rs, efs)
 	c.Assert(err, IsNil)
 
-	// The old engine must still be running — not stopped.
+	// The old engine must still be running - not stopped.
 	c.Assert(currentEngine.Spec.DesireState, Equals, longhorn.InstanceStateRunning)
 }
 

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -1147,6 +1147,192 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	s.runTestCases(c, testCases)
 }
 
+func (s *TestSuite) TestOpenVolumeDependentResourcesFailsNeverStartedReplicaOnDownNode(c *C) {
+	testCases := []struct {
+		name                    string
+		nodeReady               longhorn.ConditionStatus
+		desireState             longhorn.InstanceState
+		currentState            longhorn.InstanceState
+		starting                bool
+		started                 bool
+		lastHealthyAt           string
+		expectFailed            bool
+		expectDesiredState      longhorn.InstanceState
+		expectReplicaMapUpdated bool
+	}{
+		{
+			name:                    "status starting never-started replica",
+			nodeReady:               longhorn.ConditionStatusFalse,
+			desireState:             longhorn.InstanceStateStopped,
+			currentState:            longhorn.InstanceStateStopped,
+			starting:                true,
+			expectFailed:            true,
+			expectDesiredState:      longhorn.InstanceStateStopped,
+			expectReplicaMapUpdated: true,
+		},
+		{
+			name:                    "desired running never-started replica",
+			nodeReady:               longhorn.ConditionStatusFalse,
+			desireState:             longhorn.InstanceStateRunning,
+			currentState:            longhorn.InstanceStateStopped,
+			expectFailed:            true,
+			expectDesiredState:      longhorn.InstanceStateStopped,
+			expectReplicaMapUpdated: true,
+		},
+		{
+			name:               "replica never requested to run",
+			nodeReady:          longhorn.ConditionStatusFalse,
+			desireState:        longhorn.InstanceStateStopped,
+			currentState:       longhorn.InstanceStateStopped,
+			expectDesiredState: longhorn.InstanceStateStopped,
+		},
+		{
+			name:               "stopped replica previously observed running",
+			nodeReady:          longhorn.ConditionStatusFalse,
+			desireState:        longhorn.InstanceStateRunning,
+			currentState:       longhorn.InstanceStateStopped,
+			starting:           true,
+			started:            true,
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+		{
+			name:               "stopped previously healthy replica",
+			nodeReady:          longhorn.ConditionStatusFalse,
+			desireState:        longhorn.InstanceStateRunning,
+			currentState:       longhorn.InstanceStateStopped,
+			starting:           true,
+			lastHealthyAt:      getTestNow(),
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+		{
+			name:               "replica process still starting on down node",
+			nodeReady:          longhorn.ConditionStatusFalse,
+			desireState:        longhorn.InstanceStateRunning,
+			currentState:       longhorn.InstanceStateStarting,
+			starting:           true,
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+		{
+			name:                    "never-started rebuilding replica on ready node",
+			nodeReady:               longhorn.ConditionStatusTrue,
+			desireState:             longhorn.InstanceStateRunning,
+			currentState:            longhorn.InstanceStateStopped,
+			starting:                true,
+			expectDesiredState:      longhorn.InstanceStateRunning,
+			expectReplicaMapUpdated: true,
+		},
+		{
+			name:               "replica process still starting on ready node",
+			nodeReady:          longhorn.ConditionStatusTrue,
+			desireState:        longhorn.InstanceStateRunning,
+			currentState:       longhorn.InstanceStateStarting,
+			starting:           true,
+			expectDesiredState: longhorn.InstanceStateRunning,
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Logf("testing %v", tc.name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+		c.Assert(err, IsNil)
+
+		nodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+		err = nodeIndexer.Add(newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""))
+		c.Assert(err, IsNil)
+		nodeReason := ""
+		if tc.nodeReady == longhorn.ConditionStatusFalse {
+			nodeReason = string(longhorn.NodeConditionReasonKubernetesNodeNotReady)
+		}
+		err = nodeIndexer.Add(newNode(TestNode2, TestNamespace, true, tc.nodeReady, nodeReason))
+		c.Assert(err, IsNil)
+
+		volume := newVolume(TestVolumeName, 2)
+		volume.Spec.NodeID = TestNode1
+		volume.Status.CurrentNodeID = TestNode1
+		volume.Status.CurrentImage = TestEngineImage
+		volume.Status.State = longhorn.VolumeStateAttached
+
+		engine := newEngineForVolume(volume)
+		engine.Spec.NodeID = TestNode1
+		engine.Spec.DesireState = longhorn.InstanceStateRunning
+
+		replacementReplica := newReplicaForVolume(volume, engine, TestNode1, TestDiskID1)
+		replacementReplica.Spec.DesireState = longhorn.InstanceStateRunning
+		replacementReplica.Status.CurrentState = longhorn.InstanceStateRunning
+		replacementReplica.Status.Started = true
+		replacementReplica.Status.IP = TestIP1
+		replacementReplica.Status.StorageIP = TestIP1
+		replacementReplica.Status.Port = 10000
+
+		candidate := newReplicaForVolume(volume, engine, TestNode2, TestDiskID1)
+		candidate.Spec.DesireState = tc.desireState
+		candidate.Spec.RebuildRetryCount = 1
+		candidate.Spec.LastHealthyAt = tc.lastHealthyAt
+		candidate.Status.CurrentState = tc.currentState
+		candidate.Status.Starting = tc.starting
+		candidate.Status.Started = tc.started
+
+		replacementInstanceManager := newInstanceManager(
+			TestInstanceManagerName+"-"+TestNode1, longhorn.InstanceManagerStateRunning,
+			TestOwnerID1, TestNode1, TestIP1,
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			longhorn.DataEngineTypeV1,
+			TestInstanceManagerImage,
+			false,
+		)
+		replacementReplica.Status.InstanceManagerName = replacementInstanceManager.Name
+
+		candidateInstanceManager := newInstanceManager(
+			TestInstanceManagerName+"-"+TestNode2, longhorn.InstanceManagerStateRunning,
+			TestOwnerID1, TestNode2, TestIP2,
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			map[string]longhorn.InstanceProcess{},
+			longhorn.DataEngineTypeV1,
+			TestInstanceManagerImage,
+			false,
+		)
+		candidate.Status.InstanceManagerName = candidateInstanceManager.Name
+
+		instanceManagerIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+		err = instanceManagerIndexer.Add(replacementInstanceManager)
+		c.Assert(err, IsNil)
+		err = instanceManagerIndexer.Add(candidateInstanceManager)
+		c.Assert(err, IsNil)
+
+		replicas := map[string]*longhorn.Replica{
+			replacementReplica.Name: replacementReplica,
+			candidate.Name:          candidate,
+		}
+
+		err = vc.openVolumeDependentResources(volume, engine, replicas, nil, getLoggerForVolume(vc.logger, volume))
+		c.Assert(err, IsNil)
+
+		if tc.expectFailed {
+			c.Assert(candidate.Spec.FailedAt, Equals, getTestNow())
+			c.Assert(candidate.Spec.LastFailedAt, Equals, getTestNow())
+		} else {
+			c.Assert(candidate.Spec.FailedAt, Equals, "")
+			c.Assert(candidate.Spec.LastFailedAt, Equals, "")
+		}
+		c.Assert(candidate.Spec.DesireState, Equals, tc.expectDesiredState)
+
+		expectedReplicaAddressMap := map[string]string{}
+		if tc.expectReplicaMapUpdated {
+			expectedReplicaAddressMap[replacementReplica.Name] = imutil.GetURL(replacementReplica.Status.StorageIP, replacementReplica.Status.Port)
+		}
+		c.Assert(engine.Spec.ReplicaAddressMap, DeepEquals, expectedReplicaAddressMap)
+	}
+}
+
 func (s *TestSuite) TestTooManySnapshotsThresholdBehavior(c *C) {
 	// Ensure lister skip for unit tests
 	datastore.SkipListerCheck = true
@@ -2061,7 +2247,7 @@ func setupSwitchoverTestInfra(c *C) (
 	v.Status.CurrentEngineNodeID = TestNode1
 	v.Status.Robustness = longhorn.VolumeRobustnessHealthy
 
-	// Current (old) engine — running on node1
+	// Current (old) engine - running on node1
 	currentEngine = newEngineForVolume(v)
 	currentEngine.Spec.DataEngine = longhorn.DataEngineTypeV2
 	currentEngine.Spec.Active = true
@@ -2072,7 +2258,7 @@ func setupSwitchoverTestInfra(c *C) (
 	currentEngine.Status.StorageIP = "10.1.0.1"
 	currentEngine.Status.Port = 8501
 
-	// Migration engine — running on node2
+	// Migration engine - running on node2
 	migrationEngine = newEngineForVolume(v)
 	migrationEngine.Spec.DataEngine = longhorn.DataEngineTypeV2
 	migrationEngine.Spec.Active = false
@@ -2083,7 +2269,7 @@ func setupSwitchoverTestInfra(c *C) (
 	migrationEngine.Status.StorageIP = "10.1.0.2"
 	migrationEngine.Status.Port = 8502
 
-	// Replica — assigned to the current engine, and also used for migration.
+	// Replica - assigned to the current engine, and also used for migration.
 	replica = newReplicaForVolume(v, currentEngine, TestNode1, TestDiskID1)
 	replica.Spec.DesireState = longhorn.InstanceStateRunning
 	replica.Status.CurrentState = longhorn.InstanceStateRunning
@@ -2099,7 +2285,7 @@ func setupSwitchoverTestInfra(c *C) (
 		replica.Name: imutil.GetURL(replica.Status.StorageIP, replica.Status.Port),
 	}
 
-	// EF — Spec already points to migration engine target (from a prior cycle).
+	// EF - Spec already points to migration engine target (from a prior cycle).
 	ef = newEngineFrontendForVolume(v, currentEngine.Name, TestNode1, "")
 	ef.Spec.TargetIP = migrationEngine.Status.StorageIP
 	ef.Spec.TargetPort = migrationEngine.Status.Port
@@ -2131,7 +2317,7 @@ func (s *TestSuite) TestProcessEngineSwitchoverKeepsOldEngineRunningUntilTargetS
 	err := vc.processEngineSwitchover(v, es, rs, efs)
 	c.Assert(err, IsNil)
 
-	// The old engine must still be running — not stopped.
+	// The old engine must still be running - not stopped.
 	c.Assert(currentEngine.Spec.DesireState, Equals, longhorn.InstanceStateRunning)
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13571

#### What this PR does / why we need it:

Given an attached running replica, when it require to launch multiple replicas, and some of the new replica keeps `stopped` due to node outage, such stopped replica blocks the replica map syncing. To resolve the dead lock, this PR will mark the replica as failed if the node is down.

#### Special notes for your reviewer:

This PR passes the coretest with regression job ID 11522 (the only failed case is the flaky case `test_volume_iscsi_basic_with_backing_image`). The existing features are not broken.

#### Additional documentation or context
