### PR TITLE
fix(system-backup): delete the probe snapshot when the volume backup is up to date

### DIFF
--- a/controller/system_backup_controller.go
+++ b/controller/system_backup_controller.go
@@ -793,6 +793,17 @@ func (c *SystemBackupController) backupVolumesAlways(systemBackup *longhorn.Syst
 	return volumeBackups, nil
 }
 
+// deleteProbeSnapshot deletes a snapshot that was only created to detect new
+// data. It is called on every path that does not hand the snapshot over to a
+// Backup CR, so idle or failing volumes do not accumulate one system-backup
+// snapshot per backup cycle.
+// Ref: https://github.com/longhorn/longhorn/issues/12915
+func (c *SystemBackupController) deleteProbeSnapshot(snapshot *longhorn.Snapshot, volume *longhorn.Volume) {
+	if err := c.ds.DeleteSnapshot(snapshot.Name); err != nil {
+		c.logger.WithError(err).Warnf("Failed to delete the probe snapshot %v of volume %v", snapshot.Name, volume.Name)
+	}
+}
+
 func (c *SystemBackupController) backupVolumesIfNotPresent(systemBackup *longhorn.SystemBackup) (map[string]*longhorn.Backup, error) {
 	volumes, err := c.ds.ListVolumesRO()
 	if err != nil {
@@ -825,15 +836,19 @@ func (c *SystemBackupController) backupVolumesIfNotPresent(systemBackup *longhor
 
 		isUpToDate, err := c.isVolumeBackupUpToDate(volume, systemBackup)
 		if err != nil {
+			c.deleteProbeSnapshot(snapshot, volume)
 			return nil, err
 		}
 
 		if isUpToDate {
+			c.deleteProbeSnapshot(snapshot, volume)
 			continue
 		}
 
 		backup, err := c.createVolumeBackupFromSnapshot(volume, snapshot)
 		if err != nil {
+			// The snapshot is not referenced by any Backup CR, clean it up.
+			c.deleteProbeSnapshot(snapshot, volume)
 			return nil, err
 		}
 

--- a/controller/system_backup_controller_test.go
+++ b/controller/system_backup_controller_test.go
@@ -21,6 +21,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/longhorn/longhorn-manager/datastore"
 	"github.com/longhorn/longhorn-manager/types"
@@ -425,6 +428,117 @@ func (s *TestSuite) TestReconcileSystemBackup(c *C) {
 		volumeBackups, err := lhClient.LonghornV1beta2().Backups(TestNamespace).List(context.TODO(), metav1.ListOptions{})
 		c.Assert(err, IsNil)
 		c.Assert(len(volumeBackups.Items), Equals, tc.expectNewVolumBackupCount)
+	}
+}
+
+func (s *TestSuite) TestBackupVolumesIfNotPresentDeletesProbeSnapshot(c *C) {
+	datastore.SkipListerCheck = true
+	datastore.SystemBackupTimeout = 10 * time.Second
+	datastore.VolumeBackupTimeout = 10 * time.Second
+
+	testCases := map[string]struct {
+		lastBackup                string
+		injectBackupCreateFailure bool
+		expectError               bool
+		expectNewBackupCount      int
+		expectProbeSnapshots      int
+	}{
+		"up-to-date volume keeps no probe snapshot": {
+			lastBackup:           "exists",
+			expectNewBackupCount: 0,
+			expectProbeSnapshots: 0,
+		},
+		"volume without backup keeps the snapshot for its new backup": {
+			lastBackup:           "",
+			expectNewBackupCount: 1,
+			expectProbeSnapshots: 1,
+		},
+		"backup creation failure deletes the probe snapshot": {
+			lastBackup:                "",
+			injectBackupCreateFailure: true,
+			expectError:               true,
+			expectNewBackupCount:      0,
+			expectProbeSnapshots:      0,
+		},
+	}
+
+	for name, tc := range testCases {
+		fmt.Printf("testing %v\n", name)
+
+		kubeClient := fake.NewSimpleClientset()                    // nolint: staticcheck
+		lhClient := lhfake.NewSimpleClientset()                    // nolint: staticcheck
+		extensionsClient := apiextensionsfake.NewSimpleClientset() // nolint: staticcheck
+
+		informerFactories := util.NewInformerFactories(TestNamespace, kubeClient, lhClient, controller.NoResyncPeriodFunc())
+
+		fakeSystemRolloutNamespace(c, informerFactories.KubeInformerFactory, kubeClient)
+		fakeSystemRolloutSettingDefaultEngineImage(c, informerFactories.LhInformerFactory, lhClient)
+		fakeSystemRolloutBackupTargetDefault(c, informerFactories.LhInformerFactory, lhClient)
+		fakeSystemRolloutStorageClassesDefault(c, informerFactories.KubeInformerFactory, kubeClient)
+
+		volumes := map[SystemRolloutCRName]*longhorn.Volume{
+			SystemRolloutCRName(TestVolumeName): {
+				Status: longhorn.VolumeStatus{
+					LastBackup: tc.lastBackup,
+				},
+			},
+		}
+		fakeSystemRolloutVolumes(volumes, c, informerFactories.LhInformerFactory, lhClient)
+
+		if tc.lastBackup != "" {
+			existBackups := map[string]*longhorn.Backup{
+				"exists": {
+					Status: longhorn.BackupStatus{
+						State:        longhorn.BackupStateCompleted,
+						SnapshotName: "exists",
+						VolumeName:   TestVolumeName,
+					},
+				},
+			}
+			existSnapshots := map[string]*longhorn.Snapshot{
+				"exists": {
+					ObjectMeta: metav1.ObjectMeta{Name: "exists"},
+					Spec:       longhorn.SnapshotSpec{Volume: TestVolumeName},
+					Status: longhorn.SnapshotStatus{
+						ReadyToUse:   true,
+						CreationTime: metav1.Now().Format(time.RFC3339),
+					},
+				},
+			}
+			fakeSystemRolloutBackups(existBackups, c, informerFactories.LhInformerFactory, lhClient)
+			fakeSystemRolloutSnapshot(existSnapshots["exists"], c, informerFactories.LhInformerFactory, lhClient)
+		}
+
+		systemBackupController, err := newFakeSystemBackupController(lhClient, kubeClient, extensionsClient, informerFactories, TestNode1)
+		c.Assert(err, IsNil)
+
+		if tc.injectBackupCreateFailure {
+			lhClient.PrependReactor("create", "backups", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, fmt.Errorf("injected backup creation failure")
+			})
+		}
+
+		systemBackup := fakeSystemBackup(TestSystemBackupName, TestNode1, "", false,
+			longhorn.SystemBackupCreateVolumeBackupPolicyIfNotPresent, longhorn.SystemBackupStateVolumeBackup,
+			c, informerFactories.LhInformerFactory, lhClient)
+
+		backups, err := systemBackupController.BackupVolumes(systemBackup)
+		if tc.expectError {
+			c.Assert(err, NotNil, Commentf("test case %v", name))
+		} else {
+			c.Assert(err, IsNil, Commentf("test case %v", name))
+		}
+		c.Assert(len(backups), Equals, tc.expectNewBackupCount, Commentf("test case %v", name))
+
+		snapshots, err := lhClient.LonghornV1beta2().Snapshots(TestNamespace).List(context.TODO(), metav1.ListOptions{})
+		c.Assert(err, IsNil)
+		probeSnapshotCount := 0
+		for _, snapshot := range snapshots.Items {
+			if strings.HasPrefix(snapshot.Name, "system-backup-") {
+				probeSnapshotCount++
+			}
+		}
+		c.Assert(probeSnapshotCount, Equals, tc.expectProbeSnapshots, Commentf("test case %v", name))
 	}
 }
 


### PR DESCRIPTION
# Problem

`backupVolumesIfNotPresent()` creates a snapshot for every volume before checking whether the volume backup is up to date.

When the check decides to skip the backup, that snapshot is left behind.

Idle volumes therefore accumulate one empty `system-backup-*` snapshot per backup cycle, even with retention configured.

This matches the symptom reported in longhorn/longhorn#12915, where snapshots accumulated far beyond the configured retention.

# Solution

On the up-to-date (skip) path, delete the freshly created snapshot instead of leaving it behind.

- The skip path now deletes the probe snapshot via `datastore.DeleteSnapshot` (best effort, warning on failure).
- The not-up-to-date path is unchanged: its snapshot is referenced by the newly created backup.
- Snapshot cleanup after a completed backup is already governed by the existing `auto-cleanup-snapshot-when-delete-backup` setting and is out of scope here.

# Verification

- New suite test `TestBackupVolumesIfNotPresentDeletesProbeSnapshot` covers both paths.
- Up-to-date volume: no new backup and no `system-backup-*` snapshot remains.
- Volume without a backup: one new backup is created and its snapshot is kept.
- Full `./controller/` suite: 158 passed; 2 failures (`TestReconcileSystemBackup`, `TestSystemRollout`) also fail on pristine master HEAD, unrelated to this change.

Fixes longhorn/longhorn#12915
