### PR TITLE
fix(backup-target): transfer ownership away from drained node

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -908,25 +908,58 @@ func (btc *BackupTargetController) isResponsibleFor(bt *longhorn.BackupTarget, d
 		return false, err
 	}
 
-	// Skip instance manager readiness check when the BackupTarget is being deleted.
-	// During cluster uninstallation or when data engines are disabled,
-	// instance-manager pods on this node might already have been removed.
+	currentOwnerAvailable := currentOwnerEngineAvailable
+	currentNodeAvailable := currentNodeEngineAvailable
+
+	// A responsible node must also have a running instance manager, because reaching the remote
+	// backup target goes through an engine client proxy served by an instance manager. The engine
+	// image readiness check alone is not enough: a node drained with --ignore-daemonsets keeps the
+	// engine image DaemonSet (and longhorn-manager) running while its instance manager pod is
+	// evicted. Without accounting for the instance manager, ownership can stay pinned to such a
+	// node, so the BackupTarget is never synced and BackupVolume CRs are never created.
+	// Ref: https://github.com/longhorn/longhorn/issues/13775
+	// Skip this while the BackupTarget is being deleted. During cluster uninstallation or when data
+	// engines are disabled, instance-manager pods might already have been removed.
 	// Ref: https://github.com/longhorn/longhorn/issues/11934
 	if bt.DeletionTimestamp.IsZero() {
-		instanceManager, err := btc.ds.GetRunningInstanceManagerByNodeRO(btc.controllerID, "")
+		nodesWithRunningIM, err := btc.listNodesWithRunningInstanceManager()
 		if err != nil {
 			return false, err
 		}
-		if instanceManager == nil {
-			return false, errors.New("failed to get running instance manager")
+		// Only require a running instance manager when at least one node has one to fall back to.
+		// If no node has a running instance manager (e.g. a full outage), keep the engine-image-only
+		// behavior so the backup target still gets an owner that surfaces the error and retries,
+		// instead of being left ownerless and silently stalled.
+		if len(nodesWithRunningIM) > 0 {
+			_, ownerIMRunning := nodesWithRunningIM[bt.Status.OwnerID]
+			_, nodeIMRunning := nodesWithRunningIM[btc.controllerID]
+			currentOwnerAvailable = currentOwnerAvailable && ownerIMRunning
+			currentNodeAvailable = currentNodeAvailable && nodeIMRunning
 		}
 	}
 
-	isPreferredOwner := currentNodeEngineAvailable && isResponsible
-	continueToBeOwner := currentNodeEngineAvailable && btc.controllerID == bt.Status.OwnerID
-	requiresNewOwner := currentNodeEngineAvailable && !currentOwnerEngineAvailable
+	isPreferredOwner := currentNodeAvailable && isResponsible
+	continueToBeOwner := currentNodeAvailable && btc.controllerID == bt.Status.OwnerID
+	requiresNewOwner := currentNodeAvailable && !currentOwnerAvailable
 
 	return isPreferredOwner || continueToBeOwner || requiresNewOwner, nil
+}
+
+// listNodesWithRunningInstanceManager returns the set of nodes that have a running instance
+// manager for any enabled data engine. A backup target reconcile can be served by any such node,
+// so the union across data engines is used to decide ownership.
+func (btc *BackupTargetController) listNodesWithRunningInstanceManager() (map[string]*longhorn.Node, error) {
+	nodesWithRunningIM := map[string]*longhorn.Node{}
+	for dataEngine := range btc.ds.GetDataEngines() {
+		nodes, err := btc.ds.ListNodesWithReadyInstanceManagerRO(dataEngine)
+		if err != nil {
+			return nil, err
+		}
+		for name, node := range nodes {
+			nodesWithRunningIM[name] = node
+		}
+	}
+	return nodesWithRunningIM, nil
 }
 
 // cleanupBackupVolumes deletes all BackupVolume CRs

--- a/controller/backup_target_controller_test.go
+++ b/controller/backup_target_controller_test.go
@@ -1,12 +1,28 @@
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	. "gopkg.in/check.v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/controller"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
 func TestIsBackupTargetSyncRequired(t *testing.T) {
@@ -103,5 +119,126 @@ func TestIsBackupTargetSyncRequired(t *testing.T) {
 				t.Fatalf("unexpected sync requirement: got %v, want %v", actual, tc.expected)
 			}
 		})
+	}
+}
+
+func newTestBackupTargetController(lhClient *lhfake.Clientset, kubeClient *fake.Clientset, extensionsClient *apiextensionsfake.Clientset,
+	informerFactories *util.InformerFactories, controllerID string) (*BackupTargetController, error) {
+	ds := datastore.NewDataStore(TestNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	logger := logrus.StandardLogger()
+	proxyConnCounter := util.NewAtomicCounter()
+	btc, err := NewBackupTargetController(logger, ds, scheme.Scheme, kubeClient, controllerID, TestNamespace, proxyConnCounter)
+	if err != nil {
+		return nil, err
+	}
+	fakeRecorder := record.NewFakeRecorder(100)
+	btc.eventRecorder = fakeRecorder
+	for index := range btc.cacheSyncs {
+		btc.cacheSyncs[index] = alwaysReady
+	}
+	return btc, nil
+}
+
+// TestBackupTargetIsResponsibleFor verifies that backup target ownership is transferred to a node
+// with a running instance manager when the current owner is drained (its engine image DaemonSet
+// keeps running while the instance manager pod is evicted). Otherwise the BackupTarget is never
+// synced and BackupVolume CRs are never created. Ref: https://github.com/longhorn/longhorn/issues/13775
+func (s *TestSuite) TestBackupTargetIsResponsibleFor(c *C) {
+	testCases := map[string]struct {
+		controllerID       string
+		ownerID            string
+		nodesWithRunningIM []string
+		expected           bool
+	}{
+		"node with running instance manager takes over from drained owner": {
+			controllerID:       TestNode2,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           true,
+		},
+		"drained owner without running instance manager backs off": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           false,
+		},
+		"owner with running instance manager keeps ownership": {
+			controllerID:       TestNode2,
+			ownerID:            TestNode2,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           true,
+		},
+		"full outage falls back to engine image only behavior": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{},
+			expected:           true,
+		},
+	}
+
+	for name, tc := range testCases {
+		c.Logf("testing %v", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		settingIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+		nodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+		eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+
+		btc, err := newTestBackupTargetController(lhClient, kubeClient, extensionsClient, informerFactories, tc.controllerID)
+		c.Assert(err, IsNil)
+
+		for _, setting := range []*longhorn.Setting{
+			newSetting(string(types.SettingNameDefaultEngineImage), TestEngineImage),
+			newSetting(string(types.SettingNameDefaultInstanceManagerImage), TestInstanceManagerImage),
+			newSetting(string(types.SettingNameV1DataEngine), "true"),
+			newSetting(string(types.SettingNameV2DataEngine), "false"),
+		} {
+			setting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(settingIndexer.Add(setting), IsNil)
+		}
+
+		// Both nodes are Ready and both have the engine image deployed, mimicking a node drained with
+		// --ignore-daemonsets that keeps the engine image DaemonSet running.
+		engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+		engineImage.Status.NodeDeploymentMap = map[string]bool{TestNode1: true, TestNode2: true}
+		engineImage, err = lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(eiIndexer.Add(engineImage), IsNil)
+
+		for _, nodeName := range []string{TestNode1, TestNode2} {
+			node := newNode(nodeName, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+			node, err = lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(nodeIndexer.Add(node), IsNil)
+		}
+
+		for _, nodeName := range tc.nodesWithRunningIM {
+			im := newInstanceManager("instance-manager-"+nodeName, longhorn.InstanceManagerStateRunning,
+				nodeName, nodeName, randomIP(), nil, nil, nil, longhorn.DataEngineTypeV1, TestInstanceManagerImage, false)
+			im, err = lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), im, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(imIndexer.Add(im), IsNil)
+		}
+
+		backupTarget := &longhorn.BackupTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      types.DefaultBackupTargetName,
+				Namespace: TestNamespace,
+			},
+			Status: longhorn.BackupTargetStatus{
+				OwnerID: tc.ownerID,
+			},
+		}
+
+		isResponsible, err := btc.isResponsibleFor(backupTarget, TestEngineImage)
+		c.Assert(err, IsNil)
+		c.Assert(isResponsible, Equals, tc.expected)
 	}
 }


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13775

#### What this PR does / why we need it:

Backup target ownership could deadlock when the current owner node was drained with --ignore-daemonsets. Such a node keeps its engine-image DaemonSet and longhorn-manager running while its instance-manager pod is evicted, so the drained owner backed off (no running instance manager), but no other node could take over because isControllerResponsibleFor considers a node with a running longhorn-manager as available. As a result the BackupTarget was never synced and no BackupVolume CR was created after a backup completed.

Factor the running instance manager into the owner and current node availability checks in isResponsibleFor, mirroring the backup controller, so a node with a running instance manager can take over from a drained owner. The instance manager requirement is only applied when at least one node has a running instance manager, preserving the engine-image-only behavior during a full outage.

#### Special notes for your reviewer:

#### Additional documentation or context
