### PR TITLE
fix(csi): ignore terminal workloads in NodePublishVolume

### DIFF
--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -201,8 +201,8 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	podsStatus := ns.collectWorkloadPodsStatus(volume, log)
-	if len(podsStatus[corev1.PodPending]) == 0 && len(podsStatus[corev1.PodRunning]) != len(volume.KubernetesStatus.WorkloadsStatus) {
-		return nil, status.Errorf(codes.Aborted, "no %v workload pods for volume %v to be mounted: %+v", corev1.PodPending, volumeID, podsStatus)
+	if !isWorkloadMountReady(podsStatus) {
+		return nil, status.Errorf(codes.Aborted, "volume %v workload pods are not ready to be mounted: %+v", volumeID, podsStatus)
 	}
 
 	// It may be necessary to restage the volume before we can publish it. For example, sometimes kubelet calls
@@ -291,6 +291,34 @@ func (ns *NodeServer) collectWorkloadPodsStatus(volume *longhornclient.Volume, l
 	}
 
 	return podsStatus
+}
+
+// isWorkloadMountReady reports whether NodePublishVolume may proceed based on workload pod states.
+// A volume is considered mount-ready if any of the following is true:
+//   - No workload pod status is recorded; an empty status alone is not sufficient
+//     to reject the mount.
+//   - At least one workload pod is Pending.
+//   - At least one non-terminal workload pod exists and all non-terminal workload pods are Running.
+//
+// Failed and Succeeded workload pods are treated as terminal and excluded from
+// the non-terminal readiness check.
+func isWorkloadMountReady(podsStatus map[corev1.PodPhase][]string) bool {
+	if len(podsStatus[corev1.PodPending]) > 0 {
+		return true
+	}
+	workloadCount := 0
+	for _, pods := range podsStatus {
+		workloadCount += len(pods)
+	}
+	if workloadCount == 0 {
+		return true
+	}
+	terminalWorkloadCount := len(podsStatus[corev1.PodFailed]) + len(podsStatus[corev1.PodSucceeded])
+	nonTerminalWorkloadCount := workloadCount - terminalWorkloadCount
+	if nonTerminalWorkloadCount == 0 {
+		return false
+	}
+	return len(podsStatus[corev1.PodRunning]) == nonTerminalWorkloadCount
 }
 
 func (ns *NodeServer) nodeStageSharedVolume(volumeID, shareEndpoint, targetPath string, mounter mount.Interface, customMountOptions []string) error {

--- a/csi/node_server_test.go
+++ b/csi/node_server_test.go
@@ -10,6 +10,8 @@ import (
 
 	csipb "github.com/container-storage-interface/spec/lib/go/csi"
 
+	corev1 "k8s.io/api/core/v1"
+
 	longhornclient "github.com/longhorn/longhorn-manager/client"
 )
 
@@ -125,6 +127,137 @@ func TestGetV2VolumeEndpointForNode(t *testing.T) {
 			}
 			if endpoint != tc.expected {
 				t.Fatalf("expected endpoint %q, got %q", tc.expected, endpoint)
+			}
+		})
+	}
+}
+
+func newWorkloadStatus(podName, podStatus string) longhornclient.WorkloadStatus {
+	return longhornclient.WorkloadStatus{
+		PodName:   podName,
+		PodStatus: podStatus,
+	}
+}
+
+func TestIsWorkloadMountReady(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		workloads []longhornclient.WorkloadStatus
+		ready     bool
+	}{
+		{
+			name:      "empty workloads (first mount)",
+			workloads: nil,
+			ready:     true,
+		},
+		{
+			name: "all running",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("pod-a", string(corev1.PodRunning)),
+				newWorkloadStatus("pod-b", string(corev1.PodRunning)),
+			},
+			ready: true,
+		},
+		{
+			name: "running with retained failed workloads (regression for #13723)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("failed-2", string(corev1.PodFailed)),
+				newWorkloadStatus("failed-3", string(corev1.PodFailed)),
+				newWorkloadStatus("failed-4", string(corev1.PodFailed)),
+				newWorkloadStatus("running-1", string(corev1.PodRunning)),
+				newWorkloadStatus("running-2", string(corev1.PodRunning)),
+			},
+			ready: true,
+		},
+		{
+			name: "running plus succeeded",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("succeeded-1", string(corev1.PodSucceeded)),
+				newWorkloadStatus("running-1", string(corev1.PodRunning)),
+			},
+			ready: true,
+		},
+		{
+			name: "all failed",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("failed-2", string(corev1.PodFailed)),
+			},
+			ready: false,
+		},
+		{
+			name: "all succeeded",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("succ-1", string(corev1.PodSucceeded)),
+			},
+			ready: false,
+		},
+		{
+			name: "all terminal (failed and succeeded mixed)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("succ-1", string(corev1.PodSucceeded)),
+			},
+			ready: false,
+		},
+		{
+			name: "pending only (new pod starting)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("pending-1", string(corev1.PodPending)),
+			},
+			ready: true,
+		},
+		{
+			name: "pending plus running plus failed (pod rolling update)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("running-1", string(corev1.PodRunning)),
+				newWorkloadStatus("pending-1", string(corev1.PodPending)),
+			},
+			ready: true,
+		},
+		{
+			name: "pending plus failed (new pod replacing failed)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("pending-1", string(corev1.PodPending)),
+			},
+			ready: true,
+		},
+		{
+			name: "unknown only (node unreachable, no running pods)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("unknown-1", string(corev1.PodUnknown)),
+			},
+			ready: false,
+		},
+		{
+			name: "running plus unknown (transitioning state)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("running-1", string(corev1.PodRunning)),
+				newWorkloadStatus("unknown-1", string(corev1.PodUnknown)),
+			},
+			ready: false,
+		},
+		{
+			name: "unknown plus failed (node failure scenario)",
+			workloads: []longhornclient.WorkloadStatus{
+				newWorkloadStatus("failed-1", string(corev1.PodFailed)),
+				newWorkloadStatus("unknown-1", string(corev1.PodUnknown)),
+			},
+			ready: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			podsStatus := map[corev1.PodPhase][]string{}
+			for _, w := range tc.workloads {
+				phase := corev1.PodPhase(w.PodStatus)
+				podsStatus[phase] = append(podsStatus[phase], w.PodName)
+			}
+			got := isWorkloadMountReady(podsStatus)
+			if got != tc.ready {
+				t.Errorf("isWorkloadMountReady() = %v, want %v; podsStatus=%+v", got, tc.ready, podsStatus)
 			}
 		})
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13723

#### What this PR does / why we need it:

`NodePublishVolume` currently compares the number of workload Pods whose recorded phase is `Running` with the total number of entries in `volume.KubernetesStatus.WorkloadsStatus`.

Terminal workload Pods (`Failed` or `Succeeded`) may remain in the Kubernetes API and consequently remain in `WorkloadsStatus` after replacement/current workload Pods have been created.

In the reported case, the phases recorded in `WorkloadsStatus` were:

```text
Running = 2
Failed  = 4
Pending = 0
Total   = 6
```

The existing validation evaluates:

```text
Pending == 0 && Running != Total
0 == 0       && 2 != 6
```

and continuously returns:

```text
codes.Aborted:
no Pending workload pods for volume ... to be mounted
```

Kubelet retried the mount 497 times over approximately 19 hours.

As a manual verification, deleting only the four retained `Failed` Pod objects allowed the current workload Pods to continue the volume mount/recovery path. No Longhorn Volume, Engine, Replica, or VolumeAttachment resources were manually modified.

This PR keeps `KubernetesStatus.WorkloadsStatus` unchanged and modifies only the CSI consumer-side validation.

Terminal workload entries (`Failed` and `Succeeded`) are excluded from the workload count used by the `NodePublishVolume` validation.

The existing behavior is preserved for non-terminal workload states such as `Pending` and `Unknown`, and when there is no valid running workload.

#### Special notes for your reviewer:

The fix is intentionally implemented in the CSI consumer rather than filtering terminal Pods when `KubernetesStatus.WorkloadsStatus` is generated.

This keeps the impact minimal and avoids changing the semantics of `WorkloadsStatus` for other Longhorn consumers.

The workload validation occurs before the existing restage recovery path. Repeated `codes.Aborted` responses therefore prevent the request from reaching the existing `restageRequired()` / `NodeUnstageVolume()` / `NodeStageVolume()` recovery logic.

The affected environment showed an important distinction between the Pod phase recorded by Longhorn and the status displayed by `kubectl`: the two current Pods were recorded with phase `Running` in `WorkloadsStatus`, while `kubectl get pods` displayed them as `Unknown` with `READY=0/1` during the mount failure.

After only the four retained `Failed` Pod objects were deleted, the two current Pods successfully completed the mount/recovery process and subsequently became `Running`.

#### Additional documentation or context

The issue contains the full reproduction details, workload status information, kubelet events, and the manual recovery verification:

longhorn/longhorn#13723