### PR TITLE
fix(recurringjob): skip snapshot purge while a replica is rebuilding

### DIFF
--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -342,9 +342,53 @@ func (job *VolumeJob) eventCreate(eventType, eventReason, message string) error 
 	return nil
 }
 
+// isTransientPurgeRejection reports whether err is the engine declining to
+// start a purge because a replica is currently rebuilding.
+//
+// The engine guards ActionSnapshotPurge with a rebuild check and answers:
+//
+//	failed to purge snapshots: rpc error: code = Unknown desc =
+//	tcp://<replica>:<port>: cannot purge snapshots because
+//	tcp://<replica>:<port> is rebuilding
+//
+// That is a temporary, self-resolving condition rather than a fault: the next
+// scheduled run purges the volume once the rebuild finishes. It is matched on
+// the message because the engine surfaces it as a generic Unknown gRPC code
+// through the proxy, so there is no typed error or distinct status code to key
+// on. The substring is deliberately narrow so genuine failures still surface.
+func isTransientPurgeRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "is rebuilding")
+}
+
 func (job *VolumeJob) purgeSnapshots(volume *longhornclient.Volume, volumeAPI longhornclient.VolumeOperations) error {
 	// Trigger snapshot purge of the volume
 	if _, err := volumeAPI.ActionSnapshotPurge(volume); err != nil {
+		// A rebuilding replica means "not now", not "broken". Returning the
+		// error here fails this volume's job, and because recurringJob()
+		// collects goroutine errors through an errgroup and RecurringJobCmd()
+		// turns any non-nil result into logrus.Fatal, ONE rebuilding volume
+		// aborts the whole run -- every volume not yet processed is silently
+		// skipped for that tick. Raising concurrency does not help, since the
+		// workers share a process.
+		//
+		// On a cluster large enough that some replica is usually rebuilding,
+		// the sweep can then go for hours without completing: snapshots
+		// marked for removal never coalesce, replica directories grow well
+		// past their volume's nominal size, and nodes eventually hit
+		// DiskPressure.
+		//
+		// Skip the volume instead. This also makes the function
+		// self-consistent: the purge-status poll below already tolerates
+		// per-replica purge errors, logging them as warnings and returning
+		// nil. Only this initial trigger was fatal.
+		if isTransientPurgeRejection(err) {
+			job.logger.WithField("volume", volume.Name).Info(
+				"Skipping snapshot purge because a replica is rebuilding; will retry on the next run")
+			return nil
+		}
 		return err
 	}
 

--- a/app/recurringjob/volume_test.go
+++ b/app/recurringjob/volume_test.go
@@ -1,0 +1,57 @@
+package recurringjob
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsTransientPurgeRejection pins the matcher that decides whether a failed
+// ActionSnapshotPurge aborts the recurring job or is skipped until the next
+// run.
+//
+// This matters more than its size suggests. recurringJob() collects per-volume
+// errors through an errgroup and RecurringJobCmd() turns any non-nil result
+// into logrus.Fatal, so a single volume's error ends the whole sweep and every
+// volume not yet processed is skipped for that tick. Matching too narrowly
+// re-introduces that abort; matching too broadly silently swallows real purge
+// failures. Both regressions stay invisible until snapshots have accumulated
+// enough to fill a disk.
+func TestIsTransientPurgeRejection(t *testing.T) {
+	assert := assert.New(t)
+
+	// The real message, as produced by the engine and surfaced through the
+	// proxy. Captured verbatim from a v1.7.2 cluster.
+	realWorld := errors.New(
+		"Bad response statusCode [500]. Status [500 Internal Server Error]. " +
+			"Body: [message=failed to purge snapshot: proxyServer=10.244.77.1:8501 " +
+			"destination=10.244.77.1:18795: failed to purge snapshots: rpc error: " +
+			"code = Unknown desc = tcp://10.244.76.157:10169: cannot purge snapshots " +
+			"because tcp://10.244.76.157:10169 is rebuilding, code=Internal Server Error, " +
+			"detail=] from [http://longhorn-backend:9500/v1/volumes/pvc-x?action=snapshotPurge]")
+	assert.True(isTransientPurgeRejection(realWorld),
+		"the engine's rebuild rejection must be treated as transient, or one "+
+			"rebuilding volume aborts the entire recurring job")
+
+	// Minimal form, in case the surrounding wrapping changes.
+	assert.True(isTransientPurgeRejection(
+		errors.New("cannot purge snapshots because tcp://10.0.0.1:10000 is rebuilding")))
+
+	// Wrapped errors must still match -- callers may add context.
+	assert.True(isTransientPurgeRejection(
+		fmt.Errorf("purging volume pvc-abc: %w",
+			errors.New("cannot purge snapshots because tcp://10.0.0.1:10000 is rebuilding"))))
+
+	// Genuine failures must NOT be swallowed: these should still fail the job
+	// loudly rather than be silently skipped on every run.
+	assert.False(isTransientPurgeRejection(nil))
+	assert.False(isTransientPurgeRejection(errors.New("timed out waiting for snapshot purge to complete")))
+	assert.False(isTransientPurgeRejection(errors.New("volume pvc-x not found")))
+	assert.False(isTransientPurgeRejection(errors.New("Bad response statusCode [500]")))
+	assert.False(isTransientPurgeRejection(errors.New("failed to purge snapshots: connection refused")))
+	// "rebuild" alone is not the guard condition -- only an in-progress
+	// rebuild is, and the engine says "is rebuilding".
+	assert.False(isTransientPurgeRejection(errors.New("replica rebuild scheduled")))
+}


### PR DESCRIPTION
## Which issue(s) this PR fixes

Issue longhorn/longhorn#13623

## What this PR does / why we need it

`purgeSnapshots` returns `ActionSnapshotPurge`'s error verbatim. When the engine declines to start a purge because a replica is mid-rebuild:

```
cannot purge snapshots because tcp://<replica>:<port> is rebuilding
```

that error propagates `doSnapshotCleanup` → `startVolumeJob` → the `errgroup` in `recurringJob()`, and `RecurringJobCmd()` turns any non-nil result into `logrus.Fatal`. The process exits, so **every volume that had not yet been processed is silently skipped for that run**.

A rebuild is transient and self-resolving — the next run purges the volume fine. But on a cluster large enough that *some* replica is usually rebuilding, the sweep can go for hours without ever completing: snapshots marked for removal never coalesce, replica directories grow well past their volume's nominal size, and nodes eventually hit `DiskPressure`.

Raising `concurrency` does **not** mitigate it — the workers share one process, so any worker's `Fatal` ends the run.

This PR skips the volume instead. That also makes the function self-consistent: the purge-status poll immediately below **already** tolerates per-replica purge errors, logging them as warnings and returning `nil`. Only the initial trigger was fatal.

### Why match on the message

The engine surfaces this through the proxy as a generic `Unknown` gRPC code, so there is no typed error or distinct status code to key on. The substring is deliberately narrow so genuine failures (timeouts, missing volumes, connection errors) still fail the job loudly. The test pins both directions.

### Observed impact

On a v1.7.2 cluster, the cleanup job failing intermittently over ~8 hours left **1805.7 GB unpurged across 92 snapshots**. One node reached 82% disk and `DiskPressure=True`, which evicted a Postgres pod ~503 times and took the dependent service down for ~2.5 days.

It was slow to diagnose because nothing pointed at snapshots: kubelet's image GC reported `Failed to free sufficient space by deleting unused images (freed 0 bytes)` — images were only 28 GB of the 683 GB used, while Longhorn replicas were 512 GB. A `75Gi` volume occupying **141.8 GB** (`actualSize` ≈ 2× nominal) turned out to be the reliable tell.

## Special notes for your reviewer

- The bug exists identically on `v1.7.2` (`app/recurring_job.go#L505-L508`, pre-refactor) — happy to open a backport if wanted.
- Related but distinct: longhorn/longhorn#12229 covers the *controller's* post-rebuild purge not retrying; this is the *recurring job* aborting its whole sweep.

## Additional documentation or context

Verified on linux/amd64 in `golang:1.26` (the package pulls Linux-only vendored code, so it cannot be built or tested on macOS):

- `go build ./app/...` — clean
- `go vet ./app/...` — clean
- `go test ./app/recurringjob/ -run TestIsTransientPurgeRejection` — **PASS**
- The same test with the matcher reverted to pre-fix behaviour — **FAIL**, confirming it guards the behaviour rather than passing vacuously.
