### PR TITLE
feat(backuptarget): plumb AWS_SIGN_ACCEPT_ENCODING through

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1299,6 +1299,7 @@ func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]strin
 	credentialSecret[types.HTTPProxy] = string(secret.Data[types.HTTPProxy])
 	credentialSecret[types.NOProxy] = string(secret.Data[types.NOProxy])
 	credentialSecret[types.VirtualHostedStyle] = string(secret.Data[types.VirtualHostedStyle])
+	credentialSecret[types.AWSSignAcceptEncoding] = string(secret.Data[types.AWSSignAcceptEncoding])
 	return credentialSecret, nil
 }
 

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -118,6 +118,7 @@ func getBackupCredentialEnv(backupTarget string, credential map[string]string) (
 		envs = append(envs, fmt.Sprintf("%s=%s", types.HTTPProxy, credential[types.HTTPProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.NOProxy, credential[types.NOProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.VirtualHostedStyle, credential[types.VirtualHostedStyle]))
+		envs = append(envs, fmt.Sprintf("%s=%s", types.AWSSignAcceptEncoding, credential[types.AWSSignAcceptEncoding]))
 	case types.BackupStoreTypeCIFS:
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSUsername, credential[types.CIFSUsername]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSPassword, credential[types.CIFSPassword]))

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -147,6 +147,48 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 	}
 }
 
+// TestGetBackupCredentialEnvSignAcceptEncoding pins that the S3 branch forwards
+// AWS_SIGN_ACCEPT_ENCODING. TestGetBackupCredentialEnv above only checks the
+// value of whatever is returned, so it stays green if the entry is dropped
+// entirely, which is the silent drop this guards against.
+func TestGetBackupCredentialEnvSignAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name       string
+		credential map[string]string
+		expectEnv  string
+	}{
+		{
+			name: "forwards the value set in the secret",
+			credential: map[string]string{
+				"AWS_ACCESS_KEY_ID":        "my-aws-access-key-id",
+				"AWS_SECRET_ACCESS_KEY":    "my-aws-secret-access-key",
+				"AWS_SIGN_ACCEPT_ENCODING": "false",
+			},
+			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=false",
+		},
+		{
+			// The entry is sent whether or not the secret sets it, which is why
+			// the instance manager has to allowlist the key before this ships.
+			name: "forwards an empty value when the secret omits the key",
+			credential: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "my-aws-access-key-id",
+				"AWS_SECRET_ACCESS_KEY": "my-aws-secret-access-key",
+			},
+			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			envs, err := getBackupCredentialEnv("s3://backupbucket@us-east-1/", tt.credential)
+			assert.Nil(err)
+			assert.Contains(envs, tt.expectEnv)
+		})
+	}
+}
+
 func TestParseBackupVolumeNamesList(t *testing.T) {
 	assert := require.New(t)
 

--- a/types/types.go
+++ b/types/types.go
@@ -359,6 +359,8 @@ const (
 
 	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
 
+	AWSSignAcceptEncoding = "AWS_SIGN_ACCEPT_ENCODING"
+
 	OptionFromBackup          = "fromBackup"
 	OptionNumberOfReplicas    = "numberOfReplicas"
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"

--- a/webhook/resources/backuptarget/validator.go
+++ b/webhook/resources/backuptarget/validator.go
@@ -151,6 +151,7 @@ func (b *backupTargetValidator) validateCredentialSecret(secretName string) erro
 		types.HTTPProxy,
 		types.NOProxy,
 		types.VirtualHostedStyle,
+		types.AWSSignAcceptEncoding,
 	}
 
 	errs := multierr.NewMultiError()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13756

#### What this PR does / why we need it:

Passes the new `AWS_SIGN_ACCEPT_ENCODING` backup target secret key through to
`backupstore`, which consumes it in longhorn/backupstore#316.

Without this the key is silently dropped. `GetCredentialFromSecret` copies a fixed
list of keys out of the secret, and `getBackupCredentialEnv` builds the engine
environment from a fixed list, so an unknown key never reaches the engine or the
instance manager.

Four sites, the same set `VIRTUAL_HOSTED_STYLE` occupies:

- `types/types.go` for the constant.
- `datastore/longhorn.go`, `GetCredentialFromSecret`, which feeds the credential map
  handed to the instance manager and from there to `backupstore.SetupCredential`.
- `engineapi/backups.go`, `getBackupCredentialEnv`, the engine binary environment.
- `webhook/resources/backuptarget/validator.go`, the whitespace validation allowlist,
  so a stray leading or trailing space is reported like every other credential key
  (longhorn/longhorn#7159).

#### Special notes for your reviewer:

**Merge order matters, and getting it wrong breaks every S3 backup.**
`getBackupCredentialEnv` appends the key unconditionally, whether or not the secret
sets it, and those envs reach the instance manager through `engineapi/proxy_backup.go`.
`validateBackupEnv` there rejects the whole request on a single key outside
`backupEnvAllowlist`. So this PR must land only after
longhorn/longhorn-instance-manager#1615, which allowlists the key. Otherwise every S3
backup and restore fails with `env key "AWS_SIGN_ACCEPT_ENCODING" is not permitted by
the backup env allowlist`, for all users, not only those who set it.

The full order is: longhorn/backupstore#316, then
longhorn/longhorn-instance-manager#1615, then this PR, each with its vendor bump.

Both credential paths are covered: the env var path through `getBackupCredentialEnv`,
and the credential map path that reaches `SetupCredential` in
`longhorn-engine/pkg/sync/rpc/server.go`.

#### Additional documentation or context

`go build ./...` passes. `go vet` and `gofmt` are clean on the four touched packages,
and the Go import group check passes on the changed files.

The behaviour itself is verified end to end in longhorn/backupstore#316, against
MinIO and SeaweedFS behind an nginx that reproduces the Cloudflare header rewrite.
This PR carries no logic of its own beyond the four plumbing lines.

The docs change for the backup target secret key list in `longhorn/website` is
separate.

---

Prepared with AI assistance (Claude Code). Every test and command reported above was run, not estimated.
