### PR TITLE
feat(csi): add Kata confidential direct volumes

### DIFF
--- a/csi/KATA-CONFIDENTIAL-DIRECT-VOLUME.md
+++ b/csi/KATA-CONFIDENTIAL-DIRECT-VOLUME.md
@@ -1,0 +1,82 @@
+# Kata confidential direct-volume mode
+
+This opt-in Longhorn V1 CSI node path passes a raw block device to a Kata
+confidential guest without formatting, mounting, encrypting, or reading it on
+the host. It is inactive unless the provisioned volume carries the exact
+StorageClass parameter:
+
+```yaml
+allowVolumeExpansion: false
+parameters:
+  kataConfidentialDirectVolume: "true"
+  dataEngine: v1
+  encrypted: "false"
+  frontend: blockdev
+  migratable: "false"
+  numberOfReplicas: "1"
+```
+
+All unmarked volumes keep the standard Longhorn CSI path. Resize is not part of
+this profile, so its StorageClass must keep expansion disabled.
+
+## Contract
+
+The marked volume must be a filesystem-mode, `ReadWriteOncePod`, ext4 PVC with
+one Longhorn V1 replica, the block-device frontend, and no Longhorn host
+encryption or migration. The PVC must explicitly use `volumeMode: Filesystem`
+and contain an immutable storage-manifest URI in this annotation:
+
+```text
+io.katacontainers.storage/confidential-manifest-uri
+```
+
+The URI must have the canonical `kbs:///repository/type/tag` form. Query
+parameters, fragments, path traversal, and the legacy key/volume annotations
+are rejected before lifecycle state is created.
+
+The external provisioner runs with `--extra-create-metadata=true`, allowing the
+node plugin to find the PVC without copying its annotation into Longhorn volume
+parameters or lifecycle state.
+
+`NodeStageVolume` validates the attached raw endpoint and persists only bounded
+cleanup metadata. `NodePublishVolume` invokes the host's exact runtime-rs
+`/opt/kata/bin/kata-ctl` through the existing namespace helper and registers
+this typed mount object:
+
+```json
+{
+  "volume-type": "directvol",
+  "device": "/dev/longhorn/example-volume",
+  "fstype": "confidential-storage",
+  "confidential-storage": {
+    "manifest-uri": "kbs:///tenant/storage-manifests/workspace-v1",
+    "requested-access": "readWrite"
+  }
+}
+```
+
+Requested access is derived from the CSI `NodePublishVolume` request; v1
+accepts only read-write publication. The outer fstype is a fail-closed protocol
+discriminator. Kata validates the typed object, matches the manifest, access,
+and container mount to measured Agent policy, and asks CDH to resolve and
+enforce the manifest. Older Kata components that do not understand the object
+fail on the unknown fstype rather than silently mounting a raw ext4 device.
+
+No key, protection profile, filesystem parameters, or plaintext are present in
+CSI requests, lifecycle state, mount metadata, command output, or logs.
+Longhorn transports only the raw ciphertext device and non-secret activation
+intent. CDH owns LUKS2, dm-integrity, and ext4 initialization or reopen; Kata
+mounts only the mapper device returned by CDH.
+
+Unpublish and unstage remove Kata registration and lifecycle state
+idempotently. Volume statistics are requested from the guest through Kata.
+`NodeExpandVolume` returns a stable `FailedPrecondition` without mutation.
+
+## Runtime prerequisite
+
+The CSI plugin must run on a node whose host root contains the matching
+runtime-rs `/opt/kata/bin/kata-ctl`. The plugin uses `nsmounter --host-root` so the
+runtime observes the host's direct-volume registry and shim sockets. Kata
+command diagnostics are returned with an 8 KiB bound; the contract forbids
+secret material in those commands. If this prerequisite or any validation
+fails, the operation fails closed and never falls back to the host-mount path.

--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -125,6 +125,7 @@ func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, rootD
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 			"--default-fstype=ext4",
+			"--extra-create-metadata=true",
 			"--enable-capacity",
 			"--capacity-ownerref-level=2",
 			"--immediate-topology=false",
@@ -523,6 +524,10 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 									MountPath: "/lib/modules",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "kata-confidential-direct-volume-state",
+									MountPath: kataConfidentialDirectVolumeStateDir,
+								},
 							},
 						},
 					},
@@ -592,6 +597,15 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/lib/modules",
+								},
+							},
+						},
+						{
+							Name: "kata-confidential-direct-volume-state",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kataConfidentialDirectVolumeStateDir,
+									Type: &HostPathDirectoryOrCreate,
 								},
 							},
 						},

--- a/csi/kata_confidential_direct_volume.go
+++ b/csi/kata_confidential_direct_volume.go
@@ -1,0 +1,629 @@
+package csi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilexec "k8s.io/utils/exec"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhornclient "github.com/longhorn/longhorn-manager/client"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+const (
+	kataConfidentialDirectVolumeParameter           = "kataConfidentialDirectVolume"
+	kataConfidentialStorageManifestURIAnnotation    = "io.katacontainers.storage/confidential-manifest-uri"
+	kataConfidentialStorageLegacyKeyURIAnnotation   = "io.katacontainers.storage/confidential-key-uri"
+	kataConfidentialStorageLegacyVolumeIDAnnotation = "io.katacontainers.storage/confidential-volume-id"
+	kataConfidentialStorageFSType                   = "confidential-storage"
+	kataConfidentialStorageVolumeIDMaxBytes         = 256
+	kataConfidentialStorageManifestURIMaxBytes      = 2048
+
+	csiPVCNameKey      = "csi.storage.k8s.io/pvc/name"
+	csiPVCNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+
+	kataConfidentialDirectVolumeStateDir = "/var/lib/longhorn/kata-confidential-direct-volumes"
+	kataCtlPath                          = "/opt/kata/bin/kata-ctl"
+	nsMounterPath                        = "/usr/local/sbin/nsmounter"
+
+	kataConfidentialDirectVolumeResizeUnsupported = "Kata confidential direct volumes do not support resize"
+)
+
+type kataConfidentialDirectVolumeMountInfo struct {
+	VolumeType          string                           `json:"volume-type"`
+	Device              string                           `json:"device"`
+	FsType              string                           `json:"fstype"`
+	ConfidentialStorage *kataConfidentialStorageContract `json:"confidential-storage,omitempty"`
+}
+
+type kataConfidentialStorageContract struct {
+	ManifestURI     string `json:"manifest-uri"`
+	RequestedAccess string `json:"requested-access"`
+}
+
+type kataConfidentialDirectVolumeState struct {
+	VolumeID          string   `json:"volumeID"`
+	StagingTargetPath string   `json:"stagingTargetPath"`
+	DevicePath        string   `json:"devicePath"`
+	PublishedPaths    []string `json:"publishedPaths,omitempty"`
+}
+
+type kataDirectVolumeRuntime interface {
+	Add(ctx context.Context, targetPath string, mountInfo kataConfidentialDirectVolumeMountInfo) error
+	Remove(ctx context.Context, targetPath string) error
+	Stats(ctx context.Context, targetPath string) ([]byte, error)
+}
+
+type kataConfidentialDirectVolumeOperations interface {
+	IsManaged(volumeID string) (bool, error)
+	Stage(volumeID, stagingTargetPath, devicePath string) error
+	Publish(ctx context.Context, volumeID, targetPath string, mountInfo kataConfidentialDirectVolumeMountInfo) error
+	Unpublish(ctx context.Context, volumeID, targetPath string) error
+	Unstage(ctx context.Context, volumeID string) error
+	Stats(ctx context.Context, volumeID, targetPath string) (*csi.NodeGetVolumeStatsResponse, error)
+}
+
+type hostKataCtl struct {
+	run func(ctx context.Context, command string, args ...string) ([]byte, error)
+}
+
+func (r *hostKataCtl) command(ctx context.Context, args ...string) ([]byte, error) {
+	commandArgs := []string{"--host-root", kataCtlPath, "direct-volume"}
+	commandArgs = append(commandArgs, args...)
+	run := r.run
+	if run == nil {
+		run = func(ctx context.Context, command string, args ...string) ([]byte, error) {
+			return utilexec.New().CommandContext(ctx, command, args...).CombinedOutput()
+		}
+	}
+	output, err := run(ctx, nsMounterPath, commandArgs...)
+	if err != nil {
+		action := "unknown"
+		if len(args) != 0 {
+			action = args[0]
+		}
+		return nil, fmt.Errorf("host Kata direct-volume %s failed: %w; output: %s", action, err, boundedKataCommandOutput(output))
+	}
+	return output, nil
+}
+
+func boundedKataCommandOutput(output []byte) string {
+	const maxBytes = 8192
+	truncated := len(output) > maxBytes
+	if truncated {
+		output = output[:maxBytes]
+	}
+	message := strings.Map(func(character rune) rune {
+		if character == '\n' || character == '\t' || character >= ' ' {
+			return character
+		}
+		return '�'
+	}, strings.TrimSpace(string(output)))
+	if truncated {
+		message += " [truncated]"
+	}
+	return message
+}
+
+func (r *hostKataCtl) Add(ctx context.Context, targetPath string, mountInfo kataConfidentialDirectVolumeMountInfo) error {
+	encoded, err := json.Marshal(mountInfo)
+	if err != nil {
+		return fmt.Errorf("failed to encode Kata direct-volume mount metadata: %w", err)
+	}
+	_, err = r.command(ctx, "add", "--volume-path", targetPath, "--mount-info", string(encoded))
+	return err
+}
+
+func (r *hostKataCtl) Remove(ctx context.Context, targetPath string) error {
+	_, err := r.command(ctx, "remove", "--volume-path", targetPath)
+	return err
+}
+
+func (r *hostKataCtl) Stats(ctx context.Context, targetPath string) ([]byte, error) {
+	return r.command(ctx, "stats", "--volume-path", targetPath)
+}
+
+type kataConfidentialDirectVolumeManager struct {
+	mu       sync.Mutex
+	stateDir string
+	runtime  kataDirectVolumeRuntime
+}
+
+func newKataConfidentialDirectVolumeManager() *kataConfidentialDirectVolumeManager {
+	return &kataConfidentialDirectVolumeManager{
+		stateDir: kataConfidentialDirectVolumeStateDir,
+		runtime:  &hostKataCtl{},
+	}
+}
+
+func (m *kataConfidentialDirectVolumeManager) statePath(volumeID string) string {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(volumeID))
+	return filepath.Join(m.stateDir, encoded+".json")
+}
+
+func (m *kataConfidentialDirectVolumeManager) loadLocked(volumeID string) (*kataConfidentialDirectVolumeState, error) {
+	data, err := os.ReadFile(m.statePath(volumeID))
+	if err != nil {
+		return nil, err
+	}
+	state := &kataConfidentialDirectVolumeState{}
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, fmt.Errorf("invalid confidential direct-volume lifecycle metadata: %w", err)
+	}
+	if state.VolumeID != volumeID || state.StagingTargetPath == "" || state.DevicePath == "" {
+		return nil, fmt.Errorf("invalid confidential direct-volume lifecycle metadata for volume %q", volumeID)
+	}
+	return state, nil
+}
+
+func (m *kataConfidentialDirectVolumeManager) saveLocked(state *kataConfidentialDirectVolumeState) (err error) {
+	if err := os.MkdirAll(m.stateDir, 0700); err != nil {
+		return fmt.Errorf("failed to create confidential direct-volume state directory: %w", err)
+	}
+	if err := os.Chmod(m.stateDir, 0700); err != nil {
+		return fmt.Errorf("failed to protect confidential direct-volume state directory: %w", err)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to encode confidential direct-volume lifecycle metadata: %w", err)
+	}
+	tmp, err := os.CreateTemp(m.stateDir, ".kata-confidential-direct-volume-*")
+	if err != nil {
+		return fmt.Errorf("failed to create confidential direct-volume state file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if cleanupErr := os.Remove(tmpPath); cleanupErr != nil && !os.IsNotExist(cleanupErr) && err == nil {
+			err = fmt.Errorf("failed to remove temporary confidential direct-volume state file: %w", cleanupErr)
+		}
+	}()
+	if err := tmp.Chmod(0600); err != nil {
+		return closeTemporaryStateFile(tmp, "failed to protect confidential direct-volume state file", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return closeTemporaryStateFile(tmp, "failed to write confidential direct-volume lifecycle metadata", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return closeTemporaryStateFile(tmp, "failed to sync confidential direct-volume lifecycle metadata", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close confidential direct-volume state file: %w", err)
+	}
+	if err := os.Rename(tmpPath, m.statePath(state.VolumeID)); err != nil {
+		return fmt.Errorf("failed to persist confidential direct-volume lifecycle metadata: %w", err)
+	}
+	dir, err := os.Open(m.stateDir)
+	if err != nil {
+		return fmt.Errorf("failed to open confidential direct-volume state directory: %w", err)
+	}
+	if err := dir.Sync(); err != nil {
+		if closeErr := dir.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close confidential direct-volume state directory: %w", closeErr))
+		}
+		return fmt.Errorf("failed to sync confidential direct-volume state directory: %w", err)
+	}
+	if err := dir.Close(); err != nil {
+		return fmt.Errorf("failed to close confidential direct-volume state directory: %w", err)
+	}
+	return nil
+}
+
+func closeTemporaryStateFile(file *os.File, operation string, operationErr error) error {
+	if closeErr := file.Close(); closeErr != nil {
+		operationErr = errors.Join(operationErr, fmt.Errorf("failed to close confidential direct-volume state file: %w", closeErr))
+	}
+	return fmt.Errorf("%s: %w", operation, operationErr)
+}
+
+func (m *kataConfidentialDirectVolumeManager) IsManaged(volumeID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, err := m.loadLocked(volumeID)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (m *kataConfidentialDirectVolumeManager) Stage(volumeID, stagingTargetPath, devicePath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, err := m.loadLocked(volumeID)
+	if err == nil {
+		if state.StagingTargetPath != stagingTargetPath || state.DevicePath != devicePath {
+			return fmt.Errorf("confidential direct volume %q is already staged with different non-secret metadata", volumeID)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+	return m.saveLocked(&kataConfidentialDirectVolumeState{
+		VolumeID:          volumeID,
+		StagingTargetPath: stagingTargetPath,
+		DevicePath:        devicePath,
+	})
+}
+
+func (m *kataConfidentialDirectVolumeManager) Publish(ctx context.Context, volumeID, targetPath string, mountInfo kataConfidentialDirectVolumeMountInfo) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, err := m.loadLocked(volumeID)
+	if err != nil {
+		return err
+	}
+	if state.DevicePath != mountInfo.Device {
+		return fmt.Errorf("confidential direct volume %q device changed between stage and publish", volumeID)
+	}
+	knownTarget := false
+	for _, publishedPath := range state.PublishedPaths {
+		if publishedPath == targetPath {
+			knownTarget = true
+			break
+		}
+	}
+	if !knownTarget {
+		state.PublishedPaths = append(state.PublishedPaths, targetPath)
+		sort.Strings(state.PublishedPaths)
+		// Persist the cleanup intent before invoking Kata. If registration fails,
+		// Unpublish/Unstage can still remove any partial runtime state.
+		if err := m.saveLocked(state); err != nil {
+			return err
+		}
+	}
+	return m.runtime.Add(ctx, targetPath, mountInfo)
+}
+
+func (m *kataConfidentialDirectVolumeManager) Unpublish(ctx context.Context, volumeID, targetPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, err := m.loadLocked(volumeID)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	knownTarget := false
+	for _, publishedPath := range state.PublishedPaths {
+		if publishedPath == targetPath {
+			knownTarget = true
+			break
+		}
+	}
+	if !knownTarget {
+		return nil
+	}
+	if err := m.runtime.Remove(ctx, targetPath); err != nil {
+		return err
+	}
+	paths := state.PublishedPaths[:0]
+	for _, publishedPath := range state.PublishedPaths {
+		if publishedPath != targetPath {
+			paths = append(paths, publishedPath)
+		}
+	}
+	state.PublishedPaths = paths
+	return m.saveLocked(state)
+}
+
+func (m *kataConfidentialDirectVolumeManager) Unstage(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, err := m.loadLocked(volumeID)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, targetPath := range state.PublishedPaths {
+		if err := m.runtime.Remove(ctx, targetPath); err != nil {
+			return err
+		}
+	}
+	if err := os.Remove(m.statePath(volumeID)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove confidential direct-volume lifecycle metadata: %w", err)
+	}
+	return nil
+}
+
+func (m *kataConfidentialDirectVolumeManager) Stats(ctx context.Context, volumeID, targetPath string) (*csi.NodeGetVolumeStatsResponse, error) {
+	m.mu.Lock()
+	state, err := m.loadLocked(volumeID)
+	m.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	knownTarget := false
+	for _, publishedPath := range state.PublishedPaths {
+		if publishedPath == targetPath {
+			knownTarget = true
+			break
+		}
+	}
+	if !knownTarget {
+		return nil, fmt.Errorf("confidential direct volume %q is not published at the requested path", volumeID)
+	}
+	data, err := m.runtime.Stats(ctx, targetPath)
+	if err != nil {
+		return nil, err
+	}
+	var stats struct {
+		Usage []struct {
+			Available uint64 `json:"available"`
+			Total     uint64 `json:"total"`
+			Used      uint64 `json:"used"`
+			Unit      int32  `json:"unit"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &stats); err != nil {
+		return nil, fmt.Errorf("failed to decode redacted Kata direct-volume statistics: %w", err)
+	}
+	response := &csi.NodeGetVolumeStatsResponse{}
+	for _, usage := range stats.Usage {
+		if usage.Available > math.MaxInt64 || usage.Total > math.MaxInt64 || usage.Used > math.MaxInt64 {
+			return nil, fmt.Errorf("kata direct-volume statistics exceed CSI signed integer range")
+		}
+		unit := csi.VolumeUsage_Unit(usage.Unit)
+		if unit != csi.VolumeUsage_BYTES && unit != csi.VolumeUsage_INODES {
+			return nil, fmt.Errorf("kata direct-volume statistics contain unsupported unit %d", usage.Unit)
+		}
+		response.Usage = append(response.Usage, &csi.VolumeUsage{
+			Available: int64(usage.Available),
+			Total:     int64(usage.Total),
+			Used:      int64(usage.Used),
+			Unit:      unit,
+		})
+	}
+	return response, nil
+}
+
+func kataConfidentialDirectVolumeRequested(volumeContext map[string]string) (bool, error) {
+	value, exists := volumeContext[kataConfidentialDirectVolumeParameter]
+	if !exists {
+		return false, nil
+	}
+	if value != "true" {
+		return false, status.Errorf(codes.InvalidArgument, "%s must be exactly true when present", kataConfidentialDirectVolumeParameter)
+	}
+	return true, nil
+}
+
+func (ns *NodeServer) kataConfidentialDirectVolumeMode(volumeID string, volumeContext map[string]string) (bool, error) {
+	requested, err := kataConfidentialDirectVolumeRequested(volumeContext)
+	if err != nil {
+		return false, err
+	}
+	if requested {
+		return true, nil
+	}
+	managed, err := ns.directVolumes.IsManaged(volumeID)
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "failed to read confidential direct-volume lifecycle metadata: %v", err)
+	}
+	if managed {
+		return false, status.Error(codes.FailedPrecondition, "confidential direct-volume marker is missing from a managed volume")
+	}
+	return false, nil
+}
+
+func validateKataConfidentialDirectVolume(volume *longhornclient.Volume, capability *csi.VolumeCapability) (string, error) {
+	if volume == nil {
+		return "", status.Error(codes.NotFound, "confidential direct volume is missing")
+	}
+	if !canonicalKataConfidentialVolumeID(volume.Name) {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volume has an invalid volume ID")
+	}
+	if capability.GetMount() == nil {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes require filesystem volume mode")
+	}
+	if capability.GetAccessMode() == nil || capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes require ReadWriteOncePod access")
+	}
+	if capability.GetMount().GetFsType() != defaultFsType {
+		return "", status.Errorf(codes.InvalidArgument, "confidential direct volumes require %s", defaultFsType)
+	}
+	if len(capability.GetMount().GetMountFlags()) != 0 {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes do not accept host mount flags")
+	}
+	if volume.AccessMode != string(longhorn.AccessModeReadWriteOncePod) {
+		return "", status.Error(codes.InvalidArgument, "Longhorn volume is not ReadWriteOncePod")
+	}
+	if volume.Encrypted {
+		return "", status.Error(codes.InvalidArgument, "Longhorn host encryption is forbidden for confidential direct volumes")
+	}
+	if volume.Migratable {
+		return "", status.Error(codes.InvalidArgument, "migration is forbidden for confidential direct volumes")
+	}
+	if volume.NumberOfReplicas != 1 {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes require exactly one Longhorn replica")
+	}
+	if !types.IsDataEngineV1(longhorn.DataEngineType(volume.DataEngine)) {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes require Longhorn data engine v1")
+	}
+	if volume.DisableFrontend || volume.Frontend != string(longhorn.VolumeFrontendBlockDev) {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes require the raw block-device frontend")
+	}
+	if len(volume.Controllers) != 1 {
+		return "", status.Errorf(codes.InvalidArgument, "confidential direct volume has invalid controller count %d", len(volume.Controllers))
+	}
+	if volume.State != string(longhorn.VolumeStateAttached) || !volume.Ready {
+		return "", status.Error(codes.FailedPrecondition, "confidential direct volume is not attached and ready")
+	}
+	devicePath := volume.Controllers[0].Endpoint
+	if !filepath.IsAbs(devicePath) || filepath.Clean(devicePath) != devicePath || devicePath == "/" {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volume has an invalid raw endpoint")
+	}
+	if devicePath != filepath.Join("/dev/longhorn", volume.Name) {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volume endpoint is not the expected Longhorn raw device")
+	}
+	return devicePath, nil
+}
+
+func canonicalKataConfidentialVolumeID(value string) bool {
+	if value == "" || len(value) > kataConfidentialStorageVolumeIDMaxBytes {
+		return false
+	}
+	for _, component := range strings.Split(value, "/") {
+		if component == "" || component == "." || component == ".." {
+			return false
+		}
+	}
+	return strings.IndexFunc(value, func(character rune) bool {
+		return !(character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			strings.ContainsRune("-_.:/@", character))
+	}) == -1
+}
+
+func canonicalKataConfidentialManifestURI(value string) bool {
+	if len(value) <= len("kbs:///") ||
+		len(value) > kataConfidentialStorageManifestURIMaxBytes ||
+		!strings.HasPrefix(value, "kbs:///") ||
+		strings.ContainsAny(value, "?#") {
+		return false
+	}
+
+	components := strings.Split(strings.TrimPrefix(value, "kbs:///"), "/")
+	if len(components) != 3 {
+		return false
+	}
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." ||
+			strings.IndexFunc(component, func(character rune) bool {
+				return !(character >= 'a' && character <= 'z' ||
+					character >= 'A' && character <= 'Z' ||
+					character >= '0' && character <= '9' ||
+					strings.ContainsRune("-_.", character))
+			}) != -1 {
+			return false
+		}
+	}
+	return true
+}
+
+func (ns *NodeServer) kataConfidentialStorageManifestURI(ctx context.Context, volumeContext map[string]string) (string, error) {
+	pvcName := volumeContext[csiPVCNameKey]
+	pvcNamespace := volumeContext[csiPVCNamespaceKey]
+	if pvcName == "" || pvcNamespace == "" {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volume is missing external-provisioner PVC metadata")
+	}
+	claim, err := ns.kubeClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to read confidential direct-volume PVC metadata: %v", err)
+	}
+	if len(claim.Spec.AccessModes) != 1 || claim.Spec.AccessModes[0] != corev1.ReadWriteOncePod {
+		return "", status.Error(codes.InvalidArgument, "confidential direct-volume PVC must use only ReadWriteOncePod")
+	}
+	if claim.Spec.VolumeMode == nil || *claim.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
+		return "", status.Error(codes.InvalidArgument, "confidential direct-volume PVC must explicitly use Filesystem volume mode")
+	}
+	if _, exists := claim.Annotations[kataConfidentialStorageLegacyKeyURIAnnotation]; exists {
+		return "", status.Error(codes.InvalidArgument, "confidential direct-volume PVC contains legacy key URI metadata")
+	}
+	if _, exists := claim.Annotations[kataConfidentialStorageLegacyVolumeIDAnnotation]; exists {
+		return "", status.Error(codes.InvalidArgument, "confidential direct-volume PVC contains legacy volume ID metadata")
+	}
+	manifestURI := claim.Annotations[kataConfidentialStorageManifestURIAnnotation]
+	if !canonicalKataConfidentialManifestURI(manifestURI) {
+		return "", status.Error(codes.InvalidArgument, "confidential storage manifest URI must be a canonical immutable KBS resource URI")
+	}
+	return manifestURI, nil
+}
+
+func kataConfidentialStorageRequestedAccess(readOnly bool) (string, error) {
+	if readOnly {
+		return "", status.Error(codes.InvalidArgument, "confidential direct volumes do not support read-only publication")
+	}
+	return "readWrite", nil
+}
+
+func (ns *NodeServer) nodeStageKataConfidentialDirectVolume(ctx context.Context, req *csi.NodeStageVolumeRequest, volume *longhornclient.Volume) (*csi.NodeStageVolumeResponse, error) {
+	if len(req.GetSecrets()) != 0 {
+		return nil, status.Error(codes.InvalidArgument, "confidential direct volumes reject CSI node secrets")
+	}
+	devicePath, err := validateKataConfidentialDirectVolume(volume, req.GetVolumeCapability())
+	if err != nil {
+		return nil, err
+	}
+	if !cleanAbsolutePath(req.GetStagingTargetPath()) {
+		return nil, status.Error(codes.InvalidArgument, "confidential direct volume has an invalid staging target path")
+	}
+	if _, err := ns.kataConfidentialStorageManifestURI(ctx, req.GetVolumeContext()); err != nil {
+		return nil, err
+	}
+	if err := ns.directVolumes.Stage(req.GetVolumeId(), req.GetStagingTargetPath(), devicePath); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist confidential direct-volume lifecycle metadata: %v", err)
+	}
+	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+func (ns *NodeServer) nodePublishKataConfidentialDirectVolume(ctx context.Context, req *csi.NodePublishVolumeRequest, volume *longhornclient.Volume) (*csi.NodePublishVolumeResponse, error) {
+	if len(req.GetSecrets()) != 0 {
+		return nil, status.Error(codes.InvalidArgument, "confidential direct volumes reject CSI node secrets")
+	}
+	devicePath, err := validateKataConfidentialDirectVolume(volume, req.GetVolumeCapability())
+	if err != nil {
+		return nil, err
+	}
+	if !cleanAbsolutePath(req.GetStagingTargetPath()) || !cleanAbsolutePath(req.GetTargetPath()) {
+		return nil, status.Error(codes.InvalidArgument, "confidential direct volume has an invalid publish path")
+	}
+	manifestURI, err := ns.kataConfidentialStorageManifestURI(ctx, req.GetVolumeContext())
+	if err != nil {
+		return nil, err
+	}
+	requestedAccess, err := kataConfidentialStorageRequestedAccess(req.GetReadonly())
+	if err != nil {
+		return nil, err
+	}
+	// Kubelet can call Publish without a fresh Stage after plugin restart. Stage
+	// is metadata-only for this mode, so repairing the lifecycle record here is
+	// safe and does not touch the raw device.
+	if err := ns.directVolumes.Stage(req.GetVolumeId(), req.GetStagingTargetPath(), devicePath); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist confidential direct-volume lifecycle metadata: %v", err)
+	}
+	mountInfo := kataConfidentialDirectVolumeMountInfo{
+		VolumeType: "directvol",
+		Device:     devicePath,
+		FsType:     kataConfidentialStorageFSType,
+		ConfidentialStorage: &kataConfidentialStorageContract{
+			ManifestURI:     manifestURI,
+			RequestedAccess: requestedAccess,
+		},
+	}
+	if err := ns.directVolumes.Publish(ctx, req.GetVolumeId(), req.GetTargetPath(), mountInfo); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to register confidential direct volume with Kata: %v", err)
+	}
+	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+func cleanAbsolutePath(path string) bool {
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && path != "/"
+}

--- a/csi/kata_confidential_direct_volume_deployment_test.go
+++ b/csi/kata_confidential_direct_volume_deployment_test.go
@@ -1,0 +1,65 @@
+package csi
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func TestKataConfidentialDirectVolumeDeploymentInputs(t *testing.T) {
+	provisioner := NewProvisionerDeployment(
+		"longhorn-system", "longhorn-service-account", "provisioner:exact", "/var/lib/kubelet", 1,
+		DefaultCSIPodAntiAffinityPreset, nil, "", "", "", corev1.PullIfNotPresent, nil, nil,
+	)
+	if !containsString(provisioner.deployment.Spec.Template.Spec.Containers[0].Args, "--extra-create-metadata=true") {
+		t.Fatal("external-provisioner is missing --extra-create-metadata=true")
+	}
+
+	plugin := NewPluginDeployment(
+		"longhorn-system", "longhorn-service-account", "registrar:exact", "liveness:exact", "manager:exact",
+		"http://longhorn-backend:9500/v1", "/var/lib/kubelet", nil, "", "", "", corev1.PullIfNotPresent,
+		nil, &longhorn.Setting{Value: string(types.CniNetworkNone)}, nil, false,
+	)
+	var pluginContainer *corev1.Container
+	for i := range plugin.daemonSet.Spec.Template.Spec.Containers {
+		container := &plugin.daemonSet.Spec.Template.Spec.Containers[i]
+		if container.Name == types.CSIPluginName {
+			pluginContainer = container
+			break
+		}
+	}
+	if pluginContainer == nil {
+		t.Fatal("CSI plugin container missing")
+	}
+	foundMount := false
+	for _, volumeMount := range pluginContainer.VolumeMounts {
+		if volumeMount.Name == "kata-confidential-direct-volume-state" && volumeMount.MountPath == kataConfidentialDirectVolumeStateDir {
+			foundMount = true
+		}
+	}
+	if !foundMount {
+		t.Fatal("CSI plugin is missing confidential direct-volume state mount")
+	}
+	foundVolume := false
+	for _, volume := range plugin.daemonSet.Spec.Template.Spec.Volumes {
+		if volume.Name == "kata-confidential-direct-volume-state" && volume.HostPath != nil && volume.HostPath.Path == kataConfidentialDirectVolumeStateDir && volume.HostPath.Type != nil && *volume.HostPath.Type == corev1.HostPathDirectoryOrCreate {
+			foundVolume = true
+		}
+	}
+	if !foundVolume {
+		t.Fatal("CSI plugin is missing confidential direct-volume state hostPath")
+	}
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}

--- a/csi/kata_confidential_direct_volume_test.go
+++ b/csi/kata_confidential_direct_volume_test.go
@@ -1,0 +1,575 @@
+package csi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	longhornclient "github.com/longhorn/longhorn-manager/client"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+const testKataConfidentialManifestURI = "kbs:///tenant/storage-manifests/workspace-v1"
+
+type fakeKataDirectVolumeRuntime struct {
+	adds       []kataConfidentialDirectVolumeMountInfo
+	addTargets []string
+	removes    []string
+	stats      []byte
+	err        error
+}
+
+func (r *fakeKataDirectVolumeRuntime) Add(_ context.Context, targetPath string, mountInfo kataConfidentialDirectVolumeMountInfo) error {
+	r.addTargets = append(r.addTargets, targetPath)
+	r.adds = append(r.adds, mountInfo)
+	return r.err
+}
+
+func (r *fakeKataDirectVolumeRuntime) Remove(_ context.Context, targetPath string) error {
+	r.removes = append(r.removes, targetPath)
+	return r.err
+}
+
+func (r *fakeKataDirectVolumeRuntime) Stats(_ context.Context, _ string) ([]byte, error) {
+	return r.stats, r.err
+}
+
+func testKataConfidentialDirectVolume() *longhornclient.Volume {
+	return &longhornclient.Volume{
+		AccessMode:       string(longhorn.AccessModeReadWriteOncePod),
+		Controllers:      []longhornclient.Controller{{Endpoint: "/dev/longhorn/test-volume"}},
+		DataEngine:       string(longhorn.DataEngineTypeV1),
+		Frontend:         string(longhorn.VolumeFrontendBlockDev),
+		Name:             "test-volume",
+		NumberOfReplicas: 1,
+		Ready:            true,
+		State:            string(longhorn.VolumeStateAttached),
+	}
+}
+
+func testKataConfidentialDirectVolumeCapability() *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{FsType: defaultFsType},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+		},
+	}
+}
+
+func testKataConfidentialPVC() *corev1.PersistentVolumeClaim {
+	mode := corev1.PersistentVolumeFilesystem
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workspace",
+			Namespace: "sandbox",
+			Annotations: map[string]string{
+				kataConfidentialStorageManifestURIAnnotation: testKataConfidentialManifestURI,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+			VolumeMode:  &mode,
+		},
+	}
+}
+
+func testKataConfidentialVolumeContext() map[string]string {
+	return map[string]string{
+		kataConfidentialDirectVolumeParameter: "true",
+		csiPVCNameKey:                         "workspace",
+		csiPVCNamespaceKey:                    "sandbox",
+	}
+}
+
+func newTestKataConfidentialManager(t *testing.T, runtime kataDirectVolumeRuntime) *kataConfidentialDirectVolumeManager {
+	t.Helper()
+	return &kataConfidentialDirectVolumeManager{
+		stateDir: t.TempDir(),
+		runtime:  runtime,
+	}
+}
+
+func TestKataConfidentialDirectVolumeLifecycle(t *testing.T) {
+	ctx := context.Background()
+	runtime := &fakeKataDirectVolumeRuntime{
+		stats: []byte(`{"usage":[{"available":8,"total":10,"used":2,"unit":1},{"available":80,"total":100,"used":20,"unit":2}],"volume_condition":{"abnormal":false,"message":""}}`),
+	}
+	manager := newTestKataConfidentialManager(t, runtime)
+	ns := &NodeServer{
+		directVolumes: manager,
+		kubeClient:    fake.NewSimpleClientset(testKataConfidentialPVC()),
+		log:           logrus.New().WithField("test", "kata-confidential-direct-volume"),
+	}
+	volume := testKataConfidentialDirectVolume()
+	capability := testKataConfidentialDirectVolumeCapability()
+	volumeContext := testKataConfidentialVolumeContext()
+	stageRequest := &csi.NodeStageVolumeRequest{
+		VolumeId:          volume.Name,
+		StagingTargetPath: "/var/lib/kubelet/plugins/kubernetes.io/csi/stage/test-volume",
+		VolumeCapability:  capability,
+		VolumeContext:     volumeContext,
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := ns.nodeStageKataConfidentialDirectVolume(ctx, stageRequest, volume); err != nil {
+			t.Fatalf("stage attempt %d failed: %v", i+1, err)
+		}
+	}
+	managed, err := manager.IsManaged(volume.Name)
+	if err != nil || !managed {
+		t.Fatalf("expected staged volume to be managed, managed=%v err=%v", managed, err)
+	}
+
+	targetPath := "/var/lib/kubelet/pods/pod-id/volumes/kubernetes.io~csi/workspace/mount"
+	publishRequest := &csi.NodePublishVolumeRequest{
+		VolumeId:          volume.Name,
+		StagingTargetPath: stageRequest.StagingTargetPath,
+		TargetPath:        targetPath,
+		VolumeCapability:  capability,
+		VolumeContext:     volumeContext,
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := ns.nodePublishKataConfidentialDirectVolume(ctx, publishRequest, volume); err != nil {
+			t.Fatalf("publish attempt %d failed: %v", i+1, err)
+		}
+	}
+	if len(runtime.adds) != 2 || runtime.addTargets[0] != targetPath || runtime.addTargets[1] != targetPath {
+		t.Fatalf("expected two idempotent Kata registrations, got targets %#v", runtime.addTargets)
+	}
+	request := runtime.adds[0].ConfidentialStorage
+	if request == nil || request.ManifestURI != testKataConfidentialManifestURI || request.RequestedAccess != "readWrite" {
+		t.Fatalf("unexpected confidential storage contract: %#v", request)
+	}
+	if runtime.adds[0].VolumeType != "directvol" || runtime.adds[0].FsType != kataConfidentialStorageFSType || runtime.adds[0].Device != volume.Controllers[0].Endpoint {
+		t.Fatalf("unexpected mount info: %#v", runtime.adds[0])
+	}
+
+	stateData, err := os.ReadFile(manager.statePath(volume.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateInfo, err := os.Stat(manager.statePath(volume.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stateInfo.Mode().Perm() != 0600 {
+		t.Fatalf("unexpected lifecycle state permissions: %o", stateInfo.Mode().Perm())
+	}
+	stateDirInfo, err := os.Stat(manager.stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stateDirInfo.Mode().Perm() != 0700 {
+		t.Fatalf("unexpected lifecycle state directory permissions: %o", stateDirInfo.Mode().Perm())
+	}
+	if strings.Contains(string(stateData), testKataConfidentialManifestURI) || strings.Contains(string(stateData), "kbs://") {
+		t.Fatalf("lifecycle state contains transport metadata: %s", stateData)
+	}
+	var state kataConfidentialDirectVolumeState
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatal(err)
+	}
+	if len(state.PublishedPaths) != 1 || state.PublishedPaths[0] != targetPath {
+		t.Fatalf("unexpected published paths: %#v", state.PublishedPaths)
+	}
+
+	stats, err := ns.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{VolumeId: volume.Name, VolumePath: targetPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats.Usage) != 2 || stats.Usage[0].Total != 10 || stats.Usage[0].Unit != csi.VolumeUsage_BYTES || stats.Usage[1].Total != 100 || stats.Usage[1].Unit != csi.VolumeUsage_INODES {
+		t.Fatalf("unexpected direct-volume stats: %#v", stats)
+	}
+
+	_, err = ns.NodeExpandVolume(ctx, &csi.NodeExpandVolumeRequest{
+		VolumeId:         volume.Name,
+		CapacityRange:    &csi.CapacityRange{RequiredBytes: 20},
+		VolumeCapability: capability,
+	})
+	if status.Code(err) != codes.FailedPrecondition || status.Convert(err).Message() != kataConfidentialDirectVolumeResizeUnsupported {
+		t.Fatalf("unexpected direct-volume expansion error: %v", err)
+	}
+	stateAfterResize, err := os.ReadFile(manager.statePath(volume.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stateData, stateAfterResize) {
+		t.Fatal("resize rejection mutated confidential direct-volume lifecycle state")
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := ns.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{VolumeId: volume.Name, TargetPath: targetPath}); err != nil {
+			t.Fatalf("unpublish attempt %d failed: %v", i+1, err)
+		}
+	}
+	if len(runtime.removes) != 1 {
+		t.Fatalf("expected one Kata removal and an idempotent no-op, got %#v", runtime.removes)
+	}
+	if _, err := ns.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{VolumeId: volume.Name, StagingTargetPath: stageRequest.StagingTargetPath}); err != nil {
+		t.Fatal(err)
+	}
+	managed, err = manager.IsManaged(volume.Name)
+	if err != nil || managed {
+		t.Fatalf("expected lifecycle state removal, managed=%v err=%v", managed, err)
+	}
+}
+
+func TestKataConfidentialDirectVolumeUnstageCleansLingeringRegistration(t *testing.T) {
+	ctx := context.Background()
+	runtime := &fakeKataDirectVolumeRuntime{}
+	manager := newTestKataConfidentialManager(t, runtime)
+	if err := manager.Stage("volume", "/stage", "/dev/longhorn/volume"); err != nil {
+		t.Fatal(err)
+	}
+	info := kataConfidentialDirectVolumeMountInfo{VolumeType: "directvol", Device: "/dev/longhorn/volume", FsType: kataConfidentialStorageFSType}
+	if err := manager.Publish(ctx, "volume", "/target", info); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Unstage(ctx, "volume"); err != nil {
+		t.Fatal(err)
+	}
+	if len(runtime.removes) != 1 || runtime.removes[0] != "/target" {
+		t.Fatalf("unexpected cleanup calls: %#v", runtime.removes)
+	}
+}
+
+func TestKataConfidentialDirectVolumeCleanupRetriesAfterRuntimeFailure(t *testing.T) {
+	runtime := &fakeKataDirectVolumeRuntime{err: errors.New("runtime unavailable")}
+	manager := newTestKataConfidentialManager(t, runtime)
+	if err := manager.Stage("volume", "/stage", "/dev/longhorn/volume"); err != nil {
+		t.Fatal(err)
+	}
+	info := kataConfidentialDirectVolumeMountInfo{
+		VolumeType: "directvol",
+		Device:     "/dev/longhorn/volume",
+		FsType:     kataConfidentialStorageFSType,
+	}
+	if err := manager.Publish(context.Background(), "volume", "/target", info); err == nil {
+		t.Fatal("expected registration failure")
+	}
+
+	state, err := manager.loadLocked("volume")
+	if err != nil || len(state.PublishedPaths) != 1 || state.PublishedPaths[0] != "/target" {
+		t.Fatalf("registration failure lost cleanup intent: state=%#v err=%v", state, err)
+	}
+	if err := manager.Unstage(context.Background(), "volume"); err == nil {
+		t.Fatal("expected cleanup failure")
+	}
+	managed, err := manager.IsManaged("volume")
+	if err != nil || !managed {
+		t.Fatalf("cleanup failure lost lifecycle state: managed=%v err=%v", managed, err)
+	}
+
+	runtime.err = nil
+	if err := manager.Unstage(context.Background(), "volume"); err != nil {
+		t.Fatal(err)
+	}
+	managed, err = manager.IsManaged("volume")
+	if err != nil || managed {
+		t.Fatalf("cleanup retry did not finish: managed=%v err=%v", managed, err)
+	}
+	if len(runtime.removes) != 2 {
+		t.Fatalf("expected failed and successful cleanup attempts, got %#v", runtime.removes)
+	}
+}
+
+func TestValidateKataConfidentialDirectVolumeRejectsUnsupportedModes(t *testing.T) {
+	baseVolume := testKataConfidentialDirectVolume()
+
+	tests := []struct {
+		name   string
+		mutate func(*longhornclient.Volume, *csi.VolumeCapability)
+	}{
+		{name: "block volume mode", mutate: func(_ *longhornclient.Volume, c *csi.VolumeCapability) {
+			c.AccessType = &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}}
+		}},
+		{name: "rwo access", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.AccessMode = string(longhorn.AccessModeReadWriteOnce)
+		}},
+		{name: "non-rwop CSI mode", mutate: func(_ *longhornclient.Volume, c *csi.VolumeCapability) {
+			c.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+		}},
+		{name: "host encryption", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) { v.Encrypted = true }},
+		{name: "migration", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) { v.Migratable = true }},
+		{name: "multiple replicas", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) { v.NumberOfReplicas = 2 }},
+		{name: "v2", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.DataEngine = string(longhorn.DataEngineTypeV2)
+		}},
+		{name: "ublk", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.Frontend = string(longhorn.VolumeFrontendUblk)
+		}},
+		{name: "mount flags", mutate: func(_ *longhornclient.Volume, c *csi.VolumeCapability) { c.GetMount().MountFlags = []string{"discard"} }},
+		{name: "xfs", mutate: func(_ *longhornclient.Volume, c *csi.VolumeCapability) { c.GetMount().FsType = "xfs" }},
+		{name: "invalid volume ID", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.Name = "tenant//volume"
+		}},
+		{name: "relative endpoint", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.Controllers[0].Endpoint = "dev/longhorn/volume"
+		}},
+		{name: "non-Longhorn endpoint", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.Controllers[0].Endpoint = "/dev/nvme0n1"
+		}},
+		{name: "detached", mutate: func(v *longhornclient.Volume, _ *csi.VolumeCapability) {
+			v.State = string(longhorn.VolumeStateDetached)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			volume := *baseVolume
+			volume.Controllers = append([]longhornclient.Controller(nil), baseVolume.Controllers...)
+			capability := testKataConfidentialDirectVolumeCapability()
+			test.mutate(&volume, capability)
+			if _, err := validateKataConfidentialDirectVolume(&volume, capability); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestKataConfidentialStorageManifestURIValidation(t *testing.T) {
+	ns := &NodeServer{kubeClient: fake.NewSimpleClientset(testKataConfidentialPVC())}
+	manifestURI, err := ns.kataConfidentialStorageManifestURI(context.Background(), testKataConfidentialVolumeContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifestURI != testKataConfidentialManifestURI {
+		t.Fatalf("unexpected manifest URI: %q", manifestURI)
+	}
+
+	for _, invalidManifestURI := range []string{
+		"",
+		"https://example.invalid/manifest",
+		"kbs:///tenant/manifests/latest?revision=1",
+		"kbs:///tenant/manifests/latest#fragment",
+		"kbs:///tenant/manifest",
+		"kbs:///tenant/manifests/../latest",
+		"kbs:///tenant/manifests/not allowed",
+	} {
+		invalidClaim := testKataConfidentialPVC()
+		invalidClaim.Annotations[kataConfidentialStorageManifestURIAnnotation] = invalidManifestURI
+		ns.kubeClient = fake.NewSimpleClientset(invalidClaim)
+		if _, err := ns.kataConfidentialStorageManifestURI(context.Background(), testKataConfidentialVolumeContext()); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected manifest URI %q rejection, got %v", invalidManifestURI, err)
+		}
+	}
+
+	for _, legacyAnnotation := range []string{
+		kataConfidentialStorageLegacyKeyURIAnnotation,
+		kataConfidentialStorageLegacyVolumeIDAnnotation,
+	} {
+		legacyClaim := testKataConfidentialPVC()
+		legacyClaim.Annotations[legacyAnnotation] = "legacy-value"
+		ns.kubeClient = fake.NewSimpleClientset(legacyClaim)
+		if _, err := ns.kataConfidentialStorageManifestURI(context.Background(), testKataConfidentialVolumeContext()); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected legacy annotation %q rejection, got %v", legacyAnnotation, err)
+		}
+	}
+}
+
+func TestKataConfidentialStorageRequestedAccessIsCSIDerived(t *testing.T) {
+	access, err := kataConfidentialStorageRequestedAccess(false)
+	if err != nil || access != "readWrite" {
+		t.Fatalf("unexpected read-write access result: access=%q err=%v", access, err)
+	}
+	if _, err := kataConfidentialStorageRequestedAccess(true); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected read-only rejection, got %v", err)
+	}
+}
+
+func TestKataConfidentialDirectVolumeRejectsBeforeMutation(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		readOnly    bool
+		manifestURI string
+	}{
+		{
+			name:        "read-only access",
+			readOnly:    true,
+			manifestURI: testKataConfidentialManifestURI,
+		},
+		{
+			name:        "mutable manifest",
+			manifestURI: "kbs:///tenant/storage-manifests/latest?revision=1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			claim := testKataConfidentialPVC()
+			claim.Annotations[kataConfidentialStorageManifestURIAnnotation] = test.manifestURI
+			runtime := &fakeKataDirectVolumeRuntime{}
+			manager := newTestKataConfidentialManager(t, runtime)
+			ns := &NodeServer{
+				directVolumes: manager,
+				kubeClient:    fake.NewSimpleClientset(claim),
+			}
+			volume := testKataConfidentialDirectVolume()
+			_, err := ns.nodePublishKataConfidentialDirectVolume(context.Background(), &csi.NodePublishVolumeRequest{
+				VolumeId:          volume.Name,
+				StagingTargetPath: "/var/lib/kubelet/plugins/kubernetes.io/csi/stage/test-volume",
+				TargetPath:        "/var/lib/kubelet/pods/pod-id/volumes/kubernetes.io~csi/workspace/mount",
+				VolumeCapability:  testKataConfidentialDirectVolumeCapability(),
+				VolumeContext:     testKataConfidentialVolumeContext(),
+				Readonly:          test.readOnly,
+			}, volume)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected validation rejection, got %v", err)
+			}
+			managed, stateErr := manager.IsManaged(volume.Name)
+			if stateErr != nil || managed || len(runtime.adds) != 0 {
+				t.Fatalf("rejection mutated lifecycle: managed=%v stateErr=%v adds=%d", managed, stateErr, len(runtime.adds))
+			}
+		})
+	}
+}
+
+func TestKataConfidentialDirectVolumeMarkerFailsClosed(t *testing.T) {
+	requested, err := kataConfidentialDirectVolumeRequested(nil)
+	if err != nil || requested {
+		t.Fatalf("unmarked volume changed behavior: requested=%v err=%v", requested, err)
+	}
+	for _, value := range []string{"", "True", "false", "1"} {
+		if _, err := kataConfidentialDirectVolumeRequested(map[string]string{kataConfidentialDirectVolumeParameter: value}); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("marker %q did not fail closed: %v", value, err)
+		}
+	}
+	manager := newTestKataConfidentialManager(t, &fakeKataDirectVolumeRuntime{})
+	if err := manager.Stage("managed-volume", "/stage", "/dev/longhorn/managed-volume"); err != nil {
+		t.Fatal(err)
+	}
+	ns := &NodeServer{directVolumes: manager}
+	if _, err := ns.kataConfidentialDirectVolumeMode("managed-volume", nil); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("managed volume without marker did not fail closed: %v", err)
+	}
+	requested, err = ns.kataConfidentialDirectVolumeMode("standard-volume", nil)
+	if err != nil || requested {
+		t.Fatalf("standard volume changed behavior: requested=%v err=%v", requested, err)
+	}
+}
+
+func TestKataConfidentialDirectVolumeStatsValidation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		stats string
+	}{
+		{name: "unknown unit", stats: `{"usage":[{"total":1,"unit":0}]}`},
+		{name: "signed overflow", stats: `{"usage":[{"total":` + "9223372036854775808" + `,"unit":1}]}`},
+		{name: "invalid json", stats: `{`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manager := newTestKataConfidentialManager(t, &fakeKataDirectVolumeRuntime{stats: []byte(test.stats)})
+			if err := manager.Stage("volume", "/stage", "/dev/longhorn/volume"); err != nil {
+				t.Fatal(err)
+			}
+			info := kataConfidentialDirectVolumeMountInfo{VolumeType: "directvol", Device: "/dev/longhorn/volume", FsType: kataConfidentialStorageFSType}
+			if err := manager.Publish(context.Background(), "volume", "/target", info); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := manager.Stats(context.Background(), "volume", "/target"); err == nil {
+				t.Fatal("expected invalid stats error")
+			}
+		})
+	}
+	manager := newTestKataConfidentialManager(t, &fakeKataDirectVolumeRuntime{stats: []byte(`{"usage":[{"total":1,"unit":1}]}`), err: errors.New("runtime unavailable")})
+	if err := manager.Stage("volume", "/stage", "/dev/longhorn/volume"); err != nil {
+		t.Fatal(err)
+	}
+	info := kataConfidentialDirectVolumeMountInfo{VolumeType: "directvol", Device: "/dev/longhorn/volume", FsType: kataConfidentialStorageFSType}
+	if err := manager.Publish(context.Background(), "volume", "/target", info); err == nil {
+		t.Fatal("expected runtime add error")
+	}
+	if _, err := manager.Stats(context.Background(), "volume", "/target"); err == nil {
+		t.Fatal("expected runtime error")
+	}
+}
+
+func TestHostKataCtlUsesHostRootAndPreservesBoundedDiagnostics(t *testing.T) {
+	var command string
+	var args []string
+	runtime := &hostKataCtl{run: func(_ context.Context, gotCommand string, gotArgs ...string) ([]byte, error) {
+		command = gotCommand
+		args = append([]string(nil), gotArgs...)
+		return []byte("structural failure marker"), errors.New("exit status 1")
+	}}
+	err := runtime.Add(context.Background(), "/target", kataConfidentialDirectVolumeMountInfo{
+		VolumeType: "directvol",
+		Device:     "/dev/longhorn/volume",
+		FsType:     kataConfidentialStorageFSType,
+		ConfidentialStorage: &kataConfidentialStorageContract{
+			ManifestURI:     testKataConfidentialManifestURI,
+			RequestedAccess: "readWrite",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "structural failure marker") || !strings.Contains(err.Error(), "exit status 1") {
+		t.Fatalf("runtime error lost its diagnostic: %v", err)
+	}
+	if command != nsMounterPath || len(args) != 8 || args[0] != "--host-root" || args[1] != kataCtlPath || args[2] != "direct-volume" || args[3] != "add" || args[6] != "--mount-info" {
+		t.Fatalf("unexpected host Kata command: %q %#v", command, args)
+	}
+	wantMountInfo := `{"volume-type":"directvol","device":"/dev/longhorn/volume","fstype":"confidential-storage","confidential-storage":{"manifest-uri":"kbs:///tenant/storage-manifests/workspace-v1","requested-access":"readWrite"}}`
+	if args[7] != wantMountInfo {
+		t.Fatalf("unexpected typed Kata mount contract: %s", args[7])
+	}
+}
+
+func TestBoundedKataCommandOutput(t *testing.T) {
+	message := boundedKataCommandOutput(append(bytes.Repeat([]byte("a"), 9000), 0))
+	if !strings.HasSuffix(message, " [truncated]") || len(message) > 8300 {
+		t.Fatalf("unexpected bounded diagnostic length or marker: %d %q", len(message), message[len(message)-20:])
+	}
+	if boundedKataCommandOutput([]byte("failure\x00marker")) != "failure�marker" {
+		t.Fatal("command diagnostic did not neutralize a control character")
+	}
+}
+
+func TestNSMounterHostRootUsesTalosKubeletNamespaces(t *testing.T) {
+	procDir := filepath.Join(t.TempDir(), "proc")
+	if err := os.MkdirAll(filepath.Join(procDir, "123", "ns"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "version"), []byte("Linux talos"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "123", "status"), []byte("Name:\tkubelet\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(filepath.Join("..", "package", "nsmounter"), "--host-root", kataCtlPath, "direct-volume", "remove", "--volume-path", "/target")
+	command.Env = append(os.Environ(), "PROC_DIR="+procDir, "NSENTER_BIN=/bin/echo")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("nsmounter harness failed: %v: %s", err, output)
+	}
+	want := strings.Join([]string{
+		"--mount=" + filepath.Join(procDir, "123", "ns", "mnt"),
+		"--net=" + filepath.Join(procDir, "123", "ns", "net"),
+		"--uts=" + filepath.Join(procDir, "123", "ns", "uts"),
+		"--root=" + filepath.Join(procDir, "123", "root"),
+		"--wd=/",
+		"--",
+		kataCtlPath,
+		"direct-volume",
+		"remove",
+		"--volume-path",
+		"/target",
+	}, " ") + "\n"
+	if string(output) != want {
+		t.Fatalf("unexpected nsmounter invocation:\n%s\nwant:\n%s", output, want)
+	}
+}

--- a/csi/node_server.go
+++ b/csi/node_server.go
@@ -56,13 +56,14 @@ var supportedFs = map[string]fsParameters{
 
 type NodeServer struct {
 	csi.UnimplementedNodeServer
-	apiClient   *longhornclient.RancherClient
-	nodeID      string
-	caps        []*csi.NodeServiceCapability
-	log         *logrus.Entry
-	lhNamespace string
-	kubeClient  *clientset.Clientset
-	lhClient    *lhclientset.Clientset
+	apiClient     *longhornclient.RancherClient
+	nodeID        string
+	caps          []*csi.NodeServiceCapability
+	log           *logrus.Entry
+	lhNamespace   string
+	kubeClient    clientset.Interface
+	lhClient      *lhclientset.Clientset
+	directVolumes kataConfidentialDirectVolumeOperations
 }
 
 func NewNodeServer(apiClient *longhornclient.RancherClient, nodeID string) (*NodeServer, error) {
@@ -96,10 +97,11 @@ func NewNodeServer(apiClient *longhornclient.RancherClient, nodeID string) (*Nod
 				csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 				csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 			}),
-		log:         logrus.StandardLogger().WithField("component", "csi-node-server"),
-		lhNamespace: lhNamespace,
-		kubeClient:  kubeClient,
-		lhClient:    lhClient,
+		log:           logrus.StandardLogger().WithField("component", "csi-node-server"),
+		lhNamespace:   lhNamespace,
+		kubeClient:    kubeClient,
+		lhClient:      lhClient,
+		directVolumes: newKataConfidentialDirectVolumeManager(),
 	}, nil
 }
 
@@ -154,6 +156,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
 	}
+	direct, err := ns.kataConfidentialDirectVolumeMode(volumeID, req.GetVolumeContext())
+	if err != nil {
+		return nil, err
+	}
 
 	volume, err := ns.apiClient.Volume.ById(volumeID)
 	if err != nil {
@@ -161,6 +167,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 	if volume == nil {
 		return nil, status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+	}
+	if direct {
+		return ns.nodePublishKataConfidentialDirectVolume(ctx, req, volume)
 	}
 
 	mounter, err := ns.getMounter(volume, volumeCapability, req.VolumeContext)
@@ -463,6 +472,16 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
 	}
+	direct, err := ns.directVolumes.IsManaged(volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read confidential direct-volume lifecycle metadata: %v", err)
+	}
+	if direct {
+		if err := ns.directVolumes.Unpublish(ctx, volumeID, targetPath); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unregister confidential direct volume from Kata: %v", err)
+		}
+		return &csi.NodeUnpublishVolumeResponse{}, nil
+	}
 
 	if err := unmountAndCleanupMountPoint(targetPath, mount.New("")); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to cleanup volume %s mount point %v: %v", volumeID, targetPath, err)
@@ -491,6 +510,10 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
 	}
+	direct, err := ns.kataConfidentialDirectVolumeMode(volumeID, req.GetVolumeContext())
+	if err != nil {
+		return nil, err
+	}
 
 	volume, err := ns.apiClient.Volume.ById(volumeID)
 	if err != nil {
@@ -498,6 +521,9 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	if volume == nil {
 		return nil, status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+	}
+	if direct {
+		return ns.nodeStageKataConfidentialDirectVolume(ctx, req, volume)
 	}
 
 	mounter, err := ns.getMounter(volume, volumeCapability, req.VolumeContext)
@@ -701,6 +727,16 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
 	}
+	direct, err := ns.directVolumes.IsManaged(volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read confidential direct-volume lifecycle metadata: %v", err)
+	}
+	if direct {
+		if err := ns.directVolumes.Unstage(ctx, volumeID); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to clean up confidential direct-volume lifecycle metadata: %v", err)
+		}
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
 
 	mounter := mount.New("")
 
@@ -753,6 +789,17 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
+	}
+	direct, err := ns.directVolumes.IsManaged(volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read confidential direct-volume lifecycle metadata: %v", err)
+	}
+	if direct {
+		response, err := ns.directVolumes.Stats(ctx, volumeID, volumePath)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to retrieve confidential direct-volume statistics: %v", err)
+		}
+		return response, nil
 	}
 
 	existVol, err := ns.apiClient.Volume.ById(volumeID)
@@ -874,6 +921,13 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "volume id missing in request")
+	}
+	direct, err := ns.directVolumes.IsManaged(volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read confidential direct-volume lifecycle metadata: %v", err)
+	}
+	if direct {
+		return nil, status.Error(codes.FailedPrecondition, kataConfidentialDirectVolumeResizeUnsupported)
 	}
 
 	volume, err := ns.apiClient.Volume.ById(volumeID)

--- a/package/nsmounter
+++ b/package/nsmounter
@@ -1,17 +1,25 @@
 #!/bin/bash
 
-PROC_DIR="/host/proc"
+PROC_DIR="${PROC_DIR:-/host/proc}"
+NSENTER_BIN="${NSENTER_BIN:-nsenter}"
 
 os_distro_talos="talos"
 os_distro=""
 
 get_os_distro() {
-  local version_info=$(< $PROC_DIR/version)
+  local version_info
+  version_info=$(< "$PROC_DIR/version")
 
   [[ $version_info =~ $os_distro_talos ]] && os_distro=$os_distro_talos
 }
 
 target_pid=1
+
+host_root=false
+if [ "${1:-}" = "--host-root" ]; then
+  host_root=true
+  shift
+fi
 
 get_pid() {
   local process_name=$1
@@ -19,7 +27,7 @@ get_pid() {
   local status_file
   local name
 
-  for dir in $PROC_DIR/*/; do
+  for dir in "$PROC_DIR"/*/; do
     name=""
     pid=$(basename "$dir")
     status_file="$PROC_DIR/$pid/status"
@@ -42,7 +50,7 @@ get_pid() {
 
 get_os_distro
 
-[[ $os_distro = $os_distro_talos ]] && get_pid "kubelet"
+[[ $os_distro = "$os_distro_talos" ]] && get_pid "kubelet"
 
 # Use namespace files instead of -t to avoid the need for HostPID.
 ns_dir="$PROC_DIR/$target_pid/ns"
@@ -50,4 +58,9 @@ ns_mnt="$ns_dir/mnt"
 ns_net="$ns_dir/net"
 ns_uts="$ns_dir/uts"
 
-nsenter --mount="$ns_mnt" --net="$ns_net" --uts="$ns_uts" -- "$@"
+if [ "$host_root" = true ]; then
+  "$NSENTER_BIN" --mount="$ns_mnt" --net="$ns_net" --uts="$ns_uts" \
+    --root="$PROC_DIR/$target_pid/root" --wd=/ -- "$@"
+else
+  "$NSENTER_BIN" --mount="$ns_mnt" --net="$ns_net" --uts="$ns_uts" -- "$@"
+fi


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13730

#### What this PR does / why we need it:

This adds an explicit CSI node path for persistent Kata confidential direct
volumes. It hands the attached Longhorn V1 raw block endpoint to Kata
runtime-rs without formatting, mounting, encrypting, or reading it on the host.

The path is inactive unless the StorageClass contains the exact
`kataConfidentialDirectVolume: "true"` parameter. Marked volumes must use
`ReadWriteOncePod`, filesystem volume mode, one V1 replica, the raw block
frontend, and no Longhorn host encryption or migration. The PVC supplies a
bounded non-secret KBS resource URI. Key bytes never enter CSI requests or
lifecycle state.

The node plugin persists only non-secret cleanup metadata, invokes runtime-rs
`/opt/kata/bin/kata-ctl` through `nsmounter --host-root`, obtains usage
statistics from the guest, and rejects resize without mutation. Invalid or
incomplete contracts fail before the raw device is touched. Existing unmarked
volumes retain the current CSI path.

#### Special notes for your reviewer:

- The initial guest profile is fixed to persistent LUKS2, dm-integrity, and
  ext4. Arbitrary formatting, encryption, integrity, mount, and growth options
  are intentionally not exposed.
- The matching typed runtime-rs/Agent protocol is proposed in
  https://github.com/kata-containers/kata-containers/pull/13637.
- `--extra-create-metadata=true` lets the node plugin locate the PVC without
  copying its annotation into Longhorn volume parameters or local state.
- This profile deliberately does not support resize.

#### Additional documentation or context

Test environment:

- Longhorn manager base: `95f7f6e8f6f87917dd21f40409971f993978f00f`
- Test head: `e7b40eb8332bee8a26917b6461f84478efebf2c0`
- Local Linux amd64 development host
- Networkless KVM guest for the composed protocol test

Test results:

- `go test ./csi -count=1`: PASS
- `bash -n package/nsmounter`: PASS
- focused confidential direct-volume CSI lifecycle/deployment tests: PASS
- typed metadata through Kata runtime-rs, Agent, and CDH: PASS
- persistence after a fresh guest boot: PASS
- unauthorized tuple and downgrade cases reject before mutation: PASS
- backing-device corruption is rejected by dm-integrity: PASS

A live Kubernetes/Longhorn acceptance run has not yet been performed against
this master-based draft.
