### PR TITLE
fix(types): allow default disk creation from BDF-style and /dev/disk/by-id paths

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -12,11 +12,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
 	lhns "github.com/longhorn/go-common-libs/ns"
 
@@ -1387,45 +1385,53 @@ func CreateDisksFromAnnotation(annotation string, storageReservedPercentage int6
 		if disk.Path == "" {
 			return nil, fmt.Errorf("invalid disk %+v", disk)
 		}
-		diskStat, err := lhns.GetDiskStat(disk.Path)
-		if err != nil {
-			return nil, err
-		}
+
 		for _, vDisk := range validDisks {
 			if vDisk.Path == disk.Path {
 				return nil, fmt.Errorf("duplicate disk path %v", disk.Path)
 			}
 		}
 
-		// Set to default disk name
-		if disk.Name == "" {
-			disk.Name = DefaultDiskPrefix + diskStat.DiskID
-		}
-
-		if _, exist := existDiskID[diskStat.DiskID]; exist {
-			return nil, fmt.Errorf(
-				"the disk %v is the same"+
-					"file system with %v, diskID %v",
-				disk.Path, existDiskID[diskStat.DiskID],
-				diskStat.DiskID)
-		}
-
-		existDiskID[diskStat.DiskID] = disk.Path
-
-		if disk.StorageReserved < 0 || disk.StorageReserved > diskStat.StorageMaximum {
+		if disk.StorageReserved < 0 {
 			return nil, fmt.Errorf("the storageReserved setting of disk %v is not valid, should be positive and no more than storageMaximum and storageAvailable", disk.Path)
 		}
-		if disk.StorageReserved == 0 {
-			if disk.Type == longhorn.DiskTypeBlock {
-				size, err := getBlockDeviceSize(ReplicaHostPrefix + disk.Path)
-				if err != nil {
-					return nil, err
-				}
-				disk.StorageReserved = int64(size) * storageReservedPercentage / 100
-			} else {
+
+		if disk.Type == longhorn.DiskTypeBlock {
+			if disk.Name == "" {
+				disk.Name = DefaultDiskPrefix + util.RandomID()
+			}
+			if disk.DiskDriver == "" {
+				disk.DiskDriver = longhorn.DiskDriverAuto
+			}
+		} else {
+			diskStat, err := lhns.GetDiskStat(disk.Path)
+			if err != nil {
+				return nil, err
+			}
+
+			// Set to default disk name
+			if disk.Name == "" {
+				disk.Name = DefaultDiskPrefix + diskStat.DiskID
+			}
+
+			if _, exist := existDiskID[diskStat.DiskID]; exist {
+				return nil, fmt.Errorf(
+					"the disk %v is the same"+
+						"file system with %v, diskID %v",
+					disk.Path, existDiskID[diskStat.DiskID],
+					diskStat.DiskID)
+			}
+
+			existDiskID[diskStat.DiskID] = disk.Path
+
+			if disk.StorageReserved > diskStat.StorageMaximum {
+				return nil, fmt.Errorf("the storageReserved setting of disk %v is not valid, should be positive and no more than storageMaximum and storageAvailable", disk.Path)
+			}
+			if disk.StorageReserved == 0 {
 				disk.StorageReserved = diskStat.StorageMaximum * storageReservedPercentage / 100
 			}
 		}
+
 		tags, err := util.ValidateTags(disk.Tags)
 		if err != nil {
 			return nil, err
@@ -1439,25 +1445,6 @@ func CreateDisksFromAnnotation(annotation string, storageReservedPercentage int6
 	}
 
 	return validDisks, nil
-}
-
-func getBlockDeviceSize(devicePath string) (uint64, error) {
-	file, err := os.Open(devicePath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to open block device at %s: %w", devicePath, err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			logrus.WithError(closeErr).Warnf("Failed to close block device %s", devicePath)
-		}
-	}()
-	var size uint64
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, file.Fd(), 0x80081272, uintptr(unsafe.Pointer(&size)))
-	if errno != 0 {
-		return 0, fmt.Errorf("failed to get block device size for %s: errno=%v", devicePath, errno)
-	}
-
-	return size, nil
 }
 
 func GetNodeTagsFromAnnotation(annotation string) ([]string, error) {
@@ -1500,7 +1487,7 @@ func UnmarshalToNodeTags(s string) ([]string, error) {
 }
 
 func IsBDF(addr string) bool {
-	bdfFormat := "[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}"
+	bdfFormat := "^[a-f0-9]{4}:[a-f0-9]{2}:[a-f0-9]{2}\\.[a-f0-9]{1}$"
 	bdfPattern := regexp.MustCompile(bdfFormat)
 	return bdfPattern.MatchString(addr)
 }
@@ -1525,10 +1512,6 @@ func IsPotentialBlockDisk(path string) bool {
 
 func CreateDefaultDisk(dataPath string, storageReservedPercentage int64) (map[string]longhorn.DiskSpec, error) {
 	if IsPotentialBlockDisk(dataPath) {
-		size, err := getBlockDeviceSize(dataPath)
-		if err != nil {
-			return nil, err
-		}
 		return map[string]longhorn.DiskSpec{
 			DefaultDiskPrefix + util.RandomID(): {
 				Type:              longhorn.DiskTypeBlock,
@@ -1536,7 +1519,7 @@ func CreateDefaultDisk(dataPath string, storageReservedPercentage int64) (map[st
 				DiskDriver:        longhorn.DiskDriverAuto,
 				AllowScheduling:   true,
 				EvictionRequested: false,
-				StorageReserved:   int64(size) * storageReservedPercentage / 100,
+				StorageReserved:   0,
 				Tags:              []string{},
 			},
 		}, nil

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -588,3 +588,65 @@ func (s *TestSuite) TestIsTopologyZonePinned(c *C) {
 		{Zone: "zone-1"}, {Zone: "zone-2"},
 	}), Equals, false)
 }
+
+func (s *TestSuite) TestIsBDF(c *C) {
+	testCases := map[string]bool{
+		"0000:00:1f.0":             true,
+		"0000:00:1f":               false,
+		"0000:00:1f.00":            false,
+		"prefix0000:00:1f.0":       false,
+		"0000:00:1f.0suffix":       false,
+		"/dev/disk/by-id/scsi-foo": false,
+	}
+
+	for input, expected := range testCases {
+		c.Assert(IsBDF(input), Equals, expected, Commentf(TestErrResultFmt, input))
+	}
+}
+
+func (s *TestSuite) TestCreateDefaultDiskWithBlockDiskPath(c *C) {
+	testCases := map[string]string{
+		"bdf":        "0000:00:1f.0",
+		"disk by id": "/dev/disk/by-id/scsi-36001405b8f1e2d3c4b5a697887766554",
+	}
+
+	for testName, dataPath := range testCases {
+		disks, err := CreateDefaultDisk(dataPath, 30)
+		c.Assert(err, IsNil, Commentf(TestErrErrorFmt, testName, err))
+		c.Assert(disks, HasLen, 1, Commentf(TestErrResultFmt, testName))
+
+		for diskName, disk := range disks {
+			c.Assert(strings.HasPrefix(diskName, DefaultDiskPrefix), Equals, true, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.Type, Equals, longhorn.DiskTypeBlock, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.Path, Equals, dataPath, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.DiskDriver, Equals, longhorn.DiskDriverAuto, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.AllowScheduling, Equals, true, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.StorageReserved, Equals, int64(0), Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.Tags, DeepEquals, []string{}, Commentf(TestErrResultFmt, testName))
+		}
+	}
+}
+
+func (s *TestSuite) TestCreateDisksFromAnnotationWithBlockDiskPath(c *C) {
+	testCases := map[string]string{
+		"bdf":        "0000:00:1f.0",
+		"disk by id": "/dev/disk/by-id/scsi-36001405b8f1e2d3c4b5a697887766554",
+	}
+
+	for testName, dataPath := range testCases {
+		annotation := fmt.Sprintf(`[{"path":"%s","diskType":"block","allowScheduling":true}]`, dataPath)
+
+		disks, err := CreateDisksFromAnnotation(annotation, 30)
+		c.Assert(err, IsNil, Commentf(TestErrErrorFmt, testName, err))
+		c.Assert(disks, HasLen, 1, Commentf(TestErrResultFmt, testName))
+
+		for diskName, disk := range disks {
+			c.Assert(strings.HasPrefix(diskName, DefaultDiskPrefix), Equals, true, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.Type, Equals, longhorn.DiskTypeBlock, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.Path, Equals, dataPath, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.DiskDriver, Equals, longhorn.DiskDriverAuto, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.AllowScheduling, Equals, true, Commentf(TestErrResultFmt, testName))
+			c.Assert(disk.StorageReserved, Equals, int64(0), Commentf(TestErrResultFmt, testName))
+		}
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/13557

#### What this PR does / why we need it:

- Align the default disk path with the normal add-disk flow.
- Avoid requiring longhorn-manager to access the disk to calculate `StorageReserved`.
- Keep the existing filesystem disk behavior, including calculating `StorageReserved` from the configured reserved percentage.

#### Special notes for your reviewer:

https://github.com/longhorn/longhorn/issues/13557#issuecomment-5391353455

#### Additional documentation or context
