### PR TITLE
feat: add nvme-tcp nr-io-queues volume setting for v2 blockdev frontend

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -65,6 +65,7 @@ type Volume struct {
 	ReplicaRebuildingBandwidthLimit int64                                  `json:"replicaRebuildingBandwidthLimit"`
 	UblkQueueDepth                  int                                    `json:"ublkQueueDepth"`
 	UblkNumberOfQueue               int                                    `json:"ublkNumberOfQueue"`
+	NvmeTcpNrIoQueues               int                                    `json:"nvmeTcpNrIoQueues"`
 	FreezeFilesystemForSnapshot     longhorn.FreezeFilesystemForSnapshot   `json:"freezeFilesystemForSnapshot"`
 	BackupTargetName                string                                 `json:"backupTargetName"`
 	DataLayout                      longhorn.VolumeDataLayout              `json:"dataLayout"`

--- a/api/volume.go
+++ b/api/volume.go
@@ -219,6 +219,7 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		ReplicaRebuildingBandwidthLimit: volume.ReplicaRebuildingBandwidthLimit,
 		UblkQueueDepth:                  volume.UblkQueueDepth,
 		UblkNumberOfQueue:               volume.UblkNumberOfQueue,
+		NvmeTcpNrIoQueues:               volume.NvmeTcpNrIoQueues,
 		BackupCompressionMethod:         volume.BackupCompressionMethod,
 		BackupBlockSize:                 backupBlockSize,
 		UnmapMarkSnapChainRemoved:       volume.UnmapMarkSnapChainRemoved,

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -125,6 +125,8 @@ type Volume struct {
 
 	State string `json:"state,omitempty" yaml:"state,omitempty"`
 
+	NvmeTcpNrIoQueues int64 `json:"nvmeTcpNrIoQueues,omitempty" yaml:"nvme_tcp_nr_io_queues,omitempty"`
+
 	UblkNumberOfQueue int64 `json:"ublkNumberOfQueue,omitempty" yaml:"ublk_number_of_queue,omitempty"`
 
 	UblkQueueDepth int64 `json:"ublkQueueDepth,omitempty" yaml:"ublk_queue_depth,omitempty"`

--- a/controller/engine_frontend_controller.go
+++ b/controller/engine_frontend_controller.go
@@ -694,6 +694,20 @@ func (efc *EngineFrontendController) CreateInstance(obj interface{}) (*longhorn.
 		}
 	}
 
+	// Check ef.Spec.Frontend instead of the computed frontend so that
+	// maintenance-mode attach (DisableFrontend) still resolves the setting
+	// fallback; the stored value is used when the frontend is enabled later.
+	nvmeTcpNrIoQueues := ef.Spec.NvmeTcpNrIoQueues
+	if types.IsDataEngineV2(ef.Spec.DataEngine) && ef.Spec.Frontend == longhorn.VolumeFrontendBlockDev && nvmeTcpNrIoQueues == 0 {
+		nvmeTcpNrIoQueuesInt64, err := efc.ds.GetSettingAsIntByDataEngine(types.SettingNameDefaultNvmeTcpNrIoQueues, ef.Spec.DataEngine)
+		if err != nil {
+			efc.logger.WithError(err).Warnf("Failed to get %v setting, connecting with the kernel default number of I/O queues",
+				types.SettingNameDefaultNvmeTcpNrIoQueues)
+		} else {
+			nvmeTcpNrIoQueues = int(nvmeTcpNrIoQueuesInt64)
+		}
+	}
+
 	ef.Status.Starting = true
 	efName := ef.Name
 	if ef, err = efc.ds.UpdateEngineFrontendStatus(ef); err != nil {
@@ -712,6 +726,7 @@ func (efc *EngineFrontendController) CreateInstance(obj interface{}) (*longhorn.
 		VolumeFrontend:                frontend,
 		UblkQueueDepth:                ublkQueueDepth,
 		UblkNumberOfQueue:             ublkNumberOfQueue,
+		NvmeTcpNrIoQueues:             nvmeTcpNrIoQueues,
 		TargetIP:                      ef.Spec.TargetIP,
 		TargetPort:                    ef.Spec.TargetPort,
 		EngineName:                    ef.Spec.EngineName,

--- a/controller/setting_controller.go
+++ b/controller/setting_controller.go
@@ -1828,6 +1828,7 @@ func (info *ClusterInfo) collectSettings() error {
 		types.SettingNameDefaultBackupBlockSize:                                   true,
 		types.SettingNameReplicaRebuildingBandwidthLimit:                          true,
 		types.SettingNameDefaultUblkQueueDepth:                                    true,
+		types.SettingNameDefaultNvmeTcpNrIoQueues:                                 true,
 		types.SettingNameDefaultUblkNumberOfQueue:                                 true,
 		types.SettingNameV1DataEngine:                                             true,
 		types.SettingNameV2DataEngine:                                             true,

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -2976,6 +2976,7 @@ func (c *VolumeController) openVolumeDependentResources(v *longhorn.Volume, e *l
 				ef.Spec.Frontend = v.Spec.Frontend
 				ef.Spec.UblkQueueDepth = v.Spec.UblkQueueDepth
 				ef.Spec.UblkNumberOfQueue = v.Spec.UblkNumberOfQueue
+				ef.Spec.NvmeTcpNrIoQueues = v.Spec.NvmeTcpNrIoQueues
 				ef.Spec.DisableFrontend = v.Status.FrontendDisabled
 				ef.Spec.DesireState = longhorn.InstanceStateRunning
 				// During an engine switchover, processEngineSwitchover drives
@@ -3101,6 +3102,7 @@ func (c *VolumeController) openVolumeDependentResourcesEC(v *longhorn.Volume, e 
 			ef.Spec.Frontend = v.Spec.Frontend
 			ef.Spec.UblkQueueDepth = v.Spec.UblkQueueDepth
 			ef.Spec.UblkNumberOfQueue = v.Spec.UblkNumberOfQueue
+			ef.Spec.NvmeTcpNrIoQueues = v.Spec.NvmeTcpNrIoQueues
 			ef.Spec.DisableFrontend = v.Status.FrontendDisabled
 			ef.Spec.DesireState = longhorn.InstanceStateRunning
 			// The v2 engine exposes its NVMe-TCP target on StorageIP, so the initiator
@@ -5531,6 +5533,7 @@ func (c *VolumeController) createEngineFrontend(v *longhorn.Volume, e *longhorn.
 			Frontend:          v.Spec.Frontend,
 			UblkQueueDepth:    v.Spec.UblkQueueDepth,
 			UblkNumberOfQueue: v.Spec.UblkNumberOfQueue,
+			NvmeTcpNrIoQueues: v.Spec.NvmeTcpNrIoQueues,
 			EngineName:        engineName,
 			DisableFrontend:   v.Status.FrontendDisabled,
 		},

--- a/csi/util.go
+++ b/csi/util.go
@@ -188,6 +188,14 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		vol.UblkQueueDepth = int64(depth)
 	}
 
+	if nvmeTcpNrIoQueues, ok := volOptions["nvmeTcpNrIoQueues"]; ok {
+		nrIoQueues, err := strconv.Atoi(nvmeTcpNrIoQueues)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid parameter nvmeTcpNrIoQueues")
+		}
+		vol.NvmeTcpNrIoQueues = int64(nrIoQueues)
+	}
+
 	if replicaAutoBalance, ok := volOptions["replicaAutoBalance"]; ok {
 		err := types.ValidateReplicaAutoBalance(longhorn.ReplicaAutoBalance(replicaAutoBalance))
 		if err != nil {

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -543,6 +543,7 @@ type EngineFrontendInstanceCreateRequest struct {
 	VolumeFrontend                longhorn.VolumeFrontend
 	UblkQueueDepth                int
 	UblkNumberOfQueue             int
+	NvmeTcpNrIoQueues             int
 	TargetIP                      string
 	TargetPort                    int
 	EngineName                    string
@@ -600,6 +601,7 @@ func (c *InstanceManagerClient) EngineFrontendInstanceCreate(req *EngineFrontend
 			Frontend:          frontend,
 			UblkQueueDepth:    req.UblkQueueDepth,
 			UblkNumberOfQueue: req.UblkNumberOfQueue,
+			NvmeTcpNrIoQueues: req.NvmeTcpNrIoQueues,
 			TargetAddress:     targetAddress,
 			EngineName:        req.EngineName,
 		},

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1175,6 +1175,13 @@ spec:
                 type: boolean
               nodeID:
                 type: string
+              nvmeTcpNrIoQueues:
+                description: |-
+                  nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+                  creates when connecting the blockdev frontend over NVMe-TCP.
+                  0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+                  Takes effect on (re)attach.
+                type: integer
               salvageRequested:
                 type: boolean
               size:
@@ -4655,6 +4662,13 @@ spec:
                   type: string
                 type: array
               numberOfReplicas:
+                type: integer
+              nvmeTcpNrIoQueues:
+                description: |-
+                  nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+                  creates when connecting the blockdev frontend over NVMe-TCP.
+                  0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+                  Takes effect on (re)attach.
                 type: integer
               offlineRebuilding:
                 description: |-

--- a/k8s/pkg/apis/longhorn/v1beta2/enginefrontend.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/enginefrontend.go
@@ -37,6 +37,12 @@ type EngineFrontendSpec struct {
 	// ublkNumberOfQueue controls the number of queues for ublk frontend.
 	// +optional
 	UblkNumberOfQueue int `json:"ublkNumberOfQueue,omitempty"`
+	// nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+	// creates when connecting the blockdev frontend over NVMe-TCP.
+	// 0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+	// Takes effect on (re)attach.
+	// +optional
+	NvmeTcpNrIoQueues int `json:"nvmeTcpNrIoQueues,omitempty"`
 	// TargetIP is the IP address of the v2 engine target
 	// +optional
 	TargetIP string `json:"targetIP"`

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -313,6 +313,12 @@ type VolumeSpec struct {
 	// ublkNumberOfQueue controls the number of queues for ublk frontend.
 	// +optional
 	UblkNumberOfQueue int `json:"ublkNumberOfQueue,omitempty"`
+	// nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+	// creates when connecting the blockdev frontend over NVMe-TCP.
+	// 0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+	// Takes effect on (re)attach.
+	// +optional
+	NvmeTcpNrIoQueues int `json:"nvmeTcpNrIoQueues,omitempty"`
 	// +optional
 	FromBackup string `json:"fromBackup"`
 	// +optional

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/enginefrontendspec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/enginefrontendspec.go
@@ -36,6 +36,11 @@ type EngineFrontendSpecApplyConfiguration struct {
 	UblkQueueDepth *int `json:"ublkQueueDepth,omitempty"`
 	// ublkNumberOfQueue controls the number of queues for ublk frontend.
 	UblkNumberOfQueue *int `json:"ublkNumberOfQueue,omitempty"`
+	// nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+	// creates when connecting the blockdev frontend over NVMe-TCP.
+	// 0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+	// Takes effect on (re)attach.
+	NvmeTcpNrIoQueues *int `json:"nvmeTcpNrIoQueues,omitempty"`
 	// TargetIP is the IP address of the v2 engine target
 	TargetIP *string `json:"targetIP,omitempty"`
 	// TargetPort is the port of the v2 engine target
@@ -81,6 +86,14 @@ func (b *EngineFrontendSpecApplyConfiguration) WithUblkQueueDepth(value int) *En
 // If called multiple times, the UblkNumberOfQueue field is set to the value of the last call.
 func (b *EngineFrontendSpecApplyConfiguration) WithUblkNumberOfQueue(value int) *EngineFrontendSpecApplyConfiguration {
 	b.UblkNumberOfQueue = &value
+	return b
+}
+
+// WithNvmeTcpNrIoQueues sets the NvmeTcpNrIoQueues field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NvmeTcpNrIoQueues field is set to the value of the last call.
+func (b *EngineFrontendSpecApplyConfiguration) WithNvmeTcpNrIoQueues(value int) *EngineFrontendSpecApplyConfiguration {
+	b.NvmeTcpNrIoQueues = &value
 	return b
 }
 

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/volumespec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/volumespec.go
@@ -32,7 +32,12 @@ type VolumeSpecApplyConfiguration struct {
 	// ublkQueueDepth controls the depth of each queue for ublk frontend.
 	UblkQueueDepth *int `json:"ublkQueueDepth,omitempty"`
 	// ublkNumberOfQueue controls the number of queues for ublk frontend.
-	UblkNumberOfQueue         *int                                           `json:"ublkNumberOfQueue,omitempty"`
+	UblkNumberOfQueue *int `json:"ublkNumberOfQueue,omitempty"`
+	// nvmeTcpNrIoQueues limits the number of I/O queues the kernel initiator
+	// creates when connecting the blockdev frontend over NVMe-TCP.
+	// 0 means inheriting the global setting default-nvme-tcp-nr-io-queues.
+	// Takes effect on (re)attach.
+	NvmeTcpNrIoQueues         *int                                           `json:"nvmeTcpNrIoQueues,omitempty"`
 	FromBackup                *string                                        `json:"fromBackup,omitempty"`
 	RestoreVolumeRecurringJob *longhornv1beta2.RestoreVolumeRecurringJobType `json:"restoreVolumeRecurringJob,omitempty"`
 	DataSource                *longhornv1beta2.VolumeDataSource              `json:"dataSource,omitempty"`
@@ -134,6 +139,14 @@ func (b *VolumeSpecApplyConfiguration) WithUblkQueueDepth(value int) *VolumeSpec
 // If called multiple times, the UblkNumberOfQueue field is set to the value of the last call.
 func (b *VolumeSpecApplyConfiguration) WithUblkNumberOfQueue(value int) *VolumeSpecApplyConfiguration {
 	b.UblkNumberOfQueue = &value
+	return b
+}
+
+// WithNvmeTcpNrIoQueues sets the NvmeTcpNrIoQueues field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NvmeTcpNrIoQueues field is set to the value of the last call.
+func (b *VolumeSpecApplyConfiguration) WithNvmeTcpNrIoQueues(value int) *VolumeSpecApplyConfiguration {
+	b.NvmeTcpNrIoQueues = &value
 	return b
 }
 

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -226,6 +226,7 @@ func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurring
 			RebuildConcurrentSyncLimit:      spec.RebuildConcurrentSyncLimit,
 			UblkQueueDepth:                  spec.UblkQueueDepth,
 			UblkNumberOfQueue:               spec.UblkNumberOfQueue,
+			NvmeTcpNrIoQueues:               spec.NvmeTcpNrIoQueues,
 		},
 	}
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -183,6 +183,7 @@ const (
 	SettingNameOfflineReplicaRebuilding                                 = SettingName("offline-replica-rebuilding")
 	SettingNameReplicaRebuildingBandwidthLimit                          = SettingName("replica-rebuilding-bandwidth-limit")
 	SettingNameDefaultUblkQueueDepth                                    = SettingName("default-ublk-queue-depth")
+	SettingNameDefaultNvmeTcpNrIoQueues                                 = SettingName("default-nvme-tcp-nr-io-queues")
 	SettingNameDefaultUblkNumberOfQueue                                 = SettingName("default-ublk-number-of-queue")
 	SettingNameDefaultBackupBlockSize                                   = SettingName("default-backup-block-size")
 	SettingNameEngineImagePodLivenessProbePeriod                        = SettingName("engine-image-pod-liveness-probe-period")
@@ -316,6 +317,7 @@ var (
 		SettingNameOfflineReplicaRebuilding,
 		SettingNameReplicaRebuildingBandwidthLimit,
 		SettingNameDefaultUblkQueueDepth,
+		SettingNameDefaultNvmeTcpNrIoQueues,
 		SettingNameDefaultUblkNumberOfQueue,
 		SettingNameDefaultBackupBlockSize,
 		SettingNameEngineImagePodLivenessProbePeriod,
@@ -483,6 +485,7 @@ var (
 		SettingNameOfflineReplicaRebuilding:                                 SettingDefinitionOfflineReplicaRebuilding,
 		SettingNameReplicaRebuildingBandwidthLimit:                          SettingDefinitionReplicaRebuildingBandwidthLimit,
 		SettingNameDefaultUblkQueueDepth:                                    SettingDefinitionDefaultUblkQueueDepth,
+		SettingNameDefaultNvmeTcpNrIoQueues:                                 SettingDefinitionDefaultNvmeTcpNrIoQueues,
 		SettingNameDefaultUblkNumberOfQueue:                                 SettingDefinitionDefaultUblkNumberOfQueue,
 		SettingNameDefaultBackupBlockSize:                                   SettingDefinitionDefaultBackupBlockSize,
 		SettingNameEngineImagePodLivenessProbePeriod:                        SettingDefinitionEngineImagePodLivenessProbePeriod,
@@ -2019,6 +2022,21 @@ var (
 		ReadOnly:           false,
 		DataEngineSpecific: true,
 		Default:            fmt.Sprintf("{%q:\"0\"}", longhorn.DataEngineTypeV2),
+	}
+
+	SettingDefinitionDefaultNvmeTcpNrIoQueues = SettingDefinition{
+		DisplayName:        "Default NVMe-TCP Number Of IO Queues",
+		Description:        "The default number of I/O queues the kernel initiator creates when connecting a volume frontend over NVMe-TCP. This caps the per-volume in-flight commands to the number of I/O queues multiplied by the negotiated queue size (128). This setting applies to volumes using the V2 Data Engine with the block device front end, takes effect on (re)attach, and can be overridden per volume. 0 means unspecified (kernel default, one queue per online core).",
+		Category:           SettingCategoryGeneral,
+		Type:               SettingTypeInt,
+		Required:           true,
+		ReadOnly:           false,
+		DataEngineSpecific: true,
+		Default:            fmt.Sprintf("{%q:\"0\"}", longhorn.DataEngineTypeV2),
+		ValueIntRange: map[string]int{
+			ValueIntRangeMinimum: 0,
+			ValueIntRangeMaximum: 128,
+		},
 	}
 
 	SettingDefinitionDefaultUblkQueueDepth = SettingDefinition{

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -81,6 +81,9 @@ func (v *volumeValidator) Create(request *admission.Request, newObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "spec.ublkQueueDepth")
 	}
 
+	if err := validateNvmeTcpNrIoQueues(volume.Spec.NvmeTcpNrIoQueues, volume.Spec.DataEngine); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
 	if err := validateUblkNumberOfQueue(volume.Spec.UblkNumberOfQueue); err != nil {
 		return werror.NewInvalidError(err.Error(), "spec.ublkNumberOfQueue")
 	}
@@ -265,6 +268,9 @@ func (v *volumeValidator) Update(request *admission.Request, oldObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "spec.ublkQueueDepth")
 	}
 
+	if err := validateNvmeTcpNrIoQueues(newVolume.Spec.NvmeTcpNrIoQueues, newVolume.Spec.DataEngine); err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
 	if err := validateUblkNumberOfQueue(newVolume.Spec.UblkNumberOfQueue); err != nil {
 		return werror.NewInvalidError(err.Error(), "spec.ublkNumberOfQueue")
 	}
@@ -733,6 +739,19 @@ func validateReplicaCount(cloneMode longhorn.CloneMode, dataLocality longhorn.Da
 		if replicaCount != 1 {
 			return werror.NewInvalidError(fmt.Sprintf("number of replica count should be 1 when data locality is %v", longhorn.DataLocalityStrictLocal), "")
 		}
+	}
+	return nil
+}
+
+func validateNvmeTcpNrIoQueues(n int, dataEngine longhorn.DataEngineType) error {
+	if n == 0 {
+		return nil
+	}
+	if n < 1 || n > 128 {
+		return fmt.Errorf("NVMe-TCP number of I/O queues must be either 0 (meaning unspecified) or between 1 and 128. Got %d", n)
+	}
+	if !types.IsDataEngineV2(dataEngine) {
+		return fmt.Errorf("NVMe-TCP number of I/O queues is only supported by data engine v2. Got data engine %v", dataEngine)
 	}
 	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/longhorn/longhorn/issues/13706

#### What this PR does / why we need it:

Adds the `default-nvme-tcp-nr-io-queues` setting and the per-volume field / storage class parameter `nvmeTcpNrIoQueues`. The value flows Volume -> EngineFrontend -> instance manager, falls back to the setting when the per-volume value is zero, and takes effect on (re)attach.

#### Special notes for your reviewer:

Depends on https://github.com/longhorn/types/pull/118 and https://github.com/longhorn/longhorn-instance-manager/pull/1605. A vendor bump commit follows once they merge.

#### Additional documentation or context

Verified end to end on a test cluster running upstream master: the storage class parameter and the setting fallback each produce the requested queue count (`/sys/class/nvme/<ctrl>/queue_count`, `creating N I/O queues` in the kernel log), a changed value applies from the next reattach, and a volume with neither set keeps the kernel default.
