### PR TITLE
fix(backup-volume): transfer ownership away from drained node

### DIFF
--- a/controller/backup_target_controller.go
+++ b/controller/backup_target_controller.go
@@ -922,19 +922,19 @@ func (btc *BackupTargetController) isResponsibleFor(bt *longhorn.BackupTarget, d
 	// engines are disabled, instance-manager pods might already have been removed.
 	// Ref: https://github.com/longhorn/longhorn/issues/11934
 	if bt.DeletionTimestamp.IsZero() {
-		nodesWithRunningIM, err := btc.listNodesWithRunningInstanceManager()
+		eligibleNodes, err := btc.ds.ListNodesEligibleForBackupReconcileRO(defaultEngineImage)
 		if err != nil {
 			return false, err
 		}
-		// Only require a running instance manager when at least one node has one to fall back to.
-		// If no node has a running instance manager (e.g. a full outage), keep the engine-image-only
+		// Only require a running instance manager when at least one node can actually serve the
+		// reconcile. If no node is eligible (e.g. a full outage), keep the engine-image-only
 		// behavior so the backup target still gets an owner that surfaces the error and retries,
 		// instead of being left ownerless and silently stalled.
-		if len(nodesWithRunningIM) > 0 {
-			_, ownerIMRunning := nodesWithRunningIM[bt.Status.OwnerID]
-			_, nodeIMRunning := nodesWithRunningIM[btc.controllerID]
-			currentOwnerAvailable = currentOwnerAvailable && ownerIMRunning
-			currentNodeAvailable = currentNodeAvailable && nodeIMRunning
+		if len(eligibleNodes) > 0 {
+			_, ownerEligible := eligibleNodes[bt.Status.OwnerID]
+			_, nodeEligible := eligibleNodes[btc.controllerID]
+			currentOwnerAvailable = ownerEligible
+			currentNodeAvailable = nodeEligible
 		}
 	}
 
@@ -943,23 +943,6 @@ func (btc *BackupTargetController) isResponsibleFor(bt *longhorn.BackupTarget, d
 	requiresNewOwner := currentNodeAvailable && !currentOwnerAvailable
 
 	return isPreferredOwner || continueToBeOwner || requiresNewOwner, nil
-}
-
-// listNodesWithRunningInstanceManager returns the set of nodes that have a running instance
-// manager for any enabled data engine. A backup target reconcile can be served by any such node,
-// so the union across data engines is used to decide ownership.
-func (btc *BackupTargetController) listNodesWithRunningInstanceManager() (map[string]*longhorn.Node, error) {
-	nodesWithRunningIM := map[string]*longhorn.Node{}
-	for dataEngine := range btc.ds.GetDataEngines() {
-		nodes, err := btc.ds.ListNodesWithReadyInstanceManagerRO(dataEngine)
-		if err != nil {
-			return nil, err
-		}
-		for name, node := range nodes {
-			nodesWithRunningIM[name] = node
-		}
-	}
-	return nodesWithRunningIM, nil
 }
 
 // cleanupBackupVolumes deletes all BackupVolume CRs

--- a/controller/backup_volume_controller.go
+++ b/controller/backup_volume_controller.go
@@ -539,9 +539,39 @@ func (bvc *BackupVolumeController) isResponsibleFor(bv *longhorn.BackupVolume, d
 		return false, err
 	}
 
-	isPreferredOwner := currentNodeEngineAvailable && isResponsible
-	continueToBeOwner := currentNodeEngineAvailable && bvc.controllerID == bv.Status.OwnerID
-	requiresNewOwner := currentNodeEngineAvailable && !currentOwnerEngineAvailable
+	currentOwnerAvailable := currentOwnerEngineAvailable
+	currentNodeAvailable := currentNodeEngineAvailable
+
+	// A responsible node must also have a running instance manager, because syncing the backup
+	// volume from the remote backup target goes through an engine client proxy served by an
+	// instance manager. The engine image readiness check alone is not enough: a node drained with
+	// --ignore-daemonsets keeps the engine image DaemonSet (and longhorn-manager) running while its
+	// instance manager pod is evicted. Without accounting for the instance manager, ownership can
+	// stay pinned to such a node, so the BackupVolume status is never synced.
+	// Ref: https://github.com/longhorn/longhorn/issues/13775
+	// Skip this while the BackupVolume is being deleted. During cluster uninstallation or when data
+	// engines are disabled, instance-manager pods might already have been removed.
+	// Ref: https://github.com/longhorn/longhorn/issues/11934
+	if bv.DeletionTimestamp.IsZero() {
+		eligibleNodes, err := bvc.ds.ListNodesEligibleForBackupReconcileRO(defaultEngineImage)
+		if err != nil {
+			return false, err
+		}
+		// Only require a running instance manager when at least one node can actually serve the
+		// reconcile. If no node is eligible (e.g. a full outage), keep the engine-image-only
+		// behavior so the backup volume still gets an owner that surfaces the error and retries,
+		// instead of being left ownerless and silently stalled.
+		if len(eligibleNodes) > 0 {
+			_, ownerEligible := eligibleNodes[bv.Status.OwnerID]
+			_, nodeEligible := eligibleNodes[bvc.controllerID]
+			currentOwnerAvailable = ownerEligible
+			currentNodeAvailable = nodeEligible
+		}
+	}
+
+	isPreferredOwner := currentNodeAvailable && isResponsible
+	continueToBeOwner := currentNodeAvailable && bvc.controllerID == bv.Status.OwnerID
+	requiresNewOwner := currentNodeAvailable && !currentOwnerAvailable
 
 	return isPreferredOwner || continueToBeOwner || requiresNewOwner, nil
 }

--- a/controller/backup_volume_controller_test.go
+++ b/controller/backup_volume_controller_test.go
@@ -1,0 +1,194 @@
+package controller
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+
+	. "gopkg.in/check.v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/controller"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+func newTestBackupVolumeController(lhClient *lhfake.Clientset, kubeClient *fake.Clientset, extensionsClient *apiextensionsfake.Clientset,
+	informerFactories *util.InformerFactories, controllerID string) (*BackupVolumeController, error) {
+	ds := datastore.NewDataStore(TestNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	logger := logrus.StandardLogger()
+	proxyConnCounter := util.NewAtomicCounter()
+	bvc, err := NewBackupVolumeController(logger, ds, scheme.Scheme, kubeClient, controllerID, TestNamespace, proxyConnCounter)
+	if err != nil {
+		return nil, err
+	}
+	fakeRecorder := record.NewFakeRecorder(100)
+	bvc.eventRecorder = fakeRecorder
+	for index := range bvc.cacheSyncs {
+		bvc.cacheSyncs[index] = alwaysReady
+	}
+	return bvc, nil
+}
+
+// TestBackupVolumeIsResponsibleFor verifies that backup volume ownership is transferred to a node
+// with a running instance manager when the current owner is drained (its engine image DaemonSet
+// keeps running while the instance manager pod is evicted). Otherwise the BackupVolume status is
+// never synced. Ref: https://github.com/longhorn/longhorn/issues/13775
+func (s *TestSuite) TestBackupVolumeIsResponsibleFor(c *C) {
+	testCases := map[string]struct {
+		controllerID       string
+		ownerID            string
+		nodesWithRunningIM []string
+		engineImageNodes   []string
+		v1Enabled          bool
+		v2Enabled          bool
+		imDataEngine       longhorn.DataEngineType
+		deleting           bool
+		expected           bool
+	}{
+		"node with running instance manager takes over from drained owner": {
+			controllerID:       TestNode2,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           true,
+		},
+		"drained owner without running instance manager backs off": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           false,
+		},
+		"owner with running instance manager keeps ownership": {
+			controllerID:       TestNode2,
+			ownerID:            TestNode2,
+			nodesWithRunningIM: []string{TestNode2},
+			expected:           true,
+		},
+		"full outage falls back to engine image only behavior": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{},
+			expected:           true,
+		},
+		"v2 data engine node with running instance manager takes over": {
+			controllerID:       TestNode2,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			v1Enabled:          false,
+			v2Enabled:          true,
+			imDataEngine:       longhorn.DataEngineTypeV2,
+			expected:           true,
+		},
+		"instance manager node without engine image falls back to engine image only behavior": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			engineImageNodes:   []string{TestNode1},
+			expected:           true,
+		},
+		"deleting backup volume ignores instance manager availability": {
+			controllerID:       TestNode1,
+			ownerID:            TestNode1,
+			nodesWithRunningIM: []string{TestNode2},
+			deleting:           true,
+			expected:           true,
+		},
+	}
+
+	for name, tc := range testCases {
+		c.Logf("testing %v", name)
+
+		if tc.engineImageNodes == nil {
+			tc.engineImageNodes = []string{TestNode1, TestNode2}
+		}
+		if !tc.v1Enabled && !tc.v2Enabled {
+			tc.v1Enabled = true
+		}
+		if tc.imDataEngine == "" {
+			tc.imDataEngine = longhorn.DataEngineTypeV1
+		}
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		settingIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+		nodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+		eiIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer()
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+
+		bvc, err := newTestBackupVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, tc.controllerID)
+		c.Assert(err, IsNil)
+
+		for _, setting := range []*longhorn.Setting{
+			newSetting(string(types.SettingNameDefaultEngineImage), TestEngineImage),
+			newSetting(string(types.SettingNameDefaultInstanceManagerImage), TestInstanceManagerImage),
+			newSetting(string(types.SettingNameV1DataEngine), strconv.FormatBool(tc.v1Enabled)),
+			newSetting(string(types.SettingNameV2DataEngine), strconv.FormatBool(tc.v2Enabled)),
+		} {
+			setting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(settingIndexer.Add(setting), IsNil)
+		}
+
+		// Both nodes are Ready. The engine image is deployed on engineImageNodes, mimicking a node
+		// drained with --ignore-daemonsets that keeps the engine image DaemonSet running.
+		engineImage := newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed)
+		engineImage.Status.NodeDeploymentMap = map[string]bool{}
+		for _, nodeName := range tc.engineImageNodes {
+			engineImage.Status.NodeDeploymentMap[nodeName] = true
+		}
+		engineImage, err = lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), engineImage, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(eiIndexer.Add(engineImage), IsNil)
+
+		for _, nodeName := range []string{TestNode1, TestNode2} {
+			node := newNode(nodeName, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+			node, err = lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), node, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(nodeIndexer.Add(node), IsNil)
+		}
+
+		for _, nodeName := range tc.nodesWithRunningIM {
+			im := newInstanceManager("instance-manager-"+nodeName, longhorn.InstanceManagerStateRunning,
+				nodeName, nodeName, randomIP(), nil, nil, nil, tc.imDataEngine, TestInstanceManagerImage, false)
+			im, err = lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), im, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			c.Assert(imIndexer.Add(im), IsNil)
+		}
+
+		backupVolume := &longhorn.BackupVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TestVolumeName,
+				Namespace: TestNamespace,
+			},
+			Spec: longhorn.BackupVolumeSpec{
+				VolumeName: TestVolumeName,
+			},
+			Status: longhorn.BackupVolumeStatus{
+				OwnerID: tc.ownerID,
+			},
+		}
+		if tc.deleting {
+			now := metav1.Now()
+			backupVolume.DeletionTimestamp = &now
+		}
+
+		isResponsible, err := bvc.isResponsibleFor(backupVolume, TestEngineImage)
+		c.Assert(err, IsNil)
+		c.Assert(isResponsible, Equals, tc.expected)
+	}
+}

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3739,6 +3739,88 @@ func (s *DataStore) ListNodesWithReadyInstanceManagerRO(dataEngine longhorn.Data
 	return result, nil
 }
 
+// ListNodesWithRunningInstanceManagerForAllDataEnginesRO returns the set of nodes that have a
+// running instance manager for any enabled data engine. Requests that can be served by any
+// instance manager regardless of data engine (e.g. backup target/volume reconciles) use this
+// union to decide ownership. It mirrors the selection semantics of GetRunningInstanceManagerByNodeRO
+// (used by the backup engine client proxy): any non-terminating running all-in-one instance manager
+// counts, regardless of its image, so a node still serving through an old instance manager image
+// during a rollout is not omitted.
+func (s *DataStore) ListNodesWithRunningInstanceManagerForAllDataEnginesRO() (map[string]*longhorn.Node, error) {
+	enabledDataEngines := s.GetDataEngines()
+
+	ims, err := s.ListInstanceManagersRO()
+	if err != nil {
+		return nil, err
+	}
+
+	nodeList, err := s.ListNodesRO()
+	if err != nil {
+		return nil, err
+	}
+	nodes := make(map[string]*longhorn.Node, len(nodeList))
+	for _, node := range nodeList {
+		nodes[node.Name] = node
+	}
+
+	nodesWithRunningIM := map[string]*longhorn.Node{}
+	for _, im := range ims {
+		if im.Spec.Type != longhorn.InstanceManagerTypeAllInOne {
+			continue
+		}
+		if _, ok := enabledDataEngines[im.Spec.DataEngine]; !ok {
+			continue
+		}
+		// Skip terminating instance managers, they may still report Running while their pod is being
+		// removed (e.g. during a node drain).
+		if im.DeletionTimestamp != nil || im.Status.CurrentState != longhorn.InstanceManagerStateRunning {
+			continue
+		}
+		node, ok := nodes[im.Spec.NodeID]
+		if !ok {
+			continue
+		}
+		nodesWithRunningIM[im.Spec.NodeID] = node
+	}
+	return nodesWithRunningIM, nil
+}
+
+// ListNodesEligibleForBackupReconcileRO returns the set of nodes that can actually serve a backup
+// target/volume reconcile: they have both a running instance manager (for any enabled data engine)
+// and the given engine image ready. Engine image readiness and instance manager readiness are
+// independent, so callers must intersect them instead of gating on the instance manager alone,
+// otherwise a node with the image but no instance manager could be disqualified while the only node
+// with a running instance manager lacks the image, leaving the resource ownerless.
+func (s *DataStore) ListNodesEligibleForBackupReconcileRO(engineImage string) (map[string]*longhorn.Node, error) {
+	nodesWithRunningIM, err := s.ListNodesWithRunningInstanceManagerForAllDataEnginesRO()
+	if err != nil {
+		return nil, err
+	}
+
+	eligibleNodes := map[string]*longhorn.Node{}
+	if len(nodesWithRunningIM) == 0 {
+		return eligibleNodes, nil
+	}
+
+	// Fetch the engine image once and intersect its NodeDeploymentMap with the running-instance-manager
+	// nodes, instead of calling CheckEngineImageReadiness per node (which relists all nodes each time).
+	ei, err := s.GetEngineImageRO(types.GetEngineImageChecksumName(engineImage))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get engine image %v", engineImage)
+	}
+	if ei.Status.State != longhorn.EngineImageStateDeployed &&
+		ei.Status.State != longhorn.EngineImageStateDeploying {
+		return eligibleNodes, nil
+	}
+
+	for name, node := range nodesWithRunningIM {
+		if ei.Status.NodeDeploymentMap[name] {
+			eligibleNodes[name] = node
+		}
+	}
+	return eligibleNodes, nil
+}
+
 func (s *DataStore) ListReadyAndSchedulableNodesRO() (map[string]*longhorn.Node, error) {
 	nodes, err := s.ListReadyNodesRO()
 	if err != nil {


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13775 Longhorn/longhorn#13859

#### What this PR does / why we need it:

The BackupTarget and BackupVolume controllers elected a responsible node based on engine image readiness alone. A node drained with --ignore-daemonsets keeps its engine image DaemonSet (and longhorn-manager) running while its instance manager pod is evicted, so ownership stayed pinned to a node that can no longer reach the remote backup target through the engine client proxy. As a result the BackupTarget was never synced and its BackupVolume CRs were never created or updated, leaving backups stalled.

Make isResponsibleFor instance-manager-aware: a node is eligible only when it has both a running instance manager (for any enabled data engine) and the engine image ready. Because instance manager readiness and engine image readiness are independent, the two sets are intersected via the new `ListNodesEligibleForBackupReconcileRO` datastore helper so a node with the image but no instance manager is not disqualified while the only node with a running instance manager lacks the image. When no node is eligible (e.g. a full outage) the controllers fall back to the previous engine-image-only behavior so the resource still gets an owner that surfaces the error and retries. The check is skipped while the resource is being deleted, since instance managers may already be gone during uninstallation.


#### Special notes for your reviewer:

#### Additional documentation or context
