### PR TITLE
fix(volume): avoid dual active engines after switchover cleanup conflict

### DIFF
--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -802,6 +802,10 @@ func (c *VolumeController) ReconcileEngineReplicaState(v *longhorn.Volume, es ma
 		return nil
 	}
 
+	// Selection is read-only. Persist recovery promotion here on the engine
+	// copy owned by volume reconciliation, never on an informer object.
+	e.Spec.Active = true
+
 	log := getLoggerForVolume(c.logger, v).WithField("currentEngine", e.Name)
 
 	if e.Status.CurrentState == longhorn.InstanceStateUnknown {
@@ -6010,6 +6014,7 @@ func (c *VolumeController) getCurrentEngineAndCleanupOthers(v *longhorn.Volume, 
 			}
 		}
 	}
+	current.Spec.Active = true
 	return current, nil
 }
 
@@ -6347,7 +6352,7 @@ func (c *VolumeController) processMigration(v *longhorn.Volume, es map[string]*l
 		}
 	}()
 
-	currentEngine, extras, err := datastore.GetCurrentEngineAndExtras(v, es)
+	currentEngine, extras, err := datastore.PickAndPromoteCurrentEngine(v, es)
 	if err != nil {
 		return err
 	}
@@ -6480,19 +6485,17 @@ func (c *VolumeController) processEngineSwitchover(v *longhorn.Volume, es map[st
 		return nil
 	}
 
-	// Always re-sync CurrentEngineNodeID from the active engine's actual
-	// node. The deferred update loop in syncVolume persists engine changes
-	// before volume status changes. If a previous reconcile completed a
-	// switchover (setting migrationEngine.Active=true and
-	// CurrentEngineNodeID in memory), the engine update may trigger a
-	// re-queue before the volume status is persisted. Without this
-	// re-sync the new reconcile would see a stale CurrentEngineNodeID and
-	// incorrectly create a duplicate migration engine.
-	for _, e := range es {
-		if e.Spec.Active && e.Spec.NodeID != "" {
-			v.Status.CurrentEngineNodeID = e.Spec.NodeID
-			break
-		}
+	// Re-sync from the selected current engine, including an inactive target
+	// recovered after the old engine was deleted. The deferred engine update
+	// can conflict after deletion succeeds, leaving both Active and the volume
+	// status stale. Resume finalization of that target instead of treating it
+	// as the source of another switchover.
+	currentEngine, extras, err := datastore.GetCurrentEngineAndExtras(v, es)
+	if err != nil {
+		return err
+	}
+	if currentEngine.Spec.NodeID != "" {
+		v.Status.CurrentEngineNodeID = currentEngine.Spec.NodeID
 	}
 	if v.Status.CurrentEngineNodeID == "" {
 		v.Status.CurrentEngineNodeID = targetNodeID
@@ -6503,16 +6506,9 @@ func (c *VolumeController) processEngineSwitchover(v *longhorn.Volume, es map[st
 	if targetNodeID == v.Status.CurrentEngineNodeID {
 		// No switchover in progress (or switchover already completed).
 		// Only need to cleanup extra engines from a previous engine switchover.
-		if len(es) <= 1 {
-			v.Status.SwitchoverState = longhorn.VolumeSwitchoverStateEmpty
-			return nil
-		}
-
-		currentEngine, extras, err := datastore.GetCurrentEngineAndExtras(v, es)
-		if err != nil {
-			log.WithError(err).Warn("Failed to finalize the engine switchover")
-			return nil
-		}
+		// Finish promotion even if the old engine has already disappeared.
+		// Replica updates may also need retrying after a partial finalization.
+		hasExtraEngines := len(es) > 1
 		for i := range extras {
 			e := extras[i]
 			if e.DeletionTimestamp == nil {
@@ -6531,7 +6527,11 @@ func (c *VolumeController) processEngineSwitchover(v *longhorn.Volume, es map[st
 			r.Spec.MigrationEngineName = ""
 			r.Spec.EngineName = currentEngine.Name
 		}
+
 		v.Status.SwitchoverState = longhorn.VolumeSwitchoverStateFinalizing
+		if !hasExtraEngines {
+			v.Status.SwitchoverState = longhorn.VolumeSwitchoverStateEmpty
+		}
 		return nil
 	}
 
@@ -6582,11 +6582,6 @@ func (c *VolumeController) processEngineSwitchover(v *longhorn.Volume, es map[st
 			r.Spec.EngineName = currentEngine.Name
 		}
 	}()
-
-	currentEngine, extras, err := datastore.GetCurrentEngineAndExtras(v, es)
-	if err != nil {
-		return err
-	}
 
 	if currentEngine.Status.CurrentState != longhorn.InstanceStateRunning {
 		revertRequired = true
@@ -6700,35 +6695,29 @@ func (c *VolumeController) processEngineSwitchover(v *longhorn.Volume, es map[st
 
 	v.Status.SwitchoverState = longhorn.VolumeSwitchoverStateFinalizing
 
-	// Step 5: Switchover complete. Finalize in-memory state and delete the
-	// old engine immediately to avoid extra reconcile cycles.
+	// Step 5: Switchover complete. Delete the old engine before promoting the
+	// migration engine.
 	log.Info("Volume engine switchover completed. EngineFrontend has switched to migration engine.")
 
-	// Now that the EF has confirmed the new target, stop the old engine.
-	if currentEngine.Spec.DesireState != longhorn.InstanceStateStopped {
-		currentEngine.Spec.DesireState = longhorn.InstanceStateStopped
+	// Do not touch the old engine's spec before the delete request: a failed delete
+	// after a successful update could leave both engines inactive. Unlike the other
+	// v2 engine deletions, DesireState=Stopped is not needed first here because the
+	// engine is still Running and the engine controller serializes syncs per engine,
+	// so no sync can see CurrentState=Stopped without also seeing the DeletionTimestamp.
+	if currentEngine.DeletionTimestamp == nil {
+		log.Infof("Deleting old engine %v after successful switchover", currentEngine.Name)
+		if err := c.ds.DeleteEngine(currentEngine.Name); err != nil {
+			return err
+		}
+		delete(es, currentEngine.Name)
 	}
-	currentEngine.Spec.Active = false
-	migrationEngine.Spec.Active = true
 
+	migrationEngine.Spec.Active = true
 	for _, r := range rs {
 		r.Spec.MigrationEngineName = ""
 		r.Spec.EngineName = migrationEngine.Name
 	}
-
 	v.Status.CurrentEngineNodeID = targetNodeID
-
-	// Delete the old engine immediately. deleteEngine persists the in-memory
-	// spec changes (Active=false, DesireState=Stopped) via UpdateEngine, then
-	// issues DeleteEngine, and removes the entry from the engines map so the
-	// deferred update loop in syncVolume skips it.
-	if currentEngine.DeletionTimestamp == nil {
-		log.Infof("Deleting old engine %v after successful switchover", currentEngine.Name)
-		if err := c.deleteEngine(currentEngine, es); err != nil {
-			// Non-fatal: the cleanup branch will handle it in the next cycle.
-			log.WithError(err).Warn("Failed to delete old engine immediately after switchover, will retry in next cycle")
-		}
-	}
 
 	return nil
 }

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -21,7 +21,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/longhorn/backupstore"
 
@@ -2322,16 +2324,20 @@ func (s *TestSuite) TestProcessEngineSwitchoverKeepsOldEngineRunningUntilTargetS
 	c.Assert(currentEngine.Spec.DesireState, Equals, longhorn.InstanceStateRunning)
 }
 
-// TestProcessEngineSwitchoverStopsOldEngineAfterSwitchoverComplete verifies
-// that the old engine is stopped only after the EngineFrontend status
-// confirms the migration target is active.
-func (s *TestSuite) TestProcessEngineSwitchoverStopsOldEngineAfterSwitchoverComplete(c *C) {
-	vc, _, _, v, currentEngine, migrationEngine, replica, ef := setupSwitchoverTestInfra(c)
+// TestProcessEngineSwitchoverRequestsOldEngineDeletionAfterSwitchoverComplete
+// verifies that the old engine deletion is requested only after the
+// EngineFrontend status confirms the migration target is active.
+func (s *TestSuite) TestProcessEngineSwitchoverRequestsOldEngineDeletionAfterSwitchoverComplete(c *C) {
+	vc, lhClient, _, v, currentEngine, migrationEngine, replica, ef := setupSwitchoverTestInfra(c)
 
 	// EF switchover is complete: both Spec and Status show the new target.
 	ef.Status.CurrentState = longhorn.InstanceStateRunning
 	ef.Status.TargetIP = migrationEngine.Status.StorageIP
 	ef.Status.TargetPort = migrationEngine.Status.Port
+
+	createdCurrentEngine, err := lhClient.LonghornV1beta2().Engines(TestNamespace).Create(context.TODO(), currentEngine, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+	currentEngine = createdCurrentEngine
 
 	es := map[string]*longhorn.Engine{
 		currentEngine.Name:   currentEngine,
@@ -2340,12 +2346,11 @@ func (s *TestSuite) TestProcessEngineSwitchoverStopsOldEngineAfterSwitchoverComp
 	rs := map[string]*longhorn.Replica{replica.Name: replica}
 	efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
 
-	err := vc.processEngineSwitchover(v, es, rs, efs)
+	err = vc.processEngineSwitchover(v, es, rs, efs)
 	c.Assert(err, IsNil)
 
-	// The old engine must be stopped after switchover is confirmed.
-	c.Assert(currentEngine.Spec.DesireState, Equals, longhorn.InstanceStateStopped)
-	c.Assert(currentEngine.Spec.Active, Equals, false)
+	// The old engine is removed from the local map after its deletion is requested.
+	c.Assert(es[currentEngine.Name], IsNil)
 
 	// The migration engine is now the active engine.
 	c.Assert(migrationEngine.Spec.Active, Equals, true)
@@ -2356,6 +2361,138 @@ func (s *TestSuite) TestProcessEngineSwitchoverStopsOldEngineAfterSwitchoverComp
 	// Replica should be reassigned to the migration engine.
 	c.Assert(replica.Spec.EngineName, Equals, migrationEngine.Name)
 	c.Assert(replica.Spec.MigrationEngineName, Equals, "")
+}
+
+// TestProcessEngineSwitchoverDoesNotPromoteMigrationEngineWhenOldEngineDeleteFails
+// verifies that an old engine delete failure leaves the migration state unchanged.
+// This prevents a persisted state with two active engines from blocking later cleanup.
+func (s *TestSuite) TestProcessEngineSwitchoverDoesNotPromoteMigrationEngineWhenOldEngineDeleteFails(c *C) {
+	vc, lhClient, _, v, currentEngine, migrationEngine, replica, ef := setupSwitchoverTestInfra(c)
+
+	ef.Status.CurrentState = longhorn.InstanceStateRunning
+	ef.Status.TargetIP = migrationEngine.Status.StorageIP
+	ef.Status.TargetPort = migrationEngine.Status.Port
+
+	lhClient.PrependReactor("delete", "engines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("transient delete failure")
+	})
+
+	es := map[string]*longhorn.Engine{
+		currentEngine.Name:   currentEngine,
+		migrationEngine.Name: migrationEngine,
+	}
+	rs := map[string]*longhorn.Replica{replica.Name: replica}
+	efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
+
+	err := vc.processEngineSwitchover(v, es, rs, efs)
+	c.Assert(err, NotNil)
+
+	c.Assert(currentEngine.Spec.Active, Equals, true)
+	c.Assert(currentEngine.Spec.DesireState, Equals, longhorn.InstanceStateRunning)
+	c.Assert(migrationEngine.Spec.Active, Equals, false)
+	c.Assert(replica.Spec.EngineName, Equals, currentEngine.Name)
+	c.Assert(replica.Spec.MigrationEngineName, Equals, migrationEngine.Name)
+	c.Assert(v.Status.CurrentEngineNodeID, Equals, TestNode1)
+}
+
+func (s *TestSuite) TestProcessEngineSwitchoverRecoversAfterPromotionConflict(c *C) {
+	for _, oldEngineDeleted := range []bool{false, true} {
+		vc, lhClient, engineIndexer, v, currentEngine, migrationEngine, replica, ef := setupSwitchoverTestInfra(c)
+		ef.Status.CurrentState = longhorn.InstanceStateRunning
+		ef.Status.TargetIP = migrationEngine.Status.StorageIP
+		ef.Status.TargetPort = migrationEngine.Status.Port
+		persistedVolume := v.DeepCopy()
+		for _, engine := range []*longhorn.Engine{currentEngine, migrationEngine} {
+			_, err := lhClient.LonghornV1beta2().Engines(TestNamespace).Create(context.TODO(), engine, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+		}
+		failPromotion := true
+		lhClient.PrependReactor("update", "engines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if !failPromotion {
+				return false, nil, nil
+			}
+			return true, nil, apierrors.NewConflict(longhorn.Resource("engines"), migrationEngine.Name, fmt.Errorf("engine status changed"))
+		})
+		es := map[string]*longhorn.Engine{currentEngine.Name: currentEngine, migrationEngine.Name: migrationEngine}
+		rs := map[string]*longhorn.Replica{replica.Name: replica}
+		efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
+		err := vc.processEngineSwitchover(v, es, rs, efs)
+		c.Assert(err, IsNil)
+		c.Assert(es[currentEngine.Name], IsNil)
+
+		// Simulate the deferred engine update conflicting after replica ownership
+		// has changed. The volume status update is then skipped.
+		_, err = vc.ds.UpdateEngine(migrationEngine)
+		c.Assert(apierrors.IsConflict(err), Equals, true)
+		persistedMigrationEngine, err := lhClient.LonghornV1beta2().Engines(TestNamespace).Get(context.TODO(), migrationEngine.Name, metav1.GetOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(persistedMigrationEngine.Spec.Active, Equals, false)
+		c.Assert(persistedVolume.Status.CurrentEngineNodeID, Equals, TestNode1)
+		c.Assert(engineIndexer.Add(persistedMigrationEngine), IsNil)
+		if !oldEngineDeleted {
+			// The fake client deletes immediately; model the informer retaining
+			// the old engine while its finalizer runs.
+			deletionTime := metav1.Now()
+			currentEngine.DeletionTimestamp = &deletionTime
+			c.Assert(engineIndexer.Add(currentEngine), IsNil)
+		}
+
+		// A retry works on fresh copies and must reuse the existing target,
+		// whether the old engine is still deleting or has disappeared.
+		es, err = vc.ds.ListVolumeEngines(v.Name)
+		c.Assert(err, IsNil)
+		engineCount := len(es)
+		lhClient.ClearActions()
+		err = vc.processEngineSwitchover(persistedVolume, es, rs, efs)
+		c.Assert(err, IsNil)
+		c.Assert(lhClient.Actions(), HasLen, 0)
+		c.Assert(es, HasLen, engineCount)
+		c.Assert(es[migrationEngine.Name].Spec.Active, Equals, true)
+		c.Assert(persistedVolume.Status.CurrentEngineNodeID, Equals, TestNode2)
+		c.Assert(replica.Spec.EngineName, Equals, migrationEngine.Name)
+		c.Assert(replica.Spec.MigrationEngineName, Equals, "")
+		c.Assert(persistedMigrationEngine.Spec.Active, Equals, false)
+
+		failPromotion = false
+		_, err = vc.ds.UpdateEngine(es[migrationEngine.Name])
+		c.Assert(err, IsNil)
+		promotedEngine, err := lhClient.LonghornV1beta2().Engines(TestNamespace).Get(context.TODO(), migrationEngine.Name, metav1.GetOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(promotedEngine.Spec.Active, Equals, true)
+	}
+}
+
+func (s *TestSuite) TestProcessEngineSwitchoverIgnoresDeletingActiveEngine(c *C) {
+	vc, lhClient, _, v, currentEngine, migrationEngine, replica, ef := setupSwitchoverTestInfra(c)
+
+	// The old engine remains visible while its finalizer runs, and the new
+	// engine has been promoted before the volume status update is observed.
+	now := metav1.Now()
+	currentEngine.DeletionTimestamp = &now
+	migrationEngine.Spec.Active = true
+	replica.Spec.EngineName = migrationEngine.Name
+	replica.Spec.MigrationEngineName = ""
+
+	es := map[string]*longhorn.Engine{
+		currentEngine.Name:   currentEngine,
+		migrationEngine.Name: migrationEngine,
+	}
+	rs := map[string]*longhorn.Replica{replica.Name: replica}
+	efs := map[string]*longhorn.EngineFrontend{ef.Name: ef}
+	lhClient.ClearActions()
+
+	// Repeat to exercise different map iteration orders while deletion is pending.
+	for i := 0; i < 100; i++ {
+		v.Status.CurrentEngineNodeID = TestNode1
+		err := vc.processEngineSwitchover(v, es, rs, efs)
+		c.Assert(err, IsNil)
+		c.Assert(v.Status.CurrentEngineNodeID, Equals, TestNode2)
+		c.Assert(v.Status.SwitchoverState, Equals, longhorn.VolumeSwitchoverStateFinalizing)
+		c.Assert(es, HasLen, 2)
+		c.Assert(replica.Spec.EngineName, Equals, migrationEngine.Name)
+		c.Assert(replica.Spec.MigrationEngineName, Equals, "")
+		c.Assert(lhClient.Actions(), HasLen, 0)
+	}
 }
 
 // TestProcessEngineSwitchoverCleanupUsesActiveEngine verifies that once

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1696,9 +1696,15 @@ func checkEngine(engine *longhorn.Engine) error {
 	return nil
 }
 
-// GetCurrentEngineAndExtras pick the current Engine and extra Engines from the Engine list of a volume with the given namespace
+// GetCurrentEngineAndExtras picks the current Engine and extra Engines without modifying them.
 func GetCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.Engine) (currentEngine *longhorn.Engine, extras []*longhorn.Engine, err error) {
 	for _, e := range es {
+		// A deleting engine may still have Active=true until its finalizer
+		// removes the instance. It cannot be the current engine.
+		if e.DeletionTimestamp != nil {
+			extras = append(extras, e)
+			continue
+		}
 		if e.Spec.Active {
 			if currentEngine != nil {
 				return nil, nil, fmt.Errorf("BUG: found the second active engine %v besides %v", e.Name, currentEngine.Name)
@@ -1715,10 +1721,20 @@ func GetCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.Engin
 		if err != nil {
 			return nil, nil, err
 		}
-		newCurrentEngine.Spec.Active = true
 		return newCurrentEngine, extras, nil
 	}
 	return
+}
+
+// PickAndPromoteCurrentEngine picks the current engine and marks it active in memory.
+// The caller must own the given engines; never pass informer objects.
+func PickAndPromoteCurrentEngine(v *longhorn.Volume, es map[string]*longhorn.Engine) (*longhorn.Engine, []*longhorn.Engine, error) {
+	currentEngine, extras, err := GetCurrentEngineAndExtras(v, es)
+	if err != nil {
+		return nil, nil, err
+	}
+	currentEngine.Spec.Active = true
+	return currentEngine, extras, nil
 }
 
 // GetNewCurrentEngineAndExtras detects the new current Engine and extra Engines from the Engine list of a volume with the given namespace during engine switching.
@@ -1780,7 +1796,7 @@ func GetNewCurrentEngineAndExtras(v *longhorn.Volume, es map[string]*longhorn.En
 	if currentEngine == nil {
 		if len(es) == 1 {
 			for _, e := range es {
-				if e.Spec.Active && e.Spec.NodeID == "" {
+				if e.DeletionTimestamp == nil && e.Spec.Active && e.Spec.NodeID == "" {
 					currentEngine = e
 					extras = []*longhorn.Engine{}
 				}

--- a/datastore/longhorn_test.go
+++ b/datastore/longhorn_test.go
@@ -15,6 +15,7 @@ import (
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/longhorn/longhorn-manager/types"
 	"github.com/longhorn/longhorn-manager/util"
 
 	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -239,4 +240,105 @@ func TestGetVolumeCurrentEngineFrontendReturnsErrorWhenMissing(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, ef)
 	require.Contains(t, err.Error(), "cannot find the current engine frontend")
+}
+
+func TestGetCurrentEngineAndExtrasIgnoresDeletingActiveEngine(t *testing.T) {
+	deletionTime := metav1.Now()
+	deletingEngine := &longhorn.Engine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-engine",
+			DeletionTimestamp: &deletionTime,
+		},
+		Spec: longhorn.EngineSpec{Active: true},
+	}
+	currentEngine := &longhorn.Engine{
+		ObjectMeta: metav1.ObjectMeta{Name: "current-engine"},
+		Spec:       longhorn.EngineSpec{Active: true},
+	}
+
+	engine, extras, err := GetCurrentEngineAndExtras(&longhorn.Volume{}, map[string]*longhorn.Engine{
+		deletingEngine.Name: deletingEngine,
+		currentEngine.Name:  currentEngine,
+	})
+	require.NoError(t, err)
+	assert.Same(t, currentEngine, engine)
+	require.Len(t, extras, 1)
+	assert.Same(t, deletingEngine, extras[0])
+}
+
+func TestGetVolumeCurrentEngineDoesNotPromoteCachedEngine(t *testing.T) {
+	const namespace = "longhorn-system"
+	volume := &longhorn.Volume{
+		ObjectMeta: metav1.ObjectMeta{Name: "volume", Namespace: namespace},
+		Spec: longhorn.VolumeSpec{
+			DataEngine:   longhorn.DataEngineTypeV2,
+			NodeID:       "old-node",
+			EngineNodeID: "target-node",
+		},
+		Status: longhorn.VolumeStatus{CurrentNodeID: "old-node", CurrentEngineNodeID: "old-node"},
+	}
+	deletionTime := metav1.Now()
+	oldEngine := &longhorn.Engine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-engine", Namespace: namespace,
+			Labels: types.GetVolumeLabels(volume.Name), DeletionTimestamp: &deletionTime,
+		},
+		Spec: longhorn.EngineSpec{Active: true, InstanceSpec: longhorn.InstanceSpec{NodeID: "old-node"}},
+	}
+	targetEngine := &longhorn.Engine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "target-engine", Namespace: namespace, Labels: types.GetVolumeLabels(volume.Name),
+		},
+		Spec: longhorn.EngineSpec{InstanceSpec: longhorn.InstanceSpec{NodeID: "target-node"}},
+	}
+	factory := lhinformerfactory.NewSharedInformerFactory(lhfake.NewSimpleClientset(), 0) // nolint: staticcheck
+	engineInformer := factory.Longhorn().V1beta2().Engines()
+	volumeInformer := factory.Longhorn().V1beta2().Volumes()
+	require.NoError(t, engineInformer.Informer().GetIndexer().Add(oldEngine))
+	require.NoError(t, engineInformer.Informer().GetIndexer().Add(targetEngine))
+	require.NoError(t, volumeInformer.Informer().GetIndexer().Add(volume))
+	ds := &DataStore{namespace: namespace, engineLister: engineInformer.Lister(), volumeLister: volumeInformer.Lister()}
+
+	engine, err := ds.GetVolumeCurrentEngine(volume.Name)
+	require.NoError(t, err)
+	assert.Equal(t, targetEngine.Name, engine.Name)
+	assert.False(t, engine.Spec.Active)
+	assert.False(t, targetEngine.Spec.Active, "selection must not promote the informer object")
+	assert.True(t, oldEngine.Spec.Active)
+	assert.Equal(t, "old-node", volume.Status.CurrentEngineNodeID)
+}
+
+func TestCurrentEngineSelectionWithSingleActiveEngineWithoutNodeID(t *testing.T) {
+	for name, selectEngine := range map[string]func(*longhorn.Volume, map[string]*longhorn.Engine) (*longhorn.Engine, []*longhorn.Engine, error){
+		"GetCurrentEngineAndExtras":    GetCurrentEngineAndExtras,
+		"GetNewCurrentEngineAndExtras": GetNewCurrentEngineAndExtras,
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, deleting := range []bool{false, true} {
+				t.Run(fmt.Sprintf("deleting=%t", deleting), func(t *testing.T) {
+					engine := &longhorn.Engine{
+						ObjectMeta: metav1.ObjectMeta{Name: "engine"},
+						Spec:       longhorn.EngineSpec{Active: true},
+					}
+					if deleting {
+						deletionTime := metav1.Now()
+						engine.DeletionTimestamp = &deletionTime
+					}
+
+					currentEngine, extras, err := selectEngine(&longhorn.Volume{}, map[string]*longhorn.Engine{
+						engine.Name: engine,
+					})
+					if deleting {
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), "cannot find the current engine")
+						assert.Nil(t, currentEngine)
+						return
+					}
+					require.NoError(t, err)
+					assert.Same(t, engine, currentEngine)
+					assert.Empty(t, extras)
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/13951

#### What this PR does / why we need it:

When deleting the old engine fails, the controller previously promoted the migration engine and updated replica ownership anyway. This could persist two active engines and block subsequent reconciliation.

Only promote the migration engine after the old engine is deleted successfully.

#### Special notes for your reviewer:

#### Additional documentation or context
