### PR TITLE
fix(webhook): reject only block device updates for disabled v2 dataEngine

### DIFF
--- a/webhook/resources/node/validator.go
+++ b/webhook/resources/node/validator.go
@@ -204,8 +204,11 @@ func (n *nodeValidator) Update(request *admission.Request, oldObj runtime.Object
 		if err != nil {
 			return werror.NewInvalidError(err.Error(), "")
 		}
-		if !v2DataEngineEnabled {
-			if disk.Type == longhorn.DiskTypeBlock {
+
+		// Reject updating only block disks when the v2 Data Engine (SPDK) is disabled.
+		if !v2DataEngineEnabled && disk.Type == longhorn.DiskTypeBlock {
+			oldDisk, existed := oldNode.Spec.Disks[name]
+			if !existed || !reflect.DeepEqual(oldDisk, disk) {
 				return werror.NewInvalidError(fmt.Sprintf("update disk on node %v error: The disk %v(%v) is a block device, but the SPDK feature is not enabled",
 					newNode.Name, name, disk.Path), "")
 			}

--- a/webhook/resources/node/validator_test.go
+++ b/webhook/resources/node/validator_test.go
@@ -156,6 +156,36 @@ func TestNodeValidatorUpdateLostKubernetesNode(t *testing.T) {
 			},
 			expectedErrorMsg: "spec and status of disks",
 		},
+		{
+			name:           "updating block disk when v2 data engine is disabled is rejected",
+			kubeNodeExists: true,
+			disksSynced:    true,
+			mutate: func(_, newNode *longhorn.Node) {
+				newNode.Spec.Disks["disk-2"] = longhorn.DiskSpec{
+					Path:            "/var/lib/longhorn/disk2",
+					Type:            longhorn.DiskTypeBlock,
+					AllowScheduling: true,
+				}
+			},
+			expectedErrorMsg: "is a block device, but the SPDK feature is not enabled",
+		},
+		{
+			name:           "annotation update on node with block disk remaining unchanged (v2 disabled) is allowed",
+			kubeNodeExists: true,
+			disksSynced:    true,
+			mutate: func(oldNode, newNode *longhorn.Node) {
+				blockDisk := oldNode.Spec.Disks["disk-1"]
+				blockDisk.Type = longhorn.DiskTypeBlock
+
+				oldNode.Spec.Disks["disk-1"] = blockDisk
+				newNode.Spec.Disks["disk-1"] = blockDisk
+
+				if newNode.Annotations == nil {
+					newNode.Annotations = make(map[string]string)
+				}
+				newNode.Annotations["example.com/test-annotation"] = "updated-value"
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13572

#### What this PR does / why we need it:
At present, any updates to node.longhorn.io with block disk when `v2DataEngine` is `disabled` are rejected, leading to failures during uninstallation.
This commit rejects only disk specific updates when v2 dataEngine is disabled, allowing annotations to be added for clean uninstall.

#### Special notes for your reviewer:

#### Additional documentation or context
