### PR TITLE
fix(api): report nvmeTcpNrIoQueues in the volume response

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1765,6 +1765,7 @@ func toVolumeResource(v *longhorn.Volume, vefs []*longhorn.EngineFrontend, ves [
 		ReplicaRebuildingBandwidthLimit: v.Spec.ReplicaRebuildingBandwidthLimit,
 		UblkQueueDepth:                  v.Spec.UblkQueueDepth,
 		UblkNumberOfQueue:               v.Spec.UblkNumberOfQueue,
+		NvmeTcpNrIoQueues:               v.Spec.NvmeTcpNrIoQueues,
 		BackupCompressionMethod:         v.Spec.BackupCompressionMethod,
 		BackupBlockSize:                 strconv.FormatInt(v.Spec.BackupBlockSize, 10),
 		StaleReplicaTimeout:             v.Spec.StaleReplicaTimeout,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/longhorn/longhorn/issues/13706

#### What this PR does / why we need it:

`toVolumeResource` did not copy `Volume.Spec.NvmeTcpNrIoQueues` into the API volume, so `GET /v1/volumes` and `GET /v1/volumes/<name>` reported `nvmeTcpNrIoQueues: 0` for every volume, and so did the response of a volume create that set it. Only the read-back was affected: the create path, the CSI parameter, the webhook validation and the value that reaches the instance manager all use the CR.

#### Special notes for your reviewer:

The UI work in https://github.com/longhorn/longhorn/issues/13735 reads this field, so it is worth having in before that lands. The same line is missing on `v1.12.x`, so this needs a backport.

#### Additional documentation or context

Read back with `curl -s http://<longhorn-frontend>/v1/volumes/<name> | jq .nvmeTcpNrIoQueues` (or `kubectl -n longhorn-system get volume <name> -o jsonpath='{.spec.nvmeTcpNrIoQueues}'` for comparison): before the fix the API reports 0 while the CR holds the configured value, after the fix both agree.
