### PR TITLE
fix(csi): sanitize method request logs

### DIFF
--- a/csi/controller_server.go
+++ b/csi/controller_server.go
@@ -110,7 +110,7 @@ func NewControllerServer(apiClient *longhornclient.RancherClient, nodeID string)
 func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "CreateVolume"})
 
-	log.Infof("CreateVolume is called with req %+v", req)
+	logCSIRequest(log, "CreateVolume", req)
 
 	volumeID := util.AutoCorrectName(req.GetName(), datastore.NameMaximumLength)
 	if len(volumeID) == 0 {
@@ -429,7 +429,7 @@ func (cs *ControllerServer) checkAndPrepareBackingImage(volumeName, backingImage
 func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "DeleteVolume"})
 
-	log.Infof("DeleteVolume is called with req %+v", req)
+	logCSIRequest(log, "DeleteVolume", req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -496,7 +496,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "ControllerPublishVolume"})
 
-	log.Infof("ControllerPublishVolume is called with req %+v", req)
+	logCSIRequest(log, "ControllerPublishVolume", req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -641,7 +641,7 @@ func (cs *ControllerServer) updateVolumeAccessMode(volume *longhornclient.Volume
 func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "ControllerUnpublishVolume"})
 
-	log.Infof("ControllerUnpublishVolume is called with req %+v", req)
+	logCSIRequest(log, "ControllerUnpublishVolume", req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -708,7 +708,7 @@ func (cs *ControllerServer) ListVolumes(context.Context, *csi.ListVolumesRequest
 func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (rsp *csi.GetCapacityResponse, err error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "GetCapacity"})
 
-	log.Infof("GetCapacity is called with req %+v", req)
+	logCSIRequest(log, "GetCapacity", req)
 
 	defer func() {
 		if err != nil {
@@ -875,7 +875,7 @@ func (cs *ControllerServer) getSettingAsString(ctx context.Context, name types.S
 func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "CreateSnapshot"})
 
-	log.Infof("CreateSnapshot is called with req %+v", req)
+	logCSIRequest(log, "CreateSnapshot", req)
 
 	var rsp *csi.CreateSnapshotResponse
 	var err error
@@ -1348,7 +1348,7 @@ func (cs *ControllerServer) ListSnapshots(context.Context, *csi.ListSnapshotsReq
 func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	log := cs.log.WithFields(logrus.Fields{"function": "ControllerExpandVolume"})
 
-	log.Infof("ControllerExpandVolume is called with req %+v", req)
+	logCSIRequest(log, "ControllerExpandVolume", req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -1685,8 +1685,7 @@ func (cs *ControllerServer) waitForSnapshotToBeReady(snapshotName, volumeName st
 }
 
 func (cs *ControllerServer) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
-	log := cs.log.WithFields(logrus.Fields{"function": "ControllerModifyVolume"})
-	log.Infof("ControllerModifyVolume: called with args %v", req)
+	logCSIRequest(cs.log, "ControllerModifyVolume", req)
 
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/csi/controller_server_test.go
+++ b/csi/controller_server_test.go
@@ -1,6 +1,7 @@
 package csi
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -31,6 +32,91 @@ func newTestControllerServer(t *testing.T, objs ...runtime.Object) *ControllerSe
 		log:         logrus.StandardLogger().WithField("component", "test"),
 		lhClient:    lhfake.NewSimpleClientset(objs...), // nolint: staticcheck
 		lhNamespace: testNamespace,
+	}
+}
+
+func TestControllerRequestLogsStripSecrets(t *testing.T) {
+	const secret = "sentinel-csi-secret-value"
+
+	for _, tc := range []struct {
+		name string
+		call func(*ControllerServer)
+	}{
+		{
+			name: "CreateVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "DeleteVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "ControllerPublishVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "ControllerUnpublishVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "CreateSnapshot",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.CreateSnapshot(context.Background(), &csi.CreateSnapshotRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "ControllerExpandVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "ControllerModifyVolume",
+			call: func(cs *ControllerServer) {
+				_, _ = cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := logrus.New()
+			logger.SetOutput(&output)
+			cs := &ControllerServer{
+				log: logger.WithField("component", "test"),
+			}
+
+			tc.call(cs)
+
+			logOutput := output.String()
+			if strings.Contains(logOutput, secret) {
+				t.Fatalf("request log contains secret value: %s", logOutput)
+			}
+			if !strings.Contains(logOutput, tc.name+" is called with req") {
+				t.Fatalf("request log is missing method context: %s", logOutput)
+			}
+		})
 	}
 }
 

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -133,7 +133,7 @@ func getV2VolumeEndpointForNode(volume *longhornclient.Volume, nodeID string) (s
 func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	log := ns.log.WithFields(logrus.Fields{"function": "NodePublishVolume"})
 
-	log.Infof("NodePublishVolume is called with req %+v", req)
+	logCSIRequest(log, "NodePublishVolume", req)
 
 	targetPath := req.GetTargetPath()
 	if targetPath == "" {
@@ -424,7 +424,7 @@ func (ns *NodeServer) nodePublishBlockVolume(volumeID, devicePath, targetPath st
 func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	log := ns.log.WithFields(logrus.Fields{"function": "NodeUnpublishVolume"})
 
-	log.Infof("NodeUnpublishVolume is called with req %+v", req)
+	logCSIRequest(log, "NodeUnpublishVolume", req)
 
 	targetPath := req.GetTargetPath()
 	if targetPath == "" {
@@ -447,7 +447,7 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	log := ns.log.WithFields(logrus.Fields{"function": "NodeStageVolume"})
 
-	log.Infof("NodeStageVolume is called with req %+v", req)
+	logCSIRequest(log, "NodeStageVolume", req)
 
 	stagingTargetPath := req.GetStagingTargetPath()
 	if stagingTargetPath == "" {
@@ -662,7 +662,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	log := ns.log.WithFields(logrus.Fields{"function": "NodeUnstageVolume"})
 
-	log.Infof("NodeUnstageVolume is called with req %+v", req)
+	logCSIRequest(log, "NodeUnstageVolume", req)
 
 	stagingTargetPath := req.GetStagingTargetPath()
 	if stagingTargetPath == "" {
@@ -831,7 +831,7 @@ func (ns *NodeServer) NodeExpandSharedVolume(volumeName string) error {
 func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	log := ns.log.WithFields(logrus.Fields{"function": "NodeExpandVolume"})
 
-	log.Infof("NodeExpandVolume is called with req %+v", req)
+	logCSIRequest(log, "NodeExpandVolume", req)
 
 	if req.CapacityRange == nil {
 		return nil, status.Error(codes.InvalidArgument, "capacity range missing in request")

--- a/csi/node_server_test.go
+++ b/csi/node_server_test.go
@@ -1,10 +1,70 @@
 package csi
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	csipb "github.com/container-storage-interface/spec/lib/go/csi"
 
 	longhornclient "github.com/longhorn/longhorn-manager/client"
 )
+
+func TestNodeRequestLogsStripSecrets(t *testing.T) {
+	const secret = "sentinel-csi-secret-value"
+
+	for _, tc := range []struct {
+		name string
+		call func(*NodeServer)
+	}{
+		{
+			name: "NodePublishVolume",
+			call: func(ns *NodeServer) {
+				_, _ = ns.NodePublishVolume(context.Background(), &csipb.NodePublishVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "NodeStageVolume",
+			call: func(ns *NodeServer) {
+				_, _ = ns.NodeStageVolume(context.Background(), &csipb.NodeStageVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+		{
+			name: "NodeExpandVolume",
+			call: func(ns *NodeServer) {
+				_, _ = ns.NodeExpandVolume(context.Background(), &csipb.NodeExpandVolumeRequest{
+					Secrets: map[string]string{"secret": secret},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := logrus.New()
+			logger.SetOutput(&output)
+			ns := &NodeServer{
+				log: logger.WithField("component", "test"),
+			}
+
+			tc.call(ns)
+
+			logOutput := output.String()
+			if strings.Contains(logOutput, secret) {
+				t.Fatalf("request log contains secret value: %s", logOutput)
+			}
+			if !strings.Contains(logOutput, tc.name+" is called with req") {
+				t.Fatalf("request log is missing method context: %s", logOutput)
+			}
+		})
+	}
+}
 
 func TestGetV2VolumeEndpointForNode(t *testing.T) {
 	for _, tc := range []struct {

--- a/csi/util.go
+++ b/csi/util.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
@@ -37,6 +38,10 @@ const (
 
 	tempTestMountPointValidStatusFile = ".longhorn-volume-mount-point-test.tmp"
 )
+
+func logCSIRequest(log *logrus.Entry, function string, req any) {
+	log.Infof("%s is called with req %+v", function, protosanitizer.StripSecrets(req))
+}
 
 // NewForcedParamsExec creates a osExecutor that allows for adding additional params to later occurring Run calls
 func NewForcedParamsExec(cmdParamMapping map[string]string) utilexec.Interface {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13613

#### What this PR does / why we need it:

The CSI gRPC interceptor sanitizes protobuf requests before logging them, but method-level node and controller logs were printing the original requests. Requests with a CSI `Secrets` map could therefore expose those values in the CSI plugin logs.

This change passes every existing method-level CSI request log through `protosanitizer.StripSecrets`. It also adds node and controller regression tests using a synthetic sentinel value to verify that:

- the request log retains its method context;
- the sentinel secret value is absent from the log output.

No real secret material, cluster logs, or support bundle is included in this PR.

#### Special notes for your reviewer:

The patch covers all existing node and controller method-level request logs, including request types that do not currently carry a `Secrets` field. Applying the sanitizer consistently avoids the same bypass if those protobuf messages evolve.

Test environment:

- Linux/amd64 container
- Go 1.26
- Base commit `b0ca62b7ac45`

Tests:

```text
go test ./csi -run 'Test(Node|Controller)RequestLogsStripSecrets' -count=1
ok   github.com/longhorn/longhorn-manager/csi

go test ./csi -count=1
ok   github.com/longhorn/longhorn-manager/csi

python3 .github/scripts/check_go_imports.py csi/controller_server.go csi/node_server.go csi/controller_server_test.go csi/node_server_test.go
Go import convention check passed.

git diff --check
```
