### PR TITLE
fix: modify the default value of the setting 'default-data-path'

### DIFF
--- a/types/setting.go
+++ b/types/setting.go
@@ -578,7 +578,7 @@ var (
 		Required:           true,
 		ReadOnly:           false,
 		DataEngineSpecific: false,
-		Default:            "/var/lib/longhorn/",
+		Default:            "/var/lib/longhorn",
 	}
 
 	SettingDefinitionDefaultEngineImage = SettingDefinition{


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#13910

#### What this PR does / why we need it:

update the value from "/var/lib/longhorn/" to "/var/lib/longhorn"

#### Special notes for your reviewer:

#### Additional documentation or context
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/11936/:
   `test_node.py::test_node_default_disk_labeled --count=15`
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/11953/:
   `test_basic.py`
