### PR TITLE
fix(clone): validate clone attachment node has ready IM before creating ticket

### DIFF
--- a/controller/volume_clone_controller.go
+++ b/controller/volume_clone_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -254,10 +255,84 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 
 	expectedAttachmentTickets := make(map[string]bool)
 
+	var attachableNodes map[string]*longhorn.Node
+	log := getLoggerForVolume(vcc.logger, vol)
+	pickNodeID := func(v *longhorn.Volume, va *longhorn.VolumeAttachment) (chosenNodeID string, err error) {
+		if attachableNodes == nil {
+			attachableNodes, err = vcc.ds.ListReadyNodesWithReadyInstanceManagerRO(v.Spec.DataEngine)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		// The CurrentNodeID holds the 1st priority if it is valid.
+		// The corresponding ticket is implicitly satisfied.
+		if attachableNodes[v.Status.CurrentNodeID] != nil {
+			log.Debugf("Picked node %v for volume %v clone attachment: currently attached node", v.Status.CurrentNodeID, v.Name)
+			return v.Status.CurrentNodeID, nil
+		}
+
+		// The node already selected by other tickets holds the 2nd priority if it is valid.
+		// Among tickets with the highest priority level, pick the node that appears most
+		// frequently; break ties by sorting node IDs lexicographically.
+		highestPriority := -1
+		nodeCount := map[string]int{}
+		for _, ticket := range va.Spec.AttachmentTickets {
+			if attachableNodes[ticket.NodeID] == nil {
+				continue
+			}
+			priority := longhorn.GetAttacherPriorityLevel(ticket.Type)
+			if priority > highestPriority {
+				highestPriority = priority
+				nodeCount = map[string]int{ticket.NodeID: 1}
+			} else if priority == highestPriority {
+				nodeCount[ticket.NodeID]++
+			}
+		}
+		if len(nodeCount) > 0 {
+			maxCount := 0
+			var candidates []string
+			for nodeID, count := range nodeCount {
+				if count > maxCount {
+					maxCount = count
+					candidates = []string{nodeID}
+				} else if count == maxCount {
+					candidates = append(candidates, nodeID)
+				}
+			}
+			sort.Strings(candidates)
+			log.Debugf("Picked node %v for volume %v clone attachment: majority node among highest-priority tickets", candidates[0], v.Name)
+			return candidates[0], nil
+		}
+
+		// The node of v.Status.OwnerID holds the 3rd priority if it is valid
+		if attachableNodes[v.Status.OwnerID] != nil {
+			log.Debugf("Picked node %v for volume %v clone attachment: volume owner node", v.Status.OwnerID, v.Name)
+			return v.Status.OwnerID, nil
+		}
+
+		// Otherwise, pick up the 1st node in sorted order for determinism
+		candidates := make([]string, 0, len(attachableNodes))
+		for n := range attachableNodes {
+			candidates = append(candidates, n)
+		}
+		sort.Strings(candidates)
+		if len(candidates) > 0 {
+			log.Debugf("Picked node %v for volume %v clone attachment: first available ready node", candidates[0], v.Name)
+			return candidates[0], nil
+		}
+
+		return "", fmt.Errorf("cannot find a valid node for volume %v clone attachment", v.Name)
+	}
+
 	// case 1: this volume is target of a clone and the cloning hasn't completed
 	if isCloneTargetActive(vol) {
 		cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, volName)
-		createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, vol.Status.OwnerID, longhorn.TrueValue, longhorn.AttacherTypeVolumeCloneController)
+		chosenNodeID, err := pickNodeID(vol, va)
+		if err != nil {
+			return err
+		}
+		createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, chosenNodeID, longhorn.TrueValue, longhorn.AttacherTypeVolumeCloneController)
 		expectedAttachmentTickets[cloningAttachmentTicketID] = true
 	}
 
@@ -266,18 +341,25 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 	if err != nil {
 		return err
 	}
+	var srcNodeID string
 	for _, v := range vols {
-		attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
 		if isCloneTargetCopyInProgress(v) && types.GetVolumeName(v.Spec.DataSource) == vol.Name {
-			createOrUpdateAttachmentTicket(va, attachmentTicketID, vol.Status.OwnerID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
-			expectedAttachmentTickets[attachmentTicketID] = true
+			if srcNodeID == "" {
+				srcNodeID, err = pickNodeID(vol, va)
+				if err != nil {
+					return err
+				}
+			}
+			cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
+			createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
+			expectedAttachmentTickets[cloningAttachmentTicketID] = true
 		}
 	}
 
 	// case 3: this volume is source of a linked-clone target that needs rebuild
 	// (post-initial-clone: clone completed or awaiting healthy, and has replicas pending rebuild)
-	var readyNodes map[string]*longhorn.Node
-	chosenNodeID := vol.Status.CurrentNodeID
+	// Use a single node for all clone tickets to avoid attaching the source to multiple nodes.
+	srcNodeID = ""
 	for _, v := range vols {
 		if !isLinkedClonePotentiallyNeedingSource(v, vol.Name) {
 			continue
@@ -286,26 +368,15 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 		if !vcc.hasReplicasPendingLinkedCloneRebuild(v.Name) {
 			continue
 		}
-		attachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
-		// Prefer the current attached node and the same node for all clones
-		if chosenNodeID == "" {
-			// Source not attached yet — pick a ready node
-			if readyNodes == nil {
-				readyNodes, err = vcc.ds.ListReadyNodesRO()
-				if err != nil {
-					return err
-				}
-			}
-			for n := range readyNodes {
-				chosenNodeID = n
-				break
-			}
-			if chosenNodeID == "" {
-				continue // no ready nodes, skip this ticket
+		if srcNodeID == "" {
+			srcNodeID, err = pickNodeID(vol, va)
+			if err != nil {
+				return err
 			}
 		}
-		createOrUpdateAttachmentTicket(va, attachmentTicketID, chosenNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
-		expectedAttachmentTickets[attachmentTicketID] = true
+		cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
+		createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
+		expectedAttachmentTickets[cloningAttachmentTicketID] = true
 	}
 
 	// Delete unexpected attachment tickets

--- a/controller/volume_clone_controller.go
+++ b/controller/volume_clone_controller.go
@@ -322,7 +322,8 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 			return candidates[0], nil
 		}
 
-		return "", fmt.Errorf("cannot find a valid node for volume %v clone attachment", v.Name)
+		log.Warnf("Cannot find a valid node for volume %v clone attachment, will clean up stale tickets and retry", v.Name)
+		return "", nil
 	}
 
 	// case 1: this volume is target of a clone and the cloning hasn't completed
@@ -332,8 +333,10 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 		if err != nil {
 			return err
 		}
-		createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, chosenNodeID, longhorn.TrueValue, longhorn.AttacherTypeVolumeCloneController)
-		expectedAttachmentTickets[cloningAttachmentTicketID] = true
+		if chosenNodeID != "" {
+			createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, chosenNodeID, longhorn.TrueValue, longhorn.AttacherTypeVolumeCloneController)
+			expectedAttachmentTickets[cloningAttachmentTicketID] = true
+		}
 	}
 
 	// case 2: this volume is source of a clone (initial clone in progress)
@@ -350,9 +353,11 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 					return err
 				}
 			}
-			cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
-			createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
-			expectedAttachmentTickets[cloningAttachmentTicketID] = true
+			if srcNodeID != "" {
+				cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
+				createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
+				expectedAttachmentTickets[cloningAttachmentTicketID] = true
+			}
 		}
 	}
 
@@ -374,9 +379,11 @@ func (vcc *VolumeCloneController) reconcile(volName string) (err error) {
 				return err
 			}
 		}
-		cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
-		createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
-		expectedAttachmentTickets[cloningAttachmentTicketID] = true
+		if srcNodeID != "" {
+			cloningAttachmentTicketID := longhorn.GetAttachmentTicketID(longhorn.AttacherTypeVolumeCloneController, v.Name)
+			createOrUpdateAttachmentTicket(va, cloningAttachmentTicketID, srcNodeID, longhorn.AnyValue, longhorn.AttacherTypeVolumeCloneController)
+			expectedAttachmentTickets[cloningAttachmentTicketID] = true
+		}
 	}
 
 	// Delete unexpected attachment tickets

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3738,6 +3738,28 @@ func (s *DataStore) ListReadyNodesRO() (map[string]*longhorn.Node, error) {
 	return readyNodes, nil
 }
 
+func (s *DataStore) ListReadyNodesWithReadyInstanceManagerRO(dataEngine longhorn.DataEngineType) (map[string]*longhorn.Node, error) {
+	readyNodes, err := s.ListReadyNodesRO()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*longhorn.Node, len(readyNodes))
+	for nodeName, node := range readyNodes {
+		imMap, err := s.ListInstanceManagersByNodeRO(nodeName, longhorn.InstanceManagerTypeAllInOne, dataEngine)
+		if err != nil {
+			return nil, err
+		}
+		for _, im := range imMap {
+			if im.DeletionTimestamp == nil && im.Status.CurrentState == longhorn.InstanceManagerStateRunning {
+				result[nodeName] = node
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
 func (s *DataStore) ListReadyAndSchedulableNodesRO() (map[string]*longhorn.Node, error) {
 	nodes, err := s.ListReadyNodesRO()
 	if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13639

#### What this PR does / why we need it:

The volume clone controller previously used vol.Status.OwnerID as the attachment node for clone VA tickets. OwnerID is the reconciler owner which can be a not-ready node or a node without a running instance manager, causing clone volumes to be attached to invalid nodes.

Add ListReadyNodesWithReadyInstanceManagerRO to the datastore that returns only nodes which are both Longhorn-ready and have a running instance manager for the given data engine.

Refactor pickNodeID with a clear priority chain:
1. CurrentNodeID (where the volume is actually attached)
2. Majority node among highest-priority existing VA tickets
3. OwnerID (reconciler node)
4. First available ready node (sorted for determinism)

#### Special notes for your reviewer:

#### Additional documentation or context
