### PR TITLE
fix(recurring-job): propagate volume job errors after sweep

### DIFF
--- a/app/recurringjob/volume.go
+++ b/app/recurringjob/volume.go
@@ -71,16 +71,12 @@ func startVolumeJobs(job *Job, recurringJob *longhorn.RecurringJob, startJob sta
 	for _, volumeName := range filteredVolumes {
 		startJobVolumeName := volumeName
 		ewg.Go(func() error {
-			// A per-volume failure (for example, a rebuilding replica blocking
-			// snapshot purge) must not abort the whole sweep. Log it and continue
-			// so the next scheduled run retries this volume instead of the process
-			// exiting non-zero and re-running every volume from scratch. Task
-			// handlers (doSnapshotCleanup, doRecurringFilesystemTrim) already emit
-			// their own Warning events, so we don't record a duplicate here.
-			if jobErr := startJob(job, recurringJob, startJobVolumeName, concurrentLimiter, jobGroups); jobErr != nil {
-				job.logger.WithError(jobErr).WithField("volume", startJobVolumeName).Warn("Failed to run recurring job for volume; will retry on the next run")
+			// errgroup.Group has no context here, so returning an error does not stop sibling volume jobs.
+			jobErr := startJob(job, recurringJob, startJobVolumeName, concurrentLimiter, jobGroups)
+			if jobErr != nil {
+				job.logger.WithError(jobErr).WithField("volume", startJobVolumeName).Warn("Failed to run recurring job for volume")
 			}
-			return nil
+			return jobErr
 		})
 	}
 

--- a/app/recurringjob/volume_test.go
+++ b/app/recurringjob/volume_test.go
@@ -54,11 +54,12 @@ func newAttachedRecurringVolume(name, jobName string) *longhorn.Volume {
 	}
 }
 
-// TestStartVolumeJobsSkipsFailedVolumes verifies the core fix for
-// longhorn/longhorn#13623: a per-volume failure (for example, a rebuilding
-// replica blocking snapshot purge) must not abort the whole sweep. Every volume
-// is still attempted, the run returns nil so the process exits zero and the next
-// scheduled run retries, and each failure is surfaced in the logs.
+// TestStartVolumeJobsSkipsFailedVolumes verifies that a per-volume failure (for
+// example, a rebuilding replica blocking snapshot purge) does not abort the
+// whole sweep (longhorn/longhorn#13623): every volume is still attempted and
+// each failure is surfaced in the logs. It also verifies that the sweep still
+// returns a non-nil error so the process exits non-zero and Kubernetes applies
+// the Job's OnFailure/backoff retry (longhorn/longhorn#13587).
 func TestStartVolumeJobsSkipsFailedVolumes(t *testing.T) {
 	assert := assert.New(t)
 
@@ -114,9 +115,10 @@ func TestStartVolumeJobsSkipsFailedVolumes(t *testing.T) {
 
 	err := startVolumeJobs(job, recurringJob, startJob)
 
-	// One volume failing must not fail the run; otherwise the CronJob Job exits
-	// non-zero and re-runs every volume from scratch.
-	assert.NoError(err, "a single volume's failure must not abort the sweep")
+	// A per-volume failure must not abort the sweep, but it must still be
+	// propagated so the CronJob Job exits non-zero and Kubernetes can retry.
+	assert.Error(err, "a failing volume must surface an error from the sweep")
+	assert.ErrorIs(err, rebuildErr)
 
 	sort.Strings(attempted)
 	assert.Equal([]string{"vol-a", "vol-c", "vol-fail"}, attempted,
@@ -163,10 +165,10 @@ func TestStartVolumeJobs(t *testing.T) {
 		Spec: longhorn.RecurringJobSpec{Concurrency: 1},
 	}
 
-	t.Run("swallows a volume worker error", func(t *testing.T) {
-		// A per-volume worker failure must not propagate: it is logged and the
-		// sweep returns nil so the next run retries. Here the real worker path
-		// fails at Volume.ById.
+	t.Run("propagates a volume worker error", func(t *testing.T) {
+		// A per-volume worker failure is logged and propagated so the sweep
+		// returns non-nil and the process exits non-zero. Here the real worker
+		// path fails at Volume.ById.
 		volume := &longhorn.Volume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      volumeName,
@@ -181,7 +183,7 @@ func TestStartVolumeJobs(t *testing.T) {
 
 		err := StartVolumeJobs(job, recurringJob)
 
-		assert.NoError(t, err, "a per-volume worker error must not abort the sweep")
+		assert.Error(t, err, "a per-volume worker error must be propagated")
 	})
 
 	t.Run("returns nil with no selected volumes", func(t *testing.T) {


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13587

#### What this PR does / why we need it:

A previous change kept recurring-job sweeps running when an individual volume job failed, but it also swallowed the per-volume error by returning nil from each errgroup worker. As a result, recurring-job pods could still exit with status 0 even when backup or snapshot work failed, causing the Kubernetes Job to be marked Complete.

Return the per-volume error after logging it. Since this errgroup is not created with a context, returning an error does not cancel sibling workers, so the sweep still attempts every selected volume. ewg.Wait() now reports a non-nil error when any volume job fails, allowing the recurring-job command to exit non-zero and Kubernetes to apply the configured OnFailure/backoff retry behavior.


#### Special notes for your reviewer:

#### Additional documentation or context
