### PR TITLE
fix(controller): exclude strict-local replicas from drain eviction

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -1556,6 +1556,24 @@ func (imc *InstanceManagerController) canDeleteInstanceManagerPDB(im *longhorn.I
 		return false, "", err
 	}
 
+	// The eviction policies never request eviction for replicas of strict-local volumes,
+	// since those replicas cannot be moved (see NodeController.shouldEvictReplica). Keeping
+	// the PDB for them would block the drain forever. See longhorn/longhorn#8753.
+	if nodeDrainingPolicy == string(types.NodeDrainPolicyBlockForEviction) ||
+		nodeDrainingPolicy == string(types.NodeDrainPolicyBlockForEvictionIfContainsLastReplica) {
+		evictableReplicas := []*longhorn.Replica{}
+		for _, replica := range replicasOnCurrentNode {
+			isStrictLocal, err := isStrictLocalReplica(imc.ds, replica)
+			if err != nil {
+				return false, "", err
+			}
+			if !isStrictLocal {
+				evictableReplicas = append(evictableReplicas, replica)
+			}
+		}
+		replicasOnCurrentNode = evictableReplicas
+	}
+
 	if nodeDrainingPolicy == string(types.NodeDrainPolicyBlockForEviction) && len(replicasOnCurrentNode) > 0 {
 		// We must wait for ALL replicas to be evicted before removing the PDB.
 		return false, fmt.Sprintf("some replicas block eviction %v", formatReplicaMessage(replicasOnCurrentNode)), nil

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -1087,3 +1087,134 @@ func (s *TestSuite) TestInterruptModeSettingRecreatesPodWithoutCPUIsolation(c *C
 		}
 	}
 }
+
+// newReplicaOnNodeForVolume returns a healthy replica of the given volume, scheduled
+// on the given node and labeled the way the datastore listers expect.
+func newReplicaOnNodeForVolume(name, volumeName, nodeID string) *longhorn.Replica {
+	labels := types.GetVolumeLabels(volumeName)
+	labels[types.LonghornNodeKey] = nodeID
+
+	return &longhorn.Replica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: TestNamespace,
+			Labels:    labels,
+		},
+		Spec: longhorn.ReplicaSpec{
+			InstanceSpec: longhorn.InstanceSpec{
+				NodeID:     nodeID,
+				VolumeName: volumeName,
+			},
+			HealthyAt: getTestNow(),
+		},
+	}
+}
+
+// TestCanDeleteInstanceManagerPDBWithStrictLocalReplica covers longhorn/longhorn#8753:
+// a replica of a strict-local volume can never be evicted, so it must not keep the
+// instance manager PDB alive under the block-for-eviction policies. Otherwise the
+// instance manager pod can never be evicted and the drain never completes.
+func (s *TestSuite) TestCanDeleteInstanceManagerPDBWithStrictLocalReplica(c *C) {
+	testCases := map[string]struct {
+		drainPolicy  types.NodeDrainPolicy
+		dataLocality longhorn.DataLocality
+		expected     bool
+	}{
+		"block-for-eviction with strict-local replica": {
+			drainPolicy:  types.NodeDrainPolicyBlockForEviction,
+			dataLocality: longhorn.DataLocalityStrictLocal,
+			expected:     true,
+		},
+		"block-for-eviction-if-contains-last-replica with strict-local replica": {
+			drainPolicy:  types.NodeDrainPolicyBlockForEvictionIfContainsLastReplica,
+			dataLocality: longhorn.DataLocalityStrictLocal,
+			expected:     true,
+		},
+		"block-for-eviction with normal replica": {
+			drainPolicy:  types.NodeDrainPolicyBlockForEviction,
+			dataLocality: longhorn.DataLocalityDisabled,
+			expected:     false,
+		},
+		"block-for-eviction-if-contains-last-replica with normal replica": {
+			drainPolicy:  types.NodeDrainPolicyBlockForEvictionIfContainsLastReplica,
+			dataLocality: longhorn.DataLocalityDisabled,
+			expected:     false,
+		},
+		"block-if-contains-last-replica with strict-local replica": {
+			drainPolicy:  types.NodeDrainPolicyBlockIfContainsLastReplica,
+			dataLocality: longhorn.DataLocalityStrictLocal,
+			expected:     false,
+		},
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+		vIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Volumes().Informer().GetIndexer()
+		rIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
+		kubeNodeIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+
+		imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		// The node is cordoned, as it would be during a drain.
+		kubeNode := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse,
+			corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode.Spec.Unschedulable = true
+		kubeNode, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = kubeNodeIndexer.Add(kubeNode)
+		c.Assert(err, IsNil)
+
+		drainPolicySetting := newSetting(string(types.SettingNameNodeDrainPolicy), string(tc.drainPolicy))
+		drainPolicySetting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), drainPolicySetting, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = sIndexer.Add(drainPolicySetting)
+		c.Assert(err, IsNil)
+
+		volume := newVolumeWithDataLocality(TestVolumeName, tc.dataLocality)
+		volume, err = lhClient.LonghornV1beta2().Volumes(TestNamespace).Create(context.TODO(), volume, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = vIndexer.Add(volume)
+		c.Assert(err, IsNil)
+
+		replica := newReplicaOnNodeForVolume(TestReplicaName, volume.Name, TestNode1)
+		replica, err = lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), replica, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = rIndexer.Add(replica)
+		c.Assert(err, IsNil)
+
+		// The instance manager runs no engine instance, so all volumes are already
+		// detached from the node and only the replicas decide whether the PDB stays.
+		// No PDB is registered either, so no replica is PDB protected on another node.
+		im := newInstanceManager(
+			TestInstanceManagerName,
+			longhorn.InstanceManagerStateRunning,
+			TestNode1,
+			TestNode1,
+			TestIP1,
+			nil,
+			nil,
+			map[string]longhorn.InstanceProcess{TestReplicaName: {}},
+			longhorn.DataEngineTypeV1,
+			TestInstanceManagerImage,
+			false,
+		)
+		im, err = lhClient.LonghornV1beta2().InstanceManagers(TestNamespace).Create(context.TODO(), im, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+
+		canDelete, _, err := imc.canDeleteInstanceManagerPDB(im)
+		c.Assert(err, IsNil)
+		c.Assert(canDelete, Equals, tc.expected)
+	}
+}

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -2133,6 +2133,15 @@ func (nc *NodeController) shouldEvictReplica(node *longhorn.Node, kubeNode *core
 		// Node drain policy only takes effect on cordoned nodes.
 		return false, constant.EventReasonEvictionCanceled, nil
 	}
+	// Replicas of strict-local volumes are pinned to their node by HardNodeAffinity and can
+	// never be evicted elsewhere. Requesting their eviction automatically keeps the volume
+	// attached forever and the drain can never complete. See longhorn/longhorn#8753.
+	if isStrictLocal, err := isStrictLocalReplica(nc.ds, replica); err != nil {
+		return false, "", err
+	} else if isStrictLocal {
+		return false, constant.EventReasonEvictionCanceled, nil
+	}
+
 	if nodeDrainPolicy == string(types.NodeDrainPolicyBlockForEviction) {
 		return true, constant.EventReasonEvictionAutomatic, nil
 	}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -77,6 +77,7 @@ type NodeControllerSuite struct {
 	informerFactories *util.InformerFactories
 
 	lhNodeIndexer            cache.Indexer
+	lhVolumeIndexer          cache.Indexer
 	lhReplicaIndexer         cache.Indexer
 	lhSettingsIndexer        cache.Indexer
 	lhInstanceManagerIndexer cache.Indexer
@@ -94,6 +95,7 @@ type NodeControllerSuite struct {
 // nodes and pods
 type NodeControllerFixture struct {
 	lhNodes            map[string]*longhorn.Node
+	lhVolumes          []*longhorn.Volume
 	lhReplicas         []*longhorn.Replica
 	lhSettings         map[string]*longhorn.Setting
 	lhInstanceManagers map[string]*longhorn.InstanceManager
@@ -126,6 +128,7 @@ func (s *NodeControllerSuite) SetUpTest(c *C) {
 	s.informerFactories = util.NewInformerFactories(TestNamespace, s.kubeClient, s.lhClient, controller.NoResyncPeriodFunc())
 
 	s.lhNodeIndexer = s.informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+	s.lhVolumeIndexer = s.informerFactories.LhInformerFactory.Longhorn().V1beta2().Volumes().Informer().GetIndexer()
 	s.lhReplicaIndexer = s.informerFactories.LhInformerFactory.Longhorn().V1beta2().Replicas().Informer().GetIndexer()
 	s.lhSettingsIndexer = s.informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
 	s.lhInstanceManagerIndexer = s.informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
@@ -2532,6 +2535,14 @@ func (s *NodeControllerSuite) initTest(c *C, fixture *NodeControllerFixture) {
 		c.Assert(err, IsNil)
 	}
 
+	for _, volume := range fixture.lhVolumes {
+		v, err := s.lhClient.LonghornV1beta2().Volumes(TestNamespace).Create(context.TODO(), volume, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(v, NotNil)
+		err = s.lhVolumeIndexer.Add(v)
+		c.Assert(err, IsNil)
+	}
+
 	for _, replica := range fixture.lhReplicas {
 		r, err := s.lhClient.LonghornV1beta2().Replicas(TestNamespace).Create(context.TODO(), replica, metav1.CreateOptions{})
 		c.Assert(err, IsNil)
@@ -2892,4 +2903,119 @@ func (s *NodeControllerSuite) TestAlignDiskSpecAndStatusKeepsFilesystemDiskUntou
 	c.Assert(diskStatus.Type, Equals, longhorn.DiskTypeFilesystem)
 	c.Assert(diskStatus.DiskPath, Equals, specDiskPath)
 	c.Assert(types.GetCondition(diskStatus.Conditions, longhorn.DiskConditionTypeReady).Status, Equals, longhorn.ConditionStatusTrue)
+}
+
+// ---------------------------------------------------------------------------
+// Strict-local eviction tests
+// ---------------------------------------------------------------------------
+
+// newVolumeWithDataLocality returns a volume with the given data locality and a
+// single replica, which is the only replica count strict-local volumes allow.
+func newVolumeWithDataLocality(name string, dataLocality longhorn.DataLocality) *longhorn.Volume {
+	return &longhorn.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: TestNamespace,
+		},
+		Spec: longhorn.VolumeSpec{
+			NumberOfReplicas: 1,
+			DataLocality:     dataLocality,
+			DataEngine:       longhorn.DataEngineTypeV1,
+		},
+	}
+}
+
+// TestStrictLocalReplicaEviction covers longhorn/longhorn#8753: replicas of
+// strict-local volumes are pinned by HardNodeAffinity and can never be evicted, so
+// the block-for-eviction policies must not request their eviction. Otherwise the
+// volume is kept attached for an eviction that never completes and the drain hangs.
+func (s *NodeControllerSuite) TestStrictLocalReplicaEviction(c *C) {
+	strictLocalVolume := newVolumeWithDataLocality("strict-local-volume", longhorn.DataLocalityStrictLocal)
+	normalVolume := newVolumeWithDataLocality("normal-volume", longhorn.DataLocalityDisabled)
+
+	newFixture := func(drainPolicy types.NodeDrainPolicy, cordoned, nodeEvictionRequested bool) (*NodeControllerFixture, *longhorn.Node, *corev1.Node) {
+		lhNode := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+		lhNode.Spec.EvictionRequested = nodeEvictionRequested
+		lhNode.Status.DiskStatus[TestDiskID1].ScheduledReplica = map[string]int64{
+			"strict-local-replica": 0, "normal-replica": 0,
+		}
+
+		kubeNode := newKubernetesNode(TestNode1,
+			corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse,
+			corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode.Spec.Unschedulable = cordoned
+
+		return &NodeControllerFixture{
+			lhNodes:   map[string]*longhorn.Node{TestNode1: lhNode},
+			lhVolumes: []*longhorn.Volume{strictLocalVolume, normalVolume},
+			lhReplicas: []*longhorn.Replica{
+				newSrcReplica("strict-local-replica", strictLocalVolume.Name, TestNode1, TestDiskID1),
+				newSrcReplica("normal-replica", normalVolume.Name, TestNode1, TestDiskID1),
+			},
+			lhSettings: map[string]*longhorn.Setting{
+				string(types.SettingNameNodeDrainPolicy): newSetting(
+					string(types.SettingNameNodeDrainPolicy), string(drainPolicy)),
+			},
+			nodes: map[string]*corev1.Node{TestNode1: kubeNode},
+		}, lhNode, kubeNode
+	}
+
+	assertEvictionRequested := func(replicaName string, expected bool) {
+		r, err := s.lhClient.LonghornV1beta2().Replicas(TestNamespace).Get(
+			context.TODO(), replicaName, metav1.GetOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(r.Spec.EvictionRequested, Equals, expected)
+	}
+
+	// ----------------------------------------------------------------
+	// Test 1 - block-for-eviction-if-contains-last-replica + cordoned
+	//
+	// No IM/PDB objects are registered, so ListVolumePDBProtectedHealthyReplicasRO
+	// returns empty for both volumes and both replicas are "last replicas". Only
+	// the replica of the non strict-local volume may be evicted.
+	// ----------------------------------------------------------------
+	{
+		s.SetUpTest(c)
+		fixture, lhNode, kubeNode := newFixture(types.NodeDrainPolicyBlockForEvictionIfContainsLastReplica, true, false)
+		s.initTest(c, fixture)
+
+		c.Assert(s.controller.syncReplicaEvictionRequested(lhNode, kubeNode), IsNil)
+
+		assertEvictionRequested("strict-local-replica", false)
+		assertEvictionRequested("normal-replica", true)
+	}
+
+	// ----------------------------------------------------------------
+	// Test 2 - block-for-eviction + cordoned
+	//
+	// This policy evicts every replica on the node unconditionally, but the
+	// strict-local one must still be left alone.
+	// ----------------------------------------------------------------
+	{
+		s.SetUpTest(c)
+		fixture, lhNode, kubeNode := newFixture(types.NodeDrainPolicyBlockForEviction, true, false)
+		s.initTest(c, fixture)
+
+		c.Assert(s.controller.syncReplicaEvictionRequested(lhNode, kubeNode), IsNil)
+
+		assertEvictionRequested("strict-local-replica", false)
+		assertEvictionRequested("normal-replica", true)
+	}
+
+	// ----------------------------------------------------------------
+	// Test 3 - manual node eviction is unaffected
+	//
+	// Node.Spec.EvictionRequested is an explicit user request and takes
+	// precedence over the drain policy, for strict-local volumes as well.
+	// ----------------------------------------------------------------
+	{
+		s.SetUpTest(c)
+		fixture, lhNode, kubeNode := newFixture(types.NodeDrainPolicyBlockForEvictionIfContainsLastReplica, false, true)
+		s.initTest(c, fixture)
+
+		c.Assert(s.controller.syncReplicaEvictionRequested(lhNode, kubeNode), IsNil)
+
+		assertEvictionRequested("strict-local-replica", true)
+		assertEvictionRequested("normal-replica", true)
+	}
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -70,6 +70,21 @@ func hasReplicaEvictionRequested(rs map[string]*longhorn.Replica) bool {
 	return false
 }
 
+// isStrictLocalReplica returns true when the replica belongs to a strict-local volume.
+// Such a replica is pinned to its volume's node by HardNodeAffinity and can never be
+// evicted to another node. A replica whose volume is already gone is not strict-local.
+func isStrictLocalReplica(ds *datastore.DataStore, replica *longhorn.Replica) (bool, error) {
+	volume, err := ds.GetVolumeRO(replica.Spec.VolumeName)
+	if err != nil {
+		if datastore.ErrorIsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return volume.Spec.DataLocality == longhorn.DataLocalityStrictLocal, nil
+}
+
 func hasShardEvictionRequested(shards map[string]*longhorn.Shard) bool {
 	for _, s := range shards {
 		if s.Spec.EvictionRequested {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -696,8 +696,9 @@ func (c *VolumeController) EvictReplicas(v *longhorn.Volume,
 
 	// strict-local volumes must keep exactly one local replica. Trying to
 	// replenish a second replica during eviction creates an invalid
-	// intermediate state that later blocks VolumeAttachment updates.
-	if types.IsDataEngineV2(v.Spec.DataEngine) && v.Spec.DataLocality == longhorn.DataLocalityStrictLocal {
+	// intermediate state: the new replica is pinned to the same node, never
+	// gets scheduled, and on v2 later blocks VolumeAttachment updates.
+	if isDataLocalityStrictLocal(v) {
 		return nil
 	}
 
@@ -969,8 +970,11 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 				}
 			}
 
+			// Strict-local volumes have a single replica pinned to the attached node, so there is
+			// nothing to balance. When that node is cordoned, auto-balance no longer counts the
+			// replica and would create a second one that can never be scheduled.
 			setting := c.ds.GetAutoBalancedReplicasSetting(v, log)
-			if setting != longhorn.ReplicaAutoBalanceDisabled {
+			if setting != longhorn.ReplicaAutoBalanceDisabled && !isDataLocalityStrictLocal(v) {
 				if err := c.replenishReplicas(v, e, rs, ""); err != nil {
 					return err
 				}
@@ -1295,6 +1299,14 @@ func (c *VolumeController) cleanupFailedToScheduleReplicas(v *longhorn.Volume, r
 
 	for _, r := range rs {
 		if r.Spec.HealthyAt == "" && r.Spec.NodeID == "" {
+			// A strict-local volume never needs more than its single pinned replica.
+			// This is the strict-local counterpart of the disabled data locality case (longhorn/longhorn#8522).
+			if isDataLocalityStrictLocal(v) {
+				if healthyCount >= v.Spec.NumberOfReplicas {
+					replicasToCleanUp = append(replicasToCleanUp, r)
+				}
+				continue
+			}
 			// If this unscheduled replica has HardNodeAffinity when DataLocality is disabled, we can delete it
 			// immediately. It is better to replenish a new replica without HardNodeAffinity so we can avoid corner
 			// cases like https://github.com/longhorn/longhorn/issues/8522.
@@ -3662,6 +3674,10 @@ func isDataLocalityBestEffort(v *longhorn.Volume) bool {
 
 func isDataLocalityDisabled(v *longhorn.Volume) bool {
 	return string(v.Spec.DataLocality) == "" || v.Spec.DataLocality == longhorn.DataLocalityDisabled
+}
+
+func isDataLocalityStrictLocal(v *longhorn.Volume) bool {
+	return v.Spec.DataLocality == longhorn.DataLocalityStrictLocal
 }
 
 // hasLocalReplicaOnSameNodeAsEngine returns true if one of the following condition is satisfied:

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -2454,6 +2454,108 @@ func (s *TestSuite) TestEvictReplicasSkipsReplenishmentForV2StrictLocalVolume(c 
 	c.Assert(rs[replica.Name], Equals, replica)
 }
 
+func (s *TestSuite) TestEvictReplicasSkipsReplenishmentForV1StrictLocalVolume(c *C) {
+	vc := &VolumeController{
+		baseController: newBaseController("test-volume", logrus.StandardLogger()),
+		eventRecorder:  record.NewFakeRecorder(10),
+		backoff:        flowcontrol.NewBackOff(time.Minute, time.Minute*3),
+		nowHandler:     getTestNow,
+	}
+
+	v := newVolume(TestVolumeName, 1)
+	v.Spec.DataEngine = longhorn.DataEngineTypeV1
+	v.Spec.DataLocality = longhorn.DataLocalityStrictLocal
+
+	e := newEngineForVolume(v)
+	replica := newReplicaForVolume(v, e, TestNode1, TestDiskID1)
+	replica.Spec.EvictionRequested = true
+	replica.Spec.HealthyAt = TestTimeNow
+	e.Status.ReplicaModeMap = map[string]longhorn.ReplicaMode{
+		replica.Name: longhorn.ReplicaModeRW,
+	}
+
+	rs := map[string]*longhorn.Replica{
+		replica.Name: replica,
+	}
+
+	err := vc.EvictReplicas(v, e, rs, 1)
+	c.Assert(err, IsNil)
+	c.Assert(len(rs), Equals, 1)
+	c.Assert(rs[replica.Name], Equals, replica)
+}
+
+// TestCleanupFailedToScheduleReplicasRemovesStrictLocalStray covers a strict-local volume that got a second,
+// unscheduled replica (e.g. from auto-balance while its node was cordoned). The stray replica is pinned to the
+// volume's current node, so the generic cleanup would keep it forever. It must be removed as long as the
+// single healthy replica exists, and kept otherwise.
+func (s *TestSuite) TestCleanupFailedToScheduleReplicasRemovesStrictLocalStray(c *C) {
+	datastore.SkipListerCheck = true
+	defer func() {
+		datastore.SkipListerCheck = false
+	}()
+
+	testCases := map[string]struct {
+		hasHealthyReplica bool
+		expectStrayKept   bool
+	}{
+		"healthy replica exists": {
+			hasHealthyReplica: true,
+			expectStrayKept:   false,
+		},
+		"no healthy replica": {
+			hasHealthyReplica: false,
+			expectStrayKept:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		v := newVolume(TestVolumeName, 1)
+		v.Spec.DataEngine = longhorn.DataEngineTypeV1
+		v.Spec.DataLocality = longhorn.DataLocalityStrictLocal
+		v.Spec.NodeID = TestNode1
+		v.Status.CurrentNodeID = TestNode1
+
+		e := newEngineForVolume(v)
+
+		localReplica := newReplicaForVolume(v, e, TestNode1, TestDiskID1)
+		localReplica.Namespace = TestNamespace
+		localReplica.Spec.HardNodeAffinity = TestNode1
+		if tc.hasHealthyReplica {
+			localReplica.Spec.HealthyAt = TestTimeNow
+		} else {
+			setReplicaFailedAt(localReplica, TestTimeNow)
+		}
+
+		strayReplica := newReplicaForVolume(v, e, "", "")
+		strayReplica.Namespace = TestNamespace
+		strayReplica.Spec.HardNodeAffinity = TestNode1
+
+		lhClient := lhfake.NewSimpleClientset(localReplica, strayReplica) // nolint: staticcheck
+		kubeClient := fake.NewSimpleClientset()                            // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset()         // nolint: staticcheck
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		vc := &VolumeController{
+			baseController: newBaseController("test-volume", logrus.StandardLogger()),
+			ds:             datastore.NewDataStoreForGlobal(TestNamespace, lhClient, kubeClient, extensionsClient, informerFactories),
+			eventRecorder:  record.NewFakeRecorder(10),
+			nowHandler:     getTestNow,
+		}
+
+		rs := map[string]*longhorn.Replica{
+			localReplica.Name: localReplica,
+			strayReplica.Name: strayReplica,
+		}
+
+		err := vc.cleanupFailedToScheduleReplicas(v, rs)
+		c.Assert(err, IsNil, Commentf(name))
+
+		_, strayKept := rs[strayReplica.Name]
+		c.Assert(strayKept, Equals, tc.expectStrayKept, Commentf(name))
+		c.Assert(rs[localReplica.Name], NotNil, Commentf(name))
+	}
+}
+
 // setupReplenishReplicasTestInfra builds a degraded 2-replica volume whose replica on TestNode1 has
 // failed with the given rebuild failure reason and is still within the volume controller reuse backoff.
 func setupReplenishReplicasTestInfra(c *C, rebuildFailedReason string) (


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8753

#### What this PR does / why we need it:
This PR changes the behaviour of `block-for-eviction*` drain policies regarding the strict-local volumes on a node. In particular, strict-local volumes are not evicted since they cannot be rebuilt elsewhere, and do not block a node drain anymore. This behaviour, as highlighted in the related issue, is problematic for applications that manage data redundancy at the application level (e.g. multiple replicas of a CNPG database).

According to my understanding: the issue lies in the fact that, in the presence of strict-local volumes, draining a node automatically (i.e. without manually killing the instance manager of that node) is not possible since the PDB for the instance manager is never removed. This is due to the fact that the controller attempts to evict the strict-local volume, thus attempting to move the replica to another node, which cannot be done since it has a `hardNodeAffinity` set to a specific node. In turn, this makes draining the instance manager impossible, since the instance manager has an attached volume that will never be evicted.

Briefly, this PR does the following:
- strict-local volumes are no longer evicted from a node (unless it was a manual request)
- when evaluating whether an instance-manager PDB can be deleted, ignores the strict-local volumes for `block-for-eviction*` drain policies
- adds tests for both function changes

I believe I have implemented [the behaviour that was suggested by @ejweber](https://github.com/longhorn/longhorn/issues/8753#issuecomment-2168446728) in the issue. However, that was a couple of years ago, so please feel free to highlight any changes of mind, I will gladly work to fix this bug since it's blocking my automatic node upgrades!

#### Special notes for your reviewer:

#### Additional documentation or context
While this was the expected behaviour for me, I believe this change should be highlighted in the documentation. A couple of questions (pardon my inexperience):
- Do I simply open a PR on the longhorn/longhorn-website with the changes or should it be linked (somehow) to this issue?
- What version of the Longhorn docs should the PR target? 