### PR TITLE
fix(revert): revert "test(backuptarget): assert AWS_SIGN_ACCEPT_ENCODING is forwarded"

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1262,7 +1262,6 @@ func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]strin
 	credentialSecret[types.HTTPProxy] = string(secret.Data[types.HTTPProxy])
 	credentialSecret[types.NOProxy] = string(secret.Data[types.NOProxy])
 	credentialSecret[types.VirtualHostedStyle] = string(secret.Data[types.VirtualHostedStyle])
-	credentialSecret[types.AWSSignAcceptEncoding] = string(secret.Data[types.AWSSignAcceptEncoding])
 	return credentialSecret, nil
 }
 

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -118,7 +118,6 @@ func getBackupCredentialEnv(backupTarget string, credential map[string]string) (
 		envs = append(envs, fmt.Sprintf("%s=%s", types.HTTPProxy, credential[types.HTTPProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.NOProxy, credential[types.NOProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.VirtualHostedStyle, credential[types.VirtualHostedStyle]))
-		envs = append(envs, fmt.Sprintf("%s=%s", types.AWSSignAcceptEncoding, credential[types.AWSSignAcceptEncoding]))
 	case types.BackupStoreTypeCIFS:
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSUsername, credential[types.CIFSUsername]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSPassword, credential[types.CIFSPassword]))

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -147,48 +147,6 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 	}
 }
 
-// TestGetBackupCredentialEnvSignAcceptEncoding pins that the S3 branch forwards
-// AWS_SIGN_ACCEPT_ENCODING. TestGetBackupCredentialEnv above only checks the
-// value of whatever is returned, so it stays green if the entry is dropped
-// entirely, which is the silent drop this guards against.
-func TestGetBackupCredentialEnvSignAcceptEncoding(t *testing.T) {
-	tests := []struct {
-		name       string
-		credential map[string]string
-		expectEnv  string
-	}{
-		{
-			name: "forwards the value set in the secret",
-			credential: map[string]string{
-				"AWS_ACCESS_KEY_ID":        "my-aws-access-key-id",
-				"AWS_SECRET_ACCESS_KEY":    "my-aws-secret-access-key",
-				"AWS_SIGN_ACCEPT_ENCODING": "false",
-			},
-			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=false",
-		},
-		{
-			// The entry is sent whether or not the secret sets it, which is why
-			// the instance manager has to allowlist the key before this ships.
-			name: "forwards an empty value when the secret omits the key",
-			credential: map[string]string{
-				"AWS_ACCESS_KEY_ID":     "my-aws-access-key-id",
-				"AWS_SECRET_ACCESS_KEY": "my-aws-secret-access-key",
-			},
-			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := require.New(t)
-
-			envs, err := getBackupCredentialEnv("s3://backupbucket@us-east-1/", tt.credential)
-			assert.Nil(err)
-			assert.Contains(envs, tt.expectEnv)
-		})
-	}
-}
-
 func TestParseBackupVolumeNamesList(t *testing.T) {
 	assert := require.New(t)
 

--- a/types/types.go
+++ b/types/types.go
@@ -358,8 +358,6 @@ const (
 
 	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
 
-	AWSSignAcceptEncoding = "AWS_SIGN_ACCEPT_ENCODING"
-
 	OptionFromBackup          = "fromBackup"
 	OptionNumberOfReplicas    = "numberOfReplicas"
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"

--- a/webhook/resources/backuptarget/validator.go
+++ b/webhook/resources/backuptarget/validator.go
@@ -151,7 +151,6 @@ func (b *backupTargetValidator) validateCredentialSecret(secretName string) erro
 		types.HTTPProxy,
 		types.NOProxy,
 		types.VirtualHostedStyle,
-		types.AWSSignAcceptEncoding,
 	}
 
 	errs := multierr.NewMultiError()


### PR DESCRIPTION

This reverts commit 03a58bd.Reverts longhorn/longhorn-manager#5116

Revert the implementation because the fix is only applied to v1.13.0+.