### PR TITLE
fix(webhook): Add storageClass admission validation for VolumeDataLayout parameters

### DIFF
--- a/csi/util.go
+++ b/csi/util.go
@@ -296,11 +296,11 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		vol.DataEngine = driver
 	}
 
-	layoutType, hasLayoutType := volOptions["dataLayout.type"]
-	layoutMode, hasLayoutMode := volOptions["dataLayout.mode"]
-	dataChunksRaw, hasDataChunks := volOptions["dataLayout.dataChunks"]
-	parityChunksRaw, hasParityChunks := volOptions["dataLayout.parityChunks"]
-	stripSizeKBRaw, hasStripSizeKB := volOptions["dataLayout.stripSizeKB"]
+	layoutType, hasLayoutType := volOptions[longhorn.DataLayoutParameterType]
+	layoutMode, hasLayoutMode := volOptions[longhorn.DataLayoutParameterMode]
+	dataChunksRaw, hasDataChunks := volOptions[longhorn.DataLayoutParameterDataChunks]
+	parityChunksRaw, hasParityChunks := volOptions[longhorn.DataLayoutParameterParityChunks]
+	stripSizeKBRaw, hasStripSizeKB := volOptions[longhorn.DataLayoutParameterStripSizeKB]
 
 	if hasLayoutType || hasLayoutMode || hasDataChunks || hasParityChunks || hasStripSizeKB {
 		vol.DataLayout = &longhornclient.VolumeDataLayout{}
@@ -313,21 +313,21 @@ func getVolumeOptions(volumeID string, volOptions map[string]string) (*longhornc
 		if hasDataChunks {
 			dataChunks, err := strconv.Atoi(dataChunksRaw)
 			if err != nil {
-				return nil, errors.Wrap(err, "invalid parameter dataLayout.dataChunks")
+				return nil, errors.Wrapf(err, "invalid parameter %s", longhorn.DataLayoutParameterDataChunks)
 			}
 			vol.DataLayout.DataChunks = int64(dataChunks)
 		}
 		if hasParityChunks {
 			parityChunks, err := strconv.Atoi(parityChunksRaw)
 			if err != nil {
-				return nil, errors.Wrap(err, "invalid parameter dataLayout.parityChunks")
+				return nil, errors.Wrapf(err, "invalid parameter %s", longhorn.DataLayoutParameterParityChunks)
 			}
 			vol.DataLayout.ParityChunks = int64(parityChunks)
 		}
 		if hasStripSizeKB {
 			stripSizeKB, err := strconv.Atoi(stripSizeKBRaw)
 			if err != nil {
-				return nil, errors.Wrap(err, "invalid parameter dataLayout.stripSizeKB")
+				return nil, errors.Wrapf(err, "invalid parameter %s", longhorn.DataLayoutParameterStripSizeKB)
 			}
 			vol.DataLayout.StripSizeKB = int64(stripSizeKB)
 		}

--- a/k8s/pkg/apis/longhorn/v1beta2/volume.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/volume.go
@@ -76,6 +76,15 @@ type VolumeDataLayout struct {
 	StripSizeKB int `json:"stripSizeKB,omitempty"`
 }
 
+const (
+	DataLayoutParameterPrefix       = "dataLayout"
+	DataLayoutParameterType         = DataLayoutParameterPrefix + ".type"
+	DataLayoutParameterMode         = DataLayoutParameterPrefix + ".mode"
+	DataLayoutParameterDataChunks   = DataLayoutParameterPrefix + ".dataChunks"
+	DataLayoutParameterParityChunks = DataLayoutParameterPrefix + ".parityChunks"
+	DataLayoutParameterStripSizeKB  = DataLayoutParameterPrefix + ".stripSizeKB"
+)
+
 // +kubebuilder:validation:Enum=blockdev;iscsi;nvmf;ublk;""
 type VolumeFrontend string
 

--- a/webhook/resources/storageclass/validator.go
+++ b/webhook/resources/storageclass/validator.go
@@ -1,0 +1,104 @@
+package storageclass
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	storagev1 "k8s.io/api/storage/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/webhook/admission"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	werror "github.com/longhorn/longhorn-manager/webhook/error"
+)
+
+const dataLayoutKeyPrefix = longhorn.DataLayoutParameterPrefix + "."
+
+var dataLayoutSubFields = sets.New[string](
+	longhorn.DataLayoutParameterType,
+	longhorn.DataLayoutParameterMode,
+	longhorn.DataLayoutParameterDataChunks,
+	longhorn.DataLayoutParameterParityChunks,
+	longhorn.DataLayoutParameterStripSizeKB,
+)
+
+type storageClassValidator struct {
+	admission.DefaultValidator
+	ds *datastore.DataStore
+}
+
+func NewValidator(ds *datastore.DataStore) admission.Validator {
+	return &storageClassValidator{ds: ds}
+}
+
+func (v *storageClassValidator) Resource() admission.Resource {
+	return admission.Resource{
+		Name:       "storageclasses",
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   storagev1.SchemeGroupVersion.Group,
+		APIVersion: storagev1.SchemeGroupVersion.Version,
+		ObjectType: &storagev1.StorageClass{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			// kube-apiserver already rejects changes to
+			// .parameters and .provisioner on StorageClass update,
+			// so there's nothing new to validate there.
+		},
+	}
+}
+
+func (v *storageClassValidator) Create(request *admission.Request, newObj runtime.Object) error {
+	sc, ok := newObj.(*storagev1.StorageClass)
+	if !ok {
+		return werror.NewInvalidError(fmt.Sprintf("%v is not a *storagev1.StorageClass", newObj), "")
+	}
+
+	// Only Longhorn-provisioned StorageClasses are to be validated;
+	// anything else passes through untouched.
+	if sc.Provisioner != types.LonghornDriverName {
+		return nil
+	}
+
+	if errs := validateDataLayout(sc.Parameters); len(errs) > 0 {
+		return werror.NewInvalidError(errs.ToAggregate().Error(), "parameters")
+	}
+	return nil
+}
+
+func validateDataLayout(params map[string]string) field.ErrorList {
+	errors := field.ErrorList{}
+	fp := field.NewPath("parameters")
+
+	for key := range params {
+		switch {
+		// invalidates for parameters["dataLayout"] (no type/subfield)
+		case key == longhorn.DataLayoutParameterPrefix:
+			errors = append(errors, field.Invalid(fp.Key(key), key,
+				fmt.Sprintf("must specify a subfield, e.g. %q", longhorn.DataLayoutParameterType)))
+
+		// invalidates for parameters["dataLayout.<unknown>"], e.g. a typo'd subfield
+		case strings.HasPrefix(key, dataLayoutKeyPrefix):
+			if !dataLayoutSubFields.Has(key) {
+				errors = append(errors, field.Invalid(fp.Key(key), key,
+					fmt.Sprintf("unknown field %q", key)))
+			}
+
+		// invalidates for any subfield passed without "dataLayout." prefix
+		default:
+			if dataLayoutSubFields.Has(dataLayoutKeyPrefix + key) {
+				errors = append(errors, field.Invalid(fp.Key(key), key,
+					fmt.Sprintf("%q is a dataLayout field and must be prefixed as %q", key, dataLayoutKeyPrefix+key)))
+			}
+		}
+		// NOTE: The current validation does not infer a misspelled dataLayout prefix from
+		// the leaf name (e.g. "dataLayour.mode"), as field names may be shared by unrelated nested structs.
+	}
+	return errors
+}

--- a/webhook/resources/storageclass/validator_test.go
+++ b/webhook/resources/storageclass/validator_test.go
@@ -1,0 +1,141 @@
+package storageclass
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDataLayout(t *testing.T) {
+	tests := []struct {
+		name            string
+		params          map[string]string
+		expectedFields  []string
+		incorrectFields []string
+		reasonKeyword   string
+	}{
+		{
+			name: "all valid parameters passed",
+			params: map[string]string{
+				"dataLayout.type":         "sharded",
+				"dataLayout.mode":         "erasureCoding",
+				"dataLayout.dataChunks":   "4",
+				"dataLayout.parityChunks": "2",
+				"dataLayout.stripSizeKB":  "64",
+			},
+			expectedFields: []string{
+				"dataLayout.type",
+				"dataLayout.mode",
+				"dataLayout.dataChunks",
+				"dataLayout.parityChunks",
+				"dataLayout.stripSizeKB",
+			},
+			incorrectFields: []string{},
+		},
+		{
+			name: "valid dataLayout parameters passed with other SC parameters",
+			params: map[string]string{
+				"dataEngine":            "v2",
+				"dataLayout.type":       "sharded",
+				"dataLayout.mode":       "erasureCoding",
+				"dataLayout.dataChunks": "4",
+			},
+			expectedFields: []string{
+				"dataEngine",
+				"dataLayout.type",
+				"dataLayout.mode",
+				"dataLayout.dataChunks",
+			},
+			incorrectFields: []string{},
+		},
+		{
+			name: "only dataLayout with no subfield passed",
+			params: map[string]string{
+				"dataEngine": "v2",
+				"dataLayout": "sharded",
+			},
+			expectedFields:  []string{"dataEngine"},
+			incorrectFields: []string{"dataLayout"},
+			reasonKeyword:   "must specify a subfield",
+		},
+		{
+			name: "dataLayout parameters passed without prefix",
+			params: map[string]string{
+				"dataEngine":   "v2",
+				"type":         "sharded",
+				"mode":         "erasureCoding",
+				"dataChunks":   "4",
+				"parityChunks": "2",
+				"stripSizeKB":  "64",
+			},
+			expectedFields: []string{
+				"dataEngine",
+			},
+			incorrectFields: []string{
+				"type", "mode", "dataChunks", "parityChunks", "stripSizeKB",
+			},
+			reasonKeyword: "must be prefixed",
+		},
+		{
+			name: "unknown dataLayout parameters passed",
+			params: map[string]string{
+				"dataLayout.type":    "sharded",
+				"dataLayout.unknown": "foo",
+			},
+			expectedFields:  []string{"dataLayout.type"},
+			incorrectFields: []string{"dataLayout.unknown"},
+			reasonKeyword:   "unknown field",
+		},
+		{
+			name: "no dataLayout parameters passed, but other SC parameters",
+			params: map[string]string{
+				"dataEngine":       "v1",
+				"backupTargetName": "default",
+				"fsType":           "ext4",
+			},
+			expectedFields:  []string{"dataEngine", "backupTargetName", "fsType"},
+			incorrectFields: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Every incorrectFields entry is expected to produce an error, and reasonKeyword
+			// documents what that error should say. A missing reasonKeyword at present means the
+			// test case was left incomplete rather than intentionally skipping the message check.
+			if len(tc.incorrectFields) > 0 {
+				require.NotEmpty(t, tc.reasonKeyword,
+					"test case %q has incorrectFields but no reasonKeyword set; was this intentional?", tc.name)
+			}
+
+			errs := validateDataLayout(tc.params)
+
+			require.Equal(t, len(tc.expectedFields)+len(tc.incorrectFields), len(tc.params),
+				"every param key should be classified as either expected or incorrect")
+			require.Len(t, errs, len(tc.incorrectFields),
+				"unexpected number of errors.\nexpected fields: %v\ngot errors: %+v",
+				tc.incorrectFields, errs)
+
+			gotErrorDetails := make(map[string]string)
+			for _, err := range errs {
+				fieldName, ok := err.BadValue.(string)
+				require.True(t, ok, "BadValue should be a string, got %T (%v)", err.BadValue, err.BadValue)
+				gotErrorDetails[fieldName] = err.Detail
+			}
+
+			for _, f := range tc.incorrectFields {
+				detail, found := gotErrorDetails[f]
+				assert.True(t, found, "expected an error for field %q", f)
+				if tc.reasonKeyword != "" {
+					assert.Contains(t, detail, tc.reasonKeyword, "error for field %q should indicate %q, got: %q", f, tc.reasonKeyword, detail)
+				}
+			}
+
+			for _, f := range tc.expectedFields {
+				_, found := gotErrorDetails[f]
+				assert.False(t, found, "did not expect an error for field %q", f)
+			}
+		})
+	}
+}

--- a/webhook/server/validation.go
+++ b/webhook/server/validation.go
@@ -28,6 +28,7 @@ import (
 	"github.com/longhorn/longhorn-manager/webhook/resources/shardgroup"
 	"github.com/longhorn/longhorn-manager/webhook/resources/snapshot"
 	"github.com/longhorn/longhorn-manager/webhook/resources/snapshotgroup"
+	"github.com/longhorn/longhorn-manager/webhook/resources/storageclass"
 	"github.com/longhorn/longhorn-manager/webhook/resources/supportbundle"
 	"github.com/longhorn/longhorn-manager/webhook/resources/systembackup"
 	"github.com/longhorn/longhorn-manager/webhook/resources/systemrestore"
@@ -57,6 +58,7 @@ func Validation(ds *datastore.DataStore) (http.Handler, []admission.Resource, er
 		snapshotgroup.NewValidator(ds),
 		shardgroup.NewValidator(ds),
 		shard.NewValidator(ds),
+		storageclass.NewValidator(ds),
 		supportbundle.NewValidator(ds),
 		systembackup.NewValidator(ds),
 		systemrestore.NewValidator(ds),


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13792

#### What this PR does / why we need it:

This commit:
- Introduces constants for `VolumeDataLayout` fields and replaces hard-coded string checks with them.
- Validates the `dataLayout.<field>` format for `VolumeDataLayout` fields, rejecting bare, unknown, or unprefixed field names. Valid field names are derived from these constants to keep the validation in sync with the struct.

#### Special notes for your reviewer:
A misspelled prefix is intentionally not detected, as matching subfield names may belong to unrelated nested fields.

#### Additional documentation or context
