### PR TITLE
fix: infer RecurringJob source label when PVC already has job groups

### DIFF
--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -609,6 +609,29 @@ func syncRecurringJobLabelsToTargetResource(targetKind string, targetObj, source
 	return nil
 }
 
+// inferRecurringJobSourceIfNeeded sets recurring-job.longhorn.io/source=enabled
+// when the PVC has job/group labels and the source key is absent.
+// If the source key is present with a non-enabled value, that explicit opt-out
+// is left alone.
+func inferRecurringJobSourceIfNeeded(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	if pvc.Labels == nil {
+		pvc.Labels = map[string]string{}
+	}
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	if _, present := pvc.Labels[sourceKey]; present {
+		return false, nil
+	}
+	hasJobLabels, err := pvcHasRecurringJobLabels(pvc)
+	if err != nil {
+		return false, err
+	}
+	if !hasJobLabels {
+		return false, nil
+	}
+	pvc.Labels[sourceKey] = types.LonghornLabelValueEnabled
+	return true, nil
+}
+
 func pvcHasRecurringJobLabels(obj runtime.Object) (bool, error) {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {

--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -609,6 +609,19 @@ func syncRecurringJobLabelsToTargetResource(targetKind string, targetObj, source
 	return nil
 }
 
+func pvcHasRecurringJobLabels(obj runtime.Object) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get object accessor")
+	}
+	for key := range objMeta.GetLabels() {
+		if types.IsRecurringJobLabel(key) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func hasRecurringJobSourceLabel(obj runtime.Object) (bool, error) {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {

--- a/controller/recurring_job_label_sync_test.go
+++ b/controller/recurring_job_label_sync_test.go
@@ -88,3 +88,70 @@ func TestHasRecurringJobSourceLabel(t *testing.T) {
 		t.Fatal("expected source label")
 	}
 }
+
+func TestInferRecurringJobSourceIfNeeded(t *testing.T) {
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+	rebuildableKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, "rebuildable")
+	extraKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, "extra")
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name: "app",
+		Labels: map[string]string{
+			defaultKey:     types.LonghornLabelValueEnabled,
+			rebuildableKey: types.LonghornLabelValueEnabled,
+		},
+	}}
+	inferred, err := inferRecurringJobSourceIfNeeded(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inferred {
+		t.Fatal("expected inference when source key is absent")
+	}
+	if pvc.Labels[sourceKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("source not inferred: %#v", pvc.Labels)
+	}
+
+	vol := &longhorn.Volume{ObjectMeta: metav1.ObjectMeta{
+		Name: "pvc-app",
+		Labels: map[string]string{
+			rebuildableKey: types.LonghornLabelValueEnabled,
+			extraKey:       types.LonghornLabelValueEnabled,
+		},
+	}}
+	if err := syncRecurringJobLabelsToTargetResource(types.LonghornKindVolume, vol, pvc, logrus.StandardLogger()); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Labels[defaultKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("default group missing: %#v", vol.Labels)
+	}
+	if vol.Labels[rebuildableKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("rebuildable group missing: %#v", vol.Labels)
+	}
+	if _, ok := vol.Labels[extraKey]; ok {
+		t.Fatalf("volume-only extra group should be removed: %#v", vol.Labels)
+	}
+}
+
+func TestInferRecurringJobSourceSkipsExplicitOptOut(t *testing.T) {
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{
+			sourceKey:  "ignored",
+			defaultKey: types.LonghornLabelValueEnabled,
+		},
+	}}
+	inferred, err := inferRecurringJobSourceIfNeeded(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inferred {
+		t.Fatal("must not overwrite an explicit non-enabled source value")
+	}
+	if pvc.Labels[sourceKey] != "ignored" {
+		t.Fatalf("opt-out overwritten: %#v", pvc.Labels)
+	}
+}

--- a/controller/recurring_job_label_sync_test.go
+++ b/controller/recurring_job_label_sync_test.go
@@ -1,15 +1,21 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8scontroller "k8s.io/kubernetes/pkg/controller"
 
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
 )
 
 func TestPvcHasRecurringJobLabels(t *testing.T) {
@@ -153,5 +159,118 @@ func TestInferRecurringJobSourceSkipsExplicitOptOut(t *testing.T) {
 	}
 	if pvc.Labels[sourceKey] != "ignored" {
 		t.Fatalf("opt-out overwritten: %#v", pvc.Labels)
+	}
+}
+
+func TestSyncPVCRecurringJobLabelsInfersSourceWhenAbsent(t *testing.T) {
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+	rebuildableKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, "rebuildable")
+	volumeOnlyKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJob, "volume-only")
+
+	vc, kubeClient := setupVolumeControllerWithPVC(t, map[string]string{
+		defaultKey:     types.LonghornLabelValueEnabled,
+		rebuildableKey: types.LonghornLabelValueEnabled,
+	})
+	vol := boundVolumeWithRecurringJobLabels(map[string]string{
+		volumeOnlyKey: types.LonghornLabelValueEnabled,
+	})
+
+	if err := vc.syncPVCRecurringJobLabels(vol); err != nil {
+		t.Fatal(err)
+	}
+
+	pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(TestNamespace).Get(context.TODO(), TestPVCName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pvc.Labels[sourceKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("expected persisted source=enabled, got %#v", pvc.Labels)
+	}
+	if vol.Labels[defaultKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("default group missing on volume: %#v", vol.Labels)
+	}
+	if vol.Labels[rebuildableKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("rebuildable group missing on volume: %#v", vol.Labels)
+	}
+	if _, exists := vol.Labels[volumeOnlyKey]; exists {
+		t.Fatalf("volume-only RecurringJob label should be removed: %#v", vol.Labels)
+	}
+}
+
+func TestSyncPVCRecurringJobLabelsPreservesNonEnabledSource(t *testing.T) {
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+	volumeOnlyKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJob, "volume-only")
+
+	vc, kubeClient := setupVolumeControllerWithPVC(t, map[string]string{
+		sourceKey:  "ignored",
+		defaultKey: types.LonghornLabelValueEnabled,
+	})
+	vol := boundVolumeWithRecurringJobLabels(map[string]string{
+		volumeOnlyKey: types.LonghornLabelValueEnabled,
+	})
+
+	if err := vc.syncPVCRecurringJobLabels(vol); err != nil {
+		t.Fatal(err)
+	}
+
+	pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(TestNamespace).Get(context.TODO(), TestPVCName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pvc.Labels[sourceKey] != "ignored" {
+		t.Fatalf("non-enabled source must not be overwritten, got %#v", pvc.Labels)
+	}
+	if vol.Labels[defaultKey] == types.LonghornLabelValueEnabled {
+		t.Fatalf("should not sync PVC groups when source is ignored: %#v", vol.Labels)
+	}
+	if vol.Labels[volumeOnlyKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("volume-only label must remain when source is ignored: %#v", vol.Labels)
+	}
+}
+
+func setupVolumeControllerWithPVC(t *testing.T, labels map[string]string) (*VolumeController, *fake.Clientset) {
+	t.Helper()
+
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, k8scontroller.NoResyncPeriodFunc())
+
+	vc, err := newTestVolumeController(lhClient, kubeClient, extensionsClient, informerFactories, TestOwnerID1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestPVCName,
+			Namespace: TestNamespace,
+			Labels:    labels,
+		},
+	}
+	created, err := kubeClient.CoreV1().PersistentVolumeClaims(TestNamespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := informerFactories.KubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer().GetIndexer().Add(created); err != nil {
+		t.Fatal(err)
+	}
+	return vc, kubeClient
+}
+
+func boundVolumeWithRecurringJobLabels(labels map[string]string) *longhorn.Volume {
+	return &longhorn.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   TestVolumeName,
+			Labels: labels,
+		},
+		Status: longhorn.VolumeStatus{
+			KubernetesStatus: longhorn.KubernetesStatus{
+				Namespace: TestNamespace,
+				PVCName:   TestPVCName,
+			},
+		},
 	}
 }

--- a/controller/recurring_job_label_sync_test.go
+++ b/controller/recurring_job_label_sync_test.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/types"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+)
+
+func TestPvcHasRecurringJobLabels(t *testing.T) {
+	sourceKey := types.GetRecurringJobSourceLabelKey()
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+	rebuildableKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, "rebuildable")
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		sourceKey: types.LonghornLabelValueEnabled,
+	}}}
+	ok, err := pvcHasRecurringJobLabels(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("source label alone is not a RecurringJob assignment")
+	}
+
+	pvc.Labels[rebuildableKey] = types.LonghornLabelValueEnabled
+	ok, err = pvcHasRecurringJobLabels(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("group label must count as a RecurringJob assignment")
+	}
+
+	pvc = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		defaultKey: types.LonghornLabelValueEnabled,
+	}}}
+	ok, err = pvcHasRecurringJobLabels(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("default group label must count as a RecurringJob assignment")
+	}
+}
+
+func TestSyncRecurringJobLabelsKeepsMultipleGroups(t *testing.T) {
+	defaultKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, longhorn.RecurringJobGroupDefault)
+	rebuildableKey := types.GetRecurringJobLabelKey(types.LonghornLabelRecurringJobGroup, "rebuildable")
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name: "app",
+		Labels: map[string]string{
+			types.GetRecurringJobSourceLabelKey(): types.LonghornLabelValueEnabled,
+			defaultKey:                            types.LonghornLabelValueEnabled,
+			rebuildableKey:                        types.LonghornLabelValueEnabled,
+		},
+	}}
+	vol := &longhorn.Volume{ObjectMeta: metav1.ObjectMeta{
+		Name:   "pvc-app",
+		Labels: map[string]string{rebuildableKey: types.LonghornLabelValueEnabled},
+	}}
+	if err := syncRecurringJobLabelsToTargetResource(types.LonghornKindVolume, vol, pvc, logrus.StandardLogger()); err != nil {
+		t.Fatal(err)
+	}
+	if vol.Labels[defaultKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("default group missing: %#v", vol.Labels)
+	}
+	if vol.Labels[rebuildableKey] != types.LonghornLabelValueEnabled {
+		t.Fatalf("rebuildable group missing: %#v", vol.Labels)
+	}
+}
+
+func TestHasRecurringJobSourceLabel(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		types.GetRecurringJobSourceLabelKey(): types.LonghornLabelValueEnabled,
+	}}}
+	ok, err := hasRecurringJobSourceLabel(pvc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected source label")
+	}
+}

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -5967,9 +5967,27 @@ func (c *VolumeController) syncPVCRecurringJobLabels(volume *longhorn.Volume) er
 	}
 
 	if !hasSourceLabel {
-		c.logger.Debugf("Ignoring recurring job labels on Volume %v PVC %v due to missing source label", volume.Name, pvc.Name)
-
-		return nil
+		hasJobLabels, err := pvcHasRecurringJobLabels(pvc)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check recurring job labels")
+		}
+		if !hasJobLabels {
+			c.logger.Debugf("Ignoring recurring job labels on Volume %v PVC %v due to missing source label", volume.Name, pvc.Name)
+			return nil
+		}
+		// longhorn/longhorn#13928: a PVC that already carries job/group labels
+		// is an explicit assignment. Infer the source label instead of dropping
+		// those labels on the floor. Once source is set, the PVC is the source
+		// of truth and extra Volume-only RecurringJob labels are removed.
+		if pvc.Labels == nil {
+			pvc.Labels = map[string]string{}
+		}
+		pvc.Labels[types.GetRecurringJobSourceLabelKey()] = types.LonghornLabelValueEnabled
+		pvc, err = c.ds.UpdatePersistentVolumeClaim(kubeStatus.Namespace, pvc)
+		if err != nil {
+			return errors.Wrapf(err, "failed to infer recurring-job source label on PVC %v", pvc.Name)
+		}
+		c.logger.Infof("Inferred %s=enabled on PVC %v because RecurringJob labels were set without the source label", types.GetRecurringJobSourceLabelKey(), pvc.Name)
 	}
 
 	if err := syncRecurringJobLabelsToTargetResource(types.LonghornKindVolume, volume, pvc, c.logger); err != nil {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -5967,22 +5967,14 @@ func (c *VolumeController) syncPVCRecurringJobLabels(volume *longhorn.Volume) er
 	}
 
 	if !hasSourceLabel {
-		hasJobLabels, err := pvcHasRecurringJobLabels(pvc)
+		inferred, err := inferRecurringJobSourceIfNeeded(pvc)
 		if err != nil {
 			return errors.Wrapf(err, "failed to check recurring job labels")
 		}
-		if !hasJobLabels {
+		if !inferred {
 			c.logger.Debugf("Ignoring recurring job labels on Volume %v PVC %v due to missing source label", volume.Name, pvc.Name)
 			return nil
 		}
-		// longhorn/longhorn#13928: a PVC that already carries job/group labels
-		// is an explicit assignment. Infer the source label instead of dropping
-		// those labels on the floor. Once source is set, the PVC is the source
-		// of truth and extra Volume-only RecurringJob labels are removed.
-		if pvc.Labels == nil {
-			pvc.Labels = map[string]string{}
-		}
-		pvc.Labels[types.GetRecurringJobSourceLabelKey()] = types.LonghornLabelValueEnabled
 		pvc, err = c.ds.UpdatePersistentVolumeClaim(kubeStatus.Namespace, pvc)
 		if err != nil {
 			return errors.Wrapf(err, "failed to infer recurring-job source label on PVC %v", pvc.Name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13928

#### What this PR does / why we need it:

PVC RecurringJob group labels (`recurring-job-group.longhorn.io/<group>=enabled`) are ignored unless `recurring-job.longhorn.io/source=enabled` is also set. Operators who label the PVC with groups (and skip the source label) never get those groups on the Volume CR, so RecurringJobs that select `groups: [default]` never run.

This PR infers `recurring-job.longhorn.io/source=enabled` on the PVC when job/group labels are already present, then syncs as today.

Once source is set, the PVC remains the source of truth: extra Volume-only RecurringJob labels are removed. Put every desired group on the PVC.

`spec.recurringJobSelector` is a StorageClass parameter, not a Volume spec field in v1beta2.

#### Special notes for your reviewer:

Multiple groups on one PVC (`default` + `rebuildable`) already sync together; a unit test locks that.

#### Additional documentation or context

Docs currently require the source label. The wrong key `recurring-job-group.longhorn.io/source` has appeared in examples (see discussion 10690). Inferring source when group labels exist matches the operator intent without a second label.
