### PR TITLE
fix(types): resolve symlinks when looking up device type

### DIFF
--- a/types/device.go
+++ b/types/device.go
@@ -69,10 +69,25 @@ func getDevicePathOf(mountPath, procMountPath string) (string, error) {
 	if devicePath == "" {
 		return "", fmt.Errorf("cannot find device path of %v", mountPath)
 	}
+	// /proc/mounts reports the device as it appears under /dev, which may be a
+	// symbolic link (e.g. /dev/mapper/vg1-longhorn -> ../dm-2). The matching
+	// entry under /sys/class/block is for the underlying device, so resolve
+	// the symlink here. If the path is not a symlink or cannot be resolved,
+	// fall back to the original path to keep existing behavior.
+	if resolved, err := filepath.EvalSymlinks(devicePath); err == nil {
+		devicePath = resolved
+	}
 	return devicePath, nil
 }
 
 func GetBlockDeviceType(devicePath string) (string, error) {
+	// Users may point Longhorn at a block-type disk that is itself a symlink
+	// (e.g. /dev/mapper/vg1-lv1 -> ../dm-2). The /sys entries for the device
+	// only exist under the real (resolved) name, so resolve here as well.
+	if resolved, err := filepath.EvalSymlinks(devicePath); err == nil {
+		devicePath = resolved
+	}
+
 	// Check if device rotational file exist
 	deviceID := filepath.Base(devicePath)
 	rotationalPath := fmt.Sprintf("/sys/block/%s/queue/rotational", deviceID)

--- a/types/device_test.go
+++ b/types/device_test.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+)
+
+// TestGetDevicePathOfResolvesSymlink verifies that when /proc/mounts reports
+// a device path that is a symbolic link (e.g. /dev/mapper/vg1-longhorn ->
+// ../dm-2), getDevicePathOf returns the resolved (real) device path. The
+// matching entry under /sys/class/block is for the resolved device, so the
+// symlink must be followed before the caller looks anything up in /sys.
+//
+// Regression test for https://github.com/longhorn/longhorn/issues/9479.
+func (s *TestSuite) TestGetDevicePathOfResolvesSymlink(c *C) {
+	tmp := c.MkDir()
+
+	// Real device backing file (stands in for /dev/dm-2).
+	realDevice := filepath.Join(tmp, "dm-2")
+	c.Assert(os.WriteFile(realDevice, nil, 0o644), IsNil)
+
+	// Symlink in the same dir (stands in for /dev/mapper/vg1-longhorn).
+	symlinkPath := filepath.Join(tmp, "vg1-longhorn")
+	c.Assert(os.Symlink(realDevice, symlinkPath), IsNil)
+
+	// Synthetic /proc/mounts mapping /var/lib/longhorn -> the symlink.
+	procMounts := filepath.Join(tmp, "mounts")
+	c.Assert(os.WriteFile(procMounts, []byte(symlinkPath+" /var/lib/longhorn xfs rw,relatime 0 0\n"), 0o644), IsNil)
+
+	got, err := getDevicePathOf("/var/lib/longhorn", procMounts)
+	c.Assert(err, IsNil)
+	// The expected value is EvalSymlinks(realDevice), not the literal
+	// realDevice: on systems where the temp dir lives under a symlinked
+	// prefix (e.g. macOS /var/folders/... -> /private/var/folders/...),
+	// EvalSymlinks resolves the whole path, including the prefix.
+	expected, err := filepath.EvalSymlinks(realDevice)
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, expected)
+}
+
+// TestGetDevicePathOfKeepsNonSymlink verifies that the symlink resolution is
+// a no-op for regular device paths: the original path is returned unchanged
+// so existing behavior is preserved.
+func (s *TestSuite) TestGetDevicePathOfKeepsNonSymlink(c *C) {
+	tmp := c.MkDir()
+	device := filepath.Join(tmp, "sda1")
+	c.Assert(os.WriteFile(device, nil, 0o644), IsNil)
+
+	procMounts := filepath.Join(tmp, "mounts")
+	c.Assert(os.WriteFile(procMounts, []byte(device+" /mnt xfs rw,relatime 0 0\n"), 0o644), IsNil)
+
+	got, err := getDevicePathOf("/mnt", procMounts)
+	c.Assert(err, IsNil)
+	// Compare with the EvalSymlinks-resolved form for the same macOS
+	// reason as the symlink test: a literal comparison would flake when
+	// c.MkDir() returns a path under a symlinked prefix.
+	expected, err := filepath.EvalSymlinks(device)
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, expected)
+}
+
+// TestGetDevicePathOfFallsBackOnBrokenSymlink verifies that when the
+// symlink target is missing (dangling link) the function still returns the
+// original device path instead of an error, so the existing "log a warning
+// and mark the disk type as unknown" behavior is preserved for unusual
+// mount configurations.
+func (s *TestSuite) TestGetDevicePathOfFallsBackOnBrokenSymlink(c *C) {
+	tmp := c.MkDir()
+	// Create a symlink whose target does not exist.
+	symlinkPath := filepath.Join(tmp, "vg1-longhorn")
+	c.Assert(os.Symlink(filepath.Join(tmp, "dm-missing"), symlinkPath), IsNil)
+
+	procMounts := filepath.Join(tmp, "mounts")
+	c.Assert(os.WriteFile(procMounts, []byte(symlinkPath+" /var/lib/longhorn xfs rw,relatime 0 0\n"), 0o644), IsNil)
+
+	got, err := getDevicePathOf("/var/lib/longhorn", procMounts)
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, symlinkPath)
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9479

#### What this PR does / why we need it:

longhorn-manager reports the disk type (NVMe/SSD/HDD) for each disk attached to a node. The lookup uses the device path from `/proc/mounts` or the disk spec directly, but both may be a symbolic link (e.g. `/dev/mapper/vg1-longhorn -> ../dm-2`). The corresponding entry under `/sys/block` and `/sys/class/block` only exists for the resolved device, so `lstat` on the symlink name fails and the manager logs a warning while falling back to `unknown`.

Resolve the symbolic link at the start of both `getDevicePathOf` and `GetBlockDeviceType`. If the path is not a symlink or the symlink cannot be resolved (e.g. dangling link), fall back to the original path so existing behavior is preserved.

The change matches the approach agreed on in the issue thread (@PhanLe1010, @c3y1huang): resolve in `getDevicePathOf` for the `/proc/mounts` case, and also at the top of `GetBlockDeviceType` for users that point Longhorn at a block-type disk that is itself a symlink (e.g. v2 data engine).

Unit tests for `getDevicePathOf` cover three cases:
- symlink is resolved to the real device
- non-symlink path is returned unchanged
- broken symlink falls back to the original literal without error

#### Special notes for your reviewer:

- Tests follow the existing `gopkg.in/check.v1` suite style used in `types/types_test.go` and `types/ec_test.go` (new methods on `TestSuite`).
- The expected value in the symlink test uses `filepath.EvalSymlinks(realDevice)` rather than a literal string compare, so the test is stable on systems where the temp dir lives under a symlinked prefix (e.g. macOS `/var/folders/...`).
- Happy to add a changelog entry, write a separate e2e test, or split into two commits if preferred.

#### Additional documentation or context

Discussion: longhorn/longhorn#9479 (esp. the comment thread with @PhanLe1010 and @c3y1huang agreeing on the fix location).