### PR TITLE
fix(webhook): allow lost node scheduling disable for deleted k8s node

### DIFF
--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"reflect"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
@@ -114,8 +115,32 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 			oldNode.Name), "")
 	}
 
-	// Ensure the node controller already syncs the disk spec and status.
-	if !isNodeDiskSpecAndStatusSynced(oldNode) {
+	// If the Kubernetes Node is deleted without properly evicting the Longhorn
+	// Node, the disk status may never be synced. Prevent disk configuration
+	// changes in this state, while allowing a limited spec update to disable
+	// node scheduling. Ref: https://github.com/longhorn/longhorn/issues/13494
+	if _, err := n.ds.GetKubernetesNodeRO(oldNode.Name); err != nil {
+		if !datastore.ErrorIsNotFound(err) {
+			return werror.NewInvalidError(err.Error(), "")
+		}
+		disksSpecChanged := !reflect.DeepEqual(oldNode.Spec.Disks, newNode.Spec.Disks)
+		if disksSpecChanged {
+			return werror.NewForbiddenError(fmt.Sprintf(
+				"cannot modify disks on node %v after the Kubernetes node is deleted",
+				oldNode.Name))
+		}
+
+		allowedSpec := oldNode.Spec
+		allowedSpec.AllowScheduling = false
+		if !oldNode.Spec.AllowScheduling || !reflect.DeepEqual(allowedSpec, newNode.Spec) {
+			return werror.NewForbiddenError(fmt.Sprintf(
+				"only disabling scheduling on node %v is allowed after the Kubernetes node is deleted",
+				oldNode.Name))
+		}
+		return nil
+	}
+	disksSynced := isNodeDiskSpecAndStatusSynced(oldNode)
+	if !disksSynced {
 		return werror.NewForbiddenError(fmt.Sprintf("spec and status of disks on node %v are being syncing and please retry later.", oldNode.Name))
 	}
 

--- a/webhook/resources/node/validator_test.go
+++ b/webhook/resources/node/validator_test.go
@@ -5,52 +5,215 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/longhorn/longhorn-manager/datastore"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+	managerutil "github.com/longhorn/longhorn-manager/util"
 )
 
-func TestValidateNodeDiskPathsDuplicate(t *testing.T) {
-	disks := map[string]longhorn.DiskSpec{
-		"disk-1": {Path: "/fake/path/disk1"},
-		"disk-2": {Path: "/fake/path/disk1"},
+const (
+	nodeValidatorTestName      = "lost-node"
+	nodeValidatorTestNamespace = "longhorn-system"
+)
+
+func TestValidateNodeDiskPaths(t *testing.T) {
+	testCases := []struct {
+		name          string
+		disks         map[string]longhorn.DiskSpec
+		errorMessages []string
+	}{
+		{
+			name: "duplicate paths",
+			disks: map[string]longhorn.DiskSpec{
+				"disk-1": {Path: "/fake/path/disk1"},
+				"disk-2": {Path: "/fake/path/disk1"},
+			},
+			errorMessages: []string{"duplicate disk paths", "node1", "disk-1", "disk-2", "/fake/path/disk1"},
+		},
+		{
+			name: "unique paths",
+			disks: map[string]longhorn.DiskSpec{
+				"disk-1": {Path: "/fake/path/disk1"},
+				"disk-2": {Path: "/fake/path/disk2"},
+			},
+		},
+		{
+			name: "normalized duplicate paths",
+			disks: map[string]longhorn.DiskSpec{
+				"disk-1": {Path: "/fake/path/disk1"},
+				"disk-2": {Path: "/fake/path/../path/disk1"},
+			},
+			errorMessages: []string{"duplicate disk paths", "node1", "/fake/path/disk1"},
+		},
 	}
 
-	err := validateNodeDiskPaths("node1", disks)
-	assert.Error(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNodeDiskPaths("node1", tc.disks)
+			if len(tc.errorMessages) == 0 {
+				require.NoError(t, err)
+				return
+			}
 
-	assert.Contains(t, err.Error(), "duplicate disk paths")
-	assert.Contains(t, err.Error(), "node1")
-	assert.Contains(t, err.Error(), "disk-1")
-	assert.Contains(t, err.Error(), "disk-2")
-	assert.Contains(t, err.Error(), "/fake/path/disk1")
-}
-
-func TestValidateNodeDiskPathsUnique(t *testing.T) {
-	disks := map[string]longhorn.DiskSpec{
-		"disk-1": {Path: "/fake/path/disk1"},
-		"disk-2": {Path: "/fake/path/disk2"},
+			require.Error(t, err)
+			for _, message := range tc.errorMessages {
+				assert.Contains(t, err.Error(), message)
+			}
+		})
 	}
-
-	err := validateNodeDiskPaths("node1", disks)
-	assert.NoError(t, err)
-}
-
-func TestValidateNodeDiskPathsNormalizedDuplicate(t *testing.T) {
-	disks := map[string]longhorn.DiskSpec{
-		"disk-1": {Path: "/fake/path/disk1"},
-		"disk-2": {Path: "/fake/path/disk1"},
-	}
-
-	err := validateNodeDiskPaths("node1", disks)
-	assert.Error(t, err)
-
-	assert.Contains(t, err.Error(), "duplicate disk paths")
-	assert.Contains(t, err.Error(), "node1")
-	assert.Contains(t, err.Error(), "/fake/path/disk1")
 }
 
 func TestFilepathCleanWithBDF(t *testing.T) {
 	input := "00:1f.3"
 	cleaned := filepath.Clean(input)
 	assert.Equal(t, "00:1f.3", cleaned, "filepath.Clean should not alter BDF paths")
+}
+
+func TestNodeValidatorUpdateLostKubernetesNode(t *testing.T) {
+	testCases := []struct {
+		name             string
+		kubeNodeExists   bool
+		disksSynced      bool
+		mutate           func(*longhorn.Node, *longhorn.Node)
+		expectedErrorMsg string
+	}{
+		{
+			name: "deleted node with unsynchronized disks allows scheduling disable",
+			mutate: func(_, newNode *longhorn.Node) {
+				newNode.Spec.AllowScheduling = false
+			},
+		},
+		{
+			name:        "deleted node with synchronized disks allows scheduling disable",
+			disksSynced: true,
+			mutate: func(_, newNode *longhorn.Node) {
+				newNode.Spec.AllowScheduling = false
+			},
+		},
+		{
+			name: "deleted node with unsynchronized disks rejects disk change",
+			mutate: func(_, newNode *longhorn.Node) {
+				disk := newNode.Spec.Disks["disk-1"]
+				disk.AllowScheduling = false
+				newNode.Spec.Disks["disk-1"] = disk
+			},
+			expectedErrorMsg: "cannot modify disks",
+		},
+		{
+			name:        "deleted node with synchronized disks rejects disk change",
+			disksSynced: true,
+			mutate: func(_, newNode *longhorn.Node) {
+				disk := newNode.Spec.Disks["disk-1"]
+				disk.AllowScheduling = false
+				newNode.Spec.Disks["disk-1"] = disk
+			},
+			expectedErrorMsg: "cannot modify disks",
+		},
+		{
+			name: "deleted node rejects scheduling disable with node spec co-update",
+			mutate: func(_, newNode *longhorn.Node) {
+				newNode.Spec.AllowScheduling = false
+				newNode.Spec.Tags = []string{"changed"}
+			},
+			expectedErrorMsg: "only disabling scheduling",
+		},
+		{
+			name: "deleted node with unsynchronized disks rejects unchanged scheduling",
+			mutate: func(_, _ *longhorn.Node) {
+			},
+			expectedErrorMsg: "only disabling scheduling",
+		},
+		{
+			name: "deleted node with unsynchronized disks rejects scheduling enable",
+			mutate: func(oldNode, newNode *longhorn.Node) {
+				oldNode.Spec.AllowScheduling = false
+				newNode.Spec.AllowScheduling = true
+			},
+			expectedErrorMsg: "only disabling scheduling",
+		},
+		{
+			name:        "deleted node with synchronized disks rejects scheduling enable",
+			disksSynced: true,
+			mutate: func(oldNode, newNode *longhorn.Node) {
+				oldNode.Spec.AllowScheduling = false
+				newNode.Spec.AllowScheduling = true
+			},
+			expectedErrorMsg: "only disabling scheduling",
+		},
+		{
+			name:           "existing node with unsynchronized disks rejects scheduling disable",
+			kubeNodeExists: true,
+			mutate: func(_, newNode *longhorn.Node) {
+				newNode.Spec.AllowScheduling = false
+			},
+			expectedErrorMsg: "spec and status of disks",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := kubefake.NewSimpleClientset()
+			validator := newNodeValidatorForTest(kubeClient)
+			if tc.kubeNodeExists {
+				err := validator.ds.KubeNodeInformer.GetStore().Add(&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: nodeValidatorTestName},
+				})
+				require.NoError(t, err)
+			}
+			oldNode, newNode := newNodeValidatorUpdate()
+			if tc.disksSynced {
+				oldNode.Status.DiskStatus["disk-1"] = &longhorn.DiskStatus{}
+				newNode.Status.DiskStatus["disk-1"] = &longhorn.DiskStatus{}
+			}
+			tc.mutate(oldNode, newNode)
+
+			err := validator.Update(nil, oldNode, newNode)
+			if tc.expectedErrorMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErrorMsg)
+		})
+	}
+}
+
+func newNodeValidatorForTest(kubeClient *kubefake.Clientset) *nodeValidator {
+	lhClient := lhfake.NewClientset()
+	extensionsClient := apiextensionsfake.NewSimpleClientset()
+	informerFactories := managerutil.NewInformerFactories(nodeValidatorTestNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(nodeValidatorTestNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+	return &nodeValidator{ds: ds}
+}
+
+func newNodeValidatorUpdate() (*longhorn.Node, *longhorn.Node) {
+	oldNode := &longhorn.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeValidatorTestName,
+			Namespace: nodeValidatorTestNamespace,
+		},
+		Spec: longhorn.NodeSpec{
+			Name:            nodeValidatorTestName,
+			AllowScheduling: true,
+			Disks: map[string]longhorn.DiskSpec{
+				"disk-1": {
+					Path:            "/var/lib/longhorn",
+					AllowScheduling: true,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{},
+		},
+	}
+	return oldNode, oldNode.DeepCopy()
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13494

#### What this PR does / why we need it:

When a Kubernetes Node is deleted without properly Longhorn node eviction, the disk status have no chance to be synced, and the Node CR spec is no longer mutable. Without disabling node scheduling, this Node CR would be undetectable, though the corresponding Kubernetes Node is gone.

In this PR, when the node leaves, we partially allow Node spec update.

#### Special notes for your reviewer:

#### Additional documentation or context
