### PR TITLE
fix(recurring-job): keep sweeping volumes when one volume's job fails

### DIFF
--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -25,7 +25,21 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
+// startVolumeJobFn runs a single volume's recurring job. It is injected so tests
+// can substitute a stub without a live Longhorn API.
+type startVolumeJobFn func(
+	job *Job,
+	recurringJob *longhorn.RecurringJob,
+	volumeName string,
+	concurrentLimiter chan struct{},
+	jobGroups []string,
+) error
+
 func StartVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob) error {
+	return startVolumeJobs(job, recurringJob, startVolumeJob)
+}
+
+func startVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob, startJob startVolumeJobFn) (err error) {
 	allowDetachedSetting := types.SettingNameAllowRecurringJobWhileVolumeDetached
 	allowDetached, err := getSettingAsBoolean(allowDetachedSetting, job.namespace, job.lhClient)
 	if err != nil {
@@ -57,7 +71,16 @@ func StartVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob) error {
 	for _, volumeName := range filteredVolumes {
 		startJobVolumeName := volumeName
 		ewg.Go(func() error {
-			return startVolumeJob(job, recurringJob, startJobVolumeName, concurrentLimiter, jobGroups)
+			// A per-volume failure (for example, a rebuilding replica blocking
+			// snapshot purge) must not abort the whole sweep. Log it and continue
+			// so the next scheduled run retries this volume instead of the process
+			// exiting non-zero and re-running every volume from scratch. Task
+			// handlers (doSnapshotCleanup, doRecurringFilesystemTrim) already emit
+			// their own Warning events, so we don't record a duplicate here.
+			if jobErr := startJob(job, recurringJob, startJobVolumeName, concurrentLimiter, jobGroups); jobErr != nil {
+				job.logger.WithError(jobErr).WithField("volume", startJobVolumeName).Warn("Failed to run recurring job for volume; will retry on the next run")
+			}
+			return nil
 		})
 	}
 

--- a/app/recurringjob/volume_test.go
+++ b/app/recurringjob/volume_test.go
@@ -1,14 +1,18 @@
 package recurringjob
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,6 +23,10 @@ import (
 	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
+const testVolumeJob = "snapshot-cleanup"
+
+// volumeOperationsWithGetError is a VolumeOperations whose ById always fails,
+// so the real startVolumeJob worker path returns an error.
 type volumeOperationsWithGetError struct {
 	longhornclient.VolumeOperations
 	err error
@@ -28,6 +36,101 @@ func (o *volumeOperationsWithGetError) ById(string) (*longhornclient.Volume, err
 	return nil, o.err
 }
 
+// newAttachedRecurringVolume builds a healthy, attached volume carrying the
+// recurring-job label so getVolumesBySelector/filterVolumesForJob select it.
+func newAttachedRecurringVolume(name, jobName string) *longhorn.Volume {
+	return &longhorn.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJob, jobName): types.LonghornLabelValueEnabled,
+			},
+		},
+		Status: longhorn.VolumeStatus{
+			State:      longhorn.VolumeStateAttached,
+			Robustness: longhorn.VolumeRobustnessHealthy,
+		},
+	}
+}
+
+// TestStartVolumeJobsSkipsFailedVolumes verifies the core fix for
+// longhorn/longhorn#13623: a per-volume failure (for example, a rebuilding
+// replica blocking snapshot purge) must not abort the whole sweep. Every volume
+// is still attempted, the run returns nil so the process exits zero and the next
+// scheduled run retries, and each failure is surfaced in the logs.
+func TestStartVolumeJobsSkipsFailedVolumes(t *testing.T) {
+	assert := assert.New(t)
+
+	allowDetached := &longhorn.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      string(types.SettingNameAllowRecurringJobWhileVolumeDetached),
+			Namespace: testNamespace,
+		},
+		Value: "true",
+	}
+	volA := newAttachedRecurringVolume("vol-a", testVolumeJob)
+	volFail := newAttachedRecurringVolume("vol-fail", testVolumeJob)
+	volC := newAttachedRecurringVolume("vol-c", testVolumeJob)
+
+	lhClient := lhfake.NewSimpleClientset( // nolint: staticcheck
+		runtime.Object(allowDetached), volA, volFail, volC)
+
+	var logBuf bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&logBuf)
+
+	job := &Job{
+		lhClient:      lhClient,
+		logger:        logger,
+		eventRecorder: record.NewFakeRecorder(10),
+		name:          testVolumeJob,
+		namespace:     testNamespace,
+		task:          longhorn.RecurringJobTypeSnapshotCleanup,
+	}
+	recurringJob := &longhorn.RecurringJob{
+		ObjectMeta: metav1.ObjectMeta{Name: testVolumeJob, Namespace: testNamespace},
+		Spec:       longhorn.RecurringJobSpec{Concurrency: 2},
+	}
+
+	// The engine's rebuild rejection, as it reaches startVolumeJob.
+	rebuildErr := errors.New("cannot purge snapshots because tcp://10.0.0.1:10000 is rebuilding")
+
+	var mu sync.Mutex
+	attempted := []string{}
+	startJob := func(_ *Job, _ *longhorn.RecurringJob, volumeName string, concurrentLimiter chan struct{}, _ []string) error {
+		concurrentLimiter <- struct{}{}
+		defer func() { <-concurrentLimiter }()
+
+		mu.Lock()
+		attempted = append(attempted, volumeName)
+		mu.Unlock()
+
+		if volumeName == "vol-fail" {
+			return rebuildErr
+		}
+		return nil
+	}
+
+	err := startVolumeJobs(job, recurringJob, startJob)
+
+	// One volume failing must not fail the run; otherwise the CronJob Job exits
+	// non-zero and re-runs every volume from scratch.
+	assert.NoError(err, "a single volume's failure must not abort the sweep")
+
+	sort.Strings(attempted)
+	assert.Equal([]string{"vol-a", "vol-c", "vol-fail"}, attempted,
+		"every selected volume must be attempted, including those after the failing one")
+
+	// The failure is not silently swallowed: it is logged. The per-volume event is
+	// intentionally left to the task-specific handlers to avoid duplicate events.
+	logOutput := logBuf.String()
+	assert.Contains(logOutput, "vol-fail")
+	assert.Contains(logOutput, "Failed to run recurring job for volume")
+}
+
+// TestStartVolumeJobs exercises StartVolumeJobs through the real startVolumeJob
+// worker (not the seam), covering the new behavior end to end.
 func TestStartVolumeJobs(t *testing.T) {
 	const (
 		namespace  = "longhorn-system"
@@ -48,19 +151,22 @@ func TestStartVolumeJobs(t *testing.T) {
 		logger := logrus.New()
 		logger.SetOutput(io.Discard)
 		return &Job{
-			api:       api,
-			lhClient:  lhfake.NewSimpleClientset(objects...), // nolint: staticcheck
-			logger:    logger,
-			name:      jobName,
-			namespace: namespace,
+			api:           api,
+			lhClient:      lhfake.NewSimpleClientset(objects...), // nolint: staticcheck
+			logger:        logger,
+			eventRecorder: record.NewFakeRecorder(10),
+			name:          jobName,
+			namespace:     namespace,
 		}
 	}
 	recurringJob := &longhorn.RecurringJob{
 		Spec: longhorn.RecurringJobSpec{Concurrency: 1},
 	}
 
-	t.Run("returns a volume worker error", func(t *testing.T) {
-		expectedErr := errors.New("volume API unavailable")
+	t.Run("swallows a volume worker error", func(t *testing.T) {
+		// A per-volume worker failure must not propagate: it is logged and the
+		// sweep returns nil so the next run retries. Here the real worker path
+		// fails at Volume.ById.
 		volume := &longhorn.Volume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      volumeName,
@@ -70,12 +176,12 @@ func TestStartVolumeJobs(t *testing.T) {
 			Status: longhorn.VolumeStatus{State: longhorn.VolumeStateAttached},
 		}
 		job := newJob(&longhornclient.RancherClient{
-			Volume: &volumeOperationsWithGetError{err: expectedErr},
+			Volume: &volumeOperationsWithGetError{err: errors.New("volume API unavailable")},
 		}, newSetting(), volume)
 
 		err := StartVolumeJobs(job, recurringJob)
 
-		assert.ErrorIs(t, err, expectedErr)
+		assert.NoError(t, err, "a per-volume worker error must not abort the sweep")
 	})
 
 	t.Run("returns nil with no selected volumes", func(t *testing.T) {


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13623

#### What this PR does / why we need it:

A per-volume failure previously aborted the entire recurring-job sweep. When a volume's replica is rebuilding, the engine rejects snapshot purge with "cannot purge snapshots because ... is rebuilding". That error propagated up through StartVolumeJobs and caused the process to exit non-zero, so every remaining volume in the run was skipped. Snapshots never coalesced and disks filled up, leading to DiskPressure.

Collect per-volume errors instead of failing the whole run: log a warning and record a Warning event for the failing volume, then continue with the rest and return nil so the next scheduled run retries that volume. Setup errors (settings lookup, volume listing) still propagate.

#### Special notes for your reviewer:

#### Additional documentation or context
