### PR TITLE
fix(engine): keep SalvageRequested when reaping stale stopped v1 record

### DIFF
--- a/controller/instance_handler.go
+++ b/controller/instance_handler.go
@@ -25,6 +25,11 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
+// errStaleInstanceReaped signals that createInstance only reaped a stale stopped
+// record instead of creating an instance, so the caller must not treat it as a
+// successful create (e.g. must not set SalvageExecuted).
+var errStaleInstanceReaped = errors.New("stale stopped instance reaped")
+
 // InstanceHandler can handle the state transition of correlated instance and
 // engine/replica object. It assumed the instance it's going to operate with is using
 // the SAME NAME from the engine/replica object
@@ -427,6 +432,12 @@ func (h *InstanceHandler) ReconcileInstanceState(obj interface{}, spec *longhorn
 
 		err = h.createInstance(instanceName, spec.DataEngine, runtimeObj)
 		if err != nil {
+			// A stale stopped record was only reaped, not created. Wait for the next
+			// reconcile to recreate and don't set SalvageExecuted, otherwise SalvageRequested
+			// would be cleared before the salvaged instance is actually created.
+			if errors.Is(err, errStaleInstanceReaped) {
+				break
+			}
 			return err
 		}
 
@@ -550,7 +561,10 @@ func (h *InstanceHandler) createInstance(instanceName string, dataEngine longhor
 		// here so the next reconcile can recreate the instance from a clean state.
 		if types.IsDataEngineV1(dataEngine) && instance != nil && instance.Status.State == longhorn.InstanceStateStopped {
 			logrus.Warnf("Reaping stale stopped instance %v before recreating it", instanceName)
-			return h.deleteInstance(instanceName, obj)
+			if err := h.deleteInstance(instanceName, obj); err != nil {
+				return err
+			}
+			return errStaleInstanceReaped
 		}
 		return nil
 	}

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/errors"
+
 	. "gopkg.in/check.v1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -732,6 +734,7 @@ func (s *TestSuite) TestCreateInstanceReapsStaleStoppedV1Record(c *C) {
 		getErr       error
 		expectDelete bool
 		expectCreate bool
+		expectReaped bool
 	}{
 		"v1 stale stopped record is reaped, not created": {
 			dataEngine:   longhorn.DataEngineTypeV1,
@@ -739,6 +742,7 @@ func (s *TestSuite) TestCreateInstanceReapsStaleStoppedV1Record(c *C) {
 			getErr:       nil,
 			expectDelete: true,
 			expectCreate: false,
+			expectReaped: true,
 		},
 		"v1 running record is left untouched": {
 			dataEngine:   longhorn.DataEngineTypeV1,
@@ -776,7 +780,11 @@ func (s *TestSuite) TestCreateInstanceReapsStaleStoppedV1Record(c *C) {
 		}
 
 		err := h.createInstance(ExistingInstance, tc.dataEngine, newEngineObj())
-		c.Assert(err, IsNil)
+		if tc.expectReaped {
+			c.Assert(errors.Is(err, errStaleInstanceReaped), Equals, true)
+		} else {
+			c.Assert(err, IsNil)
+		}
 		c.Assert(stub.deleteCalled, Equals, tc.expectDelete)
 		c.Assert(stub.createCalled, Equals, tc.expectCreate)
 	}
@@ -840,7 +848,7 @@ func (s *TestSuite) TestCreateInstanceRecoversFromStaleStoppedV1Record(c *C) {
 	}
 
 	// Reconcile 1: the stale stopped record is reaped instead of being treated as already created.
-	c.Assert(h.createInstance(ExistingInstance, longhorn.DataEngineTypeV1, engine), IsNil)
+	c.Assert(errors.Is(h.createInstance(ExistingInstance, longhorn.DataEngineTypeV1, engine), errStaleInstanceReaped), Equals, true)
 	c.Assert(stub.instance, IsNil)
 	c.Assert(stub.calls, DeepEquals, []string{"delete"})
 

--- a/controller/instance_handler_test.go
+++ b/controller/instance_handler_test.go
@@ -862,3 +862,75 @@ func (s *TestSuite) TestCreateInstanceRecoversFromStaleStoppedV1Record(c *C) {
 	c.Assert(h.createInstance(ExistingInstance, longhorn.DataEngineTypeV1, engine), IsNil)
 	c.Assert(stub.calls, DeepEquals, []string{"delete", "create"})
 }
+
+// TestReconcileInstanceStateKeepsSalvageRequestedWhenReapingStaleStoppedV1Record drives the reap
+// through the full ReconcileInstanceState path to prove the salvage flag is preserved: when a stale
+// stopped v1 record coexists with SalvageRequested=true, the first reconcile only reaps the record
+// and must leave SalvageExecuted=false (so the volume controller does not clear SalvageRequested
+// before the salvaged instance exists); the next reconcile recreates the instance and only then
+// sets SalvageExecuted=true. A regression that set SalvageExecuted after a reap would fail here.
+func (s *TestSuite) TestReconcileInstanceStateKeepsSalvageRequestedWhenReapingStaleStoppedV1Record(c *C) {
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+	ei, err := lhClient.LonghornV1beta2().EngineImages(TestNamespace).Create(context.TODO(), newEngineImage(TestEngineImage, longhorn.EngineImageStateDeployed), metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = informerFactories.LhInformerFactory.Longhorn().V1beta2().EngineImages().Informer().GetIndexer().Add(ei)
+	c.Assert(err, IsNil)
+
+	imImageSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), newDefaultInstanceManagerImageSetting(), metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer().Add(imImageSetting)
+	c.Assert(err, IsNil)
+
+	im, err := lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), newInstanceManager(
+		TestInstanceManagerName, longhorn.InstanceManagerStateRunning,
+		TestOwnerID1, TestNode1, TestIP1,
+		map[string]longhorn.InstanceProcess{},
+		map[string]longhorn.InstanceProcess{},
+		map[string]longhorn.InstanceProcess{},
+		longhorn.DataEngineTypeV1,
+		TestInstanceManagerImage,
+		false,
+	), metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer().Add(im)
+	c.Assert(err, IsNil)
+
+	pod := newPod(&corev1.PodStatus{PodIP: TestIP1, Phase: corev1.PodRunning}, im.Name, im.Namespace, im.Spec.NodeID)
+	err = informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+	c.Assert(err, IsNil)
+	_, err = kubeClient.CoreV1().Pods(im.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+
+	node, err := lhClient.LonghornV1beta2().Nodes(TestNamespace).Create(context.TODO(), newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, ""), metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	err = informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer().Add(node)
+	c.Assert(err, IsNil)
+
+	h := newTestInstanceHandler(lhClient, kubeClient, extensionsClient, informerFactories)
+	// Start with a leaked stopped v1 process record so the first createInstance reaps it.
+	registry := &registryInstanceManagerHandler{
+		instance: &longhorn.InstanceProcess{Status: longhorn.InstanceProcessStatus{State: longhorn.InstanceStateStopped}},
+	}
+	h.instanceManagerHandler = registry
+
+	engine := newEngine(ExistingInstance, "", TestInstanceManagerName, TestNode1, "", 0, false, longhorn.InstanceStateStopped, longhorn.InstanceStateRunning)
+	engine.Spec.SalvageRequested = true
+
+	// Reconcile 1: the stale stopped record is reaped, and SalvageExecuted must stay false so the
+	// salvage request survives until the instance is actually recreated.
+	c.Assert(h.ReconcileInstanceState(engine, &engine.Spec.InstanceSpec, &engine.Status.InstanceStatus), IsNil)
+	c.Assert(registry.calls, DeepEquals, []string{"delete"})
+	c.Assert(engine.Status.SalvageExecuted, Equals, false)
+	c.Assert(engine.Spec.SalvageRequested, Equals, true)
+	c.Assert(engine.Status.CurrentState, Equals, longhorn.InstanceStateStopped)
+
+	// Reconcile 2: with the record gone the instance is recreated, and only now is SalvageExecuted set.
+	c.Assert(h.ReconcileInstanceState(engine, &engine.Spec.InstanceSpec, &engine.Status.InstanceStatus), IsNil)
+	c.Assert(registry.calls, DeepEquals, []string{"delete", "create"})
+	c.Assert(engine.Status.SalvageExecuted, Equals, true)
+}


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13687

#### What this PR does / why we need it:

For a v1 data engine, a leaked `stopped` process record still answers
GetInstance successfully, so `createInstance` short-circuits at the
`err == nil` return and never creates the instance. The engine stays
`stopped`, the stopped-state defer clears `status.instanceManagerName`,
and the volume is wedged in `attaching` forever with no error, event,
retry, or log line. The v2 path already guards this via `isStoppedV2Engine`,
but v1 has no such guard because for v1 the stopped state arrives as a
successful response rather than an error.

Reap the stale stopped v1 record before recreating so the next reconcile
can create the instance from a clean state. The GetInstance and
DeleteInstance calls resolve to the same instance manager (both keyed on
status.InstanceManagerName, falling back to spec.NodeID), and the reap only
triggers when the live GetInstance reports `stopped`, so a running instance
is never deleted. Scope is limited to v1, since a v2 `stopped` instance is a
legitimate restart-in-place state.


#### Special notes for your reviewer:

#### Additional documentation or context
