### PR TITLE
fix(system-backup): tolerate snapshots without creationTime

### DIFF
--- a/controller/system_backup_controller.go
+++ b/controller/system_backup_controller.go
@@ -967,7 +967,8 @@ func (c *SystemBackupController) isVolumeBackupUpToDate(volume *longhorn.Volume,
 
 		snapshotTime, err := time.Parse(time.RFC3339, snapshot.Status.CreationTime)
 		if err != nil {
-			return false, err
+			log.WithError(err).Warnf("Failed to parse creation time %q for snapshot %v, assuming the volume backup is not up-to-date", snapshot.Status.CreationTime, snapshot.Name)
+			return false, nil
 		}
 
 		if snapshotTime.After(lastBackupTime) {

--- a/controller/system_backup_controller_test.go
+++ b/controller/system_backup_controller_test.go
@@ -180,6 +180,90 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 			expectState:               longhorn.SystemBackupStateBackingImageBackup,
 			expectNewVolumBackupCount: 1,
 		},
+		"system backup create volume backup if-not-present when an older snapshot has no new data": {
+			state:              longhorn.SystemBackupStateVolumeBackup,
+			volumeBackupPolicy: longhorn.SystemBackupCreateVolumeBackupPolicyIfNotPresent,
+			existVolumes: map[SystemRolloutCRName]*longhorn.Volume{
+				SystemRolloutCRName(TestVolumeName): {
+					Status: longhorn.VolumeStatus{
+						LastBackup: "exists",
+					},
+				},
+			},
+			existBackups: map[string]*longhorn.Backup{
+				"exists": {
+					Status: longhorn.BackupStatus{
+						State:        longhorn.BackupStateCompleted,
+						SnapshotName: "exists",
+						VolumeName:   TestVolumeName,
+					},
+				},
+			},
+			existSnapshots: map[string]*longhorn.Snapshot{
+				"exists": {
+					ObjectMeta: metav1.ObjectMeta{Name: "exists"},
+					Spec:       longhorn.SnapshotSpec{Volume: TestVolumeName},
+					Status: longhorn.SnapshotStatus{
+						ReadyToUse:   true,
+						Size:         1,
+						CreationTime: metav1.Now().Format(time.RFC3339),
+					},
+				},
+				"older": {
+					ObjectMeta: metav1.ObjectMeta{Name: "older"},
+					Spec:       longhorn.SnapshotSpec{Volume: TestVolumeName},
+					Status: longhorn.SnapshotStatus{
+						ReadyToUse:   true,
+						Size:         1,
+						CreationTime: metav1.NewTime(time.Now().Add(-time.Hour)).Format(time.RFC3339),
+					},
+				},
+			},
+			expectState:               longhorn.SystemBackupStateBackingImageBackup,
+			expectNewVolumBackupCount: 0,
+		},
+		"system backup create volume backup if-not-present when another snapshot creationTime is not set": {
+			state:              longhorn.SystemBackupStateVolumeBackup,
+			volumeBackupPolicy: longhorn.SystemBackupCreateVolumeBackupPolicyIfNotPresent,
+			existVolumes: map[SystemRolloutCRName]*longhorn.Volume{
+				SystemRolloutCRName(TestVolumeName): {
+					Status: longhorn.VolumeStatus{
+						LastBackup: "exists",
+					},
+				},
+			},
+			existBackups: map[string]*longhorn.Backup{
+				"exists": {
+					Status: longhorn.BackupStatus{
+						State:        longhorn.BackupStateCompleted,
+						SnapshotName: "exists",
+						VolumeName:   TestVolumeName,
+					},
+				},
+			},
+			existSnapshots: map[string]*longhorn.Snapshot{
+				"exists": {
+					ObjectMeta: metav1.ObjectMeta{Name: "exists"},
+					Spec:       longhorn.SnapshotSpec{Volume: TestVolumeName},
+					Status: longhorn.SnapshotStatus{
+						ReadyToUse:   true,
+						Size:         1,
+						CreationTime: metav1.Now().Format(time.RFC3339),
+					},
+				},
+				"leftover": {
+					ObjectMeta: metav1.ObjectMeta{Name: "leftover"},
+					Spec:       longhorn.SnapshotSpec{Volume: TestVolumeName},
+					Status: longhorn.SnapshotStatus{
+						ReadyToUse: true,
+						Size:       1,
+						// CreationTime is not set
+					},
+				},
+			},
+			expectState:               longhorn.SystemBackupStateBackingImageBackup,
+			expectNewVolumBackupCount: 1,
+		},
 		"system backup create volume backup always": {
 			state:              longhorn.SystemBackupStateVolumeBackup,
 			volumeBackupPolicy: longhorn.SystemBackupCreateVolumeBackupPolicyAlways,
@@ -361,7 +445,12 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 					fakeSystemRolloutSnapshot(existBackupSnap, c, informerFactories.LhInformerFactory, lhClient)
 				}
 			}
-			backups, _ := systemBackupController.BackupVolumes(systemBackup)
+			backups, err := systemBackupController.BackupVolumes(systemBackup)
+			if tc.expectError {
+				c.Assert(err, NotNil)
+			} else {
+				c.Assert(err, IsNil)
+			}
 
 			for _, backup := range backups {
 				backup.Status.State = longhorn.BackupStateCompleted

--- a/controller/system_restore_controller_test.go
+++ b/controller/system_restore_controller_test.go
@@ -914,6 +914,7 @@ func fakeSystemRolloutSnapshot(fakeObj *longhorn.Snapshot, c *C, informerFactory
 	}
 
 	snap := newSnapshot(fakeObj.Name)
+	snap.Labels = types.GetVolumeLabels(fakeObj.Spec.Volume)
 	snap.Spec.Volume = fakeObj.Spec.Volume
 	snap.Status = fakeObj.Status
 	exist, err := clientInterface.Create(context.TODO(), snap, metav1.CreateOptions{})


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13942

#### What this PR does / why we need it:
With `volumeBackupPolicy: if-not-present`, `isVolumeBackupUpToDate` walks every snapshot of a volume and parses `status.creationTime` as RFC3339. One snapshot with an empty (or otherwise unparseable) `creationTime` made the function return the parse error, which moved the whole SystemBackup to `Error`:

```
parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
```

This PR logs a warning for such a snapshot and treats the volume backup as not up-to-date (a backup is taken), the same way the function already handles an unparseable `creationTime` on the last-backup snapshot a few lines above (longhorn/longhorn#11232). The SystemBackup no longer fails.

#### Special notes for your reviewer:
- Two behaviours were possible for a snapshot whose age cannot be determined: skip it, or treat the volume as needing a backup. I chose the latter because it can never omit new data and it matches the existing branch for the last-backup snapshot. The cost is one incremental volume backup per SystemBackup for volumes that carry such a snapshot. If you prefer skipping the snapshot (`continue`), that is a one-line change and I am happy to switch.
- `fakeSystemRolloutSnapshot` now labels fake snapshots with `types.GetVolumeLabels(volume)`, as the snapshot mutating webhook does on a real cluster (`webhook/resources/snapshot/mutator.go`). Without the label `ListVolumeSnapshotsRO` returned nothing for the test volume, so the loop under test was unreachable in unit tests. The test harness also asserts `BackupVolumes`' error instead of discarding it.

#### Additional documentation or context
None.

## Problem
A SystemBackup with `volumeBackupPolicy: if-not-present` enters `Error` if any volume has a snapshot whose `status.creationTime` is empty (reported with snapshots left behind by unused restored volumes). Deleting those volumes is the only workaround.

## Root cause
`controller/system_backup_controller.go:968-971` (`isVolumeBackupUpToDate`): the per-snapshot `time.Parse(time.RFC3339, snapshot.Status.CreationTime)` error is returned to the caller, `backupVolumesIfNotPresent`, which aborts the whole volume-backup phase. The same function already tolerates a bad timestamp on the last-backup snapshot (`:951-955`, warn and return `false, nil`), but not on the other snapshots.

## Fix
Handle the per-snapshot parse failure like the last-backup snapshot: log a warning with the controller logger and return `false, nil` (volume backup is not up-to-date), instead of propagating the error.

## How tested
Unit test `TestReconcileSystemBackup` gained two `if-not-present` cases:
- `... when another snapshot creationTime is not set`: valid last-backup snapshot plus a snapshot with `Size: 1` and empty `CreationTime`; expects no error, state `CreatingBackingImageBackups`, one new volume backup.
- `... when an older snapshot has no new data`: valid last-backup snapshot plus an older valid snapshot; expects zero new backups (guards that the loop is exercised and does not create spurious backups).

Before the fix (`go test ./controller/ -run '^Test$' -check.f TestReconcileSystemBackup`):
```
FAIL: system_backup_controller_test.go:59: TestSuite.TestReconcileSystemBackup
system_backup_controller_test.go:452:
    c.Assert(err, IsNil)
... value *time.ParseError = &time.ParseError{Layout:"2006-01-02T15:04:05Z07:00", Value:"", LayoutElem:"2006", ValueElem:"", Message:""} ("parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"")
OOPS: 0 passed, 1 FAILED
```

After the fix:
```
ok  	github.com/longhorn/longhorn-manager/controller	82.080s
```
with the new warning emitted for the affected snapshot:
```
level=warning msg="Failed to parse creation time \"\" for snapshot leftover, assuming the volume backup is not up-to-date" controller=longhorn-system-backup volume=test-volume volumeBackupPolicy=if-not-present
```
`gofmt -l controller/` and `go vet ./controller/...` are clean.

## Links
- https://github.com/longhorn/longhorn/issues/13942
- Prior handling of the last-backup snapshot: longhorn/longhorn#11232 (commit 596d57302)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
