### PR TITLE
feat(csi): add longhorn.io/component labels for CSI pods

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -323,9 +323,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": types.CSIPluginName,
-					},
+					Labels: types.GetCSIPodLabels(types.CSIPluginName),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -347,9 +347,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": types.CSIPluginName,
-					},
+					Labels: types.GetCSIPodLabels(types.CSIPluginName),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -102,7 +102,7 @@ func getCommonDeployment(commonName, namespace, serviceAccount, image, rootDir s
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": commonName},
+					Labels: types.GetCSIPodLabels(commonName),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,

--- a/types/types.go
+++ b/types/types.go
@@ -245,6 +245,12 @@ const (
 	LonghornLabelVersion                         = "version"
 	LonghornLabelAdmissionWebhook                = "admission-webhook"
 	LonghornLabelConversionWebhook               = "conversion-webhook"
+	LonghornLabelManager                         = "manager"
+	LonghornLabelCSIPlugin                       = "csi-plugin"
+	LonghornLabelCSIAttacher                     = "csi-attacher"
+	LonghornLabelCSIProvisioner                  = "csi-provisioner"
+	LonghornLabelCSIResizer                      = "csi-resizer"
+	LonghornLabelCSISnapshotter                  = "csi-snapshotter"
 
 	LonghornRecoveryBackendServiceName = "longhorn-recovery-backend"
 
@@ -575,7 +581,19 @@ func GetLonghornLabelCRDAPIVersionKey() string {
 
 func GetManagerLabels() map[string]string {
 	return map[string]string{
-		"app": LonghornManagerDaemonSetName,
+		"app":                          LonghornManagerDaemonSetName,
+		GetLonghornLabelComponentKey(): LonghornLabelManager,
+	}
+}
+
+func GetCSIPodLabels(appName string) map[string]string {
+	component := appName
+	if appName == CSIPluginName {
+		component = LonghornLabelCSIPlugin
+	}
+	return map[string]string{
+		"app":                          appName,
+		GetLonghornLabelComponentKey(): component,
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -242,6 +242,12 @@ const (
 	LonghornLabelVersion                         = "version"
 	LonghornLabelAdmissionWebhook                = "admission-webhook"
 	LonghornLabelConversionWebhook               = "conversion-webhook"
+	LonghornLabelManager                         = "manager"
+	LonghornLabelCSIPlugin                       = "csi-plugin"
+	LonghornLabelCSIAttacher                     = "csi-attacher"
+	LonghornLabelCSIProvisioner                  = "csi-provisioner"
+	LonghornLabelCSIResizer                      = "csi-resizer"
+	LonghornLabelCSISnapshotter                  = "csi-snapshotter"
 
 	LonghornRecoveryBackendServiceName = "longhorn-recovery-backend"
 
@@ -621,7 +627,19 @@ func GetLonghornLabelCRDAPIVersionKey() string {
 
 func GetManagerLabels() map[string]string {
 	return map[string]string{
-		"app": LonghornManagerDaemonSetName,
+		"app":                          LonghornManagerDaemonSetName,
+		GetLonghornLabelComponentKey(): LonghornLabelManager,
+	}
+}
+
+func GetCSIPodLabels(appName string) map[string]string {
+	component := appName
+	if appName == CSIPluginName {
+		component = LonghornLabelCSIPlugin
+	}
+	return map[string]string{
+		"app":                          appName,
+		GetLonghornLabelComponentKey(): component,
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -245,7 +245,6 @@ const (
 	LonghornLabelVersion                         = "version"
 	LonghornLabelAdmissionWebhook                = "admission-webhook"
 	LonghornLabelConversionWebhook               = "conversion-webhook"
-	LonghornLabelManager                         = "manager"
 	LonghornLabelCSIPlugin                       = "csi-plugin"
 	LonghornLabelCSIAttacher                     = "csi-attacher"
 	LonghornLabelCSIProvisioner                  = "csi-provisioner"
@@ -579,10 +578,12 @@ func GetLonghornLabelCRDAPIVersionKey() string {
 	return GetLonghornLabelKey(LonghornLabelCRDAPIVersion)
 }
 
+// GetManagerLabels returns selector labels for longhorn-manager pods.
+// Must stay app-only so upgrade and discovery callers still match pre-upgrade
+// pods that lack longhorn.io/component. Manager pod template labels live in the chart.
 func GetManagerLabels() map[string]string {
 	return map[string]string{
-		"app":                          LonghornManagerDaemonSetName,
-		GetLonghornLabelComponentKey(): LonghornLabelManager,
+		"app": LonghornManagerDaemonSetName,
 	}
 }
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -602,3 +602,44 @@ func (s *TestSuite) TestIsHexCPUMask(c *C) {
 		c.Assert(result, Equals, testCase.expected, Commentf(TestErrResultFmt, testName))
 	}
 }
+
+func (s *TestSuite) TestGetManagerLabels(c *C) {
+	labels := GetManagerLabels()
+	c.Assert(labels["app"], Equals, LonghornManagerDaemonSetName)
+	c.Assert(labels[GetLonghornLabelComponentKey()], Equals, LonghornLabelManager)
+}
+
+func (s *TestSuite) TestGetCSIPodLabels(c *C) {
+	type testCase struct {
+		appName           string
+		expectedComponent string
+	}
+	testCases := map[string]testCase{
+		"csi-plugin": {
+			appName:           CSIPluginName,
+			expectedComponent: LonghornLabelCSIPlugin,
+		},
+		"csi-attacher": {
+			appName:           CSIAttacherName,
+			expectedComponent: LonghornLabelCSIAttacher,
+		},
+		"csi-provisioner": {
+			appName:           CSIProvisionerName,
+			expectedComponent: LonghornLabelCSIProvisioner,
+		},
+		"csi-resizer": {
+			appName:           CSIResizerName,
+			expectedComponent: LonghornLabelCSIResizer,
+		},
+		"csi-snapshotter": {
+			appName:           CSISnapshotterName,
+			expectedComponent: LonghornLabelCSISnapshotter,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		labels := GetCSIPodLabels(testCase.appName)
+		c.Assert(labels["app"], Equals, testCase.appName, Commentf(TestErrResultFmt, testName))
+		c.Assert(labels[GetLonghornLabelComponentKey()], Equals, testCase.expectedComponent, Commentf(TestErrResultFmt, testName))
+	}
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -650,3 +650,44 @@ func (s *TestSuite) TestCreateDisksFromAnnotationWithBlockDiskPath(c *C) {
 		}
 	}
 }
+
+func (s *TestSuite) TestGetManagerLabels(c *C) {
+	labels := GetManagerLabels()
+	c.Assert(labels["app"], Equals, LonghornManagerDaemonSetName)
+	c.Assert(labels[GetLonghornLabelComponentKey()], Equals, LonghornLabelManager)
+}
+
+func (s *TestSuite) TestGetCSIPodLabels(c *C) {
+	type testCase struct {
+		appName           string
+		expectedComponent string
+	}
+	testCases := map[string]testCase{
+		"csi-plugin": {
+			appName:           CSIPluginName,
+			expectedComponent: LonghornLabelCSIPlugin,
+		},
+		"csi-attacher": {
+			appName:           CSIAttacherName,
+			expectedComponent: LonghornLabelCSIAttacher,
+		},
+		"csi-provisioner": {
+			appName:           CSIProvisionerName,
+			expectedComponent: LonghornLabelCSIProvisioner,
+		},
+		"csi-resizer": {
+			appName:           CSIResizerName,
+			expectedComponent: LonghornLabelCSIResizer,
+		},
+		"csi-snapshotter": {
+			appName:           CSISnapshotterName,
+			expectedComponent: LonghornLabelCSISnapshotter,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		labels := GetCSIPodLabels(testCase.appName)
+		c.Assert(labels["app"], Equals, testCase.appName, Commentf(TestErrResultFmt, testName))
+		c.Assert(labels[GetLonghornLabelComponentKey()], Equals, testCase.expectedComponent, Commentf(TestErrResultFmt, testName))
+	}
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -653,8 +653,9 @@ func (s *TestSuite) TestCreateDisksFromAnnotationWithBlockDiskPath(c *C) {
 
 func (s *TestSuite) TestGetManagerLabels(c *C) {
 	labels := GetManagerLabels()
-	c.Assert(labels["app"], Equals, LonghornManagerDaemonSetName)
-	c.Assert(labels[GetLonghornLabelComponentKey()], Equals, LonghornLabelManager)
+	c.Assert(labels, DeepEquals, map[string]string{
+		"app": LonghornManagerDaemonSetName,
+	})
 }
 
 func (s *TestSuite) TestGetCSIPodLabels(c *C) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13634

#### What this PR does / why we need it:

System-managed Longhorn pods already get `longhorn.io/component`. Pods created by `deploy-driver` (CSI plugin and sidecars) do not — they only have `app:`.

This PR adds `longhorn.io/component` to CSI pod templates via a new `GetCSIPodLabels()` helper:

- `longhorn-csi-plugin` → `csi-plugin`
- `csi-attacher` → `csi-attacher`
- `csi-provisioner` → `csi-provisioner`
- `csi-resizer` → `csi-resizer`
- `csi-snapshotter` → `csi-snapshotter`

Existing `app:` labels are unchanged.

`GetManagerLabels()` stays app-only (`app=longhorn-manager`). It is used as a pod List/MatchLabels selector for upgrades and manager discovery; requiring `longhorn.io/component` there would hide pre-upgrade manager pods that only have the `app` label. Manager pod template labels (including `longhorn.io/component`) belong in the chart/manifests.

#### Special notes for your reviewer:

- `GetCSIPodLabels()` maps `CSIPluginName` (`longhorn-csi-plugin`) to `csi-plugin`; other sidecar `app` names already match their component value.
- Label-only change; no CSI or reconciliation logic modified.

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/13634

#### Test plan

Unit tests:
```
go test ./types/... -check.f 'GetManagerLabels|GetCSIPodLabels' -v
Result: PASS (2 test cases)
```