### PR TITLE
feat(recurring-job): add activeDeadlineSeconds to bound a run

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1048,6 +1048,12 @@ func recurringJobSchema(job *client.Schema) {
 	concurrency.Create = true
 	job.ResourceFields["concurrency"] = concurrency
 
+	activeDeadlineSeconds := job.ResourceFields["activeDeadlineSeconds"]
+	activeDeadlineSeconds.Required = false
+	activeDeadlineSeconds.Unique = false
+	activeDeadlineSeconds.Create = true
+	job.ResourceFields["activeDeadlineSeconds"] = activeDeadlineSeconds
+
 	labels := job.ResourceFields["labels"]
 	labels.Type = "map[string]"
 	labels.Nullable = true
@@ -2688,16 +2694,17 @@ func toRecurringJobResource(recurringJob *longhorn.RecurringJob, apiContext *api
 			Type: "recurringJob",
 		},
 		RecurringJobSpec: longhorn.RecurringJobSpec{
-			Name:            recurringJob.Name,
-			Groups:          recurringJob.Spec.Groups,
-			Task:            recurringJob.Spec.Task,
-			Cron:            recurringJob.Spec.Cron,
-			Retain:          recurringJob.Spec.Retain,
-			RetainAge:       recurringJob.Spec.RetainAge,
-			RetentionPolicy: recurringJob.Spec.RetentionPolicy,
-			Concurrency:     recurringJob.Spec.Concurrency,
-			Labels:          recurringJob.Spec.Labels,
-			Parameters:      recurringJob.Spec.Parameters,
+			Name:                  recurringJob.Name,
+			Groups:                recurringJob.Spec.Groups,
+			Task:                  recurringJob.Spec.Task,
+			Cron:                  recurringJob.Spec.Cron,
+			Retain:                recurringJob.Spec.Retain,
+			RetainAge:             recurringJob.Spec.RetainAge,
+			RetentionPolicy:       recurringJob.Spec.RetentionPolicy,
+			Concurrency:           recurringJob.Spec.Concurrency,
+			Labels:                recurringJob.Spec.Labels,
+			Parameters:            recurringJob.Spec.Parameters,
+			ActiveDeadlineSeconds: recurringJob.Spec.ActiveDeadlineSeconds,
 		},
 		RecurringJobStatus: longhorn.RecurringJobStatus{
 			ExecutionCount: recurringJob.Status.ExecutionCount,

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -347,3 +347,86 @@ func TestToRecurringJobResourceIncludesRetentionPolicy(t *testing.T) {
 		t.Fatalf("expected retentionPolicy %v, got %v", longhorn.RecurringJobRetentionPolicyAgeBased, resource.RetentionPolicy)
 	}
 }
+
+// A runtime bound (longhorn/longhorn#13187) is only usable if it is settable
+// through the API the same way retain is. The schema is what the UI and the
+// Python client build requests from, so a field that is not advertised as
+// creatable there is silently dropped from the request and the job is created
+// with no deadline at all.
+func TestRecurringJobSchemaAllowsSettingActiveDeadlineSeconds(t *testing.T) {
+	schemas := NewSchema()
+	job, ok := schemas.CheckSchema("recurringJob")
+	if !ok {
+		t.Fatalf("expected recurringJob schema to be registered")
+	}
+
+	retain, ok := job.CheckField("retain")
+	if !ok {
+		t.Fatalf("expected recurringJob schema to have a retain field")
+	}
+
+	activeDeadlineSeconds, ok := job.CheckField("activeDeadlineSeconds")
+	if !ok {
+		t.Fatalf("expected recurringJob schema to have an activeDeadlineSeconds field")
+	}
+	if activeDeadlineSeconds.Create != retain.Create {
+		t.Fatalf("expected activeDeadlineSeconds to be creatable like retain, got create=%v", activeDeadlineSeconds.Create)
+	}
+	// The deadline is optional: leaving it out keeps the job unbounded, which is
+	// the behavior of every recurring job created before the field existed.
+	if activeDeadlineSeconds.Required {
+		t.Fatalf("expected activeDeadlineSeconds to be optional")
+	}
+}
+
+// A caller asking for a 3600s bound must get that exact bound on the spec.
+// Losing it in decode would leave the job unbounded while the UI shows a
+// deadline the generated Job never carries.
+func TestRecurringJobActiveDeadlineSecondsRoundTripsFromClient(t *testing.T) {
+	body, err := json.Marshal(&lhclient.RecurringJob{
+		Name:                  "test-job",
+		Task:                  string(longhorn.RecurringJobTypeBackup),
+		Cron:                  "*/1 * * * *",
+		Retain:                50,
+		ActiveDeadlineSeconds: 3600,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal client recurring job: %v", err)
+	}
+
+	var input RecurringJob
+	if err := json.Unmarshal(body, &input); err != nil {
+		t.Fatalf("failed to decode client request into API model: %v", err)
+	}
+	if input.ActiveDeadlineSeconds != 3600 {
+		t.Fatalf("expected activeDeadlineSeconds 3600, got %d", input.ActiveDeadlineSeconds)
+	}
+
+	// An unset deadline must stay zero so the job keeps running unbounded.
+	body, err = json.Marshal(&lhclient.RecurringJob{Name: "test-job", Retain: 50})
+	if err != nil {
+		t.Fatalf("failed to marshal client recurring job: %v", err)
+	}
+	input = RecurringJob{}
+	if err := json.Unmarshal(body, &input); err != nil {
+		t.Fatalf("failed to decode client request into API model: %v", err)
+	}
+	if input.ActiveDeadlineSeconds != 0 {
+		t.Fatalf("expected activeDeadlineSeconds to stay zero when unset, got %d", input.ActiveDeadlineSeconds)
+	}
+}
+
+// toRecurringJobResource is what the UI and the client read back. Dropping the
+// deadline there would make a configured bound invisible after a GET, so a user
+// cannot tell a bounded job from an unbounded one.
+func TestToRecurringJobResourceIncludesActiveDeadlineSeconds(t *testing.T) {
+	recurringJob := &longhorn.RecurringJob{}
+	recurringJob.Name = "test-job"
+	recurringJob.Spec.Retain = 50
+	recurringJob.Spec.ActiveDeadlineSeconds = 3600
+
+	resource := toRecurringJobResource(recurringJob, nil)
+	if resource.ActiveDeadlineSeconds != 3600 {
+		t.Fatalf("expected activeDeadlineSeconds 3600, got %d", resource.ActiveDeadlineSeconds)
+	}
+}

--- a/api/recurringjob.go
+++ b/api/recurringjob.go
@@ -56,16 +56,17 @@ func (s *Server) RecurringJobCreate(rw http.ResponseWriter, req *http.Request) e
 	}
 
 	obj, err := s.m.CreateRecurringJob(&longhorn.RecurringJobSpec{
-		Name:            input.Name,
-		Groups:          input.Groups,
-		Task:            longhorn.RecurringJobType(input.Task),
-		Cron:            input.Cron,
-		Retain:          input.Retain,
-		RetainAge:       input.RetainAge,
-		RetentionPolicy: input.RetentionPolicy,
-		Concurrency:     input.Concurrency,
-		Labels:          input.Labels,
-		Parameters:      input.Parameters,
+		Name:                  input.Name,
+		Groups:                input.Groups,
+		Task:                  longhorn.RecurringJobType(input.Task),
+		Cron:                  input.Cron,
+		Retain:                input.Retain,
+		RetainAge:             input.RetainAge,
+		RetentionPolicy:       input.RetentionPolicy,
+		Concurrency:           input.Concurrency,
+		Labels:                input.Labels,
+		Parameters:            input.Parameters,
+		ActiveDeadlineSeconds: input.ActiveDeadlineSeconds,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to create recurring job %v", input.Name)
@@ -86,16 +87,17 @@ func (s *Server) RecurringJobUpdate(rw http.ResponseWriter, req *http.Request) e
 
 	obj, err := util.RetryOnConflictCause(func() (interface{}, error) {
 		return s.m.UpdateRecurringJob(longhorn.RecurringJobSpec{
-			Name:            name,
-			Groups:          input.Groups,
-			Task:            longhorn.RecurringJobType(input.Task),
-			Cron:            input.Cron,
-			Retain:          input.Retain,
-			RetainAge:       input.RetainAge,
-			RetentionPolicy: input.RetentionPolicy,
-			Concurrency:     input.Concurrency,
-			Labels:          input.Labels,
-			Parameters:      input.Parameters,
+			Name:                  name,
+			Groups:                input.Groups,
+			Task:                  longhorn.RecurringJobType(input.Task),
+			Cron:                  input.Cron,
+			Retain:                input.Retain,
+			RetainAge:             input.RetainAge,
+			RetentionPolicy:       input.RetentionPolicy,
+			Concurrency:           input.Concurrency,
+			Labels:                input.Labels,
+			Parameters:            input.Parameters,
+			ActiveDeadlineSeconds: input.ActiveDeadlineSeconds,
 		})
 	})
 	if err != nil {

--- a/client/generated_recurring_job.go
+++ b/client/generated_recurring_job.go
@@ -7,6 +7,8 @@ const (
 type RecurringJob struct {
 	Resource `yaml:"-"`
 
+	ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty" yaml:"active_deadline_seconds,omitempty"`
+
 	Concurrency int64 `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
 
 	Cron string `json:"cron,omitempty" yaml:"cron,omitempty"`

--- a/controller/recurring_job_controller.go
+++ b/controller/recurring_job_controller.go
@@ -441,6 +441,13 @@ func (c *RecurringJobController) checkAndUpdateCronJob(cronJob, appliedCronJob *
 
 func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob) (*batchv1.CronJob, error) {
 	backoffLimit := int32(CronJobBackoffLimit)
+	// Leave the deadline unset when the recurring job does not ask for one, so a
+	// job created before the field existed keeps running without an upper bound.
+	var activeDeadlineSeconds *int64
+	if recurringJob.Spec.ActiveDeadlineSeconds > 0 {
+		deadline := recurringJob.Spec.ActiveDeadlineSeconds
+		activeDeadlineSeconds = &deadline
+	}
 	settingSuccessfulJobsHistoryLimit, err := c.ds.GetSettingAsInt(types.SettingNameRecurringSuccessfulJobsHistoryLimit)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get setting of %v", types.SettingNameRecurringSuccessfulJobsHistoryLimit)
@@ -494,7 +501,8 @@ func (c *RecurringJobController) newCronJob(recurringJob *longhorn.RecurringJob)
 			FailedJobsHistoryLimit:     &failedJobsHistoryLimit,
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: &backoffLimit,
+					BackoffLimit:          &backoffLimit,
+					ActiveDeadlineSeconds: activeDeadlineSeconds,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: recurringJob.Name,

--- a/controller/recurring_job_controller_test.go
+++ b/controller/recurring_job_controller_test.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/util"
+
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhfake "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned/fake"
+)
+
+func newTestRecurringJobController(t *testing.T) *RecurringJobController {
+	t.Helper()
+
+	originalSkipListerCheck := datastore.SkipListerCheck
+	datastore.SkipListerCheck = true
+	t.Cleanup(func() {
+		datastore.SkipListerCheck = originalSkipListerCheck
+	})
+
+	kubeClient := fake.NewSimpleClientset()                   // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                   // nolint: staticcheck
+	extensionClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, 0)
+	ds := datastore.NewDataStore(TestNamespace, lhClient, kubeClient, extensionClient, informerFactories)
+
+	c, err := NewRecurringJobController(logrus.StandardLogger(), ds, scheme.Scheme, kubeClient,
+		TestNamespace, TestOwnerID1, TestServiceAccount, TestManagerImage)
+	if err != nil {
+		t.Fatalf("failed to create recurring job controller: %v", err)
+	}
+	return c
+}
+
+func newTestRecurringJob(activeDeadlineSeconds int64) *longhorn.RecurringJob {
+	return &longhorn.RecurringJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-recurring-job",
+			Namespace: TestNamespace,
+		},
+		Spec: longhorn.RecurringJobSpec{
+			Name:                  "test-recurring-job",
+			Task:                  longhorn.RecurringJobTypeBackup,
+			Cron:                  "0 0 * * *",
+			Retain:                1,
+			Concurrency:           1,
+			ActiveDeadlineSeconds: activeDeadlineSeconds,
+		},
+	}
+}
+
+// A recurring job with a runtime bound must pass it to the generated Job, so a
+// hung job is terminated by Kubernetes instead of running indefinitely.
+func TestNewCronJobPropagatesActiveDeadlineSeconds(t *testing.T) {
+	c := newTestRecurringJobController(t)
+
+	cronJob, err := c.newCronJob(newTestRecurringJob(3600))
+	if err != nil {
+		t.Fatalf("failed to build cron job: %v", err)
+	}
+
+	activeDeadlineSeconds := cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds
+	if activeDeadlineSeconds == nil {
+		t.Fatal("unexpected nil activeDeadlineSeconds: want 3600")
+	}
+	if *activeDeadlineSeconds != 3600 {
+		t.Fatalf("unexpected activeDeadlineSeconds: got %d, want 3600", *activeDeadlineSeconds)
+	}
+}
+
+// Without a runtime bound the generated Job must stay unbounded, which is the
+// behavior of every recurring job created before the field existed.
+func TestNewCronJobOmitsUnsetActiveDeadlineSeconds(t *testing.T) {
+	c := newTestRecurringJobController(t)
+
+	cronJob, err := c.newCronJob(newTestRecurringJob(0))
+	if err != nil {
+		t.Fatalf("failed to build cron job: %v", err)
+	}
+
+	if activeDeadlineSeconds := cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds; activeDeadlineSeconds != nil {
+		t.Fatalf("unexpected activeDeadlineSeconds: got %d, want nil", *activeDeadlineSeconds)
+	}
+}

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -2915,6 +2915,16 @@ spec:
             description: RecurringJobSpec defines the desired state of the Longhorn
               recurring job
             properties:
+              activeDeadlineSeconds:
+                description: |-
+                  The maximum duration in seconds the recurring job may run before Kubernetes
+                  terminates it, propagated to the generated Job's activeDeadlineSeconds.
+                  A job that exceeds it is marked failed, which surfaces in the Job status and
+                  releases the concurrencyPolicy=Forbid slot for the next scheduled run.
+                  When 0 (the default) the job has no deadline and can run indefinitely.
+                format: int64
+                minimum: 0
+                type: integer
               concurrency:
                 description: The concurrency of taking the snapshot/backup.
                 type: integer

--- a/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/recurringjob.go
@@ -79,6 +79,14 @@ type RecurringJobSpec struct {
 	// The concurrency of taking the snapshot/backup.
 	// +optional
 	Concurrency int `json:"concurrency"`
+	// The maximum duration in seconds the recurring job may run before Kubernetes
+	// terminates it, propagated to the generated Job's activeDeadlineSeconds.
+	// A job that exceeds it is marked failed, which surfaces in the Job status and
+	// releases the concurrencyPolicy=Forbid slot for the next scheduled run.
+	// When 0 (the default) the job has no deadline and can run indefinitely.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
 	// The label of the snapshot/backup.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/recurringjobspec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/recurringjobspec.go
@@ -55,6 +55,12 @@ type RecurringJobSpecApplyConfiguration struct {
 	RetentionPolicy *longhornv1beta2.RecurringJobRetentionPolicy `json:"retentionPolicy,omitempty"`
 	// The concurrency of taking the snapshot/backup.
 	Concurrency *int `json:"concurrency,omitempty"`
+	// The maximum duration in seconds the recurring job may run before Kubernetes
+	// terminates it, propagated to the generated Job's activeDeadlineSeconds.
+	// A job that exceeds it is marked failed, which surfaces in the Job status and
+	// releases the concurrencyPolicy=Forbid slot for the next scheduled run.
+	// When 0 (the default) the job has no deadline and can run indefinitely.
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 	// The label of the snapshot/backup.
 	Labels map[string]string `json:"labels,omitempty"`
 	// The parameters of the snapshot/backup.
@@ -131,6 +137,14 @@ func (b *RecurringJobSpecApplyConfiguration) WithRetentionPolicy(value longhornv
 // If called multiple times, the Concurrency field is set to the value of the last call.
 func (b *RecurringJobSpecApplyConfiguration) WithConcurrency(value int) *RecurringJobSpecApplyConfiguration {
 	b.Concurrency = &value
+	return b
+}
+
+// WithActiveDeadlineSeconds sets the ActiveDeadlineSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
+func (b *RecurringJobSpecApplyConfiguration) WithActiveDeadlineSeconds(value int64) *RecurringJobSpecApplyConfiguration {
+	b.ActiveDeadlineSeconds = &value
 	return b
 }
 

--- a/manager/recurringjob.go
+++ b/manager/recurringjob.go
@@ -75,6 +75,7 @@ func (m *VolumeManager) UpdateRecurringJob(spec longhorn.RecurringJobSpec) (*lon
 	recurringJob.Spec.RetainAge = spec.RetainAge
 	recurringJob.Spec.RetentionPolicy = spec.RetentionPolicy
 	recurringJob.Spec.Concurrency = spec.Concurrency
+	recurringJob.Spec.ActiveDeadlineSeconds = spec.ActiveDeadlineSeconds
 	recurringJob.Spec.Labels = spec.Labels
 	recurringJob.Spec.Parameters = spec.Parameters
 	return m.ds.UpdateRecurringJob(recurringJob)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13187

#### What this PR does / why we need it:

`RecurringJob` has no way to bound how long one run may take. The generated
`CronJob` sets `concurrencyPolicy: Forbid` and `backoffLimit: 3`, but leaves the
Job-level `activeDeadlineSeconds` unset, so a run that hangs stays `Active`
forever. `Forbid` then suppresses every later tick, and because the Job never
reaches a `Failed` condition, `kube_job_failed` stays 0 and the usual
`KubeJobFailed` alert never fires. The recurring job goes silent and nothing
reports it.

`kubectl edit` on the generated CronJob does not help: the controller
reconciles the field away on the next resync.

This PR adds an optional `spec.activeDeadlineSeconds` to
`longhorn.io/v1beta2 RecurringJob` and passes it to the generated
`CronJob.spec.jobTemplate.spec.activeDeadlineSeconds`. When the field is 0 (the
default, and the value every existing RecurringJob has) the generated Job keeps
no deadline, so behavior is unchanged.

With a deadline set, Kubernetes terminates the overrunning Job and marks it
failed. That both frees the `Forbid` slot for the next scheduled run and makes
the stall visible through the standard Job failure metrics.

#### Special notes for your reviewer:

- **`backoffLimit` is deliberately left out**, although longhorn/longhorn#13187
  asks for both. `activeDeadlineSeconds` has a natural "unset" value: 0 is not
  a legal deadline, so `0` can mean "no deadline" and the field can stay a
  plain `int64` like the other numeric fields in this spec. `backoffLimit: 0`
  is meaningful ("do not retry"), so exposing it needs pointer semantics or a
  mutating default, which is a larger change with its own upgrade question.
  Happy to follow up in a second PR if you want it in the same release.
- Validation is a `+kubebuilder:validation:Minimum=0` marker rather than a
  webhook check, since the bound needs no other field to decide it. Say the
  word if you would rather see it in
  `webhook/resources/recurringjob/validator.go` next to the retain checks.
- No upgrade path is needed. The field is optional and absent means 0, which is
  exactly today's behavior, so nothing has to be backfilled.
- The change also goes through the HTTP API plumbing (`api/`, `manager/`,
  `client/`) so a job created or updated through the API keeps the field
  instead of silently dropping it. That includes stamping the field
  `Create = true` in `recurringJobSchema`: the UI and the Python client build
  their requests from `GET /v1/schemas`, so a field that is not advertised
  there is dropped from the POST body and the job is created with no deadline
  while the user asked for one. `retainAge` and `retentionPolicy` needed the
  same stamp. The gofmt realignment in `api/recurringjob.go` and `api/model.go`
  is only whitespace — the new field name is longer than the existing keys in
  those literals.
- The bound is a pass-through with a `Minimum=0` floor only, so a deliberately
  short deadline is allowed. `SnapshotGroupSpec.DeadlineSeconds` in the same
  API group bounds itself `Minimum=10 / Maximum=3600`, which does not fit here:
  a large backup can legitimately need hours, so an upper bound would be wrong
  and any lower bound would be a policy I would be inventing. Glad to add a
  floor if you want one.
- `k8s/crds.yaml` and the applyconfiguration were regenerated with
  `bash k8s/generate_code.sh`, so the `create-crd-update-pr-in-longhorn-repo`
  workflow carries the CRD into `longhorn/longhorn` on merge. No manifest PR
  from me.
- `longhorn-ui` needs a matching input to expose this in the dashboard, and
  `longhorn/website` needs a line in the recurring job docs. Glad to open both
  once the field name here is settled.
- Happy to add an integration test in `longhorn/longhorn-tests` as well. Tell
  me the shape you want and I will open it alongside.
- CONTRIBUTING says public API changes may want a LEP. This is one optional,
  additive, opt-in field on an existing CRD, so I did not write one. Tell me if
  you want a LEP before this is reviewed further.

#### Additional documentation or context

**What was tested**

Unit tests, added in `controller/recurring_job_controller_test.go` (new file,
the plain `testing` style used by `controller/setting_controller_test.go`):

- `TestNewCronJobPropagatesActiveDeadlineSeconds` — a RecurringJob with
  `activeDeadlineSeconds: 3600` produces a CronJob whose
  `jobTemplate.spec.activeDeadlineSeconds` is 3600.
- `TestNewCronJobOmitsUnsetActiveDeadlineSeconds` — a RecurringJob without the
  field produces a CronJob with a nil `activeDeadlineSeconds`, the
  pre-change behavior.

Three more in `api/model_test.go`, matching the trio that `retainAge` and
`retentionPolicy` each carry:

- `TestRecurringJobSchemaAllowsSettingActiveDeadlineSeconds` — the schema
  advertises the field as creatable, like `retain`, and as optional.
- `TestRecurringJobActiveDeadlineSecondsRoundTripsFromClient` — a client request
  carrying 3600 decodes to 3600, and an unset field stays 0.
- `TestToRecurringJobResourceIncludesActiveDeadlineSeconds` — a GET reads the
  deadline back.

**How it was tested**

Both tests run against the fake clientsets, with no cluster and no network.

```
$ go test ./controller/ -run TestNewCronJob -count=1 -v
--- PASS: TestNewCronJobPropagatesActiveDeadlineSeconds (0.00s)
--- PASS: TestNewCronJobOmitsUnsetActiveDeadlineSeconds (0.00s)
ok      github.com/longhorn/longhorn-manager/controller 0.027s
$ go test ./api/ -run ActiveDeadlineSeconds -count=1 -v
--- PASS: TestRecurringJobSchemaAllowsSettingActiveDeadlineSeconds (0.00s)
--- PASS: TestRecurringJobActiveDeadlineSecondsRoundTripsFromClient (0.00s)
--- PASS: TestToRecurringJobResourceIncludesActiveDeadlineSeconds (0.00s)
ok      github.com/longhorn/longhorn-manager/api        0.015s
```

Both new assertions were checked against the unfixed code. With only the CRD
field added and `newCronJob` left alone:

```
--- FAIL: TestNewCronJobPropagatesActiveDeadlineSeconds (0.00s)
    recurring_job_controller_test.go:74: unexpected nil activeDeadlineSeconds: want 3600
```

With the `recurringJobSchema` stamp removed:

```
--- FAIL: TestRecurringJobSchemaAllowsSettingActiveDeadlineSeconds (0.00s)
    model_test.go:373: expected activeDeadlineSeconds to be creatable like retain, got create=false
```

Package tests, generated code and static checks:

```
$ go test -race -count=1 ./controller/ ./api/... ./manager/... ./client/...
ok      github.com/longhorn/longhorn-manager/api        1.110s
ok      github.com/longhorn/longhorn-manager/manager    1.333s
# ./controller/: 148 passed, 2 FAILED
$ bash k8s/generate_code.sh   # crds.yaml + applyconfiguration regenerated, no other drift
$ gofmt -l . && go vet ./controller/... ./api/... ./manager/... && golangci-lint run
0 issues.
```

`TestSuite.TestReconcileSystemBackup` and `TestSuite.TestSystemRollout` are the
2 failures. They fail identically on unmodified `master` in the same
environment (`148 passed, 2 FAILED` before and after this change), both on
`SystemBackupState "Error" != "Uploading"`. They are unrelated to this PR.

**Test environment**

- Go 1.26 in `registry.suse.com/bci/golang:1.26`, the repository's own build
  image, linux/amd64.
- Tests not run: `make test` needs `--privileged` and a `/dev` bind mount,
  which the build sandbox does not allow, so the package tests were run with
  `go test -race` directly. No e2e or upgrade test was run — the change adds no
  state to migrate.

**Where the problem was observed**

Longhorn v1.11.3 on a 2-node k3s cluster, namespace `longhorn`. All three
generated CronJobs confirm the gap:

```
NAME               POLICY   BACKOFF   DEADLINE
backup-daily       Forbid   3         <none>
filesystem-trim    Forbid   3         <none>
snapshot-cleanup   Forbid   3         <none>
```

The live `v1beta2` CRD spec offers `concurrency, cron, groups, labels, name,
parameters, retain, task` and nothing that maps to a runtime bound. Measured
normal runtimes there are 35s (snapshot-cleanup), 38s (filesystem-trim) and 89s
(backup-daily), so a deadline in the low thousands of seconds is pure safety
margin. Every other CronJob on that cluster sets `activeDeadlineSeconds`
between 1800 and 7200; the Longhorn ones cannot.

**Risk**

- Opt-in only. An existing RecurringJob has no `activeDeadlineSeconds`, so it
  keeps producing a Job with no deadline, byte-for-byte the same CronJob spec
  as before.
- The one new failure mode is a deadline set too low by the operator, which
  would kill a healthy long backup. That is the operator's choice, the same as
  on any other CronJob, and Longhorn resumes on the next tick.
- `checkAndUpdateCronJob` compares the serialized CronJob spec against the
  `last-applied-cronjob-spec` annotation, so changing the field on an existing
  RecurringJob updates the live CronJob without any extra handling.
- The field is copied by value into the CronJob, not aliased to the informer
  object.
- Termination is not graceful. The recurring-job binary installs no SIGTERM
  handler, so a deadline kill leaves it exactly where a pod eviction or a node
  loss leaves it today: the in-flight Backup CR finishes server-side, and that
  run's retention and cleanup are skipped until the next tick. This PR does not
  change that, and does not add backup-store lock cleanup.
- Behavior on a downgrade: an older longhorn-manager ignores the field and the
  CronJob loses its deadline, back to today's behavior. Nothing breaks.

---
Authored with AI assistance (Claude Code) by @kinorai.
