### PR TITLE
feat(v2): disable CPU isolation in interrupt mode

### DIFF
--- a/controller/instance_manager_controller.go
+++ b/controller/instance_manager_controller.go
@@ -225,7 +225,9 @@ func (imc *InstanceManagerController) isResponsibleForSetting(obj interface{}) b
 		types.SettingName(setting.Name) == types.SettingNameDataEngineIobufSmallPoolSize ||
 		types.SettingName(setting.Name) == types.SettingNameOrphanResourceAutoDeletion ||
 		types.SettingName(setting.Name) == types.SettingNameDataEngineHugepageEnabled ||
-		types.SettingName(setting.Name) == types.SettingNameDataEngineMemorySize
+		types.SettingName(setting.Name) == types.SettingNameDataEngineMemorySize ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineInterruptModeEnabled ||
+		types.SettingName(setting.Name) == types.SettingNameDataEngineCPUIsolationEnabled
 }
 
 func isInstanceManagerPod(obj interface{}) bool {
@@ -997,30 +999,40 @@ func (imc *InstanceManagerController) isSettingInterruptModeEnabledSynced(settin
 }
 
 // resolveCPUIsolationEnabled returns the effective CPU-isolation-enabled value
-// for a V2 instance manager. The per-IM Spec.DataEngineSpec.V2.CPUIsolationEnabled
-// field takes priority over the cluster-wide data-engine-cpu-isolation-enabled
-// setting:
+// for a V2 instance manager, in the following order of precedence:
 //
-//	"true"  -> enabled
-//	"false" -> disabled
-//	""      -> inherit the global setting value
+//  1. Interrupt mode: CPU isolation only protects busy-polling SPDK reactors from
+//     being preempted, so it is disabled whenever the SPDK target runs in
+//     interrupt mode, regardless of any other input.
+//  2. The per-IM Spec.DataEngineSpec.V2.CPUIsolationEnabled field:
+//     "true" -> enabled, "false" -> disabled, "" -> fall through.
+//  3. The cluster-wide data-engine-cpu-isolation-enabled setting.
 func (imc *InstanceManagerController) resolveCPUIsolationEnabled(im *longhorn.InstanceManager) (bool, error) {
-	switch im.Spec.DataEngineSpec.V2.CPUIsolationEnabled {
-	case "true":
-		return true, nil
-	case "false":
+	interruptMode, err := imc.ds.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineInterruptModeEnabled, im.Spec.DataEngine)
+	if err != nil {
+		return false, err
+	}
+	if interruptMode == longhorn.TrueValue {
 		return false, nil
 	}
+
+	switch im.Spec.DataEngineSpec.V2.CPUIsolationEnabled {
+	case longhorn.TrueValue:
+		return true, nil
+	case longhorn.FalseValue:
+		return false, nil
+	}
+
 	val, err := imc.ds.GetSettingValueExistedByDataEngine(types.SettingNameDataEngineCPUIsolationEnabled, im.Spec.DataEngine)
 	if err != nil {
 		return false, err
 	}
-	return val == "true", nil
+	return val == longhorn.TrueValue, nil
 }
 
 // isSettingCPUIsolationEnabledSynced returns true if the effective CPU-isolation
-// value (Spec.DataEngineSpec.V2.CPUIsolationEnabled, falling back to the global
-// setting) matches what the V2 instance-manager pod was started with. The pod
+// value (see resolveCPUIsolationEnabled) matches what the V2 instance-manager
+// pod was started with. The pod
 // always receives --longhorn-control-path (so we can reconcile stale state
 // across restarts even after toggling off); the actual toggle is the presence
 // of --enable-irq-affinity, --enable-workqueue-affinity, AND --enable-rps in the

--- a/controller/instance_manager_controller_test.go
+++ b/controller/instance_manager_controller_test.go
@@ -842,3 +842,248 @@ func (s *TestSuite) TestNodeHasEnoughHugepageTotalCapacity(c *C) {
 		c.Assert(ok, Equals, tc.expected)
 	}
 }
+
+func (s *TestSuite) TestResolveCPUIsolationEnabled(c *C) {
+	type testCase struct {
+		imOverride       string
+		interruptMode    string
+		isolationSetting string
+		expected         bool
+	}
+
+	testCases := map[string]testCase{
+		"polling mode inherits the enabled isolation setting": {
+			interruptMode:    longhorn.FalseValue,
+			isolationSetting: longhorn.TrueValue,
+			expected:         true,
+		},
+		"polling mode inherits the disabled isolation setting": {
+			interruptMode:    longhorn.FalseValue,
+			isolationSetting: longhorn.FalseValue,
+			expected:         false,
+		},
+		"interrupt mode disables isolation regardless of the setting": {
+			interruptMode:    longhorn.TrueValue,
+			isolationSetting: longhorn.TrueValue,
+			expected:         false,
+		},
+		"interrupt mode wins over the instance manager override": {
+			imOverride:       longhorn.TrueValue,
+			interruptMode:    longhorn.TrueValue,
+			isolationSetting: longhorn.TrueValue,
+			expected:         false,
+		},
+		"instance manager override wins over the isolation setting in polling mode": {
+			imOverride:       longhorn.FalseValue,
+			interruptMode:    longhorn.FalseValue,
+			isolationSetting: longhorn.TrueValue,
+			expected:         false,
+		},
+		"instance manager override enables isolation in polling mode": {
+			imOverride:       longhorn.TrueValue,
+			interruptMode:    longhorn.FalseValue,
+			isolationSetting: longhorn.FalseValue,
+			expected:         true,
+		},
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+
+		imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		for _, setting := range []*longhorn.Setting{
+			newSetting(string(types.SettingNameDataEngineInterruptModeEnabled), fmt.Sprintf(`{"v2":%q}`, tc.interruptMode)),
+			newSetting(string(types.SettingNameDataEngineCPUIsolationEnabled), fmt.Sprintf(`{"v2":%q}`, tc.isolationSetting)),
+		} {
+			setting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Create(context.TODO(), setting, metav1.CreateOptions{})
+			c.Assert(err, IsNil)
+			err = sIndexer.Add(setting)
+			c.Assert(err, IsNil)
+		}
+
+		im := newInstanceManager(
+			TestInstanceManagerName,
+			longhorn.InstanceManagerStateRunning,
+			TestNode1,
+			TestNode1,
+			TestIP1,
+			nil,
+			nil,
+			nil,
+			longhorn.DataEngineTypeV2,
+			TestInstanceManagerImage,
+			false,
+		)
+		im.Spec.DataEngineSpec.V2.CPUIsolationEnabled = tc.imOverride
+
+		enabled, err := imc.resolveCPUIsolationEnabled(im)
+		c.Assert(err, IsNil)
+		c.Assert(enabled, Equals, tc.expected, Commentf("test case: %v", name))
+	}
+}
+
+func (s *TestSuite) TestIsResponsibleForSetting(c *C) {
+	kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+	lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+	extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+	informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+	imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+	c.Assert(err, IsNil)
+
+	responsible := map[types.SettingName]bool{
+		types.SettingNameDataEngineInterruptModeEnabled: true,
+		types.SettingNameDataEngineCPUIsolationEnabled:  true,
+		types.SettingNameDataEngineCPUMask:              true,
+		types.SettingNameDataEngineHugepageEnabled:      true,
+		types.SettingNameBackupTarget:                   false,
+	}
+
+	for settingName, expected := range responsible {
+		setting := newSetting(string(settingName), "")
+		c.Assert(imc.isResponsibleForSetting(setting), Equals, expected, Commentf("setting: %v", settingName))
+	}
+}
+
+// TestInterruptModeSettingRecreatesPodWithoutCPUIsolation covers the whole
+// setting-update-to-pod-recreation path: enabling interrupt mode must make the
+// CPU isolation flags unsynced so the idle V2 instance-manager pod is replaced
+// by one running in interrupt mode without host CPU isolation.
+func (s *TestSuite) TestInterruptModeSettingRecreatesPodWithoutCPUIsolation(c *C) {
+	type testCase struct {
+		interruptModeEnabled bool
+		expectRecreated      bool
+	}
+
+	testCases := map[string]testCase{
+		"polling mode keeps the pod with CPU isolation flags": {
+			interruptModeEnabled: false,
+			expectRecreated:      false,
+		},
+		"interrupt mode recreates the pod without CPU isolation flags": {
+			interruptModeEnabled: true,
+			expectRecreated:      true,
+		},
+	}
+
+	isolationArgs := []string{"--enable-irq-affinity", "--enable-workqueue-affinity", "--enable-rps"}
+	hasArg := func(args []string, target string) bool {
+		for _, arg := range args {
+			if arg == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+		pIndexer := informerFactories.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+		kubeNodeIndexer := informerFactories.KubeInformerFactory.Core().V1().Nodes().Informer().GetIndexer()
+		imIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().InstanceManagers().Informer().GetIndexer()
+		sIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Settings().Informer().GetIndexer()
+		lhNodeIndexer := informerFactories.LhInformerFactory.Longhorn().V1beta2().Nodes().Informer().GetIndexer()
+
+		imc, err := newTestInstanceManagerController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		createDangerZoneSettingsForV2(c, lhClient, sIndexer)
+
+		if tc.interruptModeEnabled {
+			imSetting, err := lhClient.LonghornV1beta2().Settings(TestNamespace).Get(context.TODO(), string(types.SettingNameDataEngineInterruptModeEnabled), metav1.GetOptions{})
+			c.Assert(err, IsNil)
+			imSetting.Value = `{"v2":"true"}`
+			imSetting, err = lhClient.LonghornV1beta2().Settings(TestNamespace).Update(context.TODO(), imSetting, metav1.UpdateOptions{})
+			c.Assert(err, IsNil)
+			err = sIndexer.Update(imSetting)
+			c.Assert(err, IsNil)
+		}
+
+		kubeNode := newKubernetesNode(TestNode1, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionTrue)
+		kubeNode.Status.Allocatable = corev1.ResourceList{
+			"cpu":                                resource.MustParse("4"),
+			corev1.ResourceName("hugepages-2Mi"): resource.MustParse("2Gi"),
+		}
+		kubeNode.Status.Capacity = corev1.ResourceList{
+			corev1.ResourceName("hugepages-2Mi"): resource.MustParse("2Gi"),
+		}
+		err = kubeNodeIndexer.Add(kubeNode)
+		c.Assert(err, IsNil)
+		_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), kubeNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		lhNode := newNode(TestNode1, TestNamespace, true, longhorn.ConditionStatusTrue, "")
+		err = lhNodeIndexer.Add(lhNode)
+		c.Assert(err, IsNil)
+		_, err = lhClient.LonghornV1beta2().Nodes(lhNode.Namespace).Create(context.TODO(), lhNode, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		// A running V2 IM with no instances, started in polling mode with CPU isolation.
+		im := newInstanceManager(
+			TestInstanceManagerName,
+			longhorn.InstanceManagerStateRunning,
+			TestNode1, TestNode1, TestIP1,
+			nil, nil, nil,
+			longhorn.DataEngineTypeV2,
+			TestInstanceManagerImage,
+			false,
+		)
+		im.Status.DataEngineStatus.V2.CPUMask = "0x1"
+		im.Status.DataEngineStatus.V2.InterruptModeEnabled = longhorn.FalseValue
+		err = imIndexer.Add(im)
+		c.Assert(err, IsNil)
+		_, err = lhClient.LonghornV1beta2().InstanceManagers(im.Namespace).Create(context.TODO(), im, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		podArgs := append([]string{"--spdk-memory-size", "1024"}, isolationArgs...)
+		pod := newPod(&corev1.PodStatus{PodIP: TestIP1, Phase: corev1.PodRunning}, im.Name, im.Namespace, im.Spec.NodeID)
+		pod.Spec.Containers = []corev1.Container{{
+			Name:    "instance-manager",
+			Command: []string{"instance-manager"},
+			Args:    podArgs,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{"cpu": resource.MustParse("480m")},
+				Limits: corev1.ResourceList{
+					corev1.ResourceName("hugepages-2Mi"): resource.MustParse("1024Mi"),
+				},
+			},
+		}}
+		err = pIndexer.Add(pod)
+		c.Assert(err, IsNil)
+		_, err = kubeClient.CoreV1().Pods(im.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		c.Assert(err, IsNil)
+
+		err = imc.syncInstanceManager(getKey(im, c))
+		c.Assert(err, IsNil)
+
+		podList, err := kubeClient.CoreV1().Pods(im.Namespace).List(context.TODO(), metav1.ListOptions{})
+		c.Assert(err, IsNil)
+		c.Assert(podList.Items, HasLen, 1, Commentf("test case: %v", name))
+
+		args := podList.Items[0].Spec.Containers[0].Args
+		if !tc.expectRecreated {
+			c.Assert(args, DeepEquals, podArgs, Commentf("test case: %v", name))
+			continue
+		}
+
+		c.Assert(hasArg(args, "--spdk-interrupt-mode"), Equals, true, Commentf("test case: %v, args: %v", name, args))
+		for _, isolationArg := range isolationArgs {
+			c.Assert(hasArg(args, isolationArg), Equals, false, Commentf("test case: %v, args: %v", name, args))
+		}
+	}
+}

--- a/k8s/crds.yaml
+++ b/k8s/crds.yaml
@@ -1939,6 +1939,8 @@ spec:
                                      workqueues away from the SPDK reactor CPUs).
                           "false" -> do not pass the flags.
                           ""      -> inherit the global setting value.
+                          This field is ignored when interrupt mode is enabled, since the SPDK
+                          reactors no longer busy-poll and CPU isolation is always disabled.
                         enum:
                         - ""
                         - "true"

--- a/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
+++ b/k8s/pkg/apis/longhorn/v1beta2/instancemanager.go
@@ -186,6 +186,8 @@ type V2DataEngineSpec struct {
 	//            workqueues away from the SPDK reactor CPUs).
 	// "false" -> do not pass the flags.
 	// ""      -> inherit the global setting value.
+	// This field is ignored when interrupt mode is enabled, since the SPDK
+	// reactors no longer busy-poll and CPU isolation is always disabled.
 	// +optional
 	// +kubebuilder:validation:Enum="";"true";"false"
 	CPUIsolationEnabled string `json:"cpuIsolationEnabled"`

--- a/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/v2dataenginespec.go
+++ b/k8s/pkg/client/applyconfiguration/longhorn/v1beta2/v2dataenginespec.go
@@ -29,6 +29,8 @@ type V2DataEngineSpecApplyConfiguration struct {
 	// workqueues away from the SPDK reactor CPUs).
 	// "false" -> do not pass the flags.
 	// ""      -> inherit the global setting value.
+	// This field is ignored when interrupt mode is enabled, since the SPDK
+	// reactors no longer busy-poll and CPU isolation is always disabled.
 	CPUIsolationEnabled *string `json:"cpuIsolationEnabled,omitempty"`
 }
 

--- a/types/setting.go
+++ b/types/setting.go
@@ -1897,7 +1897,9 @@ var (
 			"This setting is applicable only when the V2 Data Engine is enabled. \n\n" +
 			"  - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached V2 volumes. \n\n" +
 			"  - `true`: Enables interrupt mode, which may reduce CPU usage. \n\n" +
-			"  - `false`: Uses polling mode for maximum performance. \n\n",
+			"  - `false`: Uses polling mode for maximum performance. \n\n" +
+			"  - When interrupt mode is enabled, **Enable Host CPU Isolation for Data Engine** is always disabled, because the SPDK reactors no longer busy-poll and do not need to be protected from host interrupt handling, deferred kernel work, or network softirq processing. " +
+			"This applies regardless of the **Enable Host CPU Isolation for Data Engine** value and of any per-Instance-Manager override. \n\n",
 		Category:           SettingCategoryDangerZone,
 		Type:               SettingTypeBool,
 		Required:           true,
@@ -1910,8 +1912,10 @@ var (
 		DisplayName: "Enable Host CPU Isolation for Data Engine",
 		Description: "Applies only to the V2 Data Engine. Steers host hardware IRQs, unbound kernel workqueue workers, *and* network Receive Packet Steering (RPS) away from the CPUs used by the Storage Performance Development Kit (SPDK) target daemon, " +
 			"so that interrupt handling, deferred kernel work, and network softirq processing do not preempt SPDK polling reactors. \n\n" +
+			"  - This setting only takes effect in polling mode. When **Enable Interrupt Mode for Data Engine** is enabled, CPU isolation is always disabled, regardless of this setting and of any per-Instance-Manager override. \n\n" +
+			"  - In polling mode, CPU isolation is enabled whenever this setting is `true`. \n\n" +
 			"  - When applying the setting, Longhorn will try to restart all V2 instance-manager pods if all volumes are detached and eventually restart the instance manager pod without instances running on the instance manager. \n\n" +
-			"  - This value can be overridden per Instance Manager via `Spec.DataEngineSpec.V2.CPUIsolationEnabled` " +
+			"  - In polling mode, this value can be overridden per Instance Manager via `Spec.DataEngineSpec.V2.CPUIsolationEnabled` " +
 			"(set to `\"true\"` or `\"false\"` on a specific instance manager to force the value on that node; leave empty to inherit this setting). \n\n",
 		Category:           SettingCategoryDangerZone,
 		Type:               SettingTypeBool,


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13973

#### What this PR does / why we need it:

CPU isolation exists to keep host IRQs, unbound kernel workqueues, and RPS softirqs from preempting busy-polling SPDK reactors. In interrupt mode the reactors no longer busy-poll, so the isolation is unnecessary.

resolveCPUIsolationEnabled now returns false when interrupt mode is enabled, unless the per-instance-manager CPUIsolationEnabled override says otherwise; the cluster-wide setting is only consulted in polling mode. Toggling interrupt mode marks the setting unsynced, so the pod is recreated without the isolation flags and start-spdk-tgt reconciles the stale host masks on startup.

#### Special notes for your reviewer:

#### Additional documentation or context
