### PR TITLE
fix(backuptarget): forward AWS_SIGN_ACCEPT_ENCODING only to proxies that accept it

### DIFF
--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -83,8 +83,11 @@ func (btc *BackupTargetClient) LonghornEngineBinary() string {
 	return filepath.Join(types.GetEngineBinaryDirectoryOnHostForImage(btc.Image), "longhorn")
 }
 
-// getBackupCredentialEnv returns the environment variables as KEY=VALUE in string slice
-func getBackupCredentialEnv(backupTarget string, credential map[string]string) ([]string, error) {
+// getBackupCredentialEnv returns the environment variables as KEY=VALUE in string slice.
+// supportsSignAcceptEncoding tells whether the consumer accepts AWS_SIGN_ACCEPT_ENCODING; an
+// instance manager proxy older than MinProxyAPIVersionForBackupSignAcceptEncoding rejects the
+// whole request when the key is present.
+func getBackupCredentialEnv(backupTarget string, credential map[string]string, supportsSignAcceptEncoding bool) ([]string, error) {
 	envs := []string{}
 	backupType, err := util.CheckBackupType(backupTarget)
 	if err != nil {
@@ -118,7 +121,9 @@ func getBackupCredentialEnv(backupTarget string, credential map[string]string) (
 		envs = append(envs, fmt.Sprintf("%s=%s", types.HTTPProxy, credential[types.HTTPProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.NOProxy, credential[types.NOProxy]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.VirtualHostedStyle, credential[types.VirtualHostedStyle]))
-		envs = append(envs, fmt.Sprintf("%s=%s", types.AWSSignAcceptEncoding, credential[types.AWSSignAcceptEncoding]))
+		if supportsSignAcceptEncoding {
+			envs = append(envs, fmt.Sprintf("%s=%s", types.AWSSignAcceptEncoding, credential[types.AWSSignAcceptEncoding]))
+		}
 	case types.BackupStoreTypeCIFS:
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSUsername, credential[types.CIFSUsername]))
 		envs = append(envs, fmt.Sprintf("%s=%s", types.CIFSPassword, credential[types.CIFSPassword]))
@@ -135,7 +140,7 @@ func getBackupCredentialEnv(backupTarget string, credential map[string]string) (
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinary(args ...string) (string, error) {
-	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential)
+	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential, true)
 	if err != nil {
 		return "", err
 	}
@@ -143,7 +148,7 @@ func (btc *BackupTargetClient) ExecuteEngineBinary(args ...string) (string, erro
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinaryWithTimeout(timeout time.Duration, args ...string) (string, error) {
-	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential)
+	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential, true)
 	if err != nil {
 		return "", err
 	}
@@ -151,7 +156,7 @@ func (btc *BackupTargetClient) ExecuteEngineBinaryWithTimeout(timeout time.Durat
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinaryWithoutTimeout(args ...string) (string, error) {
-	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential)
+	envs, err := getBackupCredentialEnv(btc.URL, btc.Credential, true)
 	if err != nil {
 		return "", err
 	}
@@ -360,7 +365,7 @@ func (e *EngineBinary) SnapshotBackup(obj DataEngineObject, snapName, backupName
 	args = append(args, snapName)
 
 	// get environment variables if backup for s3
-	envs, err := getBackupCredentialEnv(backupTarget, credential)
+	envs, err := getBackupCredentialEnv(backupTarget, credential, true)
 	if err != nil {
 		return "", "", err
 	}
@@ -431,7 +436,7 @@ func (e *EngineBinary) BackupRestore(engine *longhorn.Engine, backupTarget, back
 	backup := backupstore.EncodeBackupURL(backupName, backupVolumeName, backupTarget)
 
 	// get environment variables if backup for s3
-	envs, err := getBackupCredentialEnv(backupTarget, credential)
+	envs, err := getBackupCredentialEnv(backupTarget, credential, true)
 	if err != nil {
 		return err
 	}

--- a/engineapi/backups_test.go
+++ b/engineapi/backups_test.go
@@ -132,7 +132,7 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := require.New(t)
 
-			envs, err := getBackupCredentialEnv(tt.backupTarget, tt.credential)
+			envs, err := getBackupCredentialEnv(tt.backupTarget, tt.credential, true)
 			if tt.expectError {
 				assert.NotNil(err)
 			} else {
@@ -148,14 +148,16 @@ func TestGetBackupCredentialEnv(t *testing.T) {
 }
 
 // TestGetBackupCredentialEnvSignAcceptEncoding pins that the S3 branch forwards
-// AWS_SIGN_ACCEPT_ENCODING. TestGetBackupCredentialEnv above only checks the
-// value of whatever is returned, so it stays green if the entry is dropped
-// entirely, which is the silent drop this guards against.
+// AWS_SIGN_ACCEPT_ENCODING only when the consumer supports it. TestGetBackupCredentialEnv
+// above only checks the value of whatever is returned, so it stays green if the
+// entry is dropped entirely, which is the silent drop this guards against.
 func TestGetBackupCredentialEnvSignAcceptEncoding(t *testing.T) {
 	tests := []struct {
-		name       string
-		credential map[string]string
-		expectEnv  string
+		name                       string
+		credential                 map[string]string
+		supportsSignAcceptEncoding bool
+		env                        string
+		expectEnv                  bool
 	}{
 		{
 			name: "forwards the value set in the secret",
@@ -164,17 +166,34 @@ func TestGetBackupCredentialEnvSignAcceptEncoding(t *testing.T) {
 				"AWS_SECRET_ACCESS_KEY":    "my-aws-secret-access-key",
 				"AWS_SIGN_ACCEPT_ENCODING": "false",
 			},
-			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=false",
+			supportsSignAcceptEncoding: true,
+			env:                        "AWS_SIGN_ACCEPT_ENCODING=false",
+			expectEnv:                  true,
 		},
 		{
-			// The entry is sent whether or not the secret sets it, which is why
-			// the instance manager has to allowlist the key before this ships.
+			// The entry is sent whether or not the secret sets it, so that a value left
+			// behind in the long-lived instance manager process is cleared.
 			name: "forwards an empty value when the secret omits the key",
 			credential: map[string]string{
 				"AWS_ACCESS_KEY_ID":     "my-aws-access-key-id",
 				"AWS_SECRET_ACCESS_KEY": "my-aws-secret-access-key",
 			},
-			expectEnv: "AWS_SIGN_ACCEPT_ENCODING=",
+			supportsSignAcceptEncoding: true,
+			env:                        "AWS_SIGN_ACCEPT_ENCODING=",
+			expectEnv:                  true,
+		},
+		{
+			// An instance manager proxy older than MinProxyAPIVersionForBackupSignAcceptEncoding
+			// rejects the whole request when the key is present.
+			name: "omits the entry when the consumer does not support it",
+			credential: map[string]string{
+				"AWS_ACCESS_KEY_ID":        "my-aws-access-key-id",
+				"AWS_SECRET_ACCESS_KEY":    "my-aws-secret-access-key",
+				"AWS_SIGN_ACCEPT_ENCODING": "false",
+			},
+			supportsSignAcceptEncoding: false,
+			env:                        "AWS_SIGN_ACCEPT_ENCODING=false",
+			expectEnv:                  false,
 		},
 	}
 
@@ -182,9 +201,13 @@ func TestGetBackupCredentialEnvSignAcceptEncoding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := require.New(t)
 
-			envs, err := getBackupCredentialEnv("s3://backupbucket@us-east-1/", tt.credential)
+			envs, err := getBackupCredentialEnv("s3://backupbucket@us-east-1/", tt.credential, tt.supportsSignAcceptEncoding)
 			assert.Nil(err)
-			assert.Contains(envs, tt.expectEnv)
+			if tt.expectEnv {
+				assert.Contains(envs, tt.env)
+			} else {
+				assert.NotContains(envs, tt.env)
+			}
 		})
 	}
 }

--- a/engineapi/instance_manager.go
+++ b/engineapi/instance_manager.go
@@ -37,6 +37,12 @@ const (
 	// N-replica simultaneous linked-clone via DstReplicaSrcReplicaPairMap.
 	MinProxyAPIVersionForNReplicaLinkedClone = 7
 
+	// MinProxyAPIVersionForBackupSignAcceptEncoding is the minimum proxy API version whose backup
+	// env allowlist contains AWS_SIGN_ACCEPT_ENCODING. Older proxies reject the whole backup
+	// request when the key is present, which happens on every live upgrade until the engines move
+	// to the new instance manager.
+	MinProxyAPIVersionForBackupSignAcceptEncoding = 8
+
 	DefaultEnginePortCount = 1
 
 	DefaultReplicaPortCountV1 = 10

--- a/engineapi/proxy.go
+++ b/engineapi/proxy.go
@@ -109,15 +109,17 @@ func NewEngineClientProxy(im *longhorn.InstanceManager, logger logrus.FieldLogge
 	return &Proxy{
 		logger:           logger,
 		grpcClient:       proxyClient,
+		proxyAPIVersion:  im.Status.ProxyAPIVersion,
 		proxyConnCounter: proxyConnCounter,
 		ds:               ds,
 	}, nil
 }
 
 type Proxy struct {
-	logger     logrus.FieldLogger
-	grpcClient *imclient.ProxyClient
-	ds         *datastore.DataStore
+	logger          logrus.FieldLogger
+	grpcClient      *imclient.ProxyClient
+	proxyAPIVersion int
+	ds              *datastore.DataStore
 
 	proxyConnCounter util.Counter
 }

--- a/engineapi/proxy_backup.go
+++ b/engineapi/proxy_backup.go
@@ -12,6 +12,10 @@ import (
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
+func (p *Proxy) supportsBackupSignAcceptEncoding() bool {
+	return p.proxyAPIVersion >= MinProxyAPIVersionForBackupSignAcceptEncoding
+}
+
 func (p *Proxy) SnapshotBackup(obj DataEngineObject, snapshotName, backupName, backupTarget,
 	backingImageName, backingImageChecksum, compressionMethod string, concurrentLimit int, storageClassName string,
 	labels, credential, parameters map[string]string) (string, string, error) {
@@ -29,7 +33,7 @@ func (p *Proxy) SnapshotBackup(obj DataEngineObject, snapshotName, backupName, b
 	}
 
 	// get environment variables if backup for s3
-	credentialEnv, err := getBackupCredentialEnv(backupTarget, credential)
+	credentialEnv, err := getBackupCredentialEnv(backupTarget, credential, p.supportsBackupSignAcceptEncoding())
 	if err != nil {
 		return "", "", err
 	}
@@ -59,7 +63,7 @@ func (p *Proxy) BackupRestore(e *longhorn.Engine, backupTarget, backupName, back
 	backupURL := backupstore.EncodeBackupURL(backupName, backupVolumeName, backupTarget)
 
 	// get environment variables if backup for s3
-	envs, err := getBackupCredentialEnv(backupTarget, credential)
+	envs, err := getBackupCredentialEnv(backupTarget, credential, p.supportsBackupSignAcceptEncoding())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:


Issue Longhorn/longhorn#13911

#### What this PR does / why we need it:

getBackupCredentialEnv appends AWS_SIGN_ACCEPT_ENCODING to every S3 backup credential env list, whether or not the secret sets it. An instance manager proxy whose backup env allowlist predates the key rejects the whole request with "env key ... is not permitted by the backup env allowlist".

During a live upgrade the volume engines keep running in the old instance manager until their per-volume engine upgrade, so the new manager sends the key to an old proxy and every backup and restore fails. For a DR volume this also wedges the rebuild, because a replenished replica stays in WO mode until an incremental restore completes.

Gate the entry on the proxy API version reported by the instance manager, so the key is only sent to a proxy that allowlists it. The paths that execute the engine binary locally have no allowlist and keep forwarding it.

#### Special notes for your reviewer:

#### Additional documentation or context
