### PR TITLE
feat: add data-engine-iobuf-small-pool-size setting

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -222,6 +222,7 @@ func (imc *InstanceManagerController) isResponsibleForSetting(obj interface{}) b
 	return types.SettingName(setting.Name) == types.SettingNameKubernetesClusterAutoscalerEnabled ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineCPUMask ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineIobufLargePoolSize ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineIobufSmallPoolSize ||
 		types.SettingName(setting.Name) == types.SettingNameOrphanResourceAutoDeletion ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineHugepageEnabled ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineMemorySize
@@ -842,6 +843,8 @@ func (imc *InstanceManagerController) areDangerZoneSettingsSyncedToIMPod(im *lon
 			isSettingSynced, err = imc.isSettingInterruptModeEnabledSynced(setting, im)
 		case types.SettingNameDataEngineIobufLargePoolSize:
 			isSettingSynced, err = imc.isSettingIobufLargePoolSizeSynced(im, pod)
+		case types.SettingNameDataEngineIobufSmallPoolSize:
+			isSettingSynced, err = imc.isSettingIobufSmallPoolSizeSynced(im, pod)
 		case types.SettingNameDataEngineCPUIsolationEnabled:
 			isSettingSynced, err = imc.isSettingCPUIsolationEnabledSynced(setting, im, pod)
 		}
@@ -1232,6 +1235,30 @@ func (imc *InstanceManagerController) isSettingIobufLargePoolSizeSynced(im *long
 		expected = fmt.Sprintf("%d", iobufLargePoolSize)
 	}
 	current := getContainerArgValue(pod.Spec.Containers[0].Args, "--spdk-iobuf-large-pool-size")
+	return current == expected, nil
+}
+
+// isSettingIobufSmallPoolSizeSynced checks the pod's --spdk-iobuf-small-pool-size against the
+// setting. At or below the SPDK default the flag is omitted, so an absent flag is synced.
+func (imc *InstanceManagerController) isSettingIobufSmallPoolSizeSynced(im *longhorn.InstanceManager, pod *corev1.Pod) (bool, error) {
+	if types.IsDataEngineV1(im.Spec.DataEngine) {
+		return true, nil
+	}
+
+	if len(pod.Spec.Containers) == 0 {
+		return false, nil
+	}
+
+	iobufSmallPoolSize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineIobufSmallPoolSize, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+
+	expected := ""
+	if iobufSmallPoolSize > types.SpdkDefaultIobufSmallPoolSize {
+		expected = fmt.Sprintf("%d", iobufSmallPoolSize)
+	}
+	current := getContainerArgValue(pod.Spec.Containers[0].Args, "--spdk-iobuf-small-pool-size")
 	return current == expected, nil
 }
 
@@ -2031,6 +2058,12 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDataEngineIobufLargePoolSize)
 		}
 
+		// iobuf small pool size (small_pool_count), handled the same way as the large pool above.
+		iobufSmallPoolSize, err := imc.ds.GetSettingAsIntByDataEngine(types.SettingNameDataEngineIobufSmallPoolSize, dataEngine)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDataEngineIobufSmallPoolSize)
+		}
+
 		controlPath, err := imc.ds.GetSettingWithAutoFillingRO(types.SettingNameDefaultControlPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameDefaultControlPath)
@@ -2046,6 +2079,9 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		// Must precede "daemon" so the launch wrapper consumes it as an SPDK option.
 		if iobufLargePoolSize > types.SpdkDefaultIobufLargePoolSize {
 			args = append(args, "--spdk-iobuf-large-pool-size", fmt.Sprintf("%d", iobufLargePoolSize))
+		}
+		if iobufSmallPoolSize > types.SpdkDefaultIobufSmallPoolSize {
+			args = append(args, "--spdk-iobuf-small-pool-size", fmt.Sprintf("%d", iobufSmallPoolSize))
 		}
 		args = append(args,
 			"--longhorn-control-path", controlPath.Value,

--- a/types/setting.go
+++ b/types/setting.go
@@ -68,6 +68,10 @@ const (
 	// data-engine-iobuf-large-pool-size value not greater than this is a no-op (SPDK
 	// keeps its default), so only a larger value is passed through to override it.
 	SpdkDefaultIobufLargePoolSize = 1024
+
+	// SpdkDefaultIobufSmallPoolSize is SPDK's built-in default small_pool_count. A
+	// data-engine-iobuf-small-pool-size value not greater than this is a no-op.
+	SpdkDefaultIobufSmallPoolSize = 8192
 )
 
 type SettingName string
@@ -163,6 +167,7 @@ const (
 	SettingNameDataEngineHugepageEnabled                                = SettingName("data-engine-hugepage-enabled")
 	SettingNameDataEngineMemorySize                                     = SettingName("data-engine-memory-size")
 	SettingNameDataEngineIobufLargePoolSize                             = SettingName("data-engine-iobuf-large-pool-size")
+	SettingNameDataEngineIobufSmallPoolSize                             = SettingName("data-engine-iobuf-small-pool-size")
 	SettingNameDataEngineCPUMask                                        = SettingName("data-engine-cpu-mask")
 	SettingNameDataEngineNumberOfCPUCores                               = SettingName("data-engine-number-of-cpu-cores")
 	SettingNameDataEngineLogLevel                                       = SettingName("data-engine-log-level")
@@ -290,6 +295,7 @@ var (
 		SettingNameDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize,
 		SettingNameDataEngineIobufLargePoolSize,
+		SettingNameDataEngineIobufSmallPoolSize,
 		SettingNameDataEngineCPUMask,
 		SettingNameDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel,
@@ -457,6 +463,7 @@ var (
 		SettingNameDataEngineHugepageEnabled:                                SettingDefinitionDataEngineHugepageEnabled,
 		SettingNameDataEngineMemorySize:                                     SettingDefinitionDataEngineMemorySize,
 		SettingNameDataEngineIobufLargePoolSize:                             SettingDefinitionDataEngineIobufLargePoolSize,
+		SettingNameDataEngineIobufSmallPoolSize:                             SettingDefinitionDataEngineIobufSmallPoolSize,
 		SettingNameDataEngineCPUMask:                                        SettingDefinitionDataEngineCPUMask,
 		SettingNameDataEngineNumberOfCPUCores:                               SettingDefinitionDataEngineNumberOfCPUCores,
 		SettingNameDataEngineLogLevel:                                       SettingDefinitionDataEngineLogLevel,
@@ -1848,6 +1855,24 @@ var (
 		Default:            fmt.Sprintf("{%q:\"%v\"}", longhorn.DataEngineTypeV2, SpdkDefaultIobufLargePoolSize),
 		ValueIntRange: map[string]int{
 			ValueIntRangeMinimum: SpdkDefaultIobufLargePoolSize,
+		},
+	}
+
+	SettingDefinitionDataEngineIobufSmallPoolSize = SettingDefinition{
+		DisplayName: "Data Engine iobuf Small Pool Size",
+		Description: "Applies only to the V2 Data Engine. Sets the SPDK iobuf small buffer pool size (`small_pool_count`) on the Instance Manager's SPDK target. The Instance Manager passes the value to spdk_tgt at startup through a generated JSON configuration file (`--json`); the iobuf pool can only be sized at startup, not changed at runtime. \n\n" +
+			"  - `8192` (default): SPDK's built-in default `small_pool_count`; behavior is unchanged. \n\n" +
+			"  - A larger value relieves NVMe-oF TCP small-buffer exhaustion (the `small_pool` `retry` / `NEED_BUFFER` stalls) under workloads whose I/O size fits within the iobuf small buffer size (8 KiB), e.g. 4 KiB random reads at high queue depth across many volumes. Values not greater than 8192 keep the SPDK default. \n\n" +
+			"  - Larger values consume more hugepage memory: each small buffer is 8 KiB, so the small pool uses `small_pool_count x 8 KiB` (8192 -> 64 MiB, 16384 -> 128 MiB, 65536 -> 512 MiB). This comes out of the SPDK target's fixed `Data Engine Memory Size` budget, so raise that setting accordingly or fewer volumes will fit per node. \n\n" +
+			"  - Changing this setting recreates Instance Manager pods that have no running instances, so the new pool size takes effect.",
+		Category:           SettingCategoryDangerZone,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: true,
+		Default:            fmt.Sprintf("{%q:\"%v\"}", longhorn.DataEngineTypeV2, SpdkDefaultIobufSmallPoolSize),
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: SpdkDefaultIobufSmallPoolSize,
 		},
 	}
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13674

#### What this PR does / why we need it:

#### Special notes for your reviewer:
Requires https://github.com/longhorn/longhorn-instance-manager/pull/1593 for the `--spdk-iobuf-small-pool-size` flag.

#### Additional documentation or context
