### PR TITLE
fix: keep recovering a v2 block disk that failed to be provisioned

### DIFF
--- a/controller/monitor/disk_monitor.go
+++ b/controller/monitor/disk_monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,11 +15,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	lhtypes "github.com/longhorn/go-common-libs/types"
+	"github.com/longhorn/go-common-libs/multierr"
 
+	lhtypes "github.com/longhorn/go-common-libs/types"
 	spdkdisk "github.com/longhorn/longhorn-spdk-engine/pkg/spdk"
 
-	"github.com/longhorn/go-common-libs/multierr"
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/engineapi"
 	"github.com/longhorn/longhorn-manager/types"
@@ -35,6 +36,8 @@ const (
 	HealthDataUpdateInterval = 10 * time.Minute
 
 	volumeMetaData = "volume.meta"
+
+	diskMessageMaxLength = 1024
 )
 
 type DiskServiceClient struct {
@@ -256,10 +259,18 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 		nodeOrDiskEvicted := isNodeOrDiskEvicted(node, disk)
 
 		diskDriver := longhorn.DiskDriverNone
+		recordedDiskUUID := ""
 		if node.Status.DiskStatus != nil {
-			if diskStatus, ok := node.Status.DiskStatus[diskName]; ok {
+			if diskStatus, ok := node.Status.DiskStatus[diskName]; ok && diskStatus != nil {
 				diskDriver = diskStatus.DiskDriver
+				recordedDiskUUID = diskStatus.DiskUUID
 			}
+		}
+		// The recorded driver wins over the spec so that a re-creation reuses the
+		// driver that was already resolved for this disk.
+		requestedDiskDriver := disk.DiskDriver
+		if diskDriver != longhorn.DiskDriverNone {
+			requestedDiskDriver = diskDriver
 		}
 
 		instanceManagerName := ""
@@ -286,7 +297,7 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			instanceManagerName = diskServiceClient.c.GetInstanceManagerName()
 		}
 
-		diskInfoMap[diskName] = NewDiskInfo(diskName, "", disk.Path, diskDriver, nodeOrDiskEvicted, nil,
+		diskInfoMap[diskName] = NewDiskInfo(diskName, recordedDiskUUID, disk.Path, requestedDiskDriver, nodeOrDiskEvicted, nil,
 			orphanedReplicaDataStores, instanceManagerName, errReason, errs.Error())
 
 		diskConfig, err := m.getDiskConfigHandler(disk.Type, diskName, disk.Path, diskDriver, diskServiceClient)
@@ -294,21 +305,10 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			if !types.ErrorIsNotFound(err) {
 				errs.Append("errors", errors.Wrap(err, "failed to get disk config"))
 
-				diskInfoMap[diskName] = NewDiskInfo(diskName, "", disk.Path, diskDriver, nodeOrDiskEvicted, nil,
+				diskInfoMap[diskName] = NewDiskInfo(diskName, recordedDiskUUID, disk.Path, requestedDiskDriver, nodeOrDiskEvicted, nil,
 					orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo),
 					fmt.Sprintf("Disk %v(%v) on node %v is not ready: %v", diskName, disk.Path, node.Name, errs.Error()))
 				continue
-			}
-
-			diskUUID := ""
-			diskDriver := disk.DiskDriver
-			if node.Status.DiskStatus != nil {
-				if diskStatus, ok := node.Status.DiskStatus[diskName]; ok {
-					diskUUID = diskStatus.DiskUUID
-					if diskStatus.DiskDriver != "" {
-						diskDriver = diskStatus.DiskDriver
-					}
-				}
 			}
 
 			// Filesystem-type disk
@@ -316,21 +316,45 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			//   The handling of all disks containing the same fsid will be done in NodeController.
 			// Block-type disk
 			//   Create a bdev lvstore
-			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, diskUUID, disk.Path, string(diskDriver), diskServiceClient, m.ds)
+			diskConfig, err = m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path, string(requestedDiskDriver), diskServiceClient, m.ds)
 			if err != nil {
 				errs.Append("errors", errors.Wrap(err, "failed to generate disk config"))
 
-				diskInfoMap[diskName] = NewDiskInfo(diskName, diskUUID, disk.Path, diskDriver, nodeOrDiskEvicted, nil,
+				diskInfoMap[diskName] = NewDiskInfo(diskName, recordedDiskUUID, disk.Path, requestedDiskDriver, nodeOrDiskEvicted, nil,
 					orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo),
 					fmt.Sprintf("Disk %v(%v) on node %v is not ready: %v", diskName, disk.Path, node.Name, errs.Error()))
 				continue
 			}
+		} else if disk.Type == longhorn.DiskTypeBlock && diskConfig.State == string(spdkdisk.DiskStateError) {
+			// The disk service keeps a failed disk in the error state until it is asked
+			// to create it again, so retry here instead of waiting for an instance
+			// manager restart.
+			m.logger.Warnf("Retrying the creation of disk %v(%v) on node %v after a previous failure: %v",
+				diskName, disk.Path, node.Name, diskConfig.Message)
+
+			previousMessage := diskConfig.Message
+
+			retriedDiskConfig, retryErr := m.generateDiskConfigHandler(disk.Type, diskName, recordedDiskUUID, disk.Path, string(requestedDiskDriver), diskServiceClient, m.ds)
+			if retryErr != nil {
+				errs.Append("errors", errors.Wrap(retryErr, "failed to retry disk creation"))
+			} else {
+				diskConfig = retriedDiskConfig
+				// A retried disk restarts from the creating state with no message, so keep
+				// reporting the previous failure until the retry reaches a conclusion.
+				if diskConfig.Message == "" {
+					diskConfig.Message = previousMessage
+				}
+			}
 		}
 
 		if diskConfig.State != string(spdkdisk.DiskStateReady) {
-			errs.Append("errors", fmt.Errorf("disk is not in ready state, current state: %v", diskConfig.State))
+			if diskConfig.Message != "" {
+				errs.Append("errors", fmt.Errorf("disk is not in ready state, current state: %v, message: %v", diskConfig.State, truncateDiskMessage(diskConfig.Message)))
+			} else {
+				errs.Append("errors", fmt.Errorf("disk is not in ready state, current state: %v", diskConfig.State))
+			}
 
-			diskInfoMap[diskName] = NewDiskInfo(diskName, "", disk.Path, diskDriver, nodeOrDiskEvicted, nil,
+			diskInfoMap[diskName] = NewDiskInfo(diskName, recordedDiskUUID, disk.Path, requestedDiskDriver, nodeOrDiskEvicted, nil,
 				orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo),
 				fmt.Sprintf("Disk %v(%v) on node %v is not ready: %v", diskName, disk.Path, node.Name, errs.Error()))
 			continue
@@ -340,7 +364,7 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 		if err != nil {
 			errs.Append("errors", errors.Wrap(err, "failed to get disk stat"))
 
-			diskInfoMap[diskName] = NewDiskInfo(diskName, "", disk.Path, diskDriver, nodeOrDiskEvicted, nil,
+			diskInfoMap[diskName] = NewDiskInfo(diskName, recordedDiskUUID, disk.Path, requestedDiskDriver, nodeOrDiskEvicted, nil,
 				orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo),
 				fmt.Sprintf("Disk %v(%v) on node %v is not ready: %v", diskName, disk.Path, node.Name, errs.Error()))
 			continue
@@ -362,7 +386,7 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 			orphanedReplicaDataStores, instanceManagerName, string(longhorn.DiskConditionReasonNoDiskInfo), "")
 
 		if node.Status.DiskStatus != nil {
-			if diskStatus, ok := node.Status.DiskStatus[diskName]; ok {
+			if diskStatus, ok := node.Status.DiskStatus[diskName]; ok && diskStatus != nil {
 				// Preserve existing health data to avoid losing it between collection intervals
 				diskInfoMap[diskName].HealthData = diskStatus.HealthData
 				diskInfoMap[diskName].HealthDataLastCollectedAt = diskStatus.HealthDataLastCollectedAt.Time
@@ -386,6 +410,17 @@ func (m *DiskMonitor) collectDiskData(node *longhorn.Node) map[string]*Collected
 
 func isNodeOrDiskEvicted(node *longhorn.Node, disk longhorn.DiskSpec) bool {
 	return node.Spec.EvictionRequested || disk.EvictionRequested
+}
+
+// truncateDiskMessage bounds a message reported by the disk service, since it
+// ends up in the node CR and may embed arbitrary command output.
+func truncateDiskMessage(message string) string {
+	if len(message) <= diskMessageMaxLength {
+		return message
+	}
+	// Cutting on a byte boundary can split a rune and produce invalid UTF-8,
+	// which the API server rejects.
+	return strings.ToValidUTF8(message[:diskMessageMaxLength], "") + "..."
 }
 
 func getReplicaDataStores(diskType longhorn.DiskType, node *longhorn.Node, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient) (map[string]string, error) {

--- a/controller/monitor/disk_monitor_test.go
+++ b/controller/monitor/disk_monitor_test.go
@@ -1,0 +1,227 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	spdkdisk "github.com/longhorn/longhorn-spdk-engine/pkg/spdk"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+const (
+	testNamespace     = "longhorn-system"
+	testNodeName      = "test-node"
+	testBlockDiskName = "block-disk"
+	testBlockDiskPath = "0000:05:00.0"
+	testBlockDiskUUID = "block-disk-uuid"
+)
+
+func TestTruncateDiskMessage(t *testing.T) {
+	assert := require.New(t)
+
+	short := "unsupported disk driver vfio-pci for disk path"
+	assert.Equal(short, truncateDiskMessage(short))
+	assert.Equal("", truncateDiskMessage(""))
+
+	long := strings.Repeat("a", diskMessageMaxLength+10)
+	truncated := truncateDiskMessage(long)
+	assert.Equal(diskMessageMaxLength+len("..."), len(truncated))
+	assert.True(strings.HasSuffix(truncated, "..."))
+
+	// A multi-byte rune straddling the cut must not leave invalid UTF-8 behind.
+	multiByte := strings.Repeat("a", diskMessageMaxLength-1) + "日本語"
+	assert.True(utf8.ValidString(truncateDiskMessage(multiByte)))
+}
+
+// newTestDiskMonitor builds a disk monitor whose datastore has no settings, so no
+// disk service client is created and only the injected handlers are exercised.
+func newTestDiskMonitor(t *testing.T, getDiskConfig GetDiskConfigHandler, generateDiskConfig GenerateDiskConfigHandler) *DiskMonitor {
+	kubeClient := kubefake.NewSimpleClientset()
+	lhClient := lhfake.NewSimpleClientset() // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset()
+	informerFactories := util.NewInformerFactories(testNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(testNamespace, lhClient, kubeClient, extensionsClient, informerFactories)
+
+	m, err := NewFakeDiskMonitor(logrus.StandardLogger(), ds, testNodeName, func(string) {})
+	require.NoError(t, err)
+
+	m.getDiskConfigHandler = getDiskConfig
+	m.generateDiskConfigHandler = generateDiskConfig
+
+	return m
+}
+
+func newTestBlockDiskNode() *longhorn.Node {
+	return &longhorn.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testNodeName, Namespace: testNamespace},
+		Spec: longhorn.NodeSpec{
+			Disks: map[string]longhorn.DiskSpec{
+				testBlockDiskName: {
+					Type:       longhorn.DiskTypeBlock,
+					Path:       testBlockDiskPath,
+					DiskDriver: longhorn.DiskDriverAuto,
+				},
+			},
+		},
+		Status: longhorn.NodeStatus{
+			DiskStatus: map[string]*longhorn.DiskStatus{
+				testBlockDiskName: {
+					Type:       longhorn.DiskTypeBlock,
+					DiskUUID:   testBlockDiskUUID,
+					DiskPath:   testBlockDiskPath,
+					DiskDriver: longhorn.DiskDriverNvme,
+				},
+			},
+		},
+	}
+}
+
+// TestCollectDiskDataRetriesFailedBlockDisk covers longhorn/longhorn#13893: the disk
+// service keeps a failed disk in the error state and still answers DiskGet, so the
+// monitor has to re-issue the creation itself for the disk to ever recover.
+func TestCollectDiskDataRetriesFailedBlockDisk(t *testing.T) {
+	assert := require.New(t)
+
+	failureMessage := "unsupported disk driver vfio-pci for disk path 0000:05:00.0"
+	generateCalls := 0
+	generatedUUID, generatedDriver := "", ""
+
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName: diskName,
+				State:    string(spdkdisk.DiskStateError),
+				Message:  failureMessage,
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			generateCalls++
+			generatedUUID, generatedDriver = diskUUID, diskDriver
+			// The disk service only reports the state when a creation is started.
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
+		},
+	)
+
+	diskInfoMap := m.collectDiskData(newTestBlockDiskNode())
+
+	assert.Equal(1, generateCalls)
+	// The recorded UUID and driver must be reused, otherwise the retry orphans the
+	// lvstore of the previous attempt or re-resolves a driver that is already known.
+	assert.Equal(testBlockDiskUUID, generatedUUID)
+	assert.Equal(string(longhorn.DiskDriverNvme), generatedDriver)
+
+	diskInfo, ok := diskInfoMap[testBlockDiskName]
+	assert.True(ok)
+	assert.NotNil(diskInfo.Condition)
+	// A retry restarts from the creating state with no message, so the reason of the
+	// previous failure has to be carried over; otherwise it is never reported.
+	assert.Contains(diskInfo.Condition.Message, failureMessage)
+}
+
+// TestCollectDiskDataKeepsReportingFailureAcrossCollections covers the steady state
+// of longhorn/longhorn#13893: the retried creation fails fast on the still-bound
+// device, so the disk service latches back to the error state and keeps answering
+// DiskGet with the reason. Each collection therefore re-surfaces the failure without
+// relying on any state carried between collections.
+func TestCollectDiskDataKeepsReportingFailureAcrossCollections(t *testing.T) {
+	assert := require.New(t)
+
+	failureMessage := "unsupported disk driver vfio-pci for disk path 0000:05:00.0"
+	generateCalls := 0
+
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName: diskName,
+				State:    string(spdkdisk.DiskStateError),
+				Message:  failureMessage,
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			generateCalls++
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
+		},
+	)
+
+	for i := 0; i < 2; i++ {
+		diskInfoMap := m.collectDiskData(newTestBlockDiskNode())
+		diskInfo, ok := diskInfoMap[testBlockDiskName]
+		assert.True(ok)
+		assert.NotNil(diskInfo.Condition)
+		assert.Contains(diskInfo.Condition.Message, failureMessage)
+	}
+	// Every collection re-issues the creation, so the disk can recover as soon as the
+	// underlying device is released.
+	assert.Equal(2, generateCalls)
+}
+
+// TestCollectDiskDataDoesNotRetryReadyBlockDisk guards the retry from re-creating a
+// disk that the disk service already reports as ready.
+func TestCollectDiskDataDoesNotRetryReadyBlockDisk(t *testing.T) {
+	assert := require.New(t)
+
+	generateCalls := 0
+
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName:   diskName,
+				DiskUUID:   testBlockDiskUUID,
+				DiskDriver: longhorn.DiskDriverNvme,
+				State:      string(spdkdisk.DiskStateReady),
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			generateCalls++
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
+		},
+	)
+
+	diskInfoMap := m.collectDiskData(newTestBlockDiskNode())
+
+	assert.Equal(0, generateCalls)
+	diskInfo, ok := diskInfoMap[testBlockDiskName]
+	assert.True(ok)
+	assert.Nil(diskInfo.Condition)
+}
+
+// TestCollectDiskDataToleratesNilDiskStatus makes sure a nil status entry, which
+// the monitor may read straight from the CR before it is normalized, does not
+// panic the controller.
+func TestCollectDiskDataToleratesNilDiskStatus(t *testing.T) {
+	assert := require.New(t)
+
+	m := newTestDiskMonitor(t,
+		func(diskType longhorn.DiskType, diskName, diskPath string, diskDriver longhorn.DiskDriver, client *DiskServiceClient) (*util.DiskConfig, error) {
+			return &util.DiskConfig{
+				DiskName:   diskName,
+				DiskUUID:   testBlockDiskUUID,
+				DiskDriver: longhorn.DiskDriverNvme,
+				State:      string(spdkdisk.DiskStateReady),
+			}, nil
+		},
+		func(diskType longhorn.DiskType, diskName, diskUUID, diskPath, diskDriver string, client *DiskServiceClient, ds *datastore.DataStore) (*util.DiskConfig, error) {
+			return &util.DiskConfig{State: string(spdkdisk.DiskStateCreating)}, nil
+		},
+	)
+
+	node := newTestBlockDiskNode()
+	node.Status.DiskStatus[testBlockDiskName] = nil
+
+	assert.NotPanics(func() {
+		m.collectDiskData(node)
+	})
+}

--- a/controller/monitor/disk_utils.go
+++ b/controller/monitor/disk_utils.go
@@ -340,6 +340,7 @@ func getBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskPath string
 		DiskUUID:   info.UUID,
 		DiskDriver: longhorn.DiskDriver(info.Driver),
 		State:      info.State,
+		Message:    info.Message,
 	}, nil
 }
 
@@ -431,6 +432,7 @@ func generateBlockTypeDiskConfig(client *DiskServiceClient, diskName, diskUUID, 
 		DiskUUID:   info.UUID,
 		DiskDriver: longhorn.DiskDriver(info.Driver),
 		State:      info.State,
+		Message:    info.Message,
 	}, nil
 }
 

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -1755,13 +1755,21 @@ func (nc *NodeController) alignDiskSpecAndStatus(node *longhorn.Node) {
 		diskStatus.StorageMaximum = 0
 		diskStatus.StorageAvailable = 0
 		diskStatus.Type = node.Spec.Disks[diskName].Type
+		// Record the configured path before the disk is created. Otherwise a disk
+		// whose creation fails has no path at all, and the cleanup on removal
+		// cannot tell the disk service which device to release. Only fill it in
+		// when unset so the path never desyncs from the recorded UUID and driver.
+		if diskStatus.DiskPath == "" {
+			diskStatus.DiskPath = node.Spec.Disks[diskName].Path
+		}
 		node.Status.DiskStatus[diskName] = diskStatus
 	}
 
 	for diskName := range node.Status.DiskStatus {
 		if _, exists := node.Spec.Disks[diskName]; !exists {
 			diskStatus, ok := node.Status.DiskStatus[diskName]
-			if !ok {
+			if !ok || diskStatus == nil {
+				delete(node.Status.DiskStatus, diskName)
 				continue
 			}
 
@@ -1819,13 +1827,18 @@ func (nc *NodeController) cleanupDisksBeforeNodeDeletion(node *longhorn.Node) er
 
 	errs := multierr.NewMultiError()
 	for diskName, diskStatus := range node.Status.DiskStatus {
+		// Node deletion bypasses alignDiskSpecAndStatus, so a nil status entry is
+		// still possible here.
+		if diskStatus == nil {
+			continue
+		}
 		nc.logger.Infof("Cleaning up disk %s", diskName)
 		// Skip non-SPDK disks
 		if diskStatus.Type != longhorn.DiskTypeBlock {
 			continue
 		}
 
-		if diskStatus.DiskDriver == longhorn.DiskDriverNone {
+		if diskStatus.DiskDriver == longhorn.DiskDriverNone && diskStatus.DiskPath == "" {
 			continue
 		}
 

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -2820,3 +2820,76 @@ func (s *NodeControllerSuite) TestLinkedCloneEviction(c *C) {
 		c.Assert(r.Spec.EvictionRequested, Equals, true)
 	}
 }
+
+// TestAlignDiskSpecAndStatusRecordsConfiguredDiskPath covers longhorn/longhorn#13893:
+// without the configured path in the status, a disk whose creation failed leaves
+// nothing behind to identify the device that has to be released.
+func (s *NodeControllerSuite) TestAlignDiskSpecAndStatusRecordsConfiguredDiskPath(c *C) {
+	node := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node.Spec.Disks = map[string]longhorn.DiskSpec{
+		TestDiskID1: {
+			Type:            longhorn.DiskTypeBlock,
+			Path:            "0000:05:00.0",
+			DiskDriver:      longhorn.DiskDriverAuto,
+			AllowScheduling: true,
+		},
+	}
+	// A fresh disk starts with no recorded path, so the configured path must be
+	// filled in before creation to identify the device on removal.
+	node.Status.DiskStatus = map[string]*longhorn.DiskStatus{}
+
+	s.controller.alignDiskSpecAndStatus(node)
+
+	diskStatus, ok := node.Status.DiskStatus[TestDiskID1]
+	c.Assert(ok, Equals, true)
+	c.Assert(diskStatus.DiskPath, Equals, "0000:05:00.0")
+}
+
+// TestAlignDiskSpecAndStatusDropsRemovedDisks covers longhorn/longhorn#13893:
+// a removed disk must not keep a status entry, since the node validator rejects
+// every node update while the spec and the status disks disagree.
+func (s *NodeControllerSuite) TestAlignDiskSpecAndStatusDropsRemovedDisks(c *C) {
+	node := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node.Spec.Disks = map[string]longhorn.DiskSpec{}
+	node.Status.DiskStatus = map[string]*longhorn.DiskStatus{
+		"block-disk": {
+			Type:     longhorn.DiskTypeBlock,
+			DiskPath: "0000:05:00.0",
+		},
+		"filesystem-disk": {
+			Type:     longhorn.DiskTypeFilesystem,
+			DiskPath: TestDefaultDataPath,
+		},
+	}
+
+	// There is no running instance manager, so releasing the block device fails.
+	s.controller.alignDiskSpecAndStatus(node)
+
+	c.Assert(node.Status.DiskStatus, HasLen, 0)
+}
+
+func (s *NodeControllerSuite) TestAlignDiskSpecAndStatusDropsNilDiskStatus(c *C) {
+	node := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	node.Spec.Disks = map[string]longhorn.DiskSpec{}
+	node.Status.DiskStatus = map[string]*longhorn.DiskStatus{"stale-disk": nil}
+
+	s.controller.alignDiskSpecAndStatus(node)
+
+	_, ok := node.Status.DiskStatus["stale-disk"]
+	c.Assert(ok, Equals, false)
+}
+
+// TestAlignDiskSpecAndStatusKeepsFilesystemDiskUntouched guards the block-disk
+// path recording from changing how filesystem-type disks are handled.
+func (s *NodeControllerSuite) TestAlignDiskSpecAndStatusKeepsFilesystemDiskUntouched(c *C) {
+	node := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+	specDiskPath := node.Spec.Disks[TestDiskID1].Path
+
+	s.controller.alignDiskSpecAndStatus(node)
+
+	diskStatus, ok := node.Status.DiskStatus[TestDiskID1]
+	c.Assert(ok, Equals, true)
+	c.Assert(diskStatus.Type, Equals, longhorn.DiskTypeFilesystem)
+	c.Assert(diskStatus.DiskPath, Equals, specDiskPath)
+	c.Assert(types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeReady).Status, Equals, longhorn.ConditionStatusTrue)
+}

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/longhorn/go-spdk-helper v0.9.1-0.20260828012436-4ec507083142
 	github.com/longhorn/longhorn-engine v1.13.0-dev-20260809.0.20260901065543-e0f8f0952a6e
 	github.com/longhorn/longhorn-instance-manager v1.13.0-dev-20260809.0.20260902015206-8066229072b8
-	github.com/longhorn/longhorn-share-manager v1.12.0-dev-20260503.0.20260510090948-3e59157e1fb2
+	github.com/longhorn/longhorn-share-manager v1.13.0-dev-20260809.0.20260830145720-5093e4c95410
 	github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260809.0.20260901011635-a650e4d8d56f
 	github.com/longhorn/types v0.0.0-20260831072945-0bac432e7872
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/longhorn/longhorn-engine v1.13.0-dev-20260809.0.20260901065543-e0f8f0
 github.com/longhorn/longhorn-engine v1.13.0-dev-20260809.0.20260901065543-e0f8f0952a6e/go.mod h1:uAlWrmxnKvGAELDE47gn4Vbg7V+9cIESlyxKFEeQ+EA=
 github.com/longhorn/longhorn-instance-manager v1.13.0-dev-20260809.0.20260902015206-8066229072b8 h1:cQ6Mv2p3BYFaq26F3vKMqyWiwnCwGxS6mfb9b7Ru5oo=
 github.com/longhorn/longhorn-instance-manager v1.13.0-dev-20260809.0.20260902015206-8066229072b8/go.mod h1:qBAOHKHm2a79EkEpFsvWUbXH9wPkR8tZF6QVjRR/X/M=
-github.com/longhorn/longhorn-share-manager v1.12.0-dev-20260503.0.20260510090948-3e59157e1fb2 h1:fE8sadYwAkWi0euk5igkN8AYj5sCDQ8+jURXRFw8ESM=
-github.com/longhorn/longhorn-share-manager v1.12.0-dev-20260503.0.20260510090948-3e59157e1fb2/go.mod h1:EA3kkZCaW8MvzI2fRpeC1BuSiMN0bEuOlLIl7B0NQkY=
+github.com/longhorn/longhorn-share-manager v1.13.0-dev-20260809.0.20260830145720-5093e4c95410 h1:w+mY3UNXln0X6f0FTxR0YxxyuaUT4TUq/987KP06MCI=
+github.com/longhorn/longhorn-share-manager v1.13.0-dev-20260809.0.20260830145720-5093e4c95410/go.mod h1:kGs77fGF+9spg2VJQ1sC6bSKp/OXA4ZYtwr+jAbTXc0=
 github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260809.0.20260901011635-a650e4d8d56f h1:nygp67IVTw5Xdbp+3BK3FA23YjWf3qiAqndzCeKoaK8=
 github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260809.0.20260901011635-a650e4d8d56f/go.mod h1:R4f7bFUPVfuW+lmkmAyoxvzR1fDd5+BjLsKsc/yWI54=
 github.com/longhorn/types v0.0.0-20260831072945-0bac432e7872 h1:PzsqquPSCChJa+sPq8yp0pjvw3MR48ieqRcq90+PhYs=

--- a/util/util.go
+++ b/util/util.go
@@ -651,6 +651,8 @@ type DiskConfig struct {
 	DiskUUID   string              `json:"diskUUID"`
 	DiskDriver longhorn.DiskDriver `json:"diskDriver"`
 	State      string              `json:"state"`
+	// Message is never persisted; it only carries the reason of the current state.
+	Message string `json:"-"`
 }
 
 func MinInt(a, b int) int {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -335,7 +335,7 @@ github.com/longhorn/longhorn-instance-manager/pkg/client
 github.com/longhorn/longhorn-instance-manager/pkg/meta
 github.com/longhorn/longhorn-instance-manager/pkg/types
 github.com/longhorn/longhorn-instance-manager/pkg/util
-# github.com/longhorn/longhorn-share-manager v1.12.0-dev-20260503.0.20260510090948-3e59157e1fb2
+# github.com/longhorn/longhorn-share-manager v1.13.0-dev-20260809.0.20260830145720-5093e4c95410
 ## explicit; go 1.26.0
 github.com/longhorn/longhorn-share-manager/pkg/client
 github.com/longhorn/longhorn-share-manager/pkg/types


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13893

#### What this PR does / why we need it:

When a v2 block disk fails to be created (e.g. its NVMe device is bound to a userspace PCI driver such as vfio-pci), the disk stayed Ready=False and Schedulable=False with no way to recover, and removing it left the device
held with no hint about what happened.

The disk service keeps a failed disk in the error state until it is asked to create it again, so the disk monitor now re-issues the creation on its own instead of waiting for an instance manager restart, reusing the already-recorded disk UUID and driver. The reason reported by the disk service is propagated into the disk condition (bounded and cut on a rune boundary so the API server never rejects the update).

The node controller now records the configured disk path in the status before the disk is created, so a disk whose creation failed can still tell the disk service which device to release on removal, and emits a warning event when the device may still be held. Stale and nil disk status entries are dropped so the spec and status disks never disagree.

#### Special notes for your reviewer:

#### Additional documentation or context
