### PR TITLE
fix(system-restore): set imagePullSecrets on the system-rollout job

### DIFF
--- a/controller/system_restore_controller.go
+++ b/controller/system_restore_controller.go
@@ -384,10 +384,15 @@ func (c *SystemRestoreController) CreateSystemRestoreJob(systemRestore *longhorn
 		return nil, err
 	}
 
-	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, tolerations))
+	registrySecretSetting, err := c.ds.GetSettingWithAutoFillingRO(types.SettingNameRegistrySecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.ds.CreateJob(c.newSystemRestoreJob(systemRestore, c.namespace, cfg.ManagerImage, serviceAccountName, registrySecretSetting.Value, tolerations))
 }
 
-func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount string, tolerations []corev1.Toleration) *batchv1.Job {
+func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.SystemRestore, namespace, managerImage, serviceAccount, registrySecret string, tolerations []corev1.Toleration) *batchv1.Job {
 	backoffLimit := int32(RestoreJobBackoffLimit)
 
 	// This is required for the NFS mount to access the backup store
@@ -459,6 +464,14 @@ func (c *SystemRestoreController) newSystemRestoreJob(systemRestore *longhorn.Sy
 				},
 			},
 		},
+	}
+
+	if registrySecret != "" {
+		job.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: registrySecret,
+			},
+		}
 	}
 
 	return job

--- a/controller/system_restore_controller_test.go
+++ b/controller/system_restore_controller_test.go
@@ -47,6 +47,8 @@ const (
 
 	TestDiffSuffix   = "-diff"
 	TestIgnoreSuffix = "-ignore"
+
+	TestRegistrySecret = "test-registry-secret"
 )
 
 type SystemRolloutCRName string
@@ -59,6 +61,7 @@ type SystemRestoreTestCase struct {
 	state            longhorn.SystemRestoreState
 	notExist         bool
 	isDeleting       bool
+	registrySecret   string
 
 	expectError    bool
 	expectJobExist bool
@@ -97,6 +100,10 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 			expectState:      longhorn.SystemRestoreStateError,
 			expectJobExist:   false,
 		},
+		"system restore with private registry": {
+			registrySecret: TestRegistrySecret,
+			expectJobExist: true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -117,7 +124,13 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
 
 		fakeSystemRolloutManagerPod(c, informerFactories.KubeInformerFactory, kubeClient)
-		fakeSystemRolloutSettingDefaultEngineImage(c, informerFactories.LhInformerFactory, lhClient)
+		settings := map[SystemRolloutCRName]*longhorn.Setting{
+			SystemRolloutCRName(types.SettingNameDefaultEngineImage): {Value: TestEngineImage},
+		}
+		if tc.registrySecret != "" {
+			settings[SystemRolloutCRName(types.SettingNameRegistrySecret)] = &longhorn.Setting{Value: tc.registrySecret}
+		}
+		fakeSystemRolloutSettings(settings, c, informerFactories.LhInformerFactory, lhClient)
 		fakeSystemRolloutBackupTargetDefault(c, informerFactories.LhInformerFactory, lhClient)
 		fakeSystemBackup(tc.systemBackupName, systemRestoreOwnerID, "", false, "", longhorn.SystemBackupStateGenerating, c, informerFactories.LhInformerFactory, lhClient)
 
@@ -150,6 +163,11 @@ func (s *TestSuite) TestReconcileSystemRestore(c *C) {
 			c.Assert(job.Spec.Template.Spec.Containers[0].Image, Equals, TestManagerImage)
 			c.Assert(strings.HasPrefix(job.Name, SystemRolloutNamePrefix), Equals, true)
 			c.Assert(strings.HasPrefix(job.Spec.Template.Spec.Containers[0].Name, SystemRolloutNamePrefix), Equals, true)
+			if tc.registrySecret != "" {
+				c.Assert(job.Spec.Template.Spec.ImagePullSecrets, DeepEquals, []corev1.LocalObjectReference{{Name: tc.registrySecret}})
+			} else {
+				c.Assert(job.Spec.Template.Spec.ImagePullSecrets, HasLen, 0)
+			}
 		} else {
 			c.Assert(err, NotNil)
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13968

#### What this PR does / why we need it:

The system-rollout Job created for a SystemRestore never set `imagePullSecrets`, so with a private registry its pod could not pull the manager image and the SystemRestore stayed `Pending`. This PR applies the `registry-secret` setting to the Job, as every other manager-created pod already does.

#### Special notes for your reviewer:

`TestReconcileSystemRestore` gets a private-registry case; the existing cases now also assert that no pull secret is added by default.

#### Additional documentation or context

None.
