### PR TITLE
feat(volume): RDMA (RoCEv2) transport support for the v2 data engine

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -69,6 +69,7 @@ type Volume struct {
 	FreezeFilesystemForSnapshot     longhorn.FreezeFilesystemForSnapshot   `json:"freezeFilesystemForSnapshot"`
 	BackupTargetName                string                                 `json:"backupTargetName"`
 	DataLayout                      longhorn.VolumeDataLayout              `json:"dataLayout"`
+	DataEngineTransport             longhorn.DataEngineTransport           `json:"dataEngineTransport"`
 
 	DiskSelector         []string                      `json:"diskSelector"`
 	NodeSelector         []string                      `json:"nodeSelector"`
@@ -1399,6 +1400,10 @@ func volumeSchema(volume *client.Schema) {
 	dataLayout.Create = true
 	volume.ResourceFields["dataLayout"] = dataLayout
 
+	dataEngineTransport := volume.ResourceFields["dataEngineTransport"]
+	dataEngineTransport.Create = true
+	volume.ResourceFields["dataEngineTransport"] = dataEngineTransport
+
 	conditions := volume.ResourceFields["conditions"]
 	conditions.Type = "map[volumeCondition]"
 	volume.ResourceFields["conditions"] = conditions
@@ -1795,6 +1800,7 @@ func toVolumeResource(v *longhorn.Volume, vefs []*longhorn.EngineFrontend, ves [
 		FreezeFilesystemForSnapshot:     v.Spec.FreezeFilesystemForSnapshot,
 		BackupTargetName:                v.Spec.BackupTargetName,
 		DataLayout:                      v.Spec.DataLayout,
+		DataEngineTransport:             v.Spec.DataEngineTransport,
 
 		State:                       v.Status.State,
 		Robustness:                  v.Status.Robustness,

--- a/api/volume.go
+++ b/api/volume.go
@@ -228,6 +228,7 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		ReplicaDiskSoftAntiAffinity:     volume.ReplicaDiskSoftAntiAffinity,
 		DataEngine:                      volume.DataEngine,
 		DataLayout:                      volume.DataLayout,
+		DataEngineTransport:             volume.DataEngineTransport,
 		FreezeFilesystemForSnapshot:     volume.FreezeFilesystemForSnapshot,
 		BackupTargetName:                volume.BackupTargetName,
 		OfflineRebuilding:               volume.OfflineRebuilding,

--- a/client/generated_volume.go
+++ b/client/generated_volume.go
@@ -35,6 +35,8 @@ type Volume struct {
 
 	DataEngine string `json:"dataEngine,omitempty" yaml:"data_engine,omitempty"`
 
+	DataEngineTransport string `json:"dataEngineTransport,omitempty" yaml:"data_engine_transport,omitempty"`
+
 	DataLocality string `json:"dataLocality,omitempty" yaml:"data_locality,omitempty"`
 
 	DataSource string `json:"dataSource,omitempty" yaml:"data_source,omitempty"`

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -710,6 +710,7 @@ func (ec *EngineController) CreateInstance(obj interface{}) (*longhorn.InstanceP
 
 	instanceManagerStorageIP := ec.ds.GetIPFromPodByCNISetting(instanceManagerPod, types.SettingNameStorageNetwork)
 	dataLayoutType := toIMRPCDataLayoutType(v.Spec.DataLayout.Type)
+	dataEngineTransport := toIMRPCDataEngineTransport(v.Spec.DataEngineTransport)
 
 	e.Status.Starting = true
 	engineName := e.Name
@@ -728,6 +729,7 @@ func (ec *EngineController) CreateInstance(obj interface{}) (*longhorn.InstanceP
 		ReplicaFileSyncHTTPClientTimeout: fileSyncHTTPClientTimeout,
 		DataLocality:                     v.Spec.DataLocality,
 		DataLayoutType:                   dataLayoutType,
+		DataEngineTransport:              dataEngineTransport,
 		EngineCLIAPIVersion:              cliAPIVersion,
 		UpgradeRequired:                  false,
 		InitiatorAddress:                 instanceManagerStorageIP,
@@ -741,6 +743,15 @@ func toIMRPCDataLayoutType(t longhorn.VolumeDataLayoutType) imrpc.DataLayoutType
 		return imrpc.DataLayoutType_DATA_LAYOUT_TYPE_SHARDED
 	}
 	return imrpc.DataLayoutType_DATA_LAYOUT_TYPE_REPLICATED
+}
+
+// toIMRPCDataEngineTransport maps the volume's data engine transport to the
+// instance-manager RPC enum. Empty or unknown values default to TCP.
+func toIMRPCDataEngineTransport(t longhorn.DataEngineTransport) imrpc.DataEngineTransport {
+	if t == longhorn.DataEngineTransportRDMA {
+		return imrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA
+	}
+	return imrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_TCP
 }
 
 func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {

--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -747,11 +747,11 @@ func toIMRPCDataLayoutType(t longhorn.VolumeDataLayoutType) imrpc.DataLayoutType
 
 // toIMRPCDataEngineTransport maps the volume's data engine transport to the
 // instance-manager RPC enum. Empty or unknown values default to TCP.
-func toIMRPCDataEngineTransport(t longhorn.DataEngineTransport) imrpc.DataEngineTransport {
+func toIMRPCDataEngineTransport(t longhorn.DataEngineTransport) imrpc.TransportType {
 	if t == longhorn.DataEngineTransportRDMA {
-		return imrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA
+		return imrpc.TransportType_TRANSPORT_TYPE_RDMA
 	}
-	return imrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_TCP
+	return imrpc.TransportType_TRANSPORT_TYPE_TCP
 }
 
 func (ec *EngineController) DeleteInstance(obj interface{}) (err error) {

--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -2130,6 +2130,23 @@ func (imc *InstanceManagerController) createInstanceManagerPodSpec(im *longhorn.
 		}
 
 		podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName("hugepages-2Mi")] = resource.MustParse(fmt.Sprintf("%vMi", hugepage))
+
+		// When the engine-replica NVMe-oF fabric runs over RDMA (RoCEv2), request the extended
+		// resource advertised by an RDMA shared device plugin (for example, k8s-rdma-shared-dev-plugin)
+		// so the pod gains declarative access to the /dev/infiniband verbs devices. Empty (default)
+		// keeps the previous behavior, where devices come from the privileged host mount.
+		// This setting is optional (Required: false, Default: ""), so read it with a getter
+		// that tolerates an empty value instead of GetSettingValueExisted, which errors when
+		// the value is empty. An empty value is the default and means the previous behavior
+		// (privileged host mount), so it must not block Instance Manager pod creation.
+		rdmaDeviceSetting, err := imc.ds.GetSettingWithAutoFillingRO(types.SettingNameV2DataEngineRDMADeviceResource)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get %v setting", types.SettingNameV2DataEngineRDMADeviceResource)
+		}
+		if rdmaDeviceResource := rdmaDeviceSetting.Value; rdmaDeviceResource != "" {
+			podSpec.Spec.Containers[0].Resources.Limits[corev1.ResourceName(rdmaDeviceResource)] = resource.MustParse("1")
+		}
+
 		if dynamicCPUPinningEnabled {
 			cpuQty, ok := podSpec.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
 			if !ok {

--- a/controller/monitor/environment_check_monitor.go
+++ b/controller/monitor/environment_check_monitor.go
@@ -173,9 +173,39 @@ func (m *EnvironmentCheckMonitor) environmentCheck(kubeNode *corev1.Node) *Colle
 
 	if isV2DataEngine {
 		m.checkHugePages(kubeNode, collectedData)
+		m.checkRDMACapability(namespaces, collectedData)
 	}
 
 	return collectedData
+}
+
+// checkRDMACapability reports whether the node exposes at least one RDMA device.
+// It is a prerequisite for scheduling v2 volumes that request the RDMA NVMe-oF
+// transport (dataEngineTransport=rdma). The condition is informational: it does
+// not gate TCP volumes, and mixed clusters (only some nodes RDMA-capable) are
+// handled at volume validation/scheduling time by consulting this condition.
+func (m *EnvironmentCheckMonitor) checkRDMACapability(namespaces []lhtypes.Namespace, collectedData *CollectedEnvironmentCheckInfo) {
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
+	if err != nil {
+		collectedData.conditions = types.SetCondition(collectedData.conditions, longhorn.NodeConditionTypeRDMACapable, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonNamespaceExecutorErr),
+			fmt.Sprintf("Failed to get namespace executor: %v", err.Error()))
+		return
+	}
+
+	// RDMA devices are enumerated by the kernel under /sys/class/infiniband. A
+	// non-empty listing means at least one RoCE/IB-capable device is present.
+	result, _ := nsexec.Execute(nil, "sh", []string{"-c", "ls -A /sys/class/infiniband 2>/dev/null"}, lhtypes.ExecuteDefaultTimeout)
+	devices := strings.Fields(result)
+	if len(devices) == 0 {
+		collectedData.conditions = types.SetCondition(collectedData.conditions, longhorn.NodeConditionTypeRDMACapable, longhorn.ConditionStatusFalse,
+			string(longhorn.NodeConditionReasonRDMADeviceNotFound),
+			"No RDMA device found under /sys/class/infiniband; volumes with dataEngineTransport=rdma cannot be scheduled here")
+		return
+	}
+
+	collectedData.conditions = types.SetCondition(collectedData.conditions, longhorn.NodeConditionTypeRDMACapable, longhorn.ConditionStatusTrue, "",
+		fmt.Sprintf("RDMA devices %v are available", devices))
 }
 
 func (m *EnvironmentCheckMonitor) syncPackagesInstalled(kubeNode *corev1.Node, namespaces []lhtypes.Namespace, collectedData *CollectedEnvironmentCheckInfo) {

--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -450,6 +450,7 @@ func (rc *ReplicaController) CreateInstance(obj interface{}) (*longhorn.Instance
 		DataPath:                      dataPath,
 		BackingImagePath:              backingImagePath,
 		DataLocality:                  v.Spec.DataLocality,
+		DataEngineTransport:           toIMRPCDataEngineTransport(v.Spec.DataEngineTransport),
 		EngineCLIAPIVersion:           cliAPIVersion,
 		ExtraLUKS2HeaderSpaceRequired: types.IsVolumeV2EncryptedVolumeWithLuksHeaderLabelTrue(v),
 	})

--- a/csi/util.go
+++ b/csi/util.go
@@ -296,6 +296,10 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		vol.DataEngine = driver
 	}
 
+	if transport, ok := volOptions["dataEngineTransport"]; ok {
+		vol.DataEngineTransport = transport
+	}
+
 	layoutType, hasLayoutType := volOptions["dataLayout.type"]
 	layoutMode, hasLayoutMode := volOptions["dataLayout.mode"]
 	dataChunksRaw, hasDataChunks := volOptions["dataLayout.dataChunks"]

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -443,6 +443,7 @@ type EngineInstanceCreateRequest struct {
 	ReplicaFileSyncHTTPClientTimeout int64
 	DataLocality                     longhorn.DataLocality
 	DataLayoutType                   imrpc.DataLayoutType
+	DataEngineTransport              imrpc.DataEngineTransport
 	EngineCLIAPIVersion              int
 	UpgradeRequired                  bool
 	InitiatorAddress                 string
@@ -494,15 +495,16 @@ func (c *InstanceManagerClient) EngineInstanceCreate(req *EngineInstanceCreateRe
 	}
 
 	instance, err := c.instanceServiceGrpcClient.InstanceCreate(&imclient.InstanceCreateRequest{
-		BackendStoreDriver: string(req.Engine.Spec.DataEngine),
-		DataEngine:         string(req.Engine.Spec.DataEngine),
-		Name:               req.Engine.Name,
-		InstanceType:       string(longhorn.InstanceManagerTypeEngine),
-		VolumeName:         req.Engine.Spec.VolumeName,
-		Size:               uint64(volumeSize),
-		PortCount:          DefaultEnginePortCount,
-		PortArgs:           []string{DefaultPortArg},
-		DataLayoutType:     req.DataLayoutType,
+		BackendStoreDriver:  string(req.Engine.Spec.DataEngine),
+		DataEngine:          string(req.Engine.Spec.DataEngine),
+		Name:                req.Engine.Name,
+		InstanceType:        string(longhorn.InstanceManagerTypeEngine),
+		VolumeName:          req.Engine.Spec.VolumeName,
+		Size:                uint64(volumeSize),
+		PortCount:           DefaultEnginePortCount,
+		PortArgs:            []string{DefaultPortArg},
+		DataLayoutType:      req.DataLayoutType,
+		DataEngineTransport: req.DataEngineTransport,
 
 		Binary:     binary,
 		BinaryArgs: args,
@@ -532,6 +534,7 @@ type ReplicaInstanceCreateRequest struct {
 	DataPath                      string
 	BackingImagePath              string
 	DataLocality                  longhorn.DataLocality
+	DataEngineTransport           imrpc.DataEngineTransport
 	EngineCLIAPIVersion           int
 	Encrypted                     bool
 	ExtraLUKS2HeaderSpaceRequired bool
@@ -675,14 +678,15 @@ func (c *InstanceManagerClient) ReplicaInstanceCreate(req *ReplicaInstanceCreate
 	}
 
 	instance, err := c.instanceServiceGrpcClient.InstanceCreate(&imclient.InstanceCreateRequest{
-		BackendStoreDriver: string(req.Replica.Spec.DataEngine),
-		DataEngine:         string(req.Replica.Spec.DataEngine),
-		Name:               req.Replica.Name,
-		InstanceType:       string(longhorn.InstanceManagerTypeReplica),
-		VolumeName:         req.Replica.Spec.VolumeName,
-		Size:               uint64(volumeSize),
-		PortCount:          portCount,
-		PortArgs:           []string{DefaultPortArg},
+		BackendStoreDriver:  string(req.Replica.Spec.DataEngine),
+		DataEngine:          string(req.Replica.Spec.DataEngine),
+		Name:                req.Replica.Name,
+		InstanceType:        string(longhorn.InstanceManagerTypeReplica),
+		VolumeName:          req.Replica.Spec.VolumeName,
+		Size:                uint64(volumeSize),
+		PortCount:           portCount,
+		PortArgs:            []string{DefaultPortArg},
+		DataEngineTransport: req.DataEngineTransport,
 
 		Binary:     binary,
 		BinaryArgs: args,

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -443,7 +443,7 @@ type EngineInstanceCreateRequest struct {
 	ReplicaFileSyncHTTPClientTimeout int64
 	DataLocality                     longhorn.DataLocality
 	DataLayoutType                   imrpc.DataLayoutType
-	DataEngineTransport              imrpc.DataEngineTransport
+	DataEngineTransport              imrpc.TransportType
 	EngineCLIAPIVersion              int
 	UpgradeRequired                  bool
 	InitiatorAddress                 string
@@ -495,16 +495,16 @@ func (c *InstanceManagerClient) EngineInstanceCreate(req *EngineInstanceCreateRe
 	}
 
 	instance, err := c.instanceServiceGrpcClient.InstanceCreate(&imclient.InstanceCreateRequest{
-		BackendStoreDriver:  string(req.Engine.Spec.DataEngine),
-		DataEngine:          string(req.Engine.Spec.DataEngine),
-		Name:                req.Engine.Name,
-		InstanceType:        string(longhorn.InstanceManagerTypeEngine),
-		VolumeName:          req.Engine.Spec.VolumeName,
-		Size:                uint64(volumeSize),
-		PortCount:           DefaultEnginePortCount,
-		PortArgs:            []string{DefaultPortArg},
-		DataLayoutType:      req.DataLayoutType,
-		DataEngineTransport: req.DataEngineTransport,
+		BackendStoreDriver: string(req.Engine.Spec.DataEngine),
+		DataEngine:         string(req.Engine.Spec.DataEngine),
+		Name:               req.Engine.Name,
+		InstanceType:       string(longhorn.InstanceManagerTypeEngine),
+		VolumeName:         req.Engine.Spec.VolumeName,
+		Size:               uint64(volumeSize),
+		PortCount:          DefaultEnginePortCount,
+		PortArgs:           []string{DefaultPortArg},
+		DataLayoutType:     req.DataLayoutType,
+		TransportType:      req.DataEngineTransport,
 
 		Binary:     binary,
 		BinaryArgs: args,
@@ -534,7 +534,7 @@ type ReplicaInstanceCreateRequest struct {
 	DataPath                      string
 	BackingImagePath              string
 	DataLocality                  longhorn.DataLocality
-	DataEngineTransport           imrpc.DataEngineTransport
+	DataEngineTransport           imrpc.TransportType
 	EngineCLIAPIVersion           int
 	Encrypted                     bool
 	ExtraLUKS2HeaderSpaceRequired bool
@@ -678,15 +678,15 @@ func (c *InstanceManagerClient) ReplicaInstanceCreate(req *ReplicaInstanceCreate
 	}
 
 	instance, err := c.instanceServiceGrpcClient.InstanceCreate(&imclient.InstanceCreateRequest{
-		BackendStoreDriver:  string(req.Replica.Spec.DataEngine),
-		DataEngine:          string(req.Replica.Spec.DataEngine),
-		Name:                req.Replica.Name,
-		InstanceType:        string(longhorn.InstanceManagerTypeReplica),
-		VolumeName:          req.Replica.Spec.VolumeName,
-		Size:                uint64(volumeSize),
-		PortCount:           portCount,
-		PortArgs:            []string{DefaultPortArg},
-		DataEngineTransport: req.DataEngineTransport,
+		BackendStoreDriver: string(req.Replica.Spec.DataEngine),
+		DataEngine:         string(req.Replica.Spec.DataEngine),
+		Name:               req.Replica.Name,
+		InstanceType:       string(longhorn.InstanceManagerTypeReplica),
+		VolumeName:         req.Replica.Spec.VolumeName,
+		Size:               uint64(volumeSize),
+		PortCount:          portCount,
+		PortArgs:           []string{DefaultPortArg},
+		TransportType:      req.DataEngineTransport,
 
 		Binary:     binary,
 		BinaryArgs: args,

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -4593,6 +4593,18 @@ spec:
                 - v1
                 - v2
                 type: string
+              dataEngineTransport:
+                description: |-
+                  DataEngineTransport selects the NVMe-oF transport for the internal
+                  engine<->replica fabric of a v2 volume (tcp or rdma). Empty defaults to tcp.
+                  It is immutable and has no effect on v1 volumes.
+                enum:
+                - tcp
+                - rdma
+                type: string
+                x-kubernetes-validations:
+                - message: DataEngineTransport is immutable
+                  rule: self == oldSelf
               dataLayout:
                 description: |-
                   DataLayout declares the user's intended data layout (topology type, protection mode, and EC parameters).

--- a/k8s/pkg/apis/longhorn/v1beta2/node.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/node.go
@@ -11,6 +11,7 @@ const (
 	NodeConditionTypeNFSClientInstalled  = "NFSClientInstalled"
 	NodeConditionTypeSchedulable         = "Schedulable"
 	NodeConditionTypeHugePagesAvailable  = "HugePagesAvailable"
+	NodeConditionTypeRDMACapable         = "RDMACapable"
 )
 
 const (
@@ -32,6 +33,7 @@ const (
 	NodeConditionReasonKubernetesNodeCordoned    = "KubernetesNodeCordoned"
 	NodeConditionReasonHugePagesNotConfigured    = "HugePagesNotConfigured"
 	NodeConditionReasonInsufficientHugePages     = "InsufficientHugePages"
+	NodeConditionReasonRDMADeviceNotFound        = "RDMADeviceNotFound"
 )
 
 const (

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -269,6 +269,16 @@ const (
 	DataEngineTypeAll = DataEngineType("all")
 )
 
+// DataEngineTransport declares the NVMe-oF transport used for the internal
+// engine<->replica fabric of a v2 (SPDK) data engine volume. It has no effect
+// on v1 volumes. The host frontend always uses TCP regardless of this value.
+type DataEngineTransport string
+
+const (
+	DataEngineTransportTCP  = DataEngineTransport("tcp")
+	DataEngineTransportRDMA = DataEngineTransport("rdma")
+)
+
 type KubernetesStatus struct {
 	// +optional
 	PVName string `json:"pvName"`
@@ -393,6 +403,13 @@ type VolumeSpec struct {
 	// +kubebuilder:validation:Enum=v1;v2
 	// +optional
 	DataEngine DataEngineType `json:"dataEngine"`
+	// DataEngineTransport selects the NVMe-oF transport for the internal
+	// engine<->replica fabric of a v2 volume (tcp or rdma). Empty defaults to tcp.
+	// It is immutable and has no effect on v1 volumes.
+	// +kubebuilder:validation:Enum=tcp;rdma
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DataEngineTransport is immutable"
+	// +optional
+	DataEngineTransport DataEngineTransport `json:"dataEngineTransport,omitempty"`
 	// +optional
 	SnapshotMaxCount int `json:"snapshotMaxCount"`
 	// +kubebuilder:validation:Type=string

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -219,6 +219,7 @@ func (m *VolumeManager) Create(name string, spec *longhorn.VolumeSpec, recurring
 			ReplicaDiskSoftAntiAffinity:     spec.ReplicaDiskSoftAntiAffinity,
 			DataEngine:                      spec.DataEngine,
 			DataLayout:                      spec.DataLayout,
+			DataEngineTransport:             spec.DataEngineTransport,
 			FreezeFilesystemForSnapshot:     spec.FreezeFilesystemForSnapshot,
 			BackupTargetName:                backupTargetName,
 			OfflineRebuilding:               spec.OfflineRebuilding,

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -145,6 +145,23 @@ func (rcs *ReplicaScheduler) FindDiskCandidates(replica *longhorn.Replica, repli
 		return nil, errs
 	}
 
+	// A volume using the RDMA NVMe-oF transport can only be served from nodes
+	// that expose an RDMA device, so its replicas must be confined to
+	// RDMA-capable nodes (reported by the RDMACapable node condition). This
+	// keeps mixed clusters correct: replicas never land on TCP-only nodes.
+	if volume.Spec.DataEngineTransport == longhorn.DataEngineTransportRDMA {
+		for nodeName, node := range nodes {
+			if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeRDMACapable).Status != longhorn.ConditionStatusTrue {
+				delete(nodes, nodeName)
+			}
+		}
+		if len(nodes) == 0 {
+			errs.Append(longhorn.ErrorReplicaScheduleSchedulingFailed,
+				fmt.Errorf("no RDMA-capable node available for scheduling replica %v of RDMA volume %v", replica.Name, volume.Name))
+			return nil, errs
+		}
+	}
+
 	linkedClone := volume.Spec.CloneMode == longhorn.CloneModeLinkedClone
 	srcNodeDiskMap := map[string]map[string]struct{}{}
 	if linkedClone {

--- a/types/setting.go
+++ b/types/setting.go
@@ -174,6 +174,7 @@ const (
 	SettingNameDataEngineLogFlags                                       = SettingName("data-engine-log-flags")
 	SettingNameDataEngineInterruptModeEnabled                           = SettingName("data-engine-interrupt-mode-enabled")
 	SettingNameDataEngineCPUIsolationEnabled                            = SettingName("data-engine-cpu-isolation-enabled")
+	SettingNameV2DataEngineRDMADeviceResource                           = SettingName("v2-data-engine-rdma-device-resource")
 	SettingNameFreezeFilesystemForSnapshot                              = SettingName("freeze-filesystem-for-snapshot")
 	SettingNameAutoCleanupSnapshotWhenDeleteBackup                      = SettingName("auto-cleanup-when-delete-backup")
 	SettingNameAutoCleanupSnapshotAfterOnDemandBackupCompleted          = SettingName("auto-cleanup-snapshot-after-on-demand-backup-completed")
@@ -304,6 +305,7 @@ var (
 		SettingNameSnapshotDataIntegrity,
 		SettingNameDataEngineInterruptModeEnabled,
 		SettingNameDataEngineCPUIsolationEnabled,
+		SettingNameV2DataEngineRDMADeviceResource,
 		SettingNameReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume,
@@ -472,6 +474,7 @@ var (
 		SettingNameDataEngineLogFlags:                                       SettingDefinitionDataEngineLogFlags,
 		SettingNameDataEngineInterruptModeEnabled:                           SettingDefinitionDataEngineInterruptModeEnabled,
 		SettingNameDataEngineCPUIsolationEnabled:                            SettingDefinitionDataEngineCPUIsolationEnabled,
+		SettingNameV2DataEngineRDMADeviceResource:                           SettingDefinitionV2DataEngineRDMADeviceResource,
 		SettingNameReplicaDiskSoftAntiAffinity:                              SettingDefinitionReplicaDiskSoftAntiAffinity,
 		SettingNameAllowEmptyNodeSelectorVolume:                             SettingDefinitionAllowEmptyNodeSelectorVolume,
 		SettingNameAllowEmptyDiskSelectorVolume:                             SettingDefinitionAllowEmptyDiskSelectorVolume,
@@ -1942,6 +1945,20 @@ var (
 		ReadOnly:           false,
 		DataEngineSpecific: true,
 		Default:            fmt.Sprintf("{%q:\"true\"}", longhorn.DataEngineTypeV2),
+	}
+
+	SettingDefinitionV2DataEngineRDMADeviceResource = SettingDefinition{
+		DisplayName: "V2 Data Engine RDMA Device Resource",
+		Description: "Applies only to the V2 Data Engine. Name of the Kubernetes extended resource, advertised by an RDMA shared device plugin (for example, k8s-rdma-shared-dev-plugin), " +
+			"that the V2 Instance Manager pod should request so it gains declarative access to the RoCE-capable RDMA verbs device(s) (the `/dev/infiniband/*` devices) instead of relying on the privileged host device mount. \n\n" +
+			"  - This is only relevant when the engine-replica NVMe-oF fabric runs over RDMA (RoCEv2); it is orthogonal to the network attachment, which is provided by the Storage Network. \n\n" +
+			"  - Because the plugin advertises the port as a *shared* resource, many Instance Manager pods (and, in the future, a host-facing frontend consumer) can share the same physical function without a bond, preserving per-pod RoCEv2 GIDs. \n\n" +
+			"  - Example value: `rdma/hca_shared_f0`. Leave empty (default) to keep the previous behavior, where the pod obtains RDMA devices via its privileged host mount and no extended resource is requested. \n\n",
+		Category: SettingCategoryDangerZone,
+		Type:     SettingTypeString,
+		Required: false,
+		ReadOnly: false,
+		Default:  "",
 	}
 
 	SettingDefinitionReplicaDiskSoftAntiAffinity = SettingDefinition{

--- a/webhook/resources/volume/validator.go
+++ b/webhook/resources/volume/validator.go
@@ -88,6 +88,10 @@ func (v *volumeValidator) Create(request *admission.Request, newObj runtime.Obje
 		return werror.NewInvalidError(err.Error(), "spec.ublkNumberOfQueue")
 	}
 
+	if err := v.validateDataEngineTransport(volume.Spec.DataEngine, volume.Spec.DataEngineTransport, volume.Spec.NumberOfReplicas); err != nil {
+		return werror.NewInvalidError(err.Error(), "spec.dataEngineTransport")
+	}
+
 	if err := types.ValidateDataLocalityAndReplicaCount(volume.Spec.DataLocality, volume.Spec.NumberOfReplicas); err != nil {
 		return werror.NewInvalidError(err.Error(), "spec.dataLocality and spec.numberOfReplicas")
 	}
@@ -273,6 +277,12 @@ func (v *volumeValidator) Update(request *admission.Request, oldObj runtime.Obje
 	}
 	if err := validateUblkNumberOfQueue(newVolume.Spec.UblkNumberOfQueue); err != nil {
 		return werror.NewInvalidError(err.Error(), "spec.ublkNumberOfQueue")
+	}
+
+	// Transport is immutable, but NumberOfReplicas is not: re-check that an RDMA
+	// volume still has enough RDMA-capable nodes after a replica scale-up.
+	if err := v.validateDataEngineTransport(newVolume.Spec.DataEngine, newVolume.Spec.DataEngineTransport, newVolume.Spec.NumberOfReplicas); err != nil {
+		return werror.NewInvalidError(err.Error(), "spec.dataEngineTransport")
 	}
 
 	if err := types.ValidateAccessMode(newVolume.Spec.AccessMode); err != nil {
@@ -752,6 +762,41 @@ func validateNvmeTcpNrIoQueues(n int, dataEngine longhorn.DataEngineType) error 
 	}
 	if !types.IsDataEngineV2(dataEngine) {
 		return fmt.Errorf("NVMe-TCP number of I/O queues is only supported by data engine v2. Got data engine %v", dataEngine)
+	}
+	return nil
+}
+
+// validateDataEngineTransport rejects an RDMA volume that cannot possibly be
+// served: RDMA is a v2-only transport, and every engine/replica of the volume
+// must run on a node exposing an RDMA device. We therefore require at least
+// NumberOfReplicas RDMA-capable nodes (reported by the environment check monitor
+// via the RDMACapable node condition). An unset/TCP transport is always allowed.
+func (v *volumeValidator) validateDataEngineTransport(dataEngine longhorn.DataEngineType, transport longhorn.DataEngineTransport, numberOfReplicas int) error {
+	if transport == "" || transport == longhorn.DataEngineTransportTCP {
+		return nil
+	}
+	if transport != longhorn.DataEngineTransportRDMA {
+		return fmt.Errorf("invalid data engine transport %v, must be one of %v or %v",
+			transport, longhorn.DataEngineTransportTCP, longhorn.DataEngineTransportRDMA)
+	}
+	if !types.IsDataEngineV2(dataEngine) {
+		return fmt.Errorf("data engine transport %v is only supported by data engine v2. Got data engine %v",
+			transport, dataEngine)
+	}
+
+	nodes, err := v.ds.ListNodesRO()
+	if err != nil {
+		return errors.Wrap(err, "failed to list nodes for RDMA capability validation")
+	}
+	rdmaCapableNodes := 0
+	for _, node := range nodes {
+		if types.GetCondition(node.Status.Conditions, longhorn.NodeConditionTypeRDMACapable).Status == longhorn.ConditionStatusTrue {
+			rdmaCapableNodes++
+		}
+	}
+	if rdmaCapableNodes < numberOfReplicas {
+		return fmt.Errorf("data engine transport %v requires at least %d RDMA-capable node(s) to place all replicas, but only %d available; check the RDMACapable node condition",
+			transport, numberOfReplicas, rdmaCapableNodes)
 	}
 	return nil
 }


### PR DESCRIPTION
Part of longhorn/longhorn#13796. **Depends on longhorn/types#121 and longhorn/longhorn-instance-manager#1616.**

Adds RDMA (RoCEv2) support for the v2 (SPDK) data engine to longhorn-manager. Five pieces:

**1. Per-volume transport selector.** A `dataEngineTransport` value (`tcp`|`rdma`, default `tcp`, immutable) chooses the NVMe-oF transport for the internal engine↔replica fabric of a v2 volume. The host frontend always stays on TCP; only the backend replication fabric is affected; no-op on v1. Flow: StorageClass parameter → CSI CreateVolume → longhorn-manager HTTP API → Volume CR spec → engine/replica controllers → instance-manager InstanceCreate, mirroring the existing DataLayout plumbing. Empty/absent maps to TCP, so existing volumes and older peers are unaffected.

**2. Node RDMA capability.** A new `RDMACapable` node condition — the environment-check monitor reports whether a node exposes RDMA verbs devices (reads `/sys/class/infiniband`, only when the v2 data engine is enabled).

**3. Admission validation.** The volume webhook rejects `dataEngineTransport=rdma` unless the data engine is v2 and at least `numberOfReplicas` RDMA-capable nodes exist (on create and update).

**4. Scheduling.** The replica scheduler confines RDMA-volume replicas to RDMA-capable nodes, so mixed clusters (some nodes without RoCE) stay correct.

**5. Instance-manager RDMA device access (opt-in setting).** New setting `v2-data-engine-rdma-device-resource` (string, default empty):
   - **Empty (default) — unchanged behavior.** The v2 instance-manager pod already runs privileged with host device access, so the SPDK process sees `/dev/infiniband/*` with no extra deployment.
   - **Non-empty — declarative device access.** longhorn-manager injects `resources.limits[<value>] = 1` into the v2 IM pod, so it requests an RDMA device advertised by a Kubernetes RDMA device plugin (e.g. the [k8s-rdma-shared-dev-plugin](https://github.com/Mellanox/k8s-rdma-shared-dev-plugin), value like `rdma/hca_shared_f0`) instead of relying on the privileged host mount.

   *Why this setting exists:* it lets clusters that prefer not to grant privileged host-device access — or that want to share one RDMA-capable PF across pods (and a future frontend consumer) — hand the verbs device to the IM the standard Kubernetes way, via a device plugin. The default keeps today's zero-config behavior. The plugin is **not bundled and not required**; the setting only defines the interface, so any RDMA device-plugin resource string works.

Naming: adopts `TransportType` from longhorn/types#121 at the imrpc/instance-manager boundary; the manager keeps its own `DataEngineTransport` VolumeSpec type/field name (repo convention).

**Testing.** Validated on a 3-node arm64 (Ampere Altra) cluster with RoCEv2 over 25GbE (BlueField-2). An e2e harness creates a v2 `dataEngineTransport=rdma` StorageClass, provisions a PVC, mounts it in a pod, does filesystem I/O, and **asserts on the wire** that every engine→replica NVMe-oF controller reports `trtype=RDMA` (via SPDK `bdev_nvme_get_controllers`); a sibling `tcp` volume asserts `trtype=TCP`. Green across pod-mounted workload, block basic, snapshot (maintenance revert), and replica-rebuild scenarios, with sha256 data integrity across a pod restart. Throughput/latency benchmarks (~2.5–3× sequential, 2–4× lower QD1 latency) are on #13796.

Files: `k8s/pkg/apis/longhorn/v1beta2/{volume,node}.go`, `k8s/crds.yaml`, `api/{model,volume}.go`, `client/generated_volume.go`, `csi/util.go`, `controller/{engine,replica}_controller.go`, `controller/instance_manager_controller.go`, `controller/monitor/environment_check_monitor.go`, `scheduler/replica_scheduler.go`, `types/setting.go`, `webhook/resources/volume/validator.go`, `engineapi/instance_manager.go`, `manager/volume.go`.
