### PR TITLE
feat(replica): gate the v2 replica host-ACL restriction on cluster-wide IM version

### DIFF
--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -437,6 +437,11 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		return nil, err
 	}
 
+	restrictHostACL, err := rc.shouldRestrictReplicaHostACL(r)
+	if err != nil {
+		return nil, err
+	}
+
 	r.Status.Starting = true
 	replicaName := r.Name
 	if r, err = rc.ds.UpdateReplicaStatus(r); err != nil {
@@ -452,7 +457,36 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		DataLocality:                  v.Spec.DataLocality,
 		EngineCLIAPIVersion:           cliAPIVersion,
 		ExtraLUKS2HeaderSpaceRequired: types.IsVolumeV2EncryptedVolumeWithLuksHeaderLabelTrue(v),
+		RestrictHostACL:               restrictHostACL,
 	})
+}
+
+// shouldRestrictReplicaHostACL evaluates, fresh on every replica create, whether
+// every non-terminated v2 instance manager presents the internal host NQN on attach.
+func (rc *ReplicaController) shouldRestrictReplicaHostACL(r *longhorn.Replica) (bool, error) {
+	if !types.IsDataEngineV2(r.Spec.DataEngine) {
+		return false, nil
+	}
+
+	ims, err := rc.ds.ListInstanceManagersRO()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list instance managers to evaluate the replica host-ACL gate")
+	}
+	for _, im := range ims {
+		// v1 instance managers never act as NVMe-oF initiators for v2 replicas.
+		if !types.IsDataEngineV2(im.Spec.DataEngine) {
+			continue
+		}
+		// Only stopped/error are safe to skip; starting/unknown pods may resurface old code.
+		switch im.Status.CurrentState {
+		case longhorn.InstanceManagerStateStopped, longhorn.InstanceManagerStateError:
+			continue
+		}
+		if im.Status.APIVersion < engineapi.MinInstanceManagerAPIVersionForReplicaHostACL {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (rc *ReplicaController) getDiskNameFromUUID(r *longhorn.Replica) (string, error) {

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -29,6 +29,10 @@ const (
 	MinInstanceManagerAPIVersion     = 1
 	UnknownInstanceManagerAPIVersion = 0
 
+	// MinInstanceManagerAPIVersionForReplicaHostACL is the minimum IM API version
+	// whose initiators present the internal host NQN, so restricted replicas stay reachable.
+	MinInstanceManagerAPIVersionForReplicaHostACL = 8
+
 	UnknownInstanceManagerProxyAPIVersion = 0
 	// UnsupportedInstanceManagerProxyAPIVersion means the instance manager without the proxy client (Longhorn release before v1.3.0)
 	UnsupportedInstanceManagerProxyAPIVersion = 0
@@ -535,6 +539,9 @@ type ReplicaInstanceCreateRequest struct {
 	EngineCLIAPIVersion           int
 	Encrypted                     bool
 	ExtraLUKS2HeaderSpaceRequired bool
+	// RestrictHostACL requests that every subsystem the replica exposes be
+	// restricted to the internal host NQN (v2 data engine only).
+	RestrictHostACL bool
 }
 
 // EngineFrontendInstanceCreateRequest contains the parameters to create an engine frontend (initiator) instance
@@ -689,6 +696,7 @@ func (c *InstanceManagerClient) ReplicaInstanceCreate(req *ReplicaInstanceCreate
 			DiskName:         req.DiskName,
 			DiskUUID:         req.Replica.Spec.DiskID,
 			BackingImageName: req.Replica.Spec.BackingImage,
+			RestrictHostACL:  req.RestrictHostACL,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13699

#### What this PR does / why we need it:

Requests the replica host-ACL restriction only when every non-terminated v2 instance manager reports API version 8 or later. Evaluated fresh on every replica creation, stored nowhere.

#### Special notes for your reviewer:

Depends on the longhorn/types and longhorn-instance-manager PRs.

#### Additional documentation or context

`None`
