### PR TITLE
feat(backup): specifying the backup target for recurring backups

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -326,9 +326,10 @@ type DetachInput struct {
 }
 
 type SnapshotInput struct {
-	Name       string            `json:"name"`
-	Labels     map[string]string `json:"labels"`
-	BackupMode string            `json:"backupMode"`
+	Name         string            `json:"name"`
+	Labels       map[string]string `json:"labels"`
+	BackupMode   string            `json:"backupMode"`
+	BackupTarget string            `json:"backupTarget"`
 }
 
 type SnapshotCRInput struct {
@@ -2529,14 +2530,15 @@ func toRecurringJobResource(recurringJob *longhorn.RecurringJob, apiContext *api
 			Type: "recurringJob",
 		},
 		RecurringJobSpec: longhorn.RecurringJobSpec{
-			Name:        recurringJob.Name,
-			Groups:      recurringJob.Spec.Groups,
-			Task:        recurringJob.Spec.Task,
-			Cron:        recurringJob.Spec.Cron,
-			Retain:      recurringJob.Spec.Retain,
-			Concurrency: recurringJob.Spec.Concurrency,
-			Labels:      recurringJob.Spec.Labels,
-			Parameters:  recurringJob.Spec.Parameters,
+			Name:         recurringJob.Name,
+			Groups:       recurringJob.Spec.Groups,
+			Task:         recurringJob.Spec.Task,
+			Cron:         recurringJob.Spec.Cron,
+			Retain:       recurringJob.Spec.Retain,
+			Concurrency:  recurringJob.Spec.Concurrency,
+			Labels:       recurringJob.Spec.Labels,
+			BackupTarget: recurringJob.Spec.BackupTarget,
+			Parameters:   recurringJob.Spec.Parameters,
 		},
 		RecurringJobStatus: longhorn.RecurringJobStatus{
 			ExecutionCount: recurringJob.Status.ExecutionCount,

--- a/api/recurringjob.go
+++ b/api/recurringjob.go
@@ -56,14 +56,15 @@ func (s *Server) RecurringJobCreate(rw http.ResponseWriter, req *http.Request) e
 	}
 
 	obj, err := s.m.CreateRecurringJob(&longhorn.RecurringJobSpec{
-		Name:        input.Name,
-		Groups:      input.Groups,
-		Task:        longhorn.RecurringJobType(input.Task),
-		Cron:        input.Cron,
-		Retain:      input.Retain,
-		Concurrency: input.Concurrency,
-		Labels:      input.Labels,
-		Parameters:  input.Parameters,
+		Name:         input.Name,
+		Groups:       input.Groups,
+		Task:         longhorn.RecurringJobType(input.Task),
+		Cron:         input.Cron,
+		Retain:       input.Retain,
+		Concurrency:  input.Concurrency,
+		Labels:       input.Labels,
+		BackupTarget: input.BackupTarget,
+		Parameters:   input.Parameters,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to create recurring job %v", input.Name)

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -195,7 +195,12 @@ func (s *Server) SnapshotBackup(w http.ResponseWriter, req *http.Request) (err e
 		labels[types.KubernetesStatusLabel] = string(kubeStatus)
 	}
 
-	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), vol.Spec.BackupTargetName, volName, input.Name, labels, input.BackupMode); err != nil {
+	backupTargetName := vol.Spec.BackupTargetName
+	if input.BackupTarget != "" {
+		backupTargetName = input.BackupTarget
+	}
+
+	if err := s.m.BackupSnapshot(bsutil.GenerateName("backup"), backupTargetName, volName, input.Name, labels, input.BackupMode); err != nil {
 		return err
 	}
 

--- a/app/recurringjob/job.go
+++ b/app/recurringjob/job.go
@@ -93,6 +93,7 @@ func NewJob(name string, logger *logrus.Logger, managerURL string, recurringJob 
 		task:           recurringJob.Spec.Task,
 		parameters:     parameters,
 		executionCount: recurringJob.Status.ExecutionCount,
+		backupTarget:   recurringJob.Spec.BackupTarget,
 	}, nil
 }
 

--- a/app/recurringjob/type.go
+++ b/app/recurringjob/type.go
@@ -26,6 +26,7 @@ type Job struct {
 	task           longhorn.RecurringJobType // Type of task to be executed.
 	parameters     map[string]string         // Additional parameters for the task.
 	executionCount int                       // Number of times the job has been executed.
+	backupTarget   string                    // Backup target name for backup tasks.
 }
 
 // VolumeJob is a job for volume tasks.

--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -433,7 +433,14 @@ func (job *VolumeJob) filterExpiredSnapshotsOfCurrentRecurringJob(snapshotCRs []
 	retainingSnapshotCRs := map[string]struct{}{job.snapshotName: {}}
 	if !backupDone {
 		lastBackup, err := job.getLastBackup()
-		if err == nil && lastBackup != nil {
+		if err != nil {
+			// Without the last backup we cannot tell which snapshot to keep, and
+			// deleting it costs the incremental base of the next backup. Keep
+			// everything this run rather than guess; the next run cleans up.
+			job.logger.WithError(err).Warn("Failed to get the last backup, skipping the backup snapshot cleanup for this run")
+			return []string{}
+		}
+		if lastBackup != nil {
 			retainingSnapshotCRs[lastBackup.SnapshotName] = struct{}{}
 		}
 	}
@@ -482,10 +489,13 @@ func (job *VolumeJob) doRecurringBackup() (err error) {
 		}
 	}
 
+	backupTargetName := job.resolveBackupTargetName(volume)
+
 	if _, err := job.api.Volume.ActionSnapshotBackup(volume, &longhornclient.SnapshotInput{
-		Labels:     job.specLabels,
-		Name:       job.snapshotName,
-		BackupMode: string(backupMode),
+		Labels:       job.specLabels,
+		Name:         job.snapshotName,
+		BackupMode:   string(backupMode),
+		BackupTarget: backupTargetName,
 	}); err != nil {
 		return err
 	}
@@ -544,9 +554,12 @@ func (job *VolumeJob) doRecurringBackup() (err error) {
 		}
 	}()
 
-	backupVolume, err := job.getBackupVolume(volume.BackupTargetName)
+	backupVolume, err := job.getBackupVolume(backupTargetName)
 	if err != nil {
 		return err
+	}
+	if backupVolume == nil {
+		return fmt.Errorf("cannot find the backup volume of volume %v on backup target %v to clean up backups", job.volumeName, backupTargetName)
 	}
 	backups, err := job.api.BackupVolume.ActionBackupList(backupVolume)
 	if err != nil {
@@ -568,21 +581,35 @@ func (job *VolumeJob) doRecurringBackup() (err error) {
 	return nil
 }
 
+// resolveBackupTargetName returns the backup target the job backs up to: its own
+// when one is configured, the volume's otherwise. Every recurring job predating
+// RecurringJobSpec.BackupTarget carries an empty one and must keep using the
+// volume's backup target.
+// ref: https://github.com/longhorn/longhorn/issues/11421
+func (job *VolumeJob) resolveBackupTargetName(volume *longhornclient.Volume) string {
+	if job.backupTarget != "" {
+		return job.backupTarget
+	}
+	return volume.BackupTargetName
+}
+
+// getBackupVolume returns the backup volume of the job's volume on the given
+// backup target, or nil when there is none. A job with its own backup target has
+// no backup volume there until it has completed a backup, so a missing one is
+// not an error.
 func (job *VolumeJob) getBackupVolume(backupTargetName string) (*longhornclient.BackupVolume, error) {
 	list, err := job.api.BackupVolume.List(&longhornclient.ListOpts{})
 	if err != nil {
 		return nil, err
 	}
 
-	backupVolumeName := ""
 	for _, bv := range list.Data {
 		if bv.BackupTargetName == backupTargetName && bv.VolumeName == job.volumeName {
-			backupVolumeName = bv.Name
-			break
+			return job.api.BackupVolume.ById(bv.Name)
 		}
 	}
 
-	return job.api.BackupVolume.ById(backupVolumeName)
+	return nil, nil
 }
 
 func (job *VolumeJob) doRecurringFilesystemTrim(volume *longhornclient.Volume) (err error) {
@@ -639,8 +666,9 @@ func (job *VolumeJob) waitForBackupProcessStart(timeout int) error {
 	return fmt.Errorf("timeout waiting for the backup of the snapshot %v of volume %v to start", snapshot, volumeName)
 }
 
-// getLastBackup return the last backup of the volume
-// return nil, nil if volume doesn't have any backup
+// getLastBackup return the last backup of the volume on the backup target this
+// job backs up to
+// return nil, nil if the volume doesn't have any backup there
 func (job *VolumeJob) getLastBackup() (*longhornclient.Backup, error) {
 	var err error
 	defer func() {
@@ -654,15 +682,25 @@ func (job *VolumeJob) getLastBackup() (*longhornclient.Backup, error) {
 	if volume == nil {
 		return nil, fmt.Errorf("volume %v not found", job.volumeName)
 	}
-	if volume.LastBackup == "" {
-		return nil, nil
-	}
-	backupVolume, err := job.getBackupVolume(volume.BackupTargetName)
+
+	// Volume.Status.LastBackup only ever tracks the volume's own backup target
+	// (see VolumeController.ReconcileBackupVolumeState), so it cannot answer for
+	// a job backing up somewhere else: it names a backup that does not exist on
+	// this job's target, and it is empty whenever the volume's own target has no
+	// backup at all. Ask the backup volume of the target this job actually uses
+	// instead -- for a job without its own target that is the very value
+	// Volume.Status.LastBackup is copied from, so the default case is unchanged.
+	// ref: https://github.com/longhorn/longhorn/issues/11421
+	backupVolume, err := job.getBackupVolume(job.resolveBackupTargetName(volume))
 	if err != nil {
 		return nil, err
 	}
+	if backupVolume == nil || backupVolume.LastBackupName == "" {
+		return nil, nil
+	}
+
 	return job.api.BackupVolume.ActionBackupGet(backupVolume, &longhornclient.BackupInput{
-		Name: volume.LastBackup,
+		Name: backupVolume.LastBackupName,
 	})
 }
 

--- a/app/recurringjob/volume_test.go
+++ b/app/recurringjob/volume_test.go
@@ -1,0 +1,626 @@
+package recurringjob
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhornclient "github.com/longhorn/longhorn-manager/client"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	testVolumeJobName = "daily-backup"
+	testVolumeName    = "test-volume"
+	testSnapshotName  = "daily-ba-snapshot"
+
+	testVolumeBackupTargetName = "volume-backup-target"
+	testJobBackupTargetName    = "job-backup-target"
+)
+
+// fakeVolumeOperations implements only the VolumeOperations calls a volume job
+// makes. The embedded interface is nil, so any other call panics: an unintended
+// code path fails the test loudly instead of quietly returning a zero value.
+type fakeVolumeOperations struct {
+	longhornclient.VolumeOperations
+
+	volume      *longhornclient.Volume
+	snapshotCRs []longhornclient.SnapshotCR
+
+	backupInput      *longhornclient.SnapshotInput // captured from ActionSnapshotBackup
+	deletedSnapshots []string
+}
+
+func (f *fakeVolumeOperations) ById(id string) (*longhornclient.Volume, error) {
+	return f.volume, nil
+}
+
+func (f *fakeVolumeOperations) ActionSnapshotCRList(*longhornclient.Volume) (*longhornclient.SnapshotCRListOutput, error) {
+	return &longhornclient.SnapshotCRListOutput{Data: f.snapshotCRs}, nil
+}
+
+func (f *fakeVolumeOperations) ActionSnapshotCRCreate(_ *longhornclient.Volume, input *longhornclient.SnapshotCRInput) (*longhornclient.SnapshotCR, error) {
+	return &longhornclient.SnapshotCR{Name: input.Name}, nil
+}
+
+func (f *fakeVolumeOperations) ActionSnapshotCRGet(_ *longhornclient.Volume, input *longhornclient.SnapshotCRInput) (*longhornclient.SnapshotCR, error) {
+	return &longhornclient.SnapshotCR{Name: input.Name, ReadyToUse: true}, nil
+}
+
+func (f *fakeVolumeOperations) ActionSnapshotCRDelete(_ *longhornclient.Volume, input *longhornclient.SnapshotCRInput) (*longhornclient.Empty, error) {
+	f.deletedSnapshots = append(f.deletedSnapshots, input.Name)
+	return &longhornclient.Empty{}, nil
+}
+
+func (f *fakeVolumeOperations) ActionSnapshotBackup(_ *longhornclient.Volume, input *longhornclient.SnapshotInput) (*longhornclient.Volume, error) {
+	f.backupInput = input
+	return f.volume, nil
+}
+
+// fakeBackupVolumeOperations serves the post-backup retention pass. It reports
+// one backup volume per backup target so the lookup resolves, and no backups, so
+// nothing is pruned; backup retention itself is covered by
+// TestListBackupsForCleanup.
+type fakeBackupVolumeOperations struct {
+	longhornclient.BackupVolumeOperations
+
+	backupVolumes []longhornclient.BackupVolume
+	// backups the backup volume of the same name holds, keyed by backup volume name.
+	backups map[string][]longhornclient.Backup
+}
+
+func (f *fakeBackupVolumeOperations) List(*longhornclient.ListOpts) (*longhornclient.BackupVolumeCollection, error) {
+	return &longhornclient.BackupVolumeCollection{Data: f.backupVolumes}, nil
+}
+
+func (f *fakeBackupVolumeOperations) ById(id string) (*longhornclient.BackupVolume, error) {
+	for _, bv := range f.backupVolumes {
+		if bv.Name == id {
+			return &bv, nil
+		}
+	}
+	return nil, errors.Errorf("backup volume %v not found", id)
+}
+
+func (f *fakeBackupVolumeOperations) ActionBackupList(*longhornclient.BackupVolume) (*longhornclient.BackupListOutput, error) {
+	return &longhornclient.BackupListOutput{}, nil
+}
+
+func (f *fakeBackupVolumeOperations) ActionBackupGet(backupVolume *longhornclient.BackupVolume, input *longhornclient.BackupInput) (*longhornclient.Backup, error) {
+	for _, backup := range f.backups[backupVolume.Name] {
+		if backup.Name == input.Name {
+			return &backup, nil
+		}
+	}
+	return nil, errors.Errorf("backup %v not found in backup volume %v", input.Name, backupVolume.Name)
+}
+
+// newVolumeJobForTest wires a VolumeJob to fake Longhorn API and clientset so
+// the real code path runs without a cluster. autoCleanupBackupSnapshot seeds the
+// setting doSnapshotCleanup reads after a backup.
+func newVolumeJobForTest(t *testing.T, task longhorn.RecurringJobType, retain int, backupTarget string, volumeOps *fakeVolumeOperations, backupVolumeOps *fakeBackupVolumeOperations, settings ...runtime.Object) *VolumeJob {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	return &VolumeJob{
+		Job: &Job{
+			api: &longhornclient.RancherClient{
+				Volume:       volumeOps,
+				BackupVolume: backupVolumeOps,
+			},
+			lhClient:     lhfake.NewSimpleClientset(settings...), // nolint: staticcheck
+			logger:       logger,
+			name:         testVolumeJobName,
+			namespace:    testNamespace,
+			retain:       retain,
+			task:         task,
+			backupTarget: backupTarget,
+		},
+		logger:       logrus.NewEntry(logger),
+		volumeName:   testVolumeName,
+		snapshotName: testSnapshotName,
+		specLabels:   map[string]string{types.RecurringJobLabel: testVolumeJobName},
+	}
+}
+
+func newAutoCleanupBackupSnapshotSetting(value string) *longhorn.Setting {
+	return &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      string(types.SettingNameAutoCleanupRecurringJobBackupSnapshot),
+			Namespace: testNamespace,
+		},
+		Value: value,
+	}
+}
+
+// newSnapshotCR builds a snapshot CR as the volume job sees it. Retention sorts
+// on CrCreationTime, and only snapshots carrying the RecurringJob label of the
+// running job are candidates for deletion.
+func newSnapshotCR(name, jobName string, crCreationTime time.Time) longhornclient.SnapshotCR {
+	snapshotCR := longhornclient.SnapshotCR{
+		Name:           name,
+		CreateSnapshot: true,
+		CrCreationTime: crCreationTime.Format(time.RFC3339),
+		ReadyToUse:     true,
+	}
+	if jobName != "" {
+		snapshotCR.Labels = map[string]string{types.RecurringJobLabel: jobName}
+	}
+	return snapshotCR
+}
+
+// TestNewVolumeJob covers the per-volume job setup. StartVolumeJobs fans out one
+// volume job per volume through an errgroup, all sharing one RecurringJob, so
+// the label map must be copied rather than stamped in place -- otherwise the
+// jobs race on the shared spec map -- and each job needs its own snapshot name.
+func TestNewVolumeJob(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	job := &Job{
+		logger: logger,
+		name:   testVolumeJobName,
+		task:   longhorn.RecurringJobTypeSnapshot,
+		retain: 3,
+	}
+	recurringJob := &longhorn.RecurringJob{
+		ObjectMeta: metav1.ObjectMeta{Name: testVolumeJobName, Namespace: testNamespace},
+		Spec: longhorn.RecurringJobSpec{
+			Name:        testVolumeJobName,
+			Task:        longhorn.RecurringJobTypeSnapshot,
+			Concurrency: 2,
+			Labels:      map[string]string{"user-label": "user-value"},
+		},
+	}
+
+	volumeJob, err := newVolumeJob(job, recurringJob, testVolumeName, []string{"default"})
+	require.NoError(t, err)
+
+	assert.Equal(t, testVolumeJobName, volumeJob.specLabels[types.RecurringJobLabel],
+		"snapshots must be stamped with the owning job so retention only prunes its own")
+	assert.Equal(t, "user-value", volumeJob.specLabels["user-label"],
+		"labels configured on the RecurringJob must survive onto the snapshot")
+	assert.NotContains(t, recurringJob.Spec.Labels, types.RecurringJobLabel,
+		"the RecurringJob spec label map is shared across concurrent volume jobs and must not be mutated")
+
+	otherVolumeJob, err := newVolumeJob(job, recurringJob, "other-volume", []string{"default"})
+	require.NoError(t, err)
+	assert.NotEqual(t, volumeJob.snapshotName, otherVolumeJob.snapshotName,
+		"concurrent volume jobs must not collide on one snapshot name")
+
+	// The name is prefixed with the cron job name so an operator can tell which
+	// recurring job produced a snapshot from its name alone.
+	prefix := sliceStringSafely(types.GetCronJobNameForRecurringJob(testVolumeJobName), 0, 8)
+	assert.True(t, strings.HasPrefix(volumeJob.snapshotName, prefix+"-"),
+		"snapshot name %v should start with the cron job name prefix %v", volumeJob.snapshotName, prefix)
+}
+
+// TestListSnapshotNamesToCleanup covers the task dispatch that decides which
+// snapshots a run deletes. The three arms behave differently on purpose:
+// snapshot-delete is a cluster-wide count-based prune, snapshot-cleanup only
+// purges already-removed snapshots and must never delete CRs, and the default
+// arm is scoped to the running job's own snapshots.
+func TestListSnapshotNamesToCleanup(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	// Two snapshots from this job, one from another job, oldest first.
+	snapshotCRs := []longhornclient.SnapshotCR{
+		newSnapshotCR("own-old", testVolumeJobName, base),
+		newSnapshotCR("other-job", "weekly-backup", base.Add(time.Hour)),
+		newSnapshotCR("own-new", testVolumeJobName, base.Add(2*time.Hour)),
+	}
+
+	t.Run("snapshot-delete prunes by count across every snapshot", func(t *testing.T) {
+		// The snapshot-delete task is not scoped to its own snapshots: it keeps
+		// the newest `retain` snapshots of the volume whoever created them.
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeSnapshotDelete, 2, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{})
+
+		assert.Equal(t, []string{"own-old"}, job.listSnapshotNamesToCleanup(snapshotCRs, false),
+			"retain=2 over three snapshots expires only the oldest")
+	})
+
+	t.Run("snapshot-cleanup never deletes snapshot CRs", func(t *testing.T) {
+		// snapshot-cleanup exists to trigger a purge of snapshots already marked
+		// removed. Deleting CRs here would destroy data the user still retains.
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeSnapshotCleanup, 0, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{})
+
+		assert.Empty(t, job.listSnapshotNamesToCleanup(snapshotCRs, false),
+			"retain=0 must still delete nothing for the cleanup task")
+	})
+
+	t.Run("snapshot task only prunes its own snapshots", func(t *testing.T) {
+		// The default arm filters by the RecurringJob label first, so another
+		// job's snapshot is never counted toward, or evicted by, this job's
+		// retain.
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeSnapshot, 1, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{},
+			newAutoCleanupBackupSnapshotSetting("false"))
+
+		assert.Equal(t, []string{"own-old"}, job.listSnapshotNamesToCleanup(snapshotCRs, false),
+			"retain=1 over this job's two snapshots expires its oldest and leaves the other job's alone")
+	})
+}
+
+// TestListBackupsForCleanup covers backup retention. Backups are shared cluster
+// state: a manual backup, or one from another recurring job, must survive this
+// job's retention no matter how low its retain is.
+func TestListBackupsForCleanup(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	newBackup := func(name, jobName, created string) longhornclient.Backup {
+		backup := longhornclient.Backup{Name: name, Created: created}
+		if jobName != "" {
+			backup.Labels = map[string]string{types.RecurringJobLabel: jobName}
+		}
+		return backup
+	}
+
+	backups := []longhornclient.Backup{
+		newBackup("own-old", testVolumeJobName, base.Format(time.RFC3339)),
+		newBackup("own-new", testVolumeJobName, base.Add(2*time.Hour).Format(time.RFC3339)),
+		newBackup("other-job", "weekly-backup", base.Add(-time.Hour).Format(time.RFC3339)),
+		newBackup("manual", "", base.Add(-2*time.Hour).Format(time.RFC3339)),
+	}
+
+	t.Run("only this job's backups are expired", func(t *testing.T) {
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{})
+
+		assert.Equal(t, []string{"own-old"}, job.listBackupsForCleanup(backups),
+			"the unlabeled and other-job backups are older than retain would allow, but are not this job's to delete")
+	})
+
+	t.Run("nothing is expired within retain", func(t *testing.T) {
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 2, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{})
+
+		assert.Empty(t, job.listBackupsForCleanup(backups))
+	})
+
+	t.Run("backups with an unparsable timestamp are skipped", func(t *testing.T) {
+		// A backup whose Created cannot be parsed cannot be placed in the
+		// retention order, so it is left alone rather than guessed at.
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 0, "", &fakeVolumeOperations{}, &fakeBackupVolumeOperations{})
+
+		withBroken := append([]longhornclient.Backup{}, backups...)
+		withBroken = append(withBroken, newBackup("own-broken", testVolumeJobName, "not-a-timestamp"))
+
+		assert.Equal(t, []string{"own-old", "own-new"}, job.listBackupsForCleanup(withBroken),
+			"retain=0 expires both parsable backups of this job and skips the unparsable one")
+	})
+}
+
+// TestDoRecurringBackupBackupTarget covers the per-job backup target
+// (longhorn/longhorn#11421): doRecurringBackup now passes a backup target to
+// ActionSnapshotBackup instead of letting the manager fall back to the volume's.
+// The empty case has to keep resolving to the volume's backup target, because
+// that is what every recurring job predating the field carries.
+//
+// Each subtest runs the real doRecurringBackup, which polls for the backup to
+// start on a WaitInterval (5s) tick, so it takes a few seconds.
+func TestDoRecurringBackupBackupTarget(t *testing.T) {
+	tests := map[string]struct {
+		jobBackupTarget      string
+		expectedBackupTarget string
+	}{
+		"job backup target is used when set": {
+			jobBackupTarget:      testJobBackupTargetName,
+			expectedBackupTarget: testJobBackupTargetName,
+		},
+		"volume backup target is used when the job has none": {
+			jobBackupTarget:      "",
+			expectedBackupTarget: testVolumeBackupTargetName,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			volumeOps := &fakeVolumeOperations{
+				volume: &longhornclient.Volume{
+					Name:             testVolumeName,
+					State:            string(longhorn.VolumeStateAttached),
+					BackupTargetName: testVolumeBackupTargetName,
+					// The backup of our snapshot is already complete, so the
+					// wait loop makes a single pass.
+					BackupStatus: []longhornclient.BackupStatus{
+						{
+							Snapshot: testSnapshotName,
+							State:    string(longhorn.BackupStateCompleted),
+						},
+					},
+				},
+			}
+			// One backup volume per backup target: the post-backup retention pass
+			// looks up the one belonging to the target the backup went to, and
+			// would otherwise take the "no backup volume" path in both subtests.
+			backupVolumeOps := &fakeBackupVolumeOperations{
+				backupVolumes: []longhornclient.BackupVolume{
+					{
+						Name:             "bv-1",
+						VolumeName:       testVolumeName,
+						BackupTargetName: testVolumeBackupTargetName,
+					},
+					{
+						Name:             "bv-2",
+						VolumeName:       testVolumeName,
+						BackupTargetName: testJobBackupTargetName,
+					},
+				},
+			}
+			job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, tc.jobBackupTarget, volumeOps, backupVolumeOps,
+				newAutoCleanupBackupSnapshotSetting("false"))
+
+			require.NoError(t, job.doRecurringBackup())
+
+			require.NotNil(t, volumeOps.backupInput, "the backup was never requested")
+			assert.Equal(t, tc.expectedBackupTarget, volumeOps.backupInput.BackupTarget)
+			assert.Equal(t, testSnapshotName, volumeOps.backupInput.Name)
+			assert.Equal(t, string(longhorn.BackupModeIncremental), volumeOps.backupInput.BackupMode,
+				"without a full-backup-interval parameter every run is incremental")
+		})
+	}
+}
+
+// TestDoRecurringBackupFullBackupInterval covers the full-backup-interval
+// parameter, which is evaluated on the same call the backup target rides on. The
+// interval counts job executions, so run N is full when N is a multiple of it.
+func TestDoRecurringBackupFullBackupInterval(t *testing.T) {
+	tests := map[string]struct {
+		executionCount int
+		interval       string
+		expectedMode   longhorn.BackupMode
+	}{
+		"execution on the interval is a full backup": {
+			executionCount: 4,
+			interval:       "2",
+			expectedMode:   longhorn.BackupModeFull,
+		},
+		"execution off the interval stays incremental": {
+			executionCount: 5,
+			interval:       "2",
+			expectedMode:   longhorn.BackupModeIncremental,
+		},
+		"a zero interval disables full backups": {
+			executionCount: 0,
+			interval:       "0",
+			expectedMode:   longhorn.BackupModeIncremental,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			volumeOps := &fakeVolumeOperations{
+				volume: &longhornclient.Volume{
+					Name:             testVolumeName,
+					State:            string(longhorn.VolumeStateAttached),
+					BackupTargetName: testVolumeBackupTargetName,
+					BackupStatus: []longhornclient.BackupStatus{
+						{
+							Snapshot: testSnapshotName,
+							State:    string(longhorn.BackupStateCompleted),
+						},
+					},
+				},
+			}
+			backupVolumeOps := &fakeBackupVolumeOperations{
+				backupVolumes: []longhornclient.BackupVolume{
+					{
+						Name:             "bv-1",
+						VolumeName:       testVolumeName,
+						BackupTargetName: testVolumeBackupTargetName,
+					},
+				},
+			}
+			job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, "", volumeOps, backupVolumeOps,
+				newAutoCleanupBackupSnapshotSetting("false"))
+			job.executionCount = tc.executionCount
+			job.parameters = map[string]string{types.RecurringJobParameterFullBackupInterval: tc.interval}
+
+			require.NoError(t, job.doRecurringBackup())
+
+			require.NotNil(t, volumeOps.backupInput, "the backup was never requested")
+			assert.Equal(t, string(tc.expectedMode), volumeOps.backupInput.BackupMode)
+		})
+	}
+}
+
+// TestGetBackupVolume covers the backup volume lookup. A job with its own backup
+// target (longhorn/longhorn#11421) has no backup volume on that target until it
+// has completed its first backup, so "not found" has to be reported as such
+// rather than looked up by an empty name -- an ById("") request resolves to the
+// collection endpoint and decodes into an empty BackupVolume, which reads as a
+// real one to every caller.
+func TestGetBackupVolume(t *testing.T) {
+	backupVolumeOps := &fakeBackupVolumeOperations{
+		backupVolumes: []longhornclient.BackupVolume{
+			{Name: "bv-1", VolumeName: testVolumeName, BackupTargetName: testVolumeBackupTargetName},
+			{Name: "bv-2", VolumeName: "other-volume", BackupTargetName: testJobBackupTargetName},
+		},
+	}
+	job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, "", &fakeVolumeOperations{}, backupVolumeOps)
+
+	backupVolume, err := job.getBackupVolume(testVolumeBackupTargetName)
+	require.NoError(t, err)
+	require.NotNil(t, backupVolume)
+	assert.Equal(t, "bv-1", backupVolume.Name)
+
+	// The only backup volume on this target belongs to another volume.
+	backupVolume, err = job.getBackupVolume(testJobBackupTargetName)
+	require.NoError(t, err)
+	assert.Nil(t, backupVolume, "a volume with no backup volume on the target must not resolve to one")
+}
+
+// TestGetLastBackup covers which backup a job treats as its last one. It used to
+// be Volume.Status.LastBackup, but that field only ever tracks the volume's own
+// backup target (VolumeController.ReconcileBackupVolumeState scopes it to
+// Volume.Spec.BackupTargetName). Once a job can back up somewhere else
+// (longhorn/longhorn#11421) that value is wrong for it in both directions: it
+// names a backup absent from the job's target, and it is empty even when the
+// job's target holds backups. The last backup has to come from the backup volume
+// of the target the job actually uses.
+func TestGetLastBackup(t *testing.T) {
+	volumeTargetBackup := longhornclient.Backup{Name: "backup-on-volume-target", SnapshotName: "snapshot-on-volume-target"}
+	jobTargetBackup := longhornclient.Backup{Name: "backup-on-job-target", SnapshotName: "snapshot-on-job-target"}
+
+	newBackupVolumeOps := func(jobTargetLastBackupName string) *fakeBackupVolumeOperations {
+		return &fakeBackupVolumeOperations{
+			backupVolumes: []longhornclient.BackupVolume{
+				{
+					Name:             "bv-volume-target",
+					VolumeName:       testVolumeName,
+					BackupTargetName: testVolumeBackupTargetName,
+					LastBackupName:   volumeTargetBackup.Name,
+				},
+				{
+					Name:             "bv-job-target",
+					VolumeName:       testVolumeName,
+					BackupTargetName: testJobBackupTargetName,
+					LastBackupName:   jobTargetLastBackupName,
+				},
+			},
+			backups: map[string][]longhornclient.Backup{
+				"bv-volume-target": {volumeTargetBackup},
+				"bv-job-target":    {jobTargetBackup},
+			},
+		}
+	}
+
+	// Volume.Status.LastBackup deliberately points at the volume target's backup
+	// in every case, so a job reading it instead of its own target's backup
+	// volume picks the wrong one.
+	newVolumeOps := func() *fakeVolumeOperations {
+		return &fakeVolumeOperations{
+			volume: &longhornclient.Volume{
+				Name:             testVolumeName,
+				BackupTargetName: testVolumeBackupTargetName,
+				LastBackup:       volumeTargetBackup.Name,
+			},
+		}
+	}
+
+	t.Run("a job without its own backup target uses the volume's", func(t *testing.T) {
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, "", newVolumeOps(), newBackupVolumeOps(jobTargetBackup.Name))
+
+		lastBackup, err := job.getLastBackup()
+		require.NoError(t, err)
+		require.NotNil(t, lastBackup)
+		assert.Equal(t, volumeTargetBackup.Name, lastBackup.Name)
+	})
+
+	t.Run("a job with its own backup target uses that target's last backup", func(t *testing.T) {
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, testJobBackupTargetName, newVolumeOps(), newBackupVolumeOps(jobTargetBackup.Name))
+
+		lastBackup, err := job.getLastBackup()
+		require.NoError(t, err)
+		require.NotNil(t, lastBackup)
+		assert.Equal(t, jobTargetBackup.Name, lastBackup.Name,
+			"the volume's last backup lives on another backup target and is not this job's")
+	})
+
+	t.Run("no backup on the job's backup target yet", func(t *testing.T) {
+		// The volume has a backup on its own target, so reading
+		// Volume.Status.LastBackup here would claim a last backup that this job's
+		// target does not hold.
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, testJobBackupTargetName, newVolumeOps(), newBackupVolumeOps(""))
+
+		lastBackup, err := job.getLastBackup()
+		require.NoError(t, err)
+		assert.Nil(t, lastBackup)
+	})
+
+	t.Run("no backup volume on the job's backup target yet", func(t *testing.T) {
+		// The first run of a job with its own backup target: nothing has created
+		// a backup volume there.
+		backupVolumeOps := &fakeBackupVolumeOperations{
+			backupVolumes: []longhornclient.BackupVolume{
+				{
+					Name:             "bv-volume-target",
+					VolumeName:       testVolumeName,
+					BackupTargetName: testVolumeBackupTargetName,
+					LastBackupName:   volumeTargetBackup.Name,
+				},
+			},
+		}
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, testJobBackupTargetName, newVolumeOps(), backupVolumeOps)
+
+		lastBackup, err := job.getLastBackup()
+		require.NoError(t, err)
+		assert.Nil(t, lastBackup)
+	})
+
+	t.Run("the volume has no backup anywhere", func(t *testing.T) {
+		volumeOps := newVolumeOps()
+		volumeOps.volume.LastBackup = ""
+		backupVolumeOps := newBackupVolumeOps("")
+		backupVolumeOps.backupVolumes[0].LastBackupName = ""
+
+		job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, "", volumeOps, backupVolumeOps)
+
+		lastBackup, err := job.getLastBackup()
+		require.NoError(t, err)
+		assert.Nil(t, lastBackup)
+	})
+}
+
+// TestFilterExpiredSnapshotsRetainsLastBackupSnapshot covers what the last backup
+// is for: with auto-cleanup-recurring-job-backup-snapshot enabled a backup job
+// deletes every one of its snapshots except the current one and the one its last
+// backup was taken from, which the next incremental backup builds on. For a job
+// with its own backup target (longhorn/longhorn#11421) that snapshot has to be
+// found through that target -- resolving it through the volume's target keeps
+// the wrong snapshot and deletes the one the next backup needs.
+func TestFilterExpiredSnapshotsRetainsLastBackupSnapshot(t *testing.T) {
+	base := time.Date(2026, 5, 20, 1, 0, 0, 0, time.UTC)
+
+	snapshotCRs := []longhornclient.SnapshotCR{
+		newSnapshotCR("snapshot-on-volume-target", testVolumeJobName, base),
+		newSnapshotCR("snapshot-on-job-target", testVolumeJobName, base.Add(time.Hour)),
+		newSnapshotCR(testSnapshotName, testVolumeJobName, base.Add(2*time.Hour)),
+	}
+
+	volumeOps := &fakeVolumeOperations{
+		volume: &longhornclient.Volume{
+			Name:             testVolumeName,
+			BackupTargetName: testVolumeBackupTargetName,
+			LastBackup:       "backup-on-volume-target",
+		},
+	}
+	backupVolumeOps := &fakeBackupVolumeOperations{
+		backupVolumes: []longhornclient.BackupVolume{
+			{
+				Name:             "bv-volume-target",
+				VolumeName:       testVolumeName,
+				BackupTargetName: testVolumeBackupTargetName,
+				LastBackupName:   "backup-on-volume-target",
+			},
+			{
+				Name:             "bv-job-target",
+				VolumeName:       testVolumeName,
+				BackupTargetName: testJobBackupTargetName,
+				LastBackupName:   "backup-on-job-target",
+			},
+		},
+		backups: map[string][]longhornclient.Backup{
+			"bv-volume-target": {{Name: "backup-on-volume-target", SnapshotName: "snapshot-on-volume-target"}},
+			"bv-job-target":    {{Name: "backup-on-job-target", SnapshotName: "snapshot-on-job-target"}},
+		},
+	}
+
+	job := newVolumeJobForTest(t, longhorn.RecurringJobTypeBackup, 1, testJobBackupTargetName, volumeOps, backupVolumeOps,
+		newAutoCleanupBackupSnapshotSetting("true"))
+
+	assert.Equal(t, []string{"snapshot-on-volume-target"}, job.listSnapshotNamesToCleanup(snapshotCRs, false),
+		"the snapshot of the last backup on the job's own backup target must survive, and the volume target's must not be mistaken for it")
+}

--- a/client/generated_recurring_job.go
+++ b/client/generated_recurring_job.go
@@ -7,6 +7,8 @@ const (
 type RecurringJob struct {
 	Resource `yaml:"-"`
 
+	BackupTarget string `json:"backupTarget,omitempty" yaml:"backup_target,omitempty"`
+
 	Concurrency int64 `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
 
 	Cron string `json:"cron,omitempty" yaml:"cron,omitempty"`

--- a/client/generated_snapshot_input.go
+++ b/client/generated_snapshot_input.go
@@ -9,6 +9,8 @@ type SnapshotInput struct {
 
 	BackupMode string `json:"backupMode,omitempty" yaml:"backup_mode,omitempty"`
 
+	BackupTarget string `json:"backupTarget,omitempty" yaml:"backup_target,omitempty"`
+
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/controller/backup_controller.go
+++ b/controller/backup_controller.go
@@ -444,7 +444,7 @@ func (bc *BackupController) reconcile(backupName string) (err error) {
 
 		// v2 backing image currently doesn't support backup
 		if types.IsDataEngineV1(volume.Spec.DataEngine) {
-			if err := bc.backupBackingImage(volume); err != nil {
+			if err := bc.backupBackingImage(volume, backupTargetName); err != nil {
 				return err
 			}
 		}
@@ -712,7 +712,7 @@ func (bc *BackupController) getEngineBinaryClient(volumeName string) (*engineapi
 }
 
 // validateBackingImageChecksum validates backing image checksum
-func (bc *BackupController) validateBackingImageChecksum(volName, biName string) (string, error) {
+func (bc *BackupController) validateBackingImageChecksum(backupTargetName, volName, biName string) (string, error) {
 	if biName == "" {
 		return "", nil
 	}
@@ -722,7 +722,7 @@ func (bc *BackupController) validateBackingImageChecksum(volName, biName string)
 		return "", err
 	}
 
-	bv, err := bc.ds.GetBackupVolumeRO(volName)
+	bv, err := bc.ds.GetBackupVolumeByBackupTargetAndVolumeRO(backupTargetName, volName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return "", err
 	}
@@ -736,7 +736,7 @@ func (bc *BackupController) validateBackingImageChecksum(volName, biName string)
 	return bi.Status.Checksum, nil
 }
 
-func (bc *BackupController) backupBackingImage(volume *longhorn.Volume) error {
+func (bc *BackupController) backupBackingImage(volume *longhorn.Volume, backupTargetName string) error {
 	if volume == nil {
 		return nil
 	}
@@ -752,7 +752,6 @@ func (bc *BackupController) backupBackingImage(volume *longhorn.Volume) error {
 		return errors.Wrapf(err, "failed to get backing image %v", biName)
 	}
 
-	backupTargetName := volume.Spec.BackupTargetName
 	if backupTargetName == "" {
 		backupTargetName = types.DefaultBackupTargetName
 	}
@@ -800,7 +799,7 @@ func (bc *BackupController) checkMonitor(backup *longhorn.Backup, volume *longho
 	}
 
 	// Backing image checksum validation
-	biChecksum, err := bc.validateBackingImageChecksum(volume.Name, volume.Spec.BackingImage)
+	biChecksum, err := bc.validateBackingImageChecksum(backupTarget.Name, volume.Name, volume.Spec.BackingImage)
 	if err != nil {
 		return nil, err
 	}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -6318,6 +6318,11 @@ func (s *DataStore) ValidateRecurringJobs(jobs []longhorn.RecurringJobSpec) erro
 		if err := ValidateRecurringJob(job); err != nil {
 			return err
 		}
+		if job.BackupTarget != "" {
+			if _, err := s.GetBackupTargetRO(job.BackupTarget); err != nil {
+				return fmt.Errorf("recurring job %v has invalid backup target %v: %v", job.Name, job.BackupTarget, err)
+			}
+		}
 		totalJobRetainCount += job.Retain
 	}
 

--- a/datastore/longhorn_test.go
+++ b/datastore/longhorn_test.go
@@ -406,3 +406,87 @@ func TestValidateSettingDefaultDataPathImmutability(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateRecurringJobsBackupTarget covers the per-job backup target
+// (longhorn/longhorn#11421). A job may now point at a backup target other than
+// the one its volumes use, so the target has to be verified to exist at
+// admission time: otherwise the job is accepted and then fails on every single
+// run, which is only visible in the job pod logs. An empty backup target must
+// stay valid because that is what every job predating the field carries, and it
+// means "use the volume's backup target".
+func TestValidateRecurringJobsBackupTarget(t *testing.T) {
+	const (
+		testNamespace        = "longhorn-system"
+		testBackupTargetName = "secondary-backup-target"
+	)
+
+	backupTarget := &longhorn.BackupTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBackupTargetName,
+			Namespace: testNamespace,
+		},
+	}
+
+	newJob := func(name, backupTargetName string) longhorn.RecurringJobSpec {
+		return longhorn.RecurringJobSpec{
+			Name:         name,
+			Task:         longhorn.RecurringJobTypeBackup,
+			Cron:         "0 0 * * *",
+			Retain:       1,
+			BackupTarget: backupTargetName,
+		}
+	}
+
+	tests := map[string]struct {
+		existingObjects []runtime.Object
+		jobs            []longhorn.RecurringJobSpec
+		expectError     string
+	}{
+		"job without a backup target defers to the volume backup target": {
+			jobs: []longhorn.RecurringJobSpec{newJob("test-job", "")},
+		},
+		"job with an existing backup target is accepted": {
+			existingObjects: []runtime.Object{backupTarget.DeepCopy()},
+			jobs:            []longhorn.RecurringJobSpec{newJob("test-job", testBackupTargetName)},
+		},
+		"job with a nonexistent backup target is rejected": {
+			jobs:        []longhorn.RecurringJobSpec{newJob("test-job", testBackupTargetName)},
+			expectError: fmt.Sprintf("recurring job test-job has invalid backup target %v", testBackupTargetName),
+		},
+		"a nonexistent backup target on any job rejects the whole set": {
+			existingObjects: []runtime.Object{backupTarget.DeepCopy()},
+			jobs: []longhorn.RecurringJobSpec{
+				newJob("test-job-1", testBackupTargetName),
+				newJob("test-job-2", "missing-backup-target"),
+			},
+			expectError: "recurring job test-job-2 has invalid backup target missing-backup-target",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			lhClient := lhfake.NewSimpleClientset(tc.existingObjects...) // nolint: staticcheck
+			kubeClient := fake.NewSimpleClientset()                      // nolint: staticcheck
+			extensionsClient := apiextensionsfake.NewSimpleClientset()   // nolint: staticcheck
+			informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+			ds := NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactories.Start(stopCh)
+
+			require.True(t, cache.WaitForCacheSync(stopCh,
+				ds.BackupTargetInformer.HasSynced,
+				ds.SettingInformer.HasSynced,
+			))
+
+			err := ds.ValidateRecurringJobs(tc.jobs)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2890,6 +2890,9 @@ spec:
             description: RecurringJobSpec defines the desired state of the Longhorn
               recurring job
             properties:
+              backupTarget:
+                description: The backup target name of the backup.
+                type: string
               concurrency:
                 description: The concurrency of taking the snapshot/backup.
                 type: integer

--- a/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
@@ -54,6 +54,9 @@ type RecurringJobSpec struct {
 	// The label of the snapshot/backup.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+	// The backup target name of the backup.
+	// +optional
+	BackupTarget string `json:"backupTarget,omitempty"`
 	// The parameters of the snapshot/backup.
 	// Support parameters: "full-backup-interval", "volume-backup-policy".
 	// +optional

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/recurringjobspec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/recurringjobspec.go
@@ -42,6 +42,8 @@ type RecurringJobSpecApplyConfiguration struct {
 	Concurrency *int `json:"concurrency,omitempty"`
 	// The label of the snapshot/backup.
 	Labels map[string]string `json:"labels,omitempty"`
+	// The backup target name of the backup.
+	BackupTarget *string `json:"backupTarget,omitempty"`
 	// The parameters of the snapshot/backup.
 	// Support parameters: "full-backup-interval", "volume-backup-policy".
 	Parameters map[string]string `json:"parameters,omitempty"`
@@ -114,6 +116,14 @@ func (b *RecurringJobSpecApplyConfiguration) WithLabels(entries map[string]strin
 	for k, v := range entries {
 		b.Labels[k] = v
 	}
+	return b
+}
+
+// WithBackupTarget sets the BackupTarget field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the BackupTarget field is set to the value of the last call.
+func (b *RecurringJobSpecApplyConfiguration) WithBackupTarget(value string) *RecurringJobSpecApplyConfiguration {
+	b.BackupTarget = &value
 	return b
 }
 

--- a/manager/engine.go
+++ b/manager/engine.go
@@ -536,11 +536,7 @@ func (m *VolumeManager) ListBackupsForVolumeNameSorted(volumeName string) ([]*lo
 }
 
 func (m *VolumeManager) ListBackupsForVolume(volumeName string) (map[string]*longhorn.Backup, error) {
-	v, err := m.ds.GetVolumeRO(volumeName)
-	if err != nil {
-		return nil, err
-	}
-	return m.ds.ListBackupsWithBackupTargetAndBackupVolumeRO(v.Spec.BackupTargetName, volumeName)
+	return m.ds.ListBackupsWithVolumeNameRO(volumeName, "")
 }
 
 func (m *VolumeManager) ListBackupsForVolumeSorted(volumeName string) ([]*longhorn.Backup, error) {

--- a/webhook/resources/backup/validator.go
+++ b/webhook/resources/backup/validator.go
@@ -96,10 +96,25 @@ func (b *backupValidator) Create(request *admission.Request, newObj runtime.Obje
 			return werror.NewInvalidError(fmt.Sprintf("snapshot volume name %s and label volume name %s does not match", snapshotVolumeName, labelVolumeName), "")
 		}
 
-		//check if volume backup target matches labelbackup target
+		//check if recurring job backup target or volume backup target matches labelbackup target
 		volumeBackupTargetName := volume.Spec.BackupTargetName
 		if volumeBackupTargetName != backupTargetName {
-			return werror.NewInvalidError(fmt.Sprintf("volume backup target %s and label backup target %s does not match", volumeBackupTargetName, backupTargetName), "")
+			if backup.Spec.Labels == nil || backup.Spec.Labels[types.RecurringJobLabel] == "" {
+				return werror.NewInvalidError(fmt.Sprintf("volume backup target %s and label backup target %s does not match", volumeBackupTargetName, backupTargetName), "")
+			}
+			backupRecurringJobName := backup.Spec.Labels[types.RecurringJobLabel]
+			backupRecurringJob, err := b.ds.GetRecurringJobRO(backupRecurringJobName)
+			if err != nil {
+				return werror.NewInvalidError(fmt.Sprintf("failed to get recurring job %s: %v", backupRecurringJobName, err), "")
+			}
+
+			//check if an empty recurring job backup target means the recurring job is using the volume backup target
+			if backupRecurringJob.Spec.BackupTarget == "" {
+				return werror.NewInvalidError(fmt.Sprintf("volume backup target %s and label backup target %s does not match", volumeBackupTargetName, backupTargetName), "")
+			}
+			if backupRecurringJob.Spec.BackupTarget != backupTargetName {
+				return werror.NewInvalidError(fmt.Sprintf("recurring job backup target %s and label backup target %s does not match", backupRecurringJob.Spec.BackupTarget, backupTargetName), "")
+			}
 		}
 	}
 

--- a/webhook/resources/backup/validator_test.go
+++ b/webhook/resources/backup/validator_test.go
@@ -1,0 +1,211 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	testNamespace = "longhorn-system"
+
+	testVolumeName   = "test-volume"
+	testSnapshotName = "test-snapshot"
+	testBackupName   = "test-backup"
+
+	testVolumeBackupTargetName = "default"
+	testOtherBackupTargetName  = "secondary"
+	testThirdBackupTargetName  = "tertiary"
+
+	testRecurringJobName = "test-recurring-job"
+)
+
+func newTestBackupTarget(name string) *longhorn.BackupTarget {
+	return &longhorn.BackupTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: longhorn.BackupTargetSpec{
+			BackupTargetURL: "nfs://longhorn-test-nfs-svc.default:/opt/backupstore",
+		},
+		Status: longhorn.BackupTargetStatus{
+			Available: true,
+		},
+	}
+}
+
+func newTestVolume() *longhorn.Volume {
+	return &longhorn.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVolumeName,
+			Namespace: testNamespace,
+		},
+		Spec: longhorn.VolumeSpec{
+			// A multiple of the backup block size below; the validator rejects
+			// backups whose block size does not evenly divide the volume.
+			Size:             20 * types.BackupBlockSizeMi,
+			BackupTargetName: testVolumeBackupTargetName,
+		},
+	}
+}
+
+func newTestSnapshot() *longhorn.Snapshot {
+	return &longhorn.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSnapshotName,
+			Namespace: testNamespace,
+		},
+		Spec: longhorn.SnapshotSpec{
+			Volume: testVolumeName,
+		},
+	}
+}
+
+func newTestRecurringJob(backupTargetName string) *longhorn.RecurringJob {
+	return &longhorn.RecurringJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRecurringJobName,
+			Namespace: testNamespace,
+		},
+		Spec: longhorn.RecurringJobSpec{
+			Name:         testRecurringJobName,
+			Task:         longhorn.RecurringJobTypeBackup,
+			Cron:         "0 0 * * *",
+			Retain:       1,
+			BackupTarget: backupTargetName,
+		},
+	}
+}
+
+// newTestBackup builds a backup that is valid in every respect other than the
+// backup target it is labelled for, so each case below isolates the backup
+// target check. recurringJobName is the value of the RecurringJob spec label,
+// empty for a backup that was not created by a recurring job.
+func newTestBackup(backupTargetName, recurringJobName string) *longhorn.Backup {
+	backup := &longhorn.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBackupName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				types.LonghornLabelBackupTarget: backupTargetName,
+				types.LonghornLabelBackupVolume: testVolumeName,
+			},
+		},
+		Spec: longhorn.BackupSpec{
+			SnapshotName:    testSnapshotName,
+			BackupMode:      longhorn.BackupModeIncremental,
+			BackupBlockSize: types.BackupBlockSize2Mi,
+		},
+	}
+	if recurringJobName != "" {
+		backup.Spec.Labels = map[string]string{types.RecurringJobLabel: recurringJobName}
+	}
+	return backup
+}
+
+func newTestValidator(t *testing.T, stopCh chan struct{}, objects ...runtime.Object) *backupValidator {
+	t.Helper()
+
+	lhClient := lhfake.NewSimpleClientset(objects...)          // nolint: staticcheck
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	informerFactories.Start(stopCh)
+	require.True(t, cache.WaitForCacheSync(stopCh,
+		ds.BackupTargetInformer.HasSynced,
+		ds.VolumeInformer.HasSynced,
+		ds.SnapshotInformer.HasSynced,
+		ds.RecurringJobInformer.HasSynced,
+	))
+
+	return &backupValidator{ds: ds}
+}
+
+// TestValidatorCreateBackupTarget covers the relaxed backup target check added
+// for the per-recurring-job backup target (longhorn/longhorn#11421). Before it,
+// a backup had to be labelled for the backup target of its own volume. A
+// recurring job may now direct its backups elsewhere, so the mismatch is only
+// tolerated when the backup really came from a recurring job that is configured
+// for that target -- anything looser would let a backup be written to an
+// arbitrary target just by setting a label.
+func TestValidatorCreateBackupTarget(t *testing.T) {
+	baseObjects := func(extra ...runtime.Object) []runtime.Object {
+		objects := []runtime.Object{
+			newTestBackupTarget(testVolumeBackupTargetName),
+			newTestBackupTarget(testOtherBackupTargetName),
+			newTestVolume(),
+			newTestSnapshot(),
+		}
+		return append(objects, extra...)
+	}
+
+	tests := map[string]struct {
+		existingObjects []runtime.Object
+		backup          *longhorn.Backup
+		expectError     string
+	}{
+		"backup for the volume backup target is accepted": {
+			existingObjects: baseObjects(),
+			backup:          newTestBackup(testVolumeBackupTargetName, ""),
+		},
+		"mismatch without a recurring job label is rejected": {
+			existingObjects: baseObjects(),
+			backup:          newTestBackup(testOtherBackupTargetName, ""),
+			expectError:     "volume backup target default and label backup target secondary does not match",
+		},
+		"mismatch naming an unknown recurring job is rejected": {
+			existingObjects: baseObjects(),
+			backup:          newTestBackup(testOtherBackupTargetName, testRecurringJobName),
+			expectError:     "failed to get recurring job " + testRecurringJobName,
+		},
+		"mismatch from a recurring job without its own backup target is rejected": {
+			// The job defers to the volume backup target, so the label cannot
+			// legitimately name a different one.
+			existingObjects: baseObjects(newTestRecurringJob("")),
+			backup:          newTestBackup(testOtherBackupTargetName, testRecurringJobName),
+			expectError:     "volume backup target default and label backup target secondary does not match",
+		},
+		"mismatch from a recurring job pointing at a third backup target is rejected": {
+			existingObjects: baseObjects(newTestRecurringJob(testThirdBackupTargetName)),
+			backup:          newTestBackup(testOtherBackupTargetName, testRecurringJobName),
+			expectError:     "recurring job backup target tertiary and label backup target secondary does not match",
+		},
+		"mismatch from a recurring job pointing at that backup target is accepted": {
+			existingObjects: baseObjects(newTestRecurringJob(testOtherBackupTargetName)),
+			backup:          newTestBackup(testOtherBackupTargetName, testRecurringJobName),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			validator := newTestValidator(t, stopCh, tc.existingObjects...)
+
+			err := validator.Create(nil, tc.backup)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}

--- a/webhook/resources/recurringjob/validator.go
+++ b/webhook/resources/recurringjob/validator.go
@@ -64,14 +64,15 @@ func (r *recurringJobValidator) Create(request *admission.Request, newObj runtim
 
 	jobs := []longhorn.RecurringJobSpec{
 		{
-			Name:        recurringJob.Spec.Name,
-			Groups:      recurringJob.Spec.Groups,
-			Task:        recurringJob.Spec.Task,
-			Cron:        recurringJob.Spec.Cron,
-			Retain:      recurringJob.Spec.Retain,
-			Concurrency: recurringJob.Spec.Concurrency,
-			Labels:      recurringJob.Spec.Labels,
-			Parameters:  recurringJob.Spec.Parameters,
+			Name:         recurringJob.Spec.Name,
+			Groups:       recurringJob.Spec.Groups,
+			Task:         recurringJob.Spec.Task,
+			Cron:         recurringJob.Spec.Cron,
+			Retain:       recurringJob.Spec.Retain,
+			Concurrency:  recurringJob.Spec.Concurrency,
+			Labels:       recurringJob.Spec.Labels,
+			BackupTarget: recurringJob.Spec.BackupTarget,
+			Parameters:   recurringJob.Spec.Parameters,
 		},
 	}
 	if err := r.ds.ValidateRecurringJobs(jobs); err != nil {
@@ -99,14 +100,15 @@ func (r *recurringJobValidator) Update(request *admission.Request, oldObj runtim
 
 	jobs := []longhorn.RecurringJobSpec{
 		{
-			Name:        newRecurringJob.Spec.Name,
-			Groups:      newRecurringJob.Spec.Groups,
-			Task:        newRecurringJob.Spec.Task,
-			Cron:        newRecurringJob.Spec.Cron,
-			Retain:      newRecurringJob.Spec.Retain,
-			Concurrency: newRecurringJob.Spec.Concurrency,
-			Labels:      newRecurringJob.Spec.Labels,
-			Parameters:  newRecurringJob.Spec.Parameters,
+			Name:         newRecurringJob.Spec.Name,
+			Groups:       newRecurringJob.Spec.Groups,
+			Task:         newRecurringJob.Spec.Task,
+			Cron:         newRecurringJob.Spec.Cron,
+			Retain:       newRecurringJob.Spec.Retain,
+			Concurrency:  newRecurringJob.Spec.Concurrency,
+			Labels:       newRecurringJob.Spec.Labels,
+			BackupTarget: newRecurringJob.Spec.BackupTarget,
+			Parameters:   newRecurringJob.Spec.Parameters,
 		},
 	}
 	if err := r.ds.ValidateRecurringJobs(jobs); err != nil {

--- a/webhook/resources/recurringjob/validator_test.go
+++ b/webhook/resources/recurringjob/validator_test.go
@@ -1,0 +1,119 @@
+package recurringjob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	testNamespace        = "longhorn-system"
+	testBackupTargetName = "secondary-backup-target"
+	testRecurringJobName = "test-recurring-job"
+)
+
+func newTestBackupTarget(name string) *longhorn.BackupTarget {
+	return &longhorn.BackupTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+	}
+}
+
+func newTestRecurringJob(backupTargetName string) *longhorn.RecurringJob {
+	return &longhorn.RecurringJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRecurringJobName,
+			Namespace: testNamespace,
+		},
+		Spec: longhorn.RecurringJobSpec{
+			Name:         testRecurringJobName,
+			Task:         longhorn.RecurringJobTypeBackup,
+			Cron:         "0 0 * * *",
+			Retain:       1,
+			BackupTarget: backupTargetName,
+		},
+	}
+}
+
+func newTestValidator(t *testing.T, stopCh chan struct{}, objects ...runtime.Object) *recurringJobValidator {
+	t.Helper()
+
+	lhClient := lhfake.NewSimpleClientset(objects...)          // nolint: staticcheck
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	informerFactories.Start(stopCh)
+	require.True(t, cache.WaitForCacheSync(stopCh,
+		ds.BackupTargetInformer.HasSynced,
+		ds.SettingInformer.HasSynced,
+	))
+
+	return &recurringJobValidator{ds: ds}
+}
+
+// TestValidatorBackupTarget pins that Spec.BackupTarget (longhorn/longhorn#11421)
+// is carried into the validation call on both Create and Update. The validator
+// rebuilds a RecurringJobSpec field by field before handing it to
+// ValidateRecurringJobs, so dropping the new field there would silently accept a
+// job pointing at a backup target that does not exist -- the job would then fail
+// on every run instead of being rejected up front.
+func TestValidatorBackupTarget(t *testing.T) {
+	tests := map[string]struct {
+		existingObjects []runtime.Object
+		recurringJob    *longhorn.RecurringJob
+		expectError     string
+	}{
+		"existing backup target is accepted": {
+			existingObjects: []runtime.Object{newTestBackupTarget(testBackupTargetName)},
+			recurringJob:    newTestRecurringJob(testBackupTargetName),
+		},
+		"nonexistent backup target is rejected": {
+			recurringJob: newTestRecurringJob(testBackupTargetName),
+			expectError:  "has invalid backup target " + testBackupTargetName,
+		},
+		"empty backup target is accepted": {
+			recurringJob: newTestRecurringJob(""),
+		},
+	}
+
+	for name, tc := range tests {
+		for _, operation := range []string{"create", "update"} {
+			t.Run(operation+" "+name, func(t *testing.T) {
+				stopCh := make(chan struct{})
+				defer close(stopCh)
+				validator := newTestValidator(t, stopCh, tc.existingObjects...)
+
+				var err error
+				if operation == "create" {
+					err = validator.Create(nil, tc.recurringJob)
+				} else {
+					err = validator.Update(nil, newTestRecurringJob(""), tc.recurringJob)
+				}
+
+				if tc.expectError == "" {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.expectError)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11421

#### What this PR does / why we need it:

Introduce a new field 'RecurryingJob.Spec.BackupTarget' to specify the backup target when a recurring job runs.

#### Special notes for your reviewer:

#### Additional documentation or context
