### PR TITLE
fix(csi): cap the attacher retry interval so cloned volumes attach promptly

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -65,6 +65,11 @@ func NewAttacherDeployment(namespace, serviceAccount, attacherImage, rootDir str
 			"--v=2",
 			"--csi-address=$(ADDRESS)",
 			"--timeout=1m50s",
+			// A full-copy clone is provisioned before its data is copied, so
+			// ControllerPublishVolume is rejected with "not ready for workloads"
+			// until the copy finishes. The default retry cap of 5m means the
+			// volume can sit idle for most of that after it becomes ready.
+			"--retry-interval-max=1m",
 			"--leader-election",
 			"--leader-election-namespace=$(POD_NAMESPACE)",
 			fmt.Sprintf("--kube-api-qps=%v", types.KubeAPIQPS),


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13335

#### What this PR does / why we need it:

A full-copy clone is provisioned before its data is copied, so `ControllerPublishVolume` is rejected with `volume ... is not ready for workloads` until the copy finishes. external-attacher backs off exponentially between retries, capped by `--retry-interval-max`, which defaults to 5 minutes.

Once the backoff reaches that cap the volume can stay unattached for up to 5 more minutes after the clone has already completed. The log in the issue shows a failed attach at 11:08:16 and the next attempt at 11:13:16, which is exactly the 300s default. One reporter saw a pod sit in `ContainerCreating` for around 11 hours.

This sets `--retry-interval-max=1m` on the attacher, as suggested in https://github.com/longhorn/longhorn/issues/13335#issuecomment-5401430553.

#### Special notes for your reviewer:

**On the value.** @shuo-wu said a fixed value in the style of `--timeout=1m50s` was fine but did not name a number, so 1m is my choice and is easy to change. The backoff still grows normally (1s, 2s, 4s ... 1m), so a genuinely failing volume is not retried aggressively — only the ceiling moves. Worst-case idle window after a clone becomes ready drops from 5 minutes to 1. During a 10-minute clone this adds roughly 10 extra rejected `ControllerPublishVolume` calls, which return immediately.

**On v2.** Per @shuo-wu on the issue, CSI is the shared gateway for both data engines, so the single attacher deployment covers v1 and v2. No separate change needed.

**No test added.** There is no existing test that constructs a sidecar deployment and asserts its args — `TestNeedToUpdateArgs` tests the comparison helper, not the constructors. Adding one just for this flag felt like scope the issue does not call for, and the issue already carries `require/qa-review-coverage`. Happy to add one if you would rather have it pinned.

**What I did not verify.** I have not reproduced this locally — I do not have a cluster that can run a clone of this size. The change follows @shuo-wu's analysis on the issue and the external-attacher flag documentation, and I confirmed the 300s default and the flag's semantics against the external-attacher README. The arithmetic in the issue log matches that default exactly, but I have not observed the fix working end to end.

#### Additional documentation or context

external-attacher documents `--retry-interval-max` as "The exponential backoff maximum value. 5 minutes is used by default." — https://github.com/kubernetes-csi/external-attacher

I used an AI assistant while preparing this change. The reasoning above is mine, and I checked the external-attacher flag semantics and the 300s default myself.
