### PR TITLE
fix: retry post-rebuild snapshot purge on transient start failure

### DIFF
--- a/controller/engine_controller.go
+++ b/controller/engine_controller.go
@@ -2650,10 +2650,19 @@ func (ec *EngineController) startPostRebuildPurge(
 			"Failed to start snapshot purge for engine %v and volume %v after rebuilding: %v", engine.Name, engine.Spec.VolumeName, err)
 		return
 	}
-	if err := cleanupProxy.SnapshotPurge(dataEngineObj); err != nil {
-		log.WithError(err).Error("Failed to start snapshot purge after rebuilding")
+
+	// Unlike the pre-rebuild purge, a failure here has no later reconcile that
+	// retriggers rebuild and retries the purge as a side effect, since the
+	// rebuild already succeeded. Retry the start call directly so a transient
+	// failure does not leave the post-rebuild snapshot un-purged forever.
+	var purgeErr error
+	if err := wait.PollUntilContextTimeout(context.Background(), EnginePollInterval, EnginePollTimeout, true, func(context.Context) (bool, error) {
+		purgeErr = cleanupProxy.SnapshotPurge(dataEngineObj)
+		return purgeErr == nil, nil
+	}); err != nil {
+		log.WithError(purgeErr).Error("Failed to start snapshot purge after rebuilding")
 		ec.eventRecorder.Eventf(engine, corev1.EventTypeWarning, constant.EventReasonFailedStartingSnapshotPurge,
-			"Failed to start snapshot purge for engine %v and volume %v after rebuilding: %v", engine.Name, engine.Spec.VolumeName, err)
+			"Failed to start snapshot purge for engine %v and volume %v after rebuilding: %v", engine.Name, engine.Spec.VolumeName, purgeErr)
 		return
 	}
 }

--- a/controller/engine_controller_test.go
+++ b/controller/engine_controller_test.go
@@ -4,17 +4,24 @@ import (
 	"io"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+
 	etypes "github.com/longhorn/longhorn-engine/pkg/types"
 
+	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
 // mockEngineClientProxy wraps EngineSimulator and overrides ReplicaRebuildVerify for test control.
@@ -284,6 +291,82 @@ func TestVerifyCompletedRebuild(t *testing.T) {
 
 			newMonitor().verifyCompletedRebuild(engine, tc.addressReplicaMap, tc.rebuildStatus, proxy)
 			assert.ElementsMatch(tc.expectVerified, proxy.verifyCalled, "ReplicaRebuildVerify call mismatch")
+		})
+	}
+}
+
+// countingPurgeProxy wraps EngineSimulator and fails SnapshotPurge a fixed
+// number of times before succeeding, to exercise startPostRebuildPurge's retry.
+type countingPurgeProxy struct {
+	*engineapi.EngineSimulator
+	failCount int
+	calls     int
+}
+
+var _ engineapi.EngineClientProxy = (*countingPurgeProxy)(nil)
+
+func (p *countingPurgeProxy) Close() {}
+
+func (p *countingPurgeProxy) SnapshotPurge(_ engineapi.DataEngineObject) error {
+	p.calls++
+	if p.calls <= p.failCount {
+		return errors.New("transient failure")
+	}
+	return nil
+}
+
+// TestStartPostRebuildPurgeRetriesOnFailure guards against the regression in
+// https://github.com/longhorn/longhorn/issues/12229: unlike the pre-rebuild
+// purge (which gets retried for free on the next reconcile of an incomplete
+// rebuild), a failed post-rebuild purge start previously had no retry at all.
+func TestStartPostRebuildPurgeRetriesOnFailure(t *testing.T) {
+	origInterval, origTimeout := EnginePollInterval, EnginePollTimeout
+	EnginePollInterval = time.Millisecond
+	EnginePollTimeout = 50 * time.Millisecond
+	defer func() {
+		EnginePollInterval = origInterval
+		EnginePollTimeout = origTimeout
+	}()
+
+	datastore.SkipListerCheck = true
+	kubeClient := fake.NewSimpleClientset()             // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()              // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(TestNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	logger := logrus.New()
+	logger.Out = io.Discard
+	log := logrus.NewEntry(logger)
+
+	vol := newVolume(TestVolumeName, 1)
+	engine := newEngineForVolume(vol)
+
+	tests := map[string]struct {
+		failCount   int
+		expectCalls int
+	}{
+		"succeeds on first attempt": {failCount: 0, expectCalls: 1},
+		"retries after transient failures then succeeds": {failCount: 2, expectCalls: 3},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := require.New(t)
+
+			proxy := &countingPurgeProxy{
+				EngineSimulator: &engineapi.EngineSimulator{},
+				failCount:       tc.failCount,
+			}
+			ec := &EngineController{
+				ds:                        ds,
+				snapshotConcurrentLimiter: NewSnapshotConcurrentLimiter(),
+				eventRecorder:             record.NewFakeRecorder(10),
+			}
+
+			ec.startPostRebuildPurge(log, engine, proxy)
+
+			assert.Equal(tc.expectCalls, proxy.calls, "SnapshotPurge call count mismatch")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- There are two snapshot purges around replica rebuild: pre-rebuild and post-rebuild.
- The pre-rebuild purge gets retried for free: if `waitForPreRebuildPurge` fails to start it, rebuild does not proceed, and the whole flow (including the purge attempt) is retried on the next reconcile since the replica still needs rebuilding.
- The post-rebuild purge (`startPostRebuildPurge`) has no equivalent second chance: it fires once after a successful rebuild and, on failure, only logs + emits an event. A transient failure there left redundant system-generated snapshots un-purged indefinitely (the reported issue).
- Fix: retry the purge start call within the same poll interval/timeout (`EnginePollInterval`/`EnginePollTimeout`) already used elsewhere in `engine_controller.go` for confirming rebuild start, instead of giving up after a single attempt.

Fixes longhorn/longhorn#12229

## Test plan
- [x] Added `TestStartPostRebuildPurgeRetriesOnFailure` covering both the immediate-success case and a transient-failures-then-success case, verifying the retry count.
- [x] `go test ./controller/...` (via `golang:1.26` container, since this repo targets Linux) — 114 tests pass; 2 pre-existing failures (`TestReconcileSystemBackup`, `TestSystemRollout`) reproduce identically on a clean `master` checkout, confirming they're unrelated to this change.
- [x] `go build`/`go vet` clean (`GOOS=linux GOARCH=amd64`).